### PR TITLE
feat(cli): implement unreal-cli (16-command port of unity-mcp-cli)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -4,25 +4,55 @@ Cross-platform CLI tool for [Unreal-MCP](https://github.com/IvanMurzak/Unreal-MC
 analog of [`unity-mcp-cli`](https://github.com/IvanMurzak/Unity-MCP/tree/main/cli) and
 [`godot-cli`](https://github.com/IvanMurzak/Godot-MCP/tree/main/cli).
 
-> **Status: pre-alpha scaffold.** The package is `private: true` until the publish gate.
-> Only the `status` stub command exists today.
+> **Status: pre-alpha.** The package is `private: true` until the publish gate — no `npm publish`.
 
-## Planned command set (docs/ARCHITECTURE.md §9.1)
+## Commands (docs/ARCHITECTURE.md §9.1)
 
-`create-project`, `open`, `close`, `install-plugin`, `remove-plugin`, `configure`
-(`UNREAL_MCP_*` env/.env), `setup-mcp`, `login` (device code), `status`, `wait-for-ready`,
-`run-tool`, `run-system-tool`, `bootstrap-local`, `update`, `install-engine`
-(`LauncherInstalled.dat` detection at minimum), `setup-skills`.
+| Command | What it does |
+| --- | --- |
+| `create-project <path>` | Scaffold a minimal Unreal Engine C++ project |
+| `open [path]` | Launch the Unreal Editor, wiring `UNREAL_MCP_*` env vars (engine resolved via `EngineAssociation` + `LauncherInstalled.dat`) |
+| `close [path]` | Terminate the editor process running a project |
+| `install-plugin [path]` | Copy (or `--junction`) the UnrealMCP plugin into `<project>/Plugins` |
+| `remove-plugin [path]` | Remove the installed plugin |
+| `configure` | Write `UNREAL_MCP_*` into `<project>/.env` and gitignore `.env` (§8) |
+| `setup-mcp <agent>` | Write an MCP client config snippet (claude-code, cursor, vscode) |
+| `login` | OAuth device-code auth against ai-game.dev |
+| `status` | Report project + plugin + connection + live reachability |
+| `wait-for-ready` | Block until the project's MCP server responds to a ping |
+| `run-tool <tool>` | Invoke an MCP tool over the local HTTP path |
+| `run-system-tool <tool>` | Invoke a system tool over the local HTTP path |
+| `bootstrap-local [path]` | Build bridge + server from source into `Intermediate/UnrealMCP/` (§6) |
+| `update [path]` | Re-sync the installed plugin from the repo source |
+| `install-engine [version]` | Detect installed engines from `LauncherInstalled.dat`; link to the Epic launcher for missing versions (never installs directly) |
+| `setup-skills` | Write a Claude-Code skill stub that drives the project's MCP server |
 
-It also exports a side-effect-free library (`import { getStatus } from 'unreal-cli'`) whose
-functions return a `{ kind: 'success' | 'failure' }` discriminated union and never throw past
-the public boundary — same contract as the Unity/Godot CLIs.
+## Engine resolution
+
+`open` reads the project's `.uproject` `EngineAssociation` and resolves it against the Epic launcher
+manifest (`LauncherInstalled.dat`): a version association (`"5.7"`) maps to the matching install; an
+empty association falls back to the highest installed engine; a GUID (source build) requires
+`--engine-root`. `install-engine` enumerates the same manifest and, for a not-yet-installed version,
+hands back a `com.epicgames.launcher://` deep link rather than performing the multi-GB download.
+
+## Library export
+
+```ts
+import { configure, openProject, runTool, detectInstalledEngines } from 'unreal-cli';
+```
+
+`dist/lib.js` exposes the command logic as a side-effect-free library: no argv parsing, no stdout,
+no process exit. Every function returns a `{ kind: 'success' | 'failure' }` discriminated union and
+never throws past the boundary — the same contract as the Unity/Godot CLIs.
 
 ## Develop
 
 ```bash
 npm install
 npm run build   # tsc -> dist/ (ESM)
-npm test        # vitest
+npm test        # vitest (unit tests; fixtures under tests/fixtures/)
 node bin/unreal-cli.js status
+
+# Optional end-to-end integration test (NOT part of the default run):
+UNREAL_CLI_INTEGRATION=1 npm test
 ```

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,7 +1,23 @@
 // CLI entry-point re-exports (`unreal-cli/cli`).
 //
-// Exposes the commander Command instances so a consumer can compose them into
-// their own program. The runnable program lives in `index.ts` (imported by
-// `bin/unreal-cli.js`).
+// Exposes the commander Command instances so a consumer can compose them
+// into their own program. The runnable program lives in `index.ts`
+// (imported by `bin/unreal-cli.js`); importing THIS file has no side
+// effects (it does not parse argv or exit).
 
+export { bootstrapLocalCommand } from './commands/bootstrap-local.js';
+export { closeCommand } from './commands/close.js';
+export { configureCommand } from './commands/configure.js';
+export { createProjectCommand } from './commands/create-project.js';
+export { installEngineCommand } from './commands/install-engine.js';
+export { installPluginCommand } from './commands/install-plugin.js';
+export { loginCommand } from './commands/login.js';
+export { openCommand } from './commands/open.js';
+export { removePluginCommand } from './commands/remove-plugin.js';
+export { runSystemToolCommand } from './commands/run-system-tool.js';
+export { runToolCommand } from './commands/run-tool.js';
+export { setupMcpCommand } from './commands/setup-mcp.js';
+export { setupSkillsCommand } from './commands/setup-skills.js';
 export { statusCommand } from './commands/status.js';
+export { updateCommand } from './commands/update.js';
+export { waitForReadyCommand } from './commands/wait-for-ready.js';

--- a/cli/src/commands/bootstrap-local.ts
+++ b/cli/src/commands/bootstrap-local.ts
@@ -25,9 +25,13 @@ export const bootstrapLocalCommand = new Command('bootstrap-local')
       repoRoot,
       // --plan: don't actually build, just report the steps.
       buildImpl: opts.plan ? async () => {} : undefined,
-      onProgress: (e) => {
-        if (e.phase === 'info' || e.phase === 'file-written') ui.info(e.message);
-      },
+      // Suppress the per-step "Building/Published" progress under --plan —
+      // nothing is built, so printing build progress would be misleading.
+      onProgress: opts.plan
+        ? undefined
+        : (e) => {
+            if (e.phase === 'info' || e.phase === 'file-written') ui.info(e.message);
+          },
     });
     if (result.kind === 'failure') {
       ui.printWarnings(result.warnings);
@@ -40,5 +44,12 @@ export const bootstrapLocalCommand = new Command('bootstrap-local')
       for (const s of result.steps) ui.label(s.label, `${s.projectFile} -> ${s.outputDir} (${s.rid})`);
     } else {
       ui.success(`Bootstrapped bridge + server into ${result.outputRoot}`);
+      // A bootstrapped build writes no `version` file, so the plugin's §6
+      // version-match would treat it as mismatched. The supported way to
+      // consume a local build is the UNREAL_MCP_BRIDGE_PATH dev override,
+      // which skips the download + version check entirely.
+      ui.info(
+        `Set UNREAL_MCP_BRIDGE_PATH to the bridge binary under ${result.outputRoot} to use this local build (skips download + version check, §6).`,
+      );
     }
   });

--- a/cli/src/commands/bootstrap-local.ts
+++ b/cli/src/commands/bootstrap-local.ts
@@ -1,0 +1,44 @@
+import { Command } from 'commander';
+import { fileURLToPath } from 'url';
+import * as path from 'path';
+import { bootstrapLocal } from '../lib/bootstrap-local.js';
+import { findRepoRoot } from '../utils/repo.js';
+import * as ui from '../utils/ui.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+export const bootstrapLocalCommand = new Command('bootstrap-local')
+  .description('Build the bridge + server from source into <project>/Intermediate/UnrealMCP (§6)')
+  .argument('[path]', 'Unreal project directory (defaults to cwd)')
+  .option('--repo-root <dir>', 'Unreal-MCP repo root (defaults to the CLI\'s repo)')
+  .option('--plan', 'Print the build plan without running dotnet')
+  .action(async (pathArg: string | undefined, opts: { repoRoot?: string; plan?: boolean }) => {
+    const projectDir = pathArg ?? process.cwd();
+    const repoRoot = opts.repoRoot ?? findRepoRoot(HERE);
+    if (!repoRoot) {
+      ui.error('Could not locate the Unreal-MCP repo root. Pass --repo-root <dir>.');
+      process.exitCode = 1;
+      return;
+    }
+    const result = await bootstrapLocal({
+      projectDir,
+      repoRoot,
+      // --plan: don't actually build, just report the steps.
+      buildImpl: opts.plan ? async () => {} : undefined,
+      onProgress: (e) => {
+        if (e.phase === 'info' || e.phase === 'file-written') ui.info(e.message);
+      },
+    });
+    if (result.kind === 'failure') {
+      ui.printWarnings(result.warnings);
+      ui.error(result.error.message);
+      process.exitCode = 1;
+      return;
+    }
+    if (opts.plan) {
+      ui.heading('Build plan:');
+      for (const s of result.steps) ui.label(s.label, `${s.projectFile} -> ${s.outputDir} (${s.rid})`);
+    } else {
+      ui.success(`Bootstrapped bridge + server into ${result.outputRoot}`);
+    }
+  });

--- a/cli/src/commands/close.ts
+++ b/cli/src/commands/close.ts
@@ -1,0 +1,21 @@
+import { Command } from 'commander';
+import { close } from '../lib/close.js';
+import * as ui from '../utils/ui.js';
+
+export const closeCommand = new Command('close')
+  .description('Terminate the Unreal Editor process running a project')
+  .argument('[path]', 'Unreal project directory (defaults to cwd)')
+  .action(async (pathArg: string | undefined) => {
+    const result = await close({ projectDir: pathArg });
+    ui.printWarnings(result.warnings);
+    if (result.kind === 'failure') {
+      ui.error(result.error.message);
+      process.exitCode = 1;
+      return;
+    }
+    if (!result.wasRunning) {
+      ui.info('No running Unreal Editor matched this project.');
+      return;
+    }
+    ui.success(`Terminated ${result.terminated.length} editor process(es): ${result.terminated.join(', ')}`);
+  });

--- a/cli/src/commands/configure.ts
+++ b/cli/src/commands/configure.ts
@@ -1,0 +1,46 @@
+import { Command } from 'commander';
+import { configure } from '../lib/configure.js';
+import type { AuthOption, ConnectionMode, McpTransport } from '../lib/types.js';
+import * as ui from '../utils/ui.js';
+
+export const configureCommand = new Command('configure')
+  .description('Write UNREAL_MCP_* values into <project>/.env and gitignore .env (§8)')
+  .option('-p, --path <dir>', 'Unreal project directory (defaults to cwd)', process.cwd())
+  .option('--mode <mode>', 'Connection mode: Cloud | Custom')
+  .option('--host <url>', 'Server host (UNREAL_MCP_HOST)')
+  .option('--cloud-url <url>', 'Cloud URL (UNREAL_MCP_CLOUD_URL)')
+  .option('--token <token>', 'Auth token (UNREAL_MCP_TOKEN)')
+  .option('--auth <option>', 'Auth option: none | required')
+  .option('--keep-connected', 'Set UNREAL_MCP_KEEP_CONNECTED=true')
+  .option('--tools <list>', 'Enabled-tools override (UNREAL_MCP_TOOLS)')
+  .option('--start-server', 'Set UNREAL_MCP_START_SERVER=true')
+  .option('--transport <t>', 'Transport: stdio | http')
+  .option('--log-level <level>', 'Log level (UNREAL_MCP_LOG_LEVEL)')
+  .option('--no-gitignore', 'Do not touch .gitignore')
+  .action(async (opts) => {
+    const result = await configure({
+      projectDir: opts.path,
+      connectionMode: opts.mode as ConnectionMode | undefined,
+      host: opts.host,
+      cloudUrl: opts.cloudUrl,
+      token: opts.token,
+      authOption: opts.auth as AuthOption | undefined,
+      keepConnected: opts.keepConnected,
+      tools: opts.tools,
+      startServer: opts.startServer,
+      transport: opts.transport as McpTransport | undefined,
+      logLevel: opts.logLevel,
+      ensureGitignore: opts.gitignore !== false,
+    });
+    if (result.kind === 'failure') {
+      ui.printWarnings(result.warnings);
+      ui.error(result.error.message);
+      process.exitCode = 1;
+      return;
+    }
+    ui.printWarnings(result.warnings);
+    ui.success(`Wrote ${result.keysWritten.length} key(s) to ${result.envPath}`);
+    if (result.gitignoreAction && result.gitignoreAction !== 'skipped') {
+      ui.info(`.gitignore: ${result.gitignoreAction} (${result.gitignorePath})`);
+    }
+  });

--- a/cli/src/commands/create-project.ts
+++ b/cli/src/commands/create-project.ts
@@ -1,0 +1,26 @@
+import { Command } from 'commander';
+import { createProject } from '../lib/create-project.js';
+import * as ui from '../utils/ui.js';
+
+export const createProjectCommand = new Command('create-project')
+  .description('Scaffold a minimal Unreal Engine C++ project')
+  .argument('<path>', 'Directory to create the project in')
+  .option('--name <name>', 'Project/module name (defaults to directory name; no hyphens)')
+  .option('--engine <version>', 'EngineAssociation to bake in (e.g. 5.7)')
+  .option('--force', 'Scaffold into a non-empty directory')
+  .action(async (pathArg: string, opts: { name?: string; engine?: string; force?: boolean }) => {
+    const result = await createProject({
+      projectDir: pathArg,
+      projectName: opts.name,
+      engineAssociation: opts.engine,
+      force: opts.force,
+    });
+    ui.printWarnings(result.warnings);
+    if (result.kind === 'failure') {
+      ui.error(result.errorMessage);
+      process.exitCode = 1;
+      return;
+    }
+    ui.success(`Scaffolded ${result.projectName} (${result.filesWritten.length} files)`);
+    ui.label('uproject', result.uprojectPath);
+  });

--- a/cli/src/commands/install-engine.ts
+++ b/cli/src/commands/install-engine.ts
@@ -1,0 +1,26 @@
+import { Command } from 'commander';
+import { detectInstalledEngines, planEngineInstall } from '../lib/install-engine.js';
+import * as ui from '../utils/ui.js';
+
+export const installEngineCommand = new Command('install-engine')
+  .description('Detect installed Unreal engines; for a missing version, link to the Epic launcher')
+  .argument('[version]', 'Engine version to ensure (e.g. 5.7). Omit to just list installed engines.')
+  .option('--manifest <path>', 'Explicit LauncherInstalled.dat path')
+  .action(async (version: string | undefined, opts: { manifest?: string }) => {
+    if (!version) {
+      const detected = detectInstalledEngines({ manifestPath: opts.manifest });
+      ui.heading('Installed Unreal engines:');
+      if (detected.engines.length === 0) {
+        ui.info(`  (none found${detected.manifestPath ? ` in ${detected.manifestPath}` : ''})`);
+      } else {
+        for (const e of detected.engines) ui.label(e.engineAssociation, `${e.appName} @ ${e.installLocation}`);
+      }
+      return;
+    }
+    const plan = planEngineInstall({ version, manifestPath: opts.manifest });
+    if (plan.alreadyInstalled) {
+      ui.success(plan.message);
+    } else {
+      ui.info(plan.message);
+    }
+  });

--- a/cli/src/commands/install-plugin.ts
+++ b/cli/src/commands/install-plugin.ts
@@ -1,0 +1,31 @@
+import { Command } from 'commander';
+import { fileURLToPath } from 'url';
+import * as path from 'path';
+import { installPlugin } from '../lib/install-plugin.js';
+import { defaultPluginSource } from '../utils/repo.js';
+import * as ui from '../utils/ui.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+export const installPluginCommand = new Command('install-plugin')
+  .description('Install the UnrealMCP plugin into <project>/Plugins (copy or --junction)')
+  .argument('[path]', 'Unreal project directory (defaults to cwd)')
+  .option('--plugin-source <dir>', 'UnrealMCP plugin source dir (defaults to the repo plugin)')
+  .option('--junction', 'Create a dev junction instead of copying (Windows)')
+  .action(async (pathArg: string | undefined, opts: { pluginSource?: string; junction?: boolean }) => {
+    const projectDir = pathArg ?? process.cwd();
+    const pluginSourceDir = opts.pluginSource ?? defaultPluginSource(HERE);
+    if (!pluginSourceDir) {
+      ui.error('Could not locate the UnrealMCP plugin source. Pass --plugin-source <dir>.');
+      process.exitCode = 1;
+      return;
+    }
+    const result = await installPlugin({ projectDir, pluginSourceDir, junction: opts.junction });
+    ui.printWarnings(result.warnings);
+    if (result.kind === 'failure') {
+      ui.error(result.error.message);
+      process.exitCode = 1;
+      return;
+    }
+    ui.success(`Installed plugin (${result.mode}) at ${result.installedPath}`);
+  });

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -1,0 +1,27 @@
+import { Command } from 'commander';
+import { login } from '../lib/login.js';
+import * as ui from '../utils/ui.js';
+
+export const loginCommand = new Command('login')
+  .description('Authorize against ai-game.dev via the OAuth device-code flow')
+  .option('-p, --path <dir>', 'Persist the token into this project\'s .env')
+  .option('--base-url <url>', 'Auth base URL (defaults to https://ai-game.dev)')
+  .option('--timeout <ms>', 'Overall poll timeout in ms', (v) => parseInt(v, 10))
+  .action(async (opts: { path?: string; baseUrl?: string; timeout?: number }) => {
+    const result = await login({
+      projectDir: opts.path,
+      baseUrl: opts.baseUrl,
+      timeoutMs: opts.timeout,
+      onProgress: (e) => {
+        if (e.phase === 'info' || e.phase === 'start') ui.info(e.message);
+      },
+    });
+    if (result.kind === 'failure') {
+      ui.error(`Login failed (${result.reason}): ${result.error.message}`);
+      process.exitCode = 1;
+      return;
+    }
+    ui.success('Logged in.');
+    if (result.persisted) ui.info(`Token saved to ${result.envPath}`);
+    else ui.info('Token not persisted (pass --path to save it into a project .env).');
+  });

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -1,0 +1,40 @@
+import { Command } from 'commander';
+import { openProject } from '../lib/open.js';
+import type { AuthOption, McpTransport } from '../lib/types.js';
+import * as ui from '../utils/ui.js';
+
+export const openCommand = new Command('open')
+  .description('Launch the Unreal Editor for a project, wiring MCP connection env vars')
+  .argument('[path]', 'Unreal project directory (defaults to cwd)')
+  .option('--engine-root <dir>', 'Explicit engine install root (source builds)')
+  .option('--no-connect', 'Do not wire UNREAL_MCP_* env vars onto the editor')
+  .option('--host <url>', 'UNREAL_MCP_HOST')
+  .option('--token <token>', 'UNREAL_MCP_TOKEN')
+  .option('--auth <option>', 'UNREAL_MCP_AUTH_OPTION: none | required')
+  .option('--tools <list>', 'UNREAL_MCP_TOOLS override')
+  .option('--keep-connected', 'UNREAL_MCP_KEEP_CONNECTED=true')
+  .option('--transport <t>', 'UNREAL_MCP_TRANSPORT: stdio | http')
+  .option('--start-server', 'UNREAL_MCP_START_SERVER=true')
+  .action(async (pathArg: string | undefined, opts) => {
+    const result = await openProject({
+      projectDir: pathArg,
+      engineRoot: opts.engineRoot,
+      noConnect: opts.connect === false,
+      host: opts.host,
+      token: opts.token,
+      auth: opts.auth as AuthOption | undefined,
+      tools: opts.tools,
+      keepConnected: opts.keepConnected,
+      transport: opts.transport as McpTransport | undefined,
+      startServer: opts.startServer,
+    });
+    ui.printWarnings(result.warnings);
+    if (result.kind === 'failure') {
+      ui.error(result.errorMessage);
+      process.exitCode = 1;
+      return;
+    }
+    ui.success(`Launched Unreal Editor (PID: ${result.editorPid ?? 'unknown'})`);
+    ui.label('editor', result.editorPath);
+    ui.label('engine', result.engineRoot);
+  });

--- a/cli/src/commands/remove-plugin.ts
+++ b/cli/src/commands/remove-plugin.ts
@@ -1,0 +1,18 @@
+import { Command } from 'commander';
+import { removePlugin } from '../lib/install-plugin.js';
+import * as ui from '../utils/ui.js';
+
+export const removePluginCommand = new Command('remove-plugin')
+  .description('Remove the UnrealMCP plugin from <project>/Plugins')
+  .argument('[path]', 'Unreal project directory (defaults to cwd)')
+  .action(async (pathArg: string | undefined) => {
+    const result = await removePlugin({ projectDir: pathArg ?? process.cwd() });
+    ui.printWarnings(result.warnings);
+    if (result.kind === 'failure') {
+      ui.error(result.error.message);
+      process.exitCode = 1;
+      return;
+    }
+    if (result.removed) ui.success(`Removed plugin at ${result.installedPath}`);
+    else ui.info('Plugin was not installed — nothing to remove.');
+  });

--- a/cli/src/commands/run-system-tool.ts
+++ b/cli/src/commands/run-system-tool.ts
@@ -1,0 +1,9 @@
+import { runSystemTool } from '../lib/run-tool.js';
+import { buildRunToolCommand } from './run-tool-builder.js';
+
+export const runSystemToolCommand = buildRunToolCommand({
+  name: 'run-system-tool',
+  description: 'Invoke a system tool via the project\'s local MCP server (HTTP)',
+  errorNoun: 'system tool',
+  invoke: runSystemTool,
+});

--- a/cli/src/commands/run-tool-builder.ts
+++ b/cli/src/commands/run-tool-builder.ts
@@ -1,0 +1,43 @@
+import { Command } from 'commander';
+import type { RunToolOptions, RunToolResult } from '../lib/types.js';
+import * as ui from '../utils/ui.js';
+
+export interface RunToolCommandSpec {
+  name: string;
+  description: string;
+  errorNoun: string;
+  invoke: (opts: RunToolOptions) => Promise<RunToolResult>;
+}
+
+/**
+ * Build a `run-tool` / `run-system-tool` command from a spec — both share
+ * the exact same option surface and output handling, differing only in the
+ * underlying `invoke` (route prefix).
+ */
+export function buildRunToolCommand(spec: RunToolCommandSpec): Command {
+  return new Command(spec.name)
+    .description(spec.description)
+    .argument('<tool>', `Name of the ${spec.errorNoun} to invoke`)
+    .option('-p, --path <dir>', 'Unreal project directory (resolves URL + token)')
+    .option('--url <url>', 'Explicit MCP server URL override')
+    .option('--token <token>', 'Bearer token override')
+    .option('--input <json>', 'Tool arguments as a JSON string')
+    .option('--timeout <ms>', 'Request timeout in ms (default 60000)', (v) => parseInt(v, 10))
+    .action(async (toolName: string, opts) => {
+      const result = await spec.invoke({
+        toolName,
+        projectDir: opts.path,
+        url: opts.url,
+        token: opts.token,
+        input: opts.input,
+        timeoutMs: opts.timeout,
+      });
+      if (result.kind === 'failure') {
+        ui.error(`Failed to run ${spec.errorNoun} "${toolName}" (${result.reason}): ${result.message}`);
+        if (result.data !== undefined) ui.json(result.data);
+        process.exitCode = 1;
+        return;
+      }
+      ui.json(result.data);
+    });
+}

--- a/cli/src/commands/run-tool.ts
+++ b/cli/src/commands/run-tool.ts
@@ -1,0 +1,9 @@
+import { runTool } from '../lib/run-tool.js';
+import { buildRunToolCommand } from './run-tool-builder.js';
+
+export const runToolCommand = buildRunToolCommand({
+  name: 'run-tool',
+  description: 'Invoke an MCP tool via the project\'s local MCP server (HTTP)',
+  errorNoun: 'tool',
+  invoke: runTool,
+});

--- a/cli/src/commands/setup-mcp.ts
+++ b/cli/src/commands/setup-mcp.ts
@@ -1,0 +1,35 @@
+import { Command } from 'commander';
+import { setupMcp, listAgentIds } from '../lib/setup-mcp.js';
+import type { McpTransport } from '../lib/types.js';
+import * as ui from '../utils/ui.js';
+
+export const setupMcpCommand = new Command('setup-mcp')
+  .description(`Write an MCP client config snippet for an agent (${listAgentIds().join(', ')})`)
+  .argument('<agent>', `Agent id: ${listAgentIds().join(' | ')}`)
+  .option('-p, --path <dir>', 'Unreal project directory (defaults to cwd)')
+  .option('--transport <t>', 'Transport: http | stdio (default http)')
+  .option('--url <url>', 'Explicit MCP server URL override')
+  .option('--token <token>', 'Bearer token override')
+  .option('--dry-run', 'Print the snippet instead of writing it')
+  .action(async (agent: string, opts) => {
+    const result = await setupMcp({
+      agentId: agent,
+      projectDir: opts.path,
+      transport: opts.transport as McpTransport | undefined,
+      url: opts.url,
+      token: opts.token,
+      dryRun: opts.dryRun,
+    });
+    ui.printWarnings(result.warnings);
+    if (result.kind === 'failure') {
+      ui.error(result.error.message);
+      process.exitCode = 1;
+      return;
+    }
+    if (opts.dryRun) {
+      ui.info(result.snippet);
+    } else {
+      ui.success(`Wrote ${result.agentId} MCP config (${result.transport}) to ${result.configPath}`);
+    }
+    for (const step of result.nextSteps) ui.info(`→ ${step}`);
+  });

--- a/cli/src/commands/setup-skills.ts
+++ b/cli/src/commands/setup-skills.ts
@@ -1,0 +1,26 @@
+import { Command } from 'commander';
+import { setupSkills } from '../lib/setup-skills.js';
+import * as ui from '../utils/ui.js';
+
+export const setupSkillsCommand = new Command('setup-skills')
+  .description('Write a Claude-Code skill stub that drives this project\'s Unreal MCP server')
+  .option('-p, --path <dir>', 'Unreal project directory (defaults to cwd)')
+  .option('--url <url>', 'Explicit MCP server URL override')
+  .option('--token <token>', 'Bearer token override')
+  .option('--force', 'Overwrite an existing skill file')
+  .action(async (opts: { path?: string; url?: string; token?: string; force?: boolean }) => {
+    const result = await setupSkills({
+      projectDir: opts.path,
+      url: opts.url,
+      token: opts.token,
+      force: opts.force,
+    });
+    ui.printWarnings(result.warnings);
+    if (result.kind === 'failure') {
+      ui.error(result.error.message);
+      process.exitCode = 1;
+      return;
+    }
+    if (result.written) ui.success(`Wrote skill to ${result.skillPath}`);
+    else ui.info(`Skill already exists at ${result.skillPath} (use --force to overwrite).`);
+  });

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -29,6 +29,11 @@ export const statusCommand = new Command('status')
       ui.label('url', report.connection.url);
       ui.label('source', report.connection.source);
       ui.label('token', report.connection.hasToken ? 'present' : 'none');
+    } else if (report.connection.source === 'unresolved') {
+      // A connection could not be resolved at all — surface why instead of
+      // printing nothing (the reason is carried on probeReason).
+      ui.heading('Connection:');
+      ui.label('status', `could not resolve${report.probeReason ? ` (${report.probeReason})` : ''}`);
     }
     if (report.reachable !== undefined) {
       ui.heading('MCP server:');

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -1,13 +1,37 @@
 import { Command } from 'commander';
 import { getStatus } from '../lib/status.js';
+import * as ui from '../utils/ui.js';
 
-// Scaffold stub. The real command (port of godot-cli's `status`) will detect a
-// running Unreal Editor for a project, probe the MCP server URL, and report the
-// bridge/sidecar state. For now it proves the command plumbing end-to-end.
 export const statusCommand = new Command('status')
-  .description('Show unreal-cli status (scaffold stub: prints name and version)')
-  .action(() => {
-    const status = getStatus();
-    console.log(`${status.name} v${status.version}`);
-    console.log(`status: ${status.stage}`);
+  .description('Report package, project, plugin, and live connection status')
+  .option('-p, --path <dir>', 'Unreal project directory (defaults to cwd)')
+  .option('--url <url>', 'Explicit MCP server URL override')
+  .option('--token <token>', 'Bearer token override')
+  .option('--no-probe', 'Skip the live HTTP reachability probe')
+  .action(async (opts: { path?: string; url?: string; token?: string; probe?: boolean }) => {
+    const report = await getStatus({
+      projectDir: opts.path,
+      url: opts.url,
+      token: opts.token,
+      noProbe: opts.probe === false,
+    });
+
+    ui.info(`${report.name} v${report.version}`);
+    if (report.project) {
+      ui.heading('Project:');
+      ui.label('name', report.project.projectName);
+      ui.label('dir', report.project.projectDir);
+      ui.label('engine', report.project.engineAssociation);
+      ui.label('plugin', report.project.pluginInstalled ? 'installed' : 'not installed');
+    }
+    if (report.connection.url) {
+      ui.heading('Connection:');
+      ui.label('url', report.connection.url);
+      ui.label('source', report.connection.source);
+      ui.label('token', report.connection.hasToken ? 'present' : 'none');
+    }
+    if (report.reachable !== undefined) {
+      ui.heading('MCP server:');
+      ui.label('reachable', report.reachable ? 'yes' : `no (${report.probeReason})`);
+    }
   });

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -1,0 +1,35 @@
+import { Command } from 'commander';
+import { fileURLToPath } from 'url';
+import * as path from 'path';
+import { update } from '../lib/update.js';
+import { defaultPluginSource } from '../utils/repo.js';
+import * as ui from '../utils/ui.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+export const updateCommand = new Command('update')
+  .description('Update the UnrealMCP plugin installed in a project from the repo source')
+  .argument('[path]', 'Unreal project directory (defaults to cwd)')
+  .option('--plugin-source <dir>', 'UnrealMCP plugin source dir (defaults to the repo plugin)')
+  .option('--force', 'Re-install even when versions match')
+  .action(async (pathArg: string | undefined, opts: { pluginSource?: string; force?: boolean }) => {
+    const projectDir = pathArg ?? process.cwd();
+    const pluginSourceDir = opts.pluginSource ?? defaultPluginSource(HERE);
+    if (!pluginSourceDir) {
+      ui.error('Could not locate the UnrealMCP plugin source. Pass --plugin-source <dir>.');
+      process.exitCode = 1;
+      return;
+    }
+    const result = await update({ projectDir, pluginSourceDir, force: opts.force });
+    ui.printWarnings(result.warnings);
+    if (result.kind === 'failure') {
+      ui.error(result.error.message);
+      process.exitCode = 1;
+      return;
+    }
+    if (result.updated) {
+      ui.success(`Updated plugin ${result.fromVersion ?? 'none'} -> ${result.toVersion ?? 'unknown'}`);
+    } else {
+      ui.info(`Plugin already up to date (${result.toVersion ?? 'unknown'}).`);
+    }
+  });

--- a/cli/src/commands/wait-for-ready.ts
+++ b/cli/src/commands/wait-for-ready.ts
@@ -1,0 +1,29 @@
+import { Command } from 'commander';
+import { waitForReady } from '../lib/wait-for-ready.js';
+import * as ui from '../utils/ui.js';
+
+export const waitForReadyCommand = new Command('wait-for-ready')
+  .description('Block until the project\'s MCP server responds to a ping')
+  .option('-p, --path <dir>', 'Unreal project directory (defaults to cwd)')
+  .option('--url <url>', 'Explicit MCP server URL override')
+  .option('--token <token>', 'Bearer token override')
+  .option('--timeout <ms>', 'Overall timeout in ms (default 120000)', (v) => parseInt(v, 10))
+  .option('--interval <ms>', 'Poll interval in ms (default 2000)', (v) => parseInt(v, 10))
+  .action(async (opts: { path?: string; url?: string; token?: string; timeout?: number; interval?: number }) => {
+    const result = await waitForReady({
+      projectDir: opts.path,
+      url: opts.url,
+      token: opts.token,
+      timeoutMs: opts.timeout,
+      intervalMs: opts.interval,
+      onProgress: (e) => {
+        if (e.phase === 'info') ui.verbose(e.message);
+      },
+    });
+    if (result.kind === 'failure') {
+      ui.error(`Not ready after ${result.elapsedMs}ms (${result.attempts} attempts): ${result.lastReason}`);
+      process.exitCode = 1;
+      return;
+    }
+    ui.success(`Ready after ${result.elapsedMs}ms (${result.attempts} attempt(s)) — ${result.url}`);
+  });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,21 +1,67 @@
 import { Command } from 'commander';
-import { statusCommand } from './commands/status.js';
 import { PACKAGE_VERSION } from './version.js';
+import { setVerbose } from './utils/ui.js';
+import { bootstrapLocalCommand } from './commands/bootstrap-local.js';
+import { closeCommand } from './commands/close.js';
+import { configureCommand } from './commands/configure.js';
+import { createProjectCommand } from './commands/create-project.js';
+import { installEngineCommand } from './commands/install-engine.js';
+import { installPluginCommand } from './commands/install-plugin.js';
+import { loginCommand } from './commands/login.js';
+import { openCommand } from './commands/open.js';
+import { removePluginCommand } from './commands/remove-plugin.js';
+import { runSystemToolCommand } from './commands/run-system-tool.js';
+import { runToolCommand } from './commands/run-tool.js';
+import { setupMcpCommand } from './commands/setup-mcp.js';
+import { setupSkillsCommand } from './commands/setup-skills.js';
+import { statusCommand } from './commands/status.js';
+import { updateCommand } from './commands/update.js';
+import { waitForReadyCommand } from './commands/wait-for-ready.js';
 
 const program = new Command();
 
 program
   .name('unreal-cli')
-  .description('Cross-platform CLI tool for Unreal-MCP operations (pre-alpha scaffold)')
-  .version(PACKAGE_VERSION);
+  .description('Cross-platform CLI tool for Unreal-MCP operations')
+  .version(PACKAGE_VERSION)
+  .option('-v, --verbose', 'Enable verbose diagnostic output');
 
-// Scaffold stage: only `status`. The full command set (create-project, open,
-// close, install-plugin, remove-plugin, configure, setup-mcp, login, run-tool,
-// run-system-tool, wait-for-ready, bootstrap-local, update, install-engine,
-// setup-skills) lands with the unreal-cli task — see docs/ARCHITECTURE.md §9.1.
-program.addCommand(statusCommand);
+// The full 16-command surface (docs/ARCHITECTURE.md §9.1).
+const subcommands = [
+  createProjectCommand,
+  openCommand,
+  closeCommand,
+  installPluginCommand,
+  removePluginCommand,
+  configureCommand,
+  setupMcpCommand,
+  loginCommand,
+  statusCommand,
+  waitForReadyCommand,
+  runToolCommand,
+  runSystemToolCommand,
+  bootstrapLocalCommand,
+  updateCommand,
+  installEngineCommand,
+  setupSkillsCommand,
+];
+
+for (const cmd of subcommands) {
+  cmd.option('-v, --verbose', 'Enable verbose diagnostic output');
+  program.addCommand(cmd);
+}
+
+program.hook('preAction', (_thisCommand, actionCommand) => {
+  const opts = actionCommand.optsWithGlobals() as { verbose?: boolean };
+  if (opts.verbose) setVerbose(true);
+});
+
+// Show help when invoked with no subcommand.
+program.action(() => {
+  program.outputHelp();
+});
 
 program.parseAsync(process.argv).catch((err: unknown) => {
-  console.error(err instanceof Error ? err.message : String(err));
+  process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
   process.exit(1);
 });

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -1,15 +1,113 @@
-// Library entry point for `unreal-cli` (the dist/lib.js export the design
-// commits to — docs/ARCHITECTURE.md §9.1).
+// Library entry point for `unreal-cli` (the `dist/lib.js` export — see
+// docs/ARCHITECTURE.md §9.1).
 //
-// Constraints (same contract as unity-mcp-cli / godot-cli):
+// Contract (same as unity-mcp-cli / godot-cli):
 // - NO top-level side effects. Importing this file must not open sockets,
 //   write to stdout/stderr, or parse argv.
 // - NO `commander` import reachable from this file.
 // - Every result is a discriminated union keyed on `kind`; errors are never
 //   thrown past the public boundary.
 //
-// Consumers: `import { getStatus } from 'unreal-cli'`.
+// Consumers: `import { configure, openProject } from 'unreal-cli'`.
 
+// --- command logic ---------------------------------------------------------
+export { configure } from './lib/configure.js';
+export { openProject, buildOpenEnv } from './lib/open.js';
+export { close, selectEditorProcesses } from './lib/close.js';
+export { createProject, renderProjectTemplate, validateModuleName } from './lib/create-project.js';
+export { installPlugin, removePlugin } from './lib/install-plugin.js';
+export { runTool, runSystemTool } from './lib/run-tool.js';
+export { setupMcp, listAgentIds, buildServerEntry } from './lib/setup-mcp.js';
+export { login } from './lib/login.js';
 export { getStatus } from './lib/status.js';
-export type { CliStatus } from './lib/status.js';
+export { waitForReady } from './lib/wait-for-ready.js';
+export { bootstrapLocal, planBuildSteps, ridForPlatform } from './lib/bootstrap-local.js';
+export { update, readPluginVersion } from './lib/update.js';
+export { setupSkills, renderSkill } from './lib/setup-skills.js';
+export {
+  detectInstalledEngines,
+  planEngineInstall,
+  launcherInstallUrl,
+} from './lib/install-engine.js';
+
+// --- engine resolution -----------------------------------------------------
+export { listInstalledEngines, resolveEngineForProject } from './lib/engine.js';
+export { resolveEngine, editorBinaryPath } from './utils/engine.js';
+export {
+  parseLauncherManifest,
+  matchEngineForAssociation,
+  getDefaultLauncherManifestPath,
+} from './utils/launcher.js';
+export { readUProject, readEngineAssociation, findUProjectFile } from './utils/project.js';
+export { generatePortFromDirectory } from './utils/port.js';
+export { resolveConnection } from './utils/config.js';
+export {
+  parseEnvContent,
+  writeEnvFile,
+  ensureEnvGitignored,
+  gitignoreAlreadyIgnoresEnv,
+  KNOWN_ENV_KEYS,
+} from './utils/env-file.js';
+
 export { PACKAGE_NAME, PACKAGE_VERSION } from './version.js';
+
+// --- types -----------------------------------------------------------------
+export type {
+  ResultKind,
+  ProgressEvent,
+  ProgressCallback,
+  ConnectionMode,
+  AuthOption,
+  McpTransport,
+  ConfigureOptions,
+  ConfigureResult,
+  ConfigureSuccess,
+  ConfigureFailure,
+  OpenProjectOptions,
+  OpenProjectResult,
+  OpenProjectSuccess,
+  OpenProjectFailure,
+  CreateProjectOptions,
+  CreateProjectResult,
+  CreateProjectSuccess,
+  CreateProjectFailure,
+  InstallPluginOptions,
+  InstallPluginResult,
+  InstallPluginSuccess,
+  InstallPluginFailure,
+  RemovePluginOptions,
+  RemovePluginResult,
+  RemovePluginSuccess,
+  RemovePluginFailure,
+  RunToolOptions,
+  RunToolResult,
+  RunToolSuccess,
+  RunToolFailure,
+  RunToolFailureReason,
+  SetupMcpOptions,
+  SetupMcpResult,
+  SetupMcpSuccess,
+  SetupMcpFailure,
+  DetectEnginesOptions,
+  DetectEnginesResult,
+  PlanEngineInstallOptions,
+  PlanEngineInstallResult,
+  WaitForReadyOptions,
+  WaitForReadyResult,
+  WaitForReadySuccess,
+  WaitForReadyFailure,
+  StatusOptions,
+  StatusReport,
+  BootstrapLocalOptions,
+  BootstrapLocalResult,
+  BootstrapLocalSuccess,
+  BootstrapLocalFailure,
+  BuildStep,
+} from './lib/types.js';
+export type { EngineInstallation } from './utils/launcher.js';
+export type { UProjectInfo } from './utils/project.js';
+export type { ResolvedConnection } from './utils/config.js';
+export type { LoginOptions, LoginResult } from './lib/login.js';
+export type { UpdateOptions, UpdateResult } from './lib/update.js';
+export type { SetupSkillsOptions, SetupSkillsResult } from './lib/setup-skills.js';
+export type { CloseOptions, CloseResult, RunningProcess } from './lib/close.js';

--- a/cli/src/lib/bootstrap-local.ts
+++ b/cli/src/lib/bootstrap-local.ts
@@ -6,6 +6,11 @@
 // The build PLAN (which csproj, which RID, which output dir) is computed
 // purely so it is unit-testable; the actual `dotnet publish` is delegated
 // to an injectable `buildImpl` (defaults to spawning `dotnet`).
+//
+// No `version` file is emitted beside the binaries: a bootstrapped build is
+// meant to be consumed via the `UNREAL_MCP_BRIDGE_PATH` dev override (§6),
+// which skips the download + version-match entirely, so the absence of a
+// version file is intentional (not the §6 mismatch hazard).
 
 import * as path from 'path';
 import { spawn } from 'child_process';

--- a/cli/src/lib/bootstrap-local.ts
+++ b/cli/src/lib/bootstrap-local.ts
@@ -1,0 +1,120 @@
+// `bootstrap-local` — build the bridge + server from source into the
+// project's `Intermediate/UnrealMCP/<leg>/<platform>/` layout
+// (docs/ARCHITECTURE.md §6), the offline/dev alternative to the
+// download-on-first-run flow. Library-safe.
+//
+// The build PLAN (which csproj, which RID, which output dir) is computed
+// purely so it is unit-testable; the actual `dotnet publish` is delegated
+// to an injectable `buildImpl` (defaults to spawning `dotnet`).
+
+import * as path from 'path';
+import { spawn } from 'child_process';
+import { platform } from 'os';
+import { emitProgress } from './progress.js';
+import type { BootstrapLocalOptions, BootstrapLocalResult, BuildStep } from './types.js';
+
+const BRIDGE_CSPROJ = path.join('bridge', 'src', 'com.IvanMurzak.Unreal.MCP.Bridge.csproj');
+const SERVER_CSPROJ = path.join('Unreal-MCP-Server', 'com.IvanMurzak.Unreal.MCP.Server.csproj');
+
+/** Map a platform to the .NET RID + the §6 platform folder name. Pure. */
+export function ridForPlatform(os: NodeJS.Platform, arch: string = process.arch): string {
+  switch (os) {
+    case 'win32':
+      return 'win-x64';
+    case 'darwin':
+      return arch === 'arm64' ? 'osx-arm64' : 'osx-x64';
+    default:
+      return 'linux-x64';
+  }
+}
+
+/**
+ * Compute the two build steps (bridge, server) for a project. Pure —
+ * exported for tests so the path math is asserted without a real build.
+ */
+export function planBuildSteps(
+  repoRoot: string,
+  projectDir: string,
+  os: NodeJS.Platform,
+  arch: string = process.arch,
+): { steps: BuildStep[]; outputRoot: string } {
+  const rid = ridForPlatform(os, arch);
+  const outputRoot = path.join(path.resolve(projectDir), 'Intermediate', 'UnrealMCP');
+  const repo = path.resolve(repoRoot);
+  const steps: BuildStep[] = [
+    {
+      label: 'bridge',
+      projectFile: path.join(repo, BRIDGE_CSPROJ),
+      outputDir: path.join(outputRoot, 'bridge', rid),
+      rid,
+    },
+    {
+      label: 'server',
+      projectFile: path.join(repo, SERVER_CSPROJ),
+      outputDir: path.join(outputRoot, 'server', rid),
+      rid,
+    },
+  ];
+  return { steps, outputRoot };
+}
+
+export async function bootstrapLocal(opts: BootstrapLocalOptions): Promise<BootstrapLocalResult> {
+  const warnings: string[] = [];
+  try {
+    if (!opts?.projectDir) throw new Error('projectDir is required.');
+    if (!opts?.repoRoot) throw new Error('repoRoot is required.');
+    const os = opts.os ?? (platform() as NodeJS.Platform);
+
+    const { steps, outputRoot } = planBuildSteps(opts.repoRoot, opts.projectDir, os);
+    const build = opts.buildImpl ?? defaultDotnetPublish;
+
+    emitProgress(opts.onProgress, {
+      phase: 'start',
+      message: `Bootstrapping bridge + server into ${outputRoot}`,
+    });
+
+    for (const step of steps) {
+      emitProgress(opts.onProgress, { phase: 'info', message: `Building ${step.label} (${step.rid})` });
+      await build(step);
+      emitProgress(opts.onProgress, {
+        phase: 'file-written',
+        message: `Published ${step.label} to ${step.outputDir}`,
+        filePath: step.outputDir,
+      });
+    }
+
+    emitProgress(opts.onProgress, { phase: 'done', message: 'Bootstrap complete.' });
+    return { kind: 'success', success: true, steps, outputRoot, warnings };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
+function defaultDotnetPublish(step: BuildStep): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const args = [
+      'publish',
+      step.projectFile,
+      '-c',
+      'Release',
+      '-r',
+      step.rid,
+      '--self-contained',
+      'true',
+      '-p:PublishSingleFile=true',
+      '-o',
+      step.outputDir,
+    ];
+    const child = spawn('dotnet', args, { stdio: 'inherit' });
+    child.on('error', (err) => reject(new Error(`dotnet publish (${step.label}) failed to start: ${err.message}`)));
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`dotnet publish (${step.label}) exited with code ${code}.`));
+    });
+  });
+}

--- a/cli/src/lib/close.ts
+++ b/cli/src/lib/close.ts
@@ -1,0 +1,152 @@
+// `close` — terminate the Unreal Editor process running a given project.
+// Process discovery + kill are injectable so the matching logic is unit-
+// testable without touching real processes. Library-safe.
+
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { platform } from 'os';
+import { findUProjectFile } from '../utils/project.js';
+import { emitProgress } from './progress.js';
+import type { ProgressCallback } from './types.js';
+
+export interface RunningProcess {
+  pid: number;
+  commandLine: string;
+}
+
+export interface CloseOptions {
+  projectDir?: string;
+  os?: NodeJS.Platform;
+  /** Injectable process list (defaults to a platform-specific query). */
+  listProcessesImpl?: () => RunningProcess[];
+  /** Injectable kill (defaults to `process.kill`). */
+  killImpl?: (pid: number) => void;
+  onProgress?: ProgressCallback;
+}
+
+export interface CloseSuccess {
+  kind: 'success';
+  success: true;
+  /** PIDs that were signalled. */
+  terminated: number[];
+  /** `true` when no matching editor was running. */
+  wasRunning: boolean;
+  warnings: string[];
+}
+
+export interface CloseFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  error: Error;
+}
+
+export type CloseResult = CloseSuccess | CloseFailure;
+
+/**
+ * Select the editor processes whose command line references both the
+ * `.uproject` (or its directory) AND an `UnrealEditor` binary. Pure —
+ * exported for tests.
+ */
+export function selectEditorProcesses(
+  processes: RunningProcess[],
+  projectDir: string,
+  uprojectPath: string | null,
+): RunningProcess[] {
+  // Normalize separators so a backslash project path matches a command line
+  // written with forward slashes (and vice versa) — UE / shells emit either.
+  const norm = (s: string): string => s.toLowerCase().replace(/\\/g, '/');
+  const dirNeedle = norm(projectDir);
+  const fileNeedle = uprojectPath ? norm(uprojectPath) : null;
+  return processes.filter((p) => {
+    const cmd = norm(p.commandLine);
+    if (!cmd.includes('unrealeditor')) return false;
+    if (fileNeedle && cmd.includes(fileNeedle)) return true;
+    return cmd.includes(dirNeedle);
+  });
+}
+
+export async function close(opts: CloseOptions = {}): Promise<CloseResult> {
+  const warnings: string[] = [];
+  try {
+    const os = opts.os ?? (platform() as NodeJS.Platform);
+    const projectDir = path.resolve(opts.projectDir ?? process.cwd());
+    const uprojectPath = findUProjectFile(projectDir);
+
+    emitProgress(opts.onProgress, { phase: 'start', message: `Closing Unreal Editor for ${projectDir}` });
+
+    const processes = opts.listProcessesImpl ? opts.listProcessesImpl() : listProcesses(os);
+    const matches = selectEditorProcesses(processes, projectDir, uprojectPath);
+
+    if (matches.length === 0) {
+      emitProgress(opts.onProgress, { phase: 'done', message: 'No running editor matched this project.' });
+      return { kind: 'success', success: true, terminated: [], wasRunning: false, warnings };
+    }
+
+    const kill = opts.killImpl ?? ((pid: number) => process.kill(pid));
+    const terminated: number[] = [];
+    for (const m of matches) {
+      try {
+        kill(m.pid);
+        terminated.push(m.pid);
+      } catch (err) {
+        warnings.push(`Failed to terminate PID ${m.pid}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    emitProgress(opts.onProgress, { phase: 'done', message: `Terminated ${terminated.length} process(es).` });
+    return { kind: 'success', success: true, terminated, wasRunning: true, warnings };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
+/** Best-effort platform process listing. Never throws — `[]` on failure. */
+function listProcesses(os: NodeJS.Platform): RunningProcess[] {
+  try {
+    if (os === 'win32') {
+      // CIM CommandLine via PowerShell — CSV pid|cmdline.
+      const out = execFileSync(
+        'powershell',
+        [
+          '-NoProfile',
+          '-Command',
+          "Get-CimInstance Win32_Process | Where-Object { $_.Name -like 'UnrealEditor*' } | ForEach-Object { \"$($_.ProcessId)|$($_.CommandLine)\" }",
+        ],
+        { encoding: 'utf-8', timeout: 30000 },
+      );
+      return parseProcLines(out, '|');
+    }
+    const out = execFileSync('ps', ['-axo', 'pid=,command='], { encoding: 'utf-8', timeout: 30000 });
+    return out
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .map((line) => {
+        const sp = line.indexOf(' ');
+        const pid = parseInt(line.slice(0, sp), 10);
+        return { pid, commandLine: line.slice(sp + 1) };
+      })
+      .filter((p) => !Number.isNaN(p.pid));
+  } catch {
+    return [];
+  }
+}
+
+function parseProcLines(out: string, sep: string): RunningProcess[] {
+  return out
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const idx = line.indexOf(sep);
+      const pid = parseInt(idx >= 0 ? line.slice(0, idx) : line, 10);
+      return { pid, commandLine: idx >= 0 ? line.slice(idx + 1) : '' };
+    })
+    .filter((p) => !Number.isNaN(p.pid));
+}

--- a/cli/src/lib/close.ts
+++ b/cli/src/lib/close.ts
@@ -62,8 +62,25 @@ export function selectEditorProcesses(
     const cmd = norm(p.commandLine);
     if (!cmd.includes('unrealeditor')) return false;
     if (fileNeedle && cmd.includes(fileNeedle)) return true;
-    return cmd.includes(dirNeedle);
+    return containsDirBounded(cmd, dirNeedle);
   });
+}
+
+/**
+ * True when `cmd` references `dirNeedle` at a path-segment boundary — i.e.
+ * the needle is followed by a `/` or the end of the string. Prevents a bare
+ * substring match where `/work/MyGame` would also match `/work/MyGame2`.
+ * Both inputs are already normalized (lowercased, forward slashes).
+ */
+function containsDirBounded(cmd: string, dirNeedle: string): boolean {
+  let from = 0;
+  for (;;) {
+    const idx = cmd.indexOf(dirNeedle, from);
+    if (idx < 0) return false;
+    const after = cmd.charAt(idx + dirNeedle.length);
+    if (after === '' || after === '/') return true;
+    from = idx + 1;
+  }
 }
 
 export async function close(opts: CloseOptions = {}): Promise<CloseResult> {
@@ -72,6 +89,14 @@ export async function close(opts: CloseOptions = {}): Promise<CloseResult> {
     const os = opts.os ?? (platform() as NodeJS.Platform);
     const projectDir = path.resolve(opts.projectDir ?? process.cwd());
     const uprojectPath = findUProjectFile(projectDir);
+    if (!uprojectPath) {
+      // Without a `.uproject` we'd be forced to match editors by directory
+      // alone — and running from an ancestor dir would then terminate every
+      // editor under it. Refuse instead of guessing.
+      throw new Error(
+        `No .uproject found in ${projectDir}; refusing to match editors by directory alone.`,
+      );
+    }
 
     emitProgress(opts.onProgress, { phase: 'start', message: `Closing Unreal Editor for ${projectDir}` });
 

--- a/cli/src/lib/configure.ts
+++ b/cli/src/lib/configure.ts
@@ -55,19 +55,24 @@ export async function configure(opts: ConfigureOptions): Promise<ConfigureResult
     if (opts.transport !== undefined) updates['UNREAL_MCP_TRANSPORT'] = opts.transport;
     if (opts.logLevel !== undefined) updates['UNREAL_MCP_LOG_LEVEL'] = opts.logLevel;
 
-    if (Object.keys(updates).length === 0) {
-      warnings.push('No configuration values supplied — .env left unchanged.');
-    }
-
     const envPath = path.join(projectDir, '.env');
-    const { added, updated } = writeEnvFile(envPath, updates);
+    const hasUpdates = Object.keys(updates).length > 0;
+    // Only touch `.env` when there is something to write — otherwise the
+    // "left unchanged" warning would contradict an actual (no-op) rewrite.
+    const { added, updated } = hasUpdates
+      ? writeEnvFile(envPath, updates)
+      : { added: [], updated: [] };
     const keysWritten = [...added, ...updated];
 
-    emitProgress(opts.onProgress, {
-      phase: 'file-written',
-      message: `Wrote ${keysWritten.length} key(s) to ${envPath}`,
-      filePath: envPath,
-    });
+    if (!hasUpdates) {
+      warnings.push('No configuration values supplied — .env left unchanged.');
+    } else {
+      emitProgress(opts.onProgress, {
+        phase: 'file-written',
+        message: `Wrote ${keysWritten.length} key(s) to ${envPath}`,
+        filePath: envPath,
+      });
+    }
 
     // Token-commit hazard mitigation (§8): ensure `.env` is gitignored.
     let gitignorePath: string | undefined;

--- a/cli/src/lib/configure.ts
+++ b/cli/src/lib/configure.ts
@@ -1,0 +1,107 @@
+// `configure` — write `UNREAL_MCP_*` values into `<project>/.env` and
+// guard the token-commit hazard by ensuring `.env` is gitignored
+// (docs/ARCHITECTURE.md §8). Library-safe: never prints, never exits,
+// never throws past the boundary.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { writeEnvFile, ensureEnvGitignored, type KnownEnvKey } from '../utils/env-file.js';
+import { emitProgress } from './progress.js';
+import type { ConfigureOptions, ConfigureResult } from './types.js';
+
+/**
+ * Configure a project's `.env` for Unreal-MCP. Writes only the keys whose
+ * option was supplied (so a second call with one field updates just that
+ * field, preserving the rest of the file). Appends `.env` to `.gitignore`
+ * unless `ensureGitignore === false`.
+ */
+export async function configure(opts: ConfigureOptions): Promise<ConfigureResult> {
+  const warnings: string[] = [];
+  try {
+    if (!opts || typeof opts.projectDir !== 'string' || opts.projectDir.trim().length === 0) {
+      return {
+        kind: 'failure',
+        success: false,
+        warnings,
+        error: new Error('projectDir is required.'),
+      };
+    }
+    const projectDir = path.resolve(opts.projectDir);
+    if (!fs.existsSync(projectDir)) {
+      return {
+        kind: 'failure',
+        success: false,
+        warnings,
+        error: new Error(`Project directory does not exist: ${projectDir}`),
+      };
+    }
+
+    emitProgress(opts.onProgress, {
+      phase: 'start',
+      message: `Configuring Unreal-MCP env for ${projectDir}`,
+    });
+
+    const updates: Partial<Record<KnownEnvKey, string>> = {};
+    if (opts.connectionMode !== undefined) updates['UNREAL_MCP_CONNECTION_MODE'] = opts.connectionMode;
+    if (opts.host !== undefined) updates['UNREAL_MCP_HOST'] = opts.host;
+    if (opts.cloudUrl !== undefined) updates['UNREAL_MCP_CLOUD_URL'] = opts.cloudUrl;
+    if (opts.token !== undefined) updates['UNREAL_MCP_TOKEN'] = opts.token;
+    if (opts.authOption !== undefined) updates['UNREAL_MCP_AUTH_OPTION'] = opts.authOption;
+    if (opts.keepConnected !== undefined)
+      updates['UNREAL_MCP_KEEP_CONNECTED'] = opts.keepConnected ? 'true' : 'false';
+    if (opts.tools !== undefined) updates['UNREAL_MCP_TOOLS'] = opts.tools;
+    if (opts.startServer !== undefined)
+      updates['UNREAL_MCP_START_SERVER'] = opts.startServer ? 'true' : 'false';
+    if (opts.transport !== undefined) updates['UNREAL_MCP_TRANSPORT'] = opts.transport;
+    if (opts.logLevel !== undefined) updates['UNREAL_MCP_LOG_LEVEL'] = opts.logLevel;
+
+    if (Object.keys(updates).length === 0) {
+      warnings.push('No configuration values supplied — .env left unchanged.');
+    }
+
+    const envPath = path.join(projectDir, '.env');
+    const { added, updated } = writeEnvFile(envPath, updates);
+    const keysWritten = [...added, ...updated];
+
+    emitProgress(opts.onProgress, {
+      phase: 'file-written',
+      message: `Wrote ${keysWritten.length} key(s) to ${envPath}`,
+      filePath: envPath,
+    });
+
+    // Token-commit hazard mitigation (§8): ensure `.env` is gitignored.
+    let gitignorePath: string | undefined;
+    let gitignoreAction: 'created' | 'appended' | 'already-ignored' | 'skipped' = 'skipped';
+    if (opts.ensureGitignore !== false) {
+      const result = ensureEnvGitignored(projectDir);
+      gitignorePath = result.gitignorePath;
+      gitignoreAction = result.action;
+      emitProgress(opts.onProgress, {
+        phase: 'info',
+        message:
+          result.action === 'already-ignored'
+            ? '.env already gitignored.'
+            : `.env ${result.action} in ${result.gitignorePath}`,
+      });
+    }
+
+    emitProgress(opts.onProgress, { phase: 'done', message: 'Configure complete.' });
+
+    return {
+      kind: 'success',
+      success: true,
+      envPath,
+      keysWritten,
+      gitignorePath,
+      gitignoreAction,
+      warnings,
+    };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}

--- a/cli/src/lib/create-project.ts
+++ b/cli/src/lib/create-project.ts
@@ -1,0 +1,228 @@
+// `create-project` — scaffold a minimal Unreal Engine C++ project from
+// in-CLI templates (no engine binary required — UBT compiles it later via
+// `open` / a build). Mirrors the minimal layout of the infra
+// `Unreal-Test-Project` testbed: a `.uproject`, one runtime module, Game +
+// Editor targets, and minimal `Config/`.
+//
+// Library-safe: never prints, never exits, never throws past the boundary.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { emitProgress } from './progress.js';
+import type { CreateProjectOptions, CreateProjectResult } from './types.js';
+
+const VALID_MODULE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Validate a UE module/project name. UE module names cannot contain
+ * hyphens or spaces and must be a valid C++ identifier. Pure.
+ */
+export function validateModuleName(name: string): { ok: true } | { ok: false; reason: string } {
+  if (name.length === 0) return { ok: false, reason: 'name is empty' };
+  if (!VALID_MODULE_NAME.test(name)) {
+    return {
+      ok: false,
+      reason: `"${name}" is not a valid UE module name (letters, digits, underscore; no leading digit, no hyphen/space)`,
+    };
+  }
+  return { ok: true };
+}
+
+interface TemplateFile {
+  relPath: string;
+  content: string;
+}
+
+/**
+ * Render the full set of scaffold files for a project. Pure — returns the
+ * relative paths + contents without touching disk, so tests can assert the
+ * template output directly. Exported for tests.
+ */
+export function renderProjectTemplate(name: string, engineAssociation: string): TemplateFile[] {
+  const uproject = {
+    FileVersion: 3,
+    EngineAssociation: engineAssociation,
+    Category: '',
+    Description: '',
+    Modules: [{ Name: name, Type: 'Runtime', LoadingPhase: 'Default' }],
+  };
+
+  const buildCs = `// Copyright (c) 2026 Ivan Murzak (Apache-2.0)
+using UnrealBuildTool;
+
+public class ${name} : ModuleRules
+{
+\tpublic ${name}(ReadOnlyTargetRules Target) : base(Target)
+\t{
+\t\tPCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+\t\tPublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore" });
+\t}
+}
+`;
+
+  const moduleHeader = `// Copyright (c) 2026 Ivan Murzak (Apache-2.0)
+#pragma once
+
+#include "CoreMinimal.h"
+`;
+
+  const moduleCpp = `// Copyright (c) 2026 Ivan Murzak (Apache-2.0)
+#include "${name}.h"
+#include "Modules/ModuleManager.h"
+
+IMPLEMENT_PRIMARY_GAME_MODULE(FDefaultGameModuleImpl, ${name}, "${name}");
+`;
+
+  const gameTarget = `// Copyright (c) 2026 Ivan Murzak (Apache-2.0)
+using UnrealBuildTool;
+using System.Collections.Generic;
+
+public class ${name}Target : TargetRules
+{
+\tpublic ${name}Target(TargetInfo Target) : base(Target)
+\t{
+\t\tType = TargetType.Game;
+\t\tDefaultBuildSettings = BuildSettingsVersion.V5;
+\t\tIncludeOrderVersion = EngineIncludeOrderVersion.Latest;
+\t\tExtraModuleNames.Add("${name}");
+\t}
+}
+`;
+
+  const editorTarget = `// Copyright (c) 2026 Ivan Murzak (Apache-2.0)
+using UnrealBuildTool;
+using System.Collections.Generic;
+
+public class ${name}EditorTarget : TargetRules
+{
+\tpublic ${name}EditorTarget(TargetInfo Target) : base(Target)
+\t{
+\t\tType = TargetType.Editor;
+\t\tDefaultBuildSettings = BuildSettingsVersion.V5;
+\t\tIncludeOrderVersion = EngineIncludeOrderVersion.Latest;
+\t\tExtraModuleNames.Add("${name}");
+\t}
+}
+`;
+
+  const defaultEngine = `[/Script/EngineSettings.GameMapsSettings]
+GameDefaultMap=/Engine/Maps/Templates/OpenWorld
+
+[/Script/Engine.RendererSettings]
+r.GenerateMeshDistanceFields=True
+`;
+
+  const defaultGame = `[/Script/EngineSettings.GeneralProjectSettings]
+ProjectID=${generateProjectId()}
+ProjectName=${name}
+`;
+
+  const defaultEditor = `[/Script/UnrealEd.EditorPerProjectUserSettings]
+`;
+
+  const gitignore = `# Unreal Engine generated
+Binaries/
+Intermediate/
+Saved/
+DerivedDataCache/
+.vs/
+*.sln
+# Unreal-MCP local secrets — never commit
+.env
+`;
+
+  return [
+    { relPath: `${name}.uproject`, content: JSON.stringify(uproject, null, '\t') + '\n' },
+    { relPath: path.join('Source', name, `${name}.Build.cs`), content: buildCs },
+    { relPath: path.join('Source', name, `${name}.h`), content: moduleHeader },
+    { relPath: path.join('Source', name, `${name}.cpp`), content: moduleCpp },
+    { relPath: path.join('Source', `${name}.Target.cs`), content: gameTarget },
+    { relPath: path.join('Source', `${name}Editor.Target.cs`), content: editorTarget },
+    { relPath: path.join('Config', 'DefaultEngine.ini'), content: defaultEngine },
+    { relPath: path.join('Config', 'DefaultGame.ini'), content: defaultGame },
+    { relPath: path.join('Config', 'DefaultEditor.ini'), content: defaultEditor },
+    { relPath: '.gitignore', content: gitignore },
+  ];
+}
+
+function generateProjectId(): string {
+  // A UE ProjectID is a braced uppercase GUID. crypto.randomUUID is fine.
+  const uuid =
+    typeof globalThis.crypto?.randomUUID === 'function'
+      ? globalThis.crypto.randomUUID()
+      : '00000000-0000-0000-0000-000000000000';
+  return `{${uuid.toUpperCase()}}`;
+}
+
+export async function createProject(opts: CreateProjectOptions): Promise<CreateProjectResult> {
+  const warnings: string[] = [];
+  let projectDir: string | undefined;
+  try {
+    if (!opts || typeof opts.projectDir !== 'string' || opts.projectDir.trim().length === 0) {
+      throw new Error('projectDir is required.');
+    }
+    projectDir = path.resolve(opts.projectDir);
+    const projectName = (opts.projectName ?? path.basename(projectDir)).trim();
+
+    const nameCheck = validateModuleName(projectName);
+    if (!nameCheck.ok) {
+      throw new Error(
+        `Invalid project name: ${nameCheck.reason}. ` +
+          'Pass --name with a valid UE module name (UE module names cannot contain hyphens).',
+      );
+    }
+
+    if (fs.existsSync(projectDir)) {
+      const entries = fs.readdirSync(projectDir);
+      if (entries.length > 0 && !opts.force) {
+        throw new Error(
+          `Target directory is not empty: ${projectDir}. Pass --force to scaffold anyway.`,
+        );
+      }
+    }
+
+    emitProgress(opts.onProgress, {
+      phase: 'start',
+      message: `Scaffolding Unreal project ${projectName} at ${projectDir}`,
+    });
+
+    const engineAssociation = opts.engineAssociation?.trim() ?? '';
+    const files = renderProjectTemplate(projectName, engineAssociation);
+
+    const filesWritten: string[] = [];
+    for (const file of files) {
+      const abs = path.join(projectDir, file.relPath);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, file.content, 'utf-8');
+      filesWritten.push(abs);
+      emitProgress(opts.onProgress, {
+        phase: 'file-written',
+        message: `Wrote ${file.relPath}`,
+        filePath: abs,
+      });
+    }
+
+    const uprojectPath = path.join(projectDir, `${projectName}.uproject`);
+    emitProgress(opts.onProgress, { phase: 'done', message: 'Project scaffolded.' });
+
+    return {
+      kind: 'success',
+      success: true,
+      projectDir,
+      projectName,
+      uprojectPath,
+      filesWritten,
+      warnings,
+    };
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    return {
+      kind: 'failure',
+      success: false,
+      projectDir,
+      warnings,
+      errorMessage: error.message,
+      error,
+    };
+  }
+}

--- a/cli/src/lib/engine.ts
+++ b/cli/src/lib/engine.ts
@@ -1,0 +1,49 @@
+// Library-facing engine discovery: read the launcher manifest and resolve
+// a project's engine. Thin orchestration over utils/launcher + utils/engine
+// + utils/project so consumers don't reach into `utils/`.
+
+import { platform } from 'os';
+import {
+  getDefaultLauncherManifestPath,
+  readLauncherManifest,
+  type EngineInstallation,
+} from '../utils/launcher.js';
+import { resolveEngine, type ResolveEngineResult } from '../utils/engine.js';
+import { readUProject } from '../utils/project.js';
+
+/** Read the installed engines from the (platform-default) launcher manifest. */
+export function listInstalledEngines(manifestPath?: string, os?: NodeJS.Platform): {
+  manifestPath: string | null;
+  engines: EngineInstallation[];
+} {
+  const targetOs = os ?? (platform() as NodeJS.Platform);
+  const resolvedPath = manifestPath ?? getDefaultLauncherManifestPath(targetOs);
+  const engines = resolvedPath ? readLauncherManifest(resolvedPath) : [];
+  return { manifestPath: resolvedPath, engines };
+}
+
+/**
+ * Resolve the engine for a project on disk: read its `.uproject`
+ * `EngineAssociation`, then match it against the installed engines.
+ * Returns the resolution result plus the project info that fed it.
+ */
+export function resolveEngineForProject(opts: {
+  projectDir: string;
+  engineRootOverride?: string;
+  manifestPath?: string;
+  os?: NodeJS.Platform;
+}): {
+  uproject: ReturnType<typeof readUProject>;
+  resolution: ResolveEngineResult;
+} {
+  const os = opts.os ?? (platform() as NodeJS.Platform);
+  const uproject = readUProject(opts.projectDir);
+  const { engines } = listInstalledEngines(opts.manifestPath, os);
+  const resolution = resolveEngine({
+    engineAssociation: uproject?.engineAssociation ?? '',
+    engines,
+    engineRootOverride: opts.engineRootOverride,
+    os,
+  });
+  return { uproject, resolution };
+}

--- a/cli/src/lib/install-engine.ts
+++ b/cli/src/lib/install-engine.ts
@@ -1,0 +1,78 @@
+// `install-engine` — detect installed Unreal engines from the Epic launcher
+// manifest and, for a not-yet-installed version, hand back a launcher deep
+// link + a clear user-facing message. The CLI NEVER performs the multi-GB
+// engine install itself — that is the Epic launcher's job. Library-safe.
+
+import { platform } from 'os';
+import {
+  getDefaultLauncherManifestPath,
+  readLauncherManifest,
+  matchEngineForAssociation,
+} from '../utils/launcher.js';
+import type {
+  DetectEnginesOptions,
+  DetectEnginesResult,
+  PlanEngineInstallOptions,
+  PlanEngineInstallResult,
+} from './types.js';
+
+/**
+ * Build the `com.epicgames.launcher://` deep link that opens the install
+ * page for an engine version. Pure.
+ */
+export function launcherInstallUrl(version: string): string {
+  return `com.epicgames.launcher://ue/launcher/install?version=${encodeURIComponent(version)}`;
+}
+
+/**
+ * Detect installed engines from the launcher manifest. Never throws — a
+ * missing/malformed manifest yields an empty `engines` list.
+ */
+export function detectInstalledEngines(opts: DetectEnginesOptions = {}): DetectEnginesResult {
+  const os = opts.os ?? (platform() as NodeJS.Platform);
+  const manifestPath = opts.manifestPath ?? getDefaultLauncherManifestPath(os);
+  const engines = manifestPath ? readLauncherManifest(manifestPath) : [];
+  return { kind: 'success', success: true, manifestPath, engines };
+}
+
+/**
+ * Plan an engine install: report whether the requested version is already
+ * present, and otherwise produce the launcher deep link + guidance. Never
+ * installs. Never throws.
+ */
+export function planEngineInstall(opts: PlanEngineInstallOptions): PlanEngineInstallResult {
+  const os = opts.os ?? (platform() as NodeJS.Platform);
+  const version = opts.version.trim();
+  const manifestPath = opts.manifestPath ?? getDefaultLauncherManifestPath(os);
+  const engines = manifestPath ? readLauncherManifest(manifestPath) : [];
+
+  const existing = matchEngineForAssociation(version, engines);
+  const launcherUrl = launcherInstallUrl(version);
+
+  if (existing && existing.engineAssociation === version) {
+    return {
+      kind: 'success',
+      success: true,
+      version,
+      alreadyInstalled: true,
+      installation: existing,
+      launcherUrl,
+      message: `Unreal Engine ${version} is already installed at ${existing.installLocation}.`,
+    };
+  }
+
+  const installed = engines.map((e) => e.engineAssociation).join(', ') || '(none)';
+  return {
+    kind: 'success',
+    success: true,
+    version,
+    alreadyInstalled: false,
+    installation: null,
+    launcherUrl,
+    message:
+      `Unreal Engine ${version} is not installed (installed: ${installed}). ` +
+      'The CLI does not download engines — open the Epic Games Launcher to install it:\n' +
+      `  ${launcherUrl}\n` +
+      'Then re-run this command to confirm detection.',
+  };
+}

--- a/cli/src/lib/install-engine.ts
+++ b/cli/src/lib/install-engine.ts
@@ -17,11 +17,14 @@ import type {
 } from './types.js';
 
 /**
- * Build the `com.epicgames.launcher://` deep link that opens the install
- * page for an engine version. Pure.
+ * Build the `com.epicgames.launcher://` deep link that opens the Epic Games
+ * Launcher on its Unreal Engine page so the user can install/manage engines.
+ * A version-specific install path is not a documented launcher URL, so we use
+ * the plain, known-good `ue/` link and surface the desired version in the
+ * accompanying message instead. Pure.
  */
-export function launcherInstallUrl(version: string): string {
-  return `com.epicgames.launcher://ue/launcher/install?version=${encodeURIComponent(version)}`;
+export function launcherInstallUrl(): string {
+  return 'com.epicgames.launcher://ue/';
 }
 
 /**
@@ -47,7 +50,7 @@ export function planEngineInstall(opts: PlanEngineInstallOptions): PlanEngineIns
   const engines = manifestPath ? readLauncherManifest(manifestPath) : [];
 
   const existing = matchEngineForAssociation(version, engines);
-  const launcherUrl = launcherInstallUrl(version);
+  const launcherUrl = launcherInstallUrl();
 
   if (existing && existing.engineAssociation === version) {
     return {

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -7,6 +7,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { isUnrealProjectDir } from '../utils/project.js';
 import { emitProgress } from './progress.js';
 import type {
   InstallPluginOptions,
@@ -35,6 +36,13 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     const projectDir = path.resolve(opts.projectDir);
     const pluginSourceDir = path.resolve(opts.pluginSourceDir);
     if (!fs.existsSync(projectDir)) throw new Error(`Project directory does not exist: ${projectDir}`);
+    // Guard against a wrong-cwd run silently scaffolding Plugins/UnrealMCP in
+    // an arbitrary directory (consistent with `close`/`status`, which key on
+    // a `.uproject`). Warn rather than refuse — installing into a not-yet-
+    // initialised project tree is a valid, if rarer, flow.
+    if (!isUnrealProjectDir(projectDir)) {
+      warnings.push(`No .uproject found in ${projectDir} — is this an Unreal project directory?`);
+    }
     if (!fs.existsSync(pluginSourceDir))
       throw new Error(`Plugin source directory does not exist: ${pluginSourceDir}`);
     if (!fs.existsSync(path.join(pluginSourceDir, 'UnrealMCP.uplugin'))) {

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -1,0 +1,123 @@
+// `install-plugin` / `remove-plugin` — place (or junction) the UnrealMCP
+// plugin under `<project>/Plugins/UnrealMCP`. Library-safe.
+//
+// Copy mode recursively copies the plugin source. Junction mode (Windows,
+// dev) creates a directory junction so the project always tracks the live
+// plugin source — the same pattern the infra testbed uses.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { emitProgress } from './progress.js';
+import type {
+  InstallPluginOptions,
+  InstallPluginResult,
+  RemovePluginOptions,
+  RemovePluginResult,
+} from './types.js';
+
+const PLUGIN_DIRNAME = 'UnrealMCP';
+
+/** True when `p` is a symlink/junction (vs a real directory). */
+function isLink(p: string): boolean {
+  try {
+    return fs.lstatSync(p).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+export async function installPlugin(opts: InstallPluginOptions): Promise<InstallPluginResult> {
+  const warnings: string[] = [];
+  try {
+    if (!opts?.projectDir) throw new Error('projectDir is required.');
+    if (!opts?.pluginSourceDir) throw new Error('pluginSourceDir is required.');
+
+    const projectDir = path.resolve(opts.projectDir);
+    const pluginSourceDir = path.resolve(opts.pluginSourceDir);
+    if (!fs.existsSync(projectDir)) throw new Error(`Project directory does not exist: ${projectDir}`);
+    if (!fs.existsSync(pluginSourceDir))
+      throw new Error(`Plugin source directory does not exist: ${pluginSourceDir}`);
+    if (!fs.existsSync(path.join(pluginSourceDir, 'UnrealMCP.uplugin'))) {
+      warnings.push(`No UnrealMCP.uplugin found in ${pluginSourceDir} — installing contents anyway.`);
+    }
+
+    const pluginsDir = path.join(projectDir, 'Plugins');
+    const installedPath = path.join(pluginsDir, PLUGIN_DIRNAME);
+    fs.mkdirSync(pluginsDir, { recursive: true });
+
+    emitProgress(opts.onProgress, {
+      phase: 'start',
+      message: `Installing UnrealMCP plugin into ${installedPath}`,
+    });
+
+    // Clear any prior install (link or real dir) so the operation is
+    // idempotent and never nests a copy inside a stale junction.
+    if (fs.existsSync(installedPath) || isLink(installedPath)) {
+      if (isLink(installedPath)) {
+        fs.unlinkSync(installedPath);
+      } else {
+        fs.rmSync(installedPath, { recursive: true, force: true });
+      }
+    }
+
+    const useJunction = opts.junction === true;
+    if (useJunction) {
+      if (process.platform !== 'win32') {
+        warnings.push('Junction mode is Windows-only; falling back to copy.');
+      } else {
+        fs.symlinkSync(pluginSourceDir, installedPath, 'junction');
+        emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin junctioned.' });
+        return { kind: 'success', success: true, installedPath, mode: 'junction', warnings };
+      }
+    }
+
+    fs.cpSync(pluginSourceDir, installedPath, { recursive: true });
+    emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin copied.' });
+    return { kind: 'success', success: true, installedPath, mode: 'copy', warnings };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
+export async function removePlugin(opts: RemovePluginOptions): Promise<RemovePluginResult> {
+  const warnings: string[] = [];
+  try {
+    if (!opts?.projectDir) throw new Error('projectDir is required.');
+    const projectDir = path.resolve(opts.projectDir);
+    const installedPath = path.join(projectDir, 'Plugins', PLUGIN_DIRNAME);
+
+    emitProgress(opts.onProgress, {
+      phase: 'start',
+      message: `Removing UnrealMCP plugin from ${installedPath}`,
+    });
+
+    const present = fs.existsSync(installedPath) || isLink(installedPath);
+    if (!present) {
+      emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin was not installed.' });
+      return { kind: 'success', success: true, removed: false, installedPath, warnings };
+    }
+
+    // unlink a junction (never recurse through it into the live source);
+    // rm a real directory.
+    if (isLink(installedPath)) {
+      fs.unlinkSync(installedPath);
+    } else {
+      fs.rmSync(installedPath, { recursive: true, force: true });
+    }
+
+    emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin removed.' });
+    return { kind: 'success', success: true, removed: true, installedPath, warnings };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}

--- a/cli/src/lib/login.ts
+++ b/cli/src/lib/login.ts
@@ -5,7 +5,7 @@
 // the project's `.env`. fetch + sleep + clock are injectable for tests.
 // Library-safe: never throws past the boundary.
 
-import { writeEnvFile } from '../utils/env-file.js';
+import { writeEnvFile, ensureEnvGitignored } from '../utils/env-file.js';
 import * as path from 'path';
 import { emitProgress } from './progress.js';
 import type { ProgressCallback } from './types.js';
@@ -13,6 +13,8 @@ import type { ProgressCallback } from './types.js';
 const DEFAULT_BASE_URL = 'https://ai-game.dev';
 const DEFAULT_DEVICE_PATH = '/api/auth/device/code';
 const DEFAULT_TOKEN_PATH = '/api/auth/device/token';
+/** Per-request deadline so a hung endpoint can't stall the flow forever. */
+const PER_REQUEST_TIMEOUT_MS = 30_000;
 
 export interface LoginOptions {
   baseUrl?: string;
@@ -66,7 +68,7 @@ export async function login(opts: LoginOptions = {}): Promise<LoginResult> {
   try {
     emitProgress(opts.onProgress, { phase: 'start', message: 'Requesting device authorization' });
 
-    const codeResp = await fetchImpl(`${baseUrl}${DEFAULT_DEVICE_PATH}`, {
+    const codeResp = await fetchWithTimeout(fetchImpl, `${baseUrl}${DEFAULT_DEVICE_PATH}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: '{}',
@@ -92,7 +94,7 @@ export async function login(opts: LoginOptions = {}): Promise<LoginResult> {
 
     while (now() < deadline) {
       await sleep(intervalMs);
-      const tokenResp = await fetchImpl(`${baseUrl}${DEFAULT_TOKEN_PATH}`, {
+      const tokenResp = await fetchWithTimeout(fetchImpl, `${baseUrl}${DEFAULT_TOKEN_PATH}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ device_code: code.device_code }),
@@ -135,9 +137,33 @@ export async function login(opts: LoginOptions = {}): Promise<LoginResult> {
 
 function persistToken(projectDir: string | undefined, token: string): string | null {
   if (!projectDir) return null;
-  const envPath = path.join(path.resolve(projectDir), '.env');
+  const dir = path.resolve(projectDir);
+  const envPath = path.join(dir, '.env');
   writeEnvFile(envPath, { UNREAL_MCP_TOKEN: token, UNREAL_MCP_CONNECTION_MODE: 'Cloud' });
+  // The token is a secret — make sure `.env` is gitignored before it lands
+  // on disk (mirrors `configure`'s §8 guard so `login -p .` can't leave a
+  // committable token file behind).
+  ensureEnvGitignored(dir);
   return envPath;
+}
+
+/**
+ * `fetch` with a per-request abort deadline so a hung endpoint cannot stall
+ * the device flow indefinitely (the overall poll deadline only fires between
+ * polls). Honors the injected `fetchImpl` for tests.
+ */
+async function fetchWithTimeout(
+  fetchImpl: typeof fetch,
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PER_REQUEST_TIMEOUT_MS);
+  try {
+    return await fetchImpl(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 function fail(reason: string, message: string): LoginFailure {

--- a/cli/src/lib/login.ts
+++ b/cli/src/lib/login.ts
@@ -88,7 +88,7 @@ export async function login(opts: LoginOptions = {}): Promise<LoginResult> {
         `and enter code ${code.user_code}`,
     });
 
-    const intervalMs = Math.max(1, code.interval ?? 5) * 1000;
+    let intervalMs = Math.max(1, code.interval ?? 5) * 1000;
     const start = now();
     const deadline = start + timeoutMs;
 
@@ -121,7 +121,11 @@ export async function login(opts: LoginOptions = {}): Promise<LoginResult> {
       const error = errBody.error ?? `http-${tokenResp.status}`;
       if (error === 'authorization_pending') continue;
       if (error === 'slow_down') {
-        await sleep(intervalMs); // back off an extra interval
+        // RFC 8628 §3.5: on `slow_down` the poll interval MUST be increased by
+        // 5 seconds for this and ALL subsequent requests — a persistent
+        // back-off, not a one-shot extra sleep. The next loop iteration sleeps
+        // the new interval at the top before polling again.
+        intervalMs += 5000;
         continue;
       }
       // access_denied, expired_token, or anything else terminal.

--- a/cli/src/lib/login.ts
+++ b/cli/src/lib/login.ts
@@ -131,7 +131,10 @@ export async function login(opts: LoginOptions = {}): Promise<LoginResult> {
     return fail('timeout', `Login timed out after ${timeoutMs}ms.`);
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
-    return { kind: 'failure', success: false, reason: 'network-error', error };
+    // A per-request `fetchWithTimeout` deadline surfaces as an AbortError;
+    // classify that as a timeout rather than a generic network error.
+    const reason = error.name === 'AbortError' ? 'timeout' : 'network-error';
+    return { kind: 'failure', success: false, reason, error };
   }
 }
 
@@ -139,11 +142,12 @@ function persistToken(projectDir: string | undefined, token: string): string | n
   if (!projectDir) return null;
   const dir = path.resolve(projectDir);
   const envPath = path.join(dir, '.env');
-  writeEnvFile(envPath, { UNREAL_MCP_TOKEN: token, UNREAL_MCP_CONNECTION_MODE: 'Cloud' });
-  // The token is a secret — make sure `.env` is gitignored before it lands
-  // on disk (mirrors `configure`'s §8 guard so `login -p .` can't leave a
-  // committable token file behind).
+  // The token is a secret — make sure `.env` is gitignored BEFORE it lands on
+  // disk (mirrors `configure`'s §8 guard so `login -p .` can't leave a
+  // committable token file behind even if the process dies between the two
+  // writes).
   ensureEnvGitignored(dir);
+  writeEnvFile(envPath, { UNREAL_MCP_TOKEN: token, UNREAL_MCP_CONNECTION_MODE: 'Cloud' });
   return envPath;
 }
 

--- a/cli/src/lib/login.ts
+++ b/cli/src/lib/login.ts
@@ -1,0 +1,145 @@
+// `login` — OAuth 2.0 device authorization flow against ai-game.dev.
+// Requests a device code, surfaces the verification URL + user code via
+// `onProgress`, then polls the token endpoint until the user authorizes
+// (or the flow times out). On success, optionally persists the token into
+// the project's `.env`. fetch + sleep + clock are injectable for tests.
+// Library-safe: never throws past the boundary.
+
+import { writeEnvFile } from '../utils/env-file.js';
+import * as path from 'path';
+import { emitProgress } from './progress.js';
+import type { ProgressCallback } from './types.js';
+
+const DEFAULT_BASE_URL = 'https://ai-game.dev';
+const DEFAULT_DEVICE_PATH = '/api/auth/device/code';
+const DEFAULT_TOKEN_PATH = '/api/auth/device/token';
+
+export interface LoginOptions {
+  baseUrl?: string;
+  /** Persist the token into `<projectDir>/.env` on success. */
+  projectDir?: string;
+  /** Overall poll deadline. Default 300000 ms (5 min). */
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  sleepImpl?: (ms: number) => Promise<void>;
+  nowImpl?: () => number;
+  onProgress?: ProgressCallback;
+}
+
+export interface LoginSuccess {
+  kind: 'success';
+  success: true;
+  token: string;
+  /** `true` when the token was written to a project `.env`. */
+  persisted: boolean;
+  envPath?: string;
+}
+
+export interface LoginFailure {
+  kind: 'failure';
+  success: false;
+  /** Coarse reason — `access_denied`, `expired_token`, `timeout`, ... */
+  reason: string;
+  error: Error;
+}
+
+export type LoginResult = LoginSuccess | LoginFailure;
+
+interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  interval?: number;
+  expires_in?: number;
+}
+
+const realSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export async function login(opts: LoginOptions = {}): Promise<LoginResult> {
+  const baseUrl = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const sleep = opts.sleepImpl ?? realSleep;
+  const now = opts.nowImpl ?? Date.now;
+  const timeoutMs = typeof opts.timeoutMs === 'number' && opts.timeoutMs > 0 ? opts.timeoutMs : 300_000;
+
+  try {
+    emitProgress(opts.onProgress, { phase: 'start', message: 'Requesting device authorization' });
+
+    const codeResp = await fetchImpl(`${baseUrl}${DEFAULT_DEVICE_PATH}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    if (!codeResp.ok) {
+      return fail('device-code-failed', `Device code request failed: HTTP ${codeResp.status}`);
+    }
+    const code = (await codeResp.json()) as DeviceCodeResponse;
+    if (!code.device_code || !code.user_code || !code.verification_uri) {
+      return fail('device-code-malformed', 'Device code response missing required fields.');
+    }
+
+    emitProgress(opts.onProgress, {
+      phase: 'info',
+      message:
+        `To authorize, open ${code.verification_uri_complete ?? code.verification_uri} ` +
+        `and enter code ${code.user_code}`,
+    });
+
+    const intervalMs = Math.max(1, code.interval ?? 5) * 1000;
+    const start = now();
+    const deadline = start + timeoutMs;
+
+    while (now() < deadline) {
+      await sleep(intervalMs);
+      const tokenResp = await fetchImpl(`${baseUrl}${DEFAULT_TOKEN_PATH}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ device_code: code.device_code }),
+      });
+
+      if (tokenResp.ok) {
+        const body = (await tokenResp.json()) as { access_token?: string };
+        if (!body.access_token) {
+          return fail('token-malformed', 'Token response missing access_token.');
+        }
+        const persisted = persistToken(opts.projectDir, body.access_token);
+        emitProgress(opts.onProgress, { phase: 'done', message: 'Login complete.' });
+        return {
+          kind: 'success',
+          success: true,
+          token: body.access_token,
+          persisted: persisted !== null,
+          envPath: persisted ?? undefined,
+        };
+      }
+
+      // Pending / slow-down / terminal errors per the device-flow spec.
+      const errBody = (await tokenResp.json().catch(() => ({}))) as { error?: string };
+      const error = errBody.error ?? `http-${tokenResp.status}`;
+      if (error === 'authorization_pending') continue;
+      if (error === 'slow_down') {
+        await sleep(intervalMs); // back off an extra interval
+        continue;
+      }
+      // access_denied, expired_token, or anything else terminal.
+      return fail(error, `Authorization failed: ${error}`);
+    }
+
+    return fail('timeout', `Login timed out after ${timeoutMs}ms.`);
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    return { kind: 'failure', success: false, reason: 'network-error', error };
+  }
+}
+
+function persistToken(projectDir: string | undefined, token: string): string | null {
+  if (!projectDir) return null;
+  const envPath = path.join(path.resolve(projectDir), '.env');
+  writeEnvFile(envPath, { UNREAL_MCP_TOKEN: token, UNREAL_MCP_CONNECTION_MODE: 'Cloud' });
+  return envPath;
+}
+
+function fail(reason: string, message: string): LoginFailure {
+  return { kind: 'failure', success: false, reason, error: new Error(message) };
+}

--- a/cli/src/lib/open.ts
+++ b/cli/src/lib/open.ts
@@ -1,0 +1,151 @@
+// `open` — launch the Unreal Editor for a project, wiring the MCP
+// connection env vars. Library-safe: never prints, never exits, never
+// throws past the boundary.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawn } from 'child_process';
+import { platform } from 'os';
+import { getDefaultLauncherManifestPath, readLauncherManifest } from '../utils/launcher.js';
+import { resolveEngine } from '../utils/engine.js';
+import { findUProjectFile, readUProject } from '../utils/project.js';
+import { emitProgress } from './progress.js';
+import type {
+  AuthOption,
+  McpTransport,
+  OpenProjectOptions,
+  OpenProjectResult,
+} from './types.js';
+
+function isValidAuth(v: unknown): v is AuthOption {
+  return v === 'none' || v === 'required';
+}
+function isValidTransport(v: unknown): v is McpTransport {
+  return v === 'stdio' || v === 'http';
+}
+
+/**
+ * Build the `UNREAL_MCP_*` env-var map propagated to the editor process.
+ * Returns `undefined` when `noConnect` is set or nothing maps. Pure;
+ * throws on invalid enum values (caught at the `openProject` boundary).
+ * Exported for tests.
+ */
+export function buildOpenEnv(opts: OpenProjectOptions): Record<string, string> | undefined {
+  if (opts.noConnect === true) return undefined;
+  const env: Record<string, string> = {};
+  if (opts.host !== undefined) env['UNREAL_MCP_HOST'] = opts.host;
+  if (opts.token !== undefined) env['UNREAL_MCP_TOKEN'] = opts.token;
+  if (opts.keepConnected) env['UNREAL_MCP_KEEP_CONNECTED'] = 'true';
+  if (opts.tools !== undefined) env['UNREAL_MCP_TOOLS'] = opts.tools;
+  if (opts.auth !== undefined) {
+    if (!isValidAuth(opts.auth)) throw new Error('auth must be "none" or "required"');
+    env['UNREAL_MCP_AUTH_OPTION'] = opts.auth;
+  }
+  if (opts.transport !== undefined) {
+    if (!isValidTransport(opts.transport)) throw new Error('transport must be "stdio" or "http"');
+    env['UNREAL_MCP_TRANSPORT'] = opts.transport;
+  }
+  if (opts.startServer !== undefined) env['UNREAL_MCP_START_SERVER'] = opts.startServer ? 'true' : 'false';
+  return Object.keys(env).length > 0 ? env : undefined;
+}
+
+export async function openProject(opts: OpenProjectOptions): Promise<OpenProjectResult> {
+  const warnings: string[] = [];
+  let projectDir: string | undefined;
+  try {
+    const os = platform() as NodeJS.Platform;
+    projectDir = path.resolve(opts.projectDir ?? process.cwd());
+
+    if (!fs.existsSync(projectDir)) {
+      throw new Error(`Project path does not exist: ${projectDir}`);
+    }
+    const uprojectPath = findUProjectFile(projectDir);
+    if (!uprojectPath) {
+      throw new Error(`No .uproject found in ${projectDir}`);
+    }
+    const uproject = readUProject(uprojectPath);
+    if (!uproject) {
+      throw new Error(`Failed to read .uproject at ${uprojectPath}`);
+    }
+
+    emitProgress(opts.onProgress, { phase: 'start', message: `Opening ${uproject.projectName}` });
+
+    // Validate enum options up-front (before engine discovery I/O).
+    const env = buildOpenEnv(opts);
+
+    const engines = opts.enginesImpl
+      ? opts.enginesImpl()
+      : (() => {
+          const manifestPath = getDefaultLauncherManifestPath(os);
+          return manifestPath ? readLauncherManifest(manifestPath) : [];
+        })();
+
+    const resolution = resolveEngine({
+      engineAssociation: uproject.engineAssociation,
+      engines,
+      engineRootOverride: opts.engineRoot,
+      os,
+    });
+    if (resolution.kind === 'unresolved') {
+      throw new Error(resolution.message);
+    }
+
+    emitProgress(opts.onProgress, {
+      phase: 'engine-resolved',
+      message: `Resolved engine at ${resolution.engineRoot}`,
+      editorPath: resolution.editorPath,
+      engineRoot: resolution.engineRoot,
+    });
+
+    emitProgress(opts.onProgress, {
+      phase: 'launching',
+      message: 'Launching Unreal Editor',
+      editorPath: resolution.editorPath,
+      projectDir,
+    });
+
+    const args = [uproject.uprojectPath];
+    const childEnv: NodeJS.ProcessEnv = { ...process.env, ...(env ?? {}) };
+    const child = opts.spawnImpl
+      ? opts.spawnImpl(resolution.editorPath, args, childEnv)
+      : spawnDetached(resolution.editorPath, args, childEnv);
+
+    emitProgress(opts.onProgress, {
+      phase: 'launched',
+      message: `Launched (PID: ${child.pid ?? 'unknown'})`,
+      pid: child.pid,
+    });
+    emitProgress(opts.onProgress, { phase: 'done', message: 'Editor launched.' });
+
+    return {
+      kind: 'success',
+      success: true,
+      editorPath: resolution.editorPath,
+      engineRoot: resolution.engineRoot,
+      projectDir,
+      editorPid: child.pid,
+      envVars: env ?? {},
+      warnings,
+    };
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    return {
+      kind: 'failure',
+      success: false,
+      projectDir,
+      warnings,
+      errorMessage: error.message,
+      error,
+    };
+  }
+}
+
+function spawnDetached(
+  editorPath: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): { pid?: number } {
+  const child = spawn(editorPath, args, { detached: true, stdio: 'ignore', env });
+  child.unref();
+  return { pid: child.pid };
+}

--- a/cli/src/lib/open.ts
+++ b/cli/src/lib/open.ts
@@ -8,7 +8,7 @@ import { spawn } from 'child_process';
 import { platform } from 'os';
 import { getDefaultLauncherManifestPath, readLauncherManifest } from '../utils/launcher.js';
 import { resolveEngine } from '../utils/engine.js';
-import { findUProjectFile, readUProject } from '../utils/project.js';
+import { readUProject } from '../utils/project.js';
 import { emitProgress } from './progress.js';
 import type {
   AuthOption,
@@ -54,19 +54,20 @@ export async function openProject(opts: OpenProjectOptions): Promise<OpenProject
   let projectDir: string | undefined;
   try {
     const os = platform() as NodeJS.Platform;
-    projectDir = path.resolve(opts.projectDir ?? process.cwd());
+    // Accept either a project directory or a `.uproject` file path (the doc
+    // on OpenProjectOptions.projectDir promises both); `readUProject`
+    // resolves both shapes.
+    const inputPath = path.resolve(opts.projectDir ?? process.cwd());
+    projectDir = inputPath;
 
-    if (!fs.existsSync(projectDir)) {
-      throw new Error(`Project path does not exist: ${projectDir}`);
+    if (!fs.existsSync(inputPath)) {
+      throw new Error(`Project path does not exist: ${inputPath}`);
     }
-    const uprojectPath = findUProjectFile(projectDir);
-    if (!uprojectPath) {
-      throw new Error(`No .uproject found in ${projectDir}`);
-    }
-    const uproject = readUProject(uprojectPath);
+    const uproject = readUProject(inputPath);
     if (!uproject) {
-      throw new Error(`Failed to read .uproject at ${uprojectPath}`);
+      throw new Error(`No .uproject found at ${inputPath}`);
     }
+    projectDir = uproject.projectDir;
 
     emitProgress(opts.onProgress, { phase: 'start', message: `Opening ${uproject.projectName}` });
 

--- a/cli/src/lib/open.ts
+++ b/cli/src/lib/open.ts
@@ -147,6 +147,11 @@ function spawnDetached(
   env: NodeJS.ProcessEnv,
 ): { pid?: number } {
   const child = spawn(editorPath, args, { detached: true, stdio: 'ignore', env });
+  // A detached spawn can fail asynchronously (EACCES, ENOENT) AFTER we have
+  // already returned success; without an 'error' listener that emits an
+  // unhandled 'error' event which crashes the CLI. Swallow it — the editor
+  // simply did not launch, and `status` will report it unreachable.
+  child.on('error', () => {});
   child.unref();
   return { pid: child.pid };
 }

--- a/cli/src/lib/open.ts
+++ b/cli/src/lib/open.ts
@@ -74,6 +74,24 @@ export async function openProject(opts: OpenProjectOptions): Promise<OpenProject
     // Validate enum options up-front (before engine discovery I/O).
     const env = buildOpenEnv(opts);
 
+    // `buildOpenEnv` returns early under `--no-connect`, so connection-related
+    // flags are silently dropped (and their enum values never validated). Tell
+    // the caller their flags had no effect rather than letting e.g.
+    // `open --no-connect --auth bogus` look accepted.
+    if (opts.noConnect === true) {
+      const ignored: string[] = [];
+      if (opts.host !== undefined) ignored.push('host');
+      if (opts.token !== undefined) ignored.push('token');
+      if (opts.auth !== undefined) ignored.push('auth');
+      if (opts.transport !== undefined) ignored.push('transport');
+      if (opts.keepConnected) ignored.push('keepConnected');
+      if (opts.tools !== undefined) ignored.push('tools');
+      if (opts.startServer !== undefined) ignored.push('startServer');
+      if (ignored.length > 0) {
+        warnings.push(`Connection options are ignored under --no-connect: ${ignored.join(', ')}.`);
+      }
+    }
+
     const engines = opts.enginesImpl
       ? opts.enginesImpl()
       : (() => {

--- a/cli/src/lib/progress.ts
+++ b/cli/src/lib/progress.ts
@@ -1,0 +1,11 @@
+import type { ProgressCallback, ProgressEvent } from './types.js';
+
+/** Safely emit a progress event — a throwing callback never escapes. */
+export function emitProgress(cb: ProgressCallback | undefined, event: ProgressEvent): void {
+  if (!cb) return;
+  try {
+    cb(event);
+  } catch {
+    /* a consumer's onProgress must never break the library call */
+  }
+}

--- a/cli/src/lib/run-tool.ts
+++ b/cli/src/lib/run-tool.ts
@@ -54,7 +54,11 @@ async function invokeTool(routePrefix: string, opts: RunToolOptions): Promise<Ru
   const timeoutMs = typeof opts.timeoutMs === 'number' && opts.timeoutMs > 0 ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
 
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
   const externalAbort = (): void => controller.abort();
   if (opts.signal) {
     if (opts.signal.aborted) controller.abort();
@@ -84,7 +88,7 @@ async function invokeTool(routePrefix: string, opts: RunToolOptions): Promise<Ru
     }
     return { kind: 'success', success: true, endpoint, httpStatus: response.status, data };
   } catch (err) {
-    return classifyFetchError(err, endpoint, timeoutMs);
+    return classifyFetchError(err, endpoint, timeoutMs, timedOut);
   } finally {
     clearTimeout(timer);
     opts.signal?.removeEventListener('abort', externalAbort);
@@ -143,9 +147,13 @@ function parseJsonOrText(text: string): unknown {
   }
 }
 
-function classifyFetchError(err: unknown, endpoint: string, timeoutMs: number): RunToolFailure {
+function classifyFetchError(err: unknown, endpoint: string, timeoutMs: number, timedOut: boolean): RunToolFailure {
   if (err instanceof Error && err.name === 'AbortError') {
-    return makeFailure({ endpoint, reason: 'timeout', message: `Tool call timed out after ${timeoutMs}ms.`, error: err });
+    // An AbortError from our own timer is a timeout; one from a caller-
+    // supplied signal is a deliberate cancellation — don't conflate them.
+    return timedOut
+      ? makeFailure({ endpoint, reason: 'timeout', message: `Tool call timed out after ${timeoutMs}ms.`, error: err })
+      : makeFailure({ endpoint, reason: 'aborted', message: 'Tool call was aborted by the caller.', error: err });
   }
   const error = err instanceof Error ? err : new Error(String(err));
   const cause = err instanceof Error && 'cause' in err ? (err.cause as { code?: string } | undefined) : undefined;

--- a/cli/src/lib/run-tool.ts
+++ b/cli/src/lib/run-tool.ts
@@ -1,0 +1,161 @@
+// `run-tool` / `run-system-tool` — POST a tool invocation to a project's
+// local MCP server over HTTP. URL/token resolution: explicit override ->
+// process env -> project `.env` -> deterministic localhost port.
+// Library-safe: errors are returned, never thrown.
+
+import { resolveConnection } from '../utils/config.js';
+import type {
+  RunToolFailure,
+  RunToolFailureReason,
+  RunToolOptions,
+  RunToolResult,
+} from './types.js';
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+export async function runTool(opts: RunToolOptions): Promise<RunToolResult> {
+  return invokeTool('/api/tools', opts);
+}
+
+export async function runSystemTool(opts: RunToolOptions): Promise<RunToolResult> {
+  return invokeTool('/api/system-tools', opts);
+}
+
+async function invokeTool(routePrefix: string, opts: RunToolOptions): Promise<RunToolResult> {
+  const invalid = validateOptions(opts);
+  if (invalid) return invalid;
+
+  let url: string;
+  let token: string | undefined;
+  try {
+    const resolved = resolveConnection({
+      projectDir: opts.projectDir,
+      url: opts.url,
+      token: opts.token,
+    });
+    url = resolved.url;
+    token = resolved.token;
+  } catch (err) {
+    return makeFailure({
+      endpoint: '',
+      reason: 'invalid-input',
+      message: err instanceof Error ? err.message : String(err),
+      error: err instanceof Error ? err : undefined,
+    });
+  }
+
+  const body = serializeInput(opts.input);
+  if ('error' in body) {
+    return makeFailure({ endpoint: '', reason: 'invalid-input', message: body.error.message, error: body.error });
+  }
+
+  const endpoint = `${url}${routePrefix}/${encodeURIComponent(opts.toolName)}`;
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const timeoutMs = typeof opts.timeoutMs === 'number' && opts.timeoutMs > 0 ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const externalAbort = (): void => controller.abort();
+  if (opts.signal) {
+    if (opts.signal.aborted) controller.abort();
+    else opts.signal.addEventListener('abort', externalAbort, { once: true });
+  }
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+
+  try {
+    const response = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers,
+      body: body.json,
+      signal: controller.signal,
+    });
+    const text = await safeReadText(response);
+    const data = parseJsonOrText(text);
+    if (!response.ok) {
+      return makeFailure({
+        endpoint,
+        reason: 'http-error',
+        httpStatus: response.status,
+        data,
+        message: response.statusText || `HTTP ${response.status}`,
+      });
+    }
+    return { kind: 'success', success: true, endpoint, httpStatus: response.status, data };
+  } catch (err) {
+    return classifyFetchError(err, endpoint, timeoutMs);
+  } finally {
+    clearTimeout(timer);
+    opts.signal?.removeEventListener('abort', externalAbort);
+  }
+}
+
+function validateOptions(opts: RunToolOptions): RunToolFailure | null {
+  if (!opts || typeof opts !== 'object') {
+    return makeFailure({ endpoint: '', reason: 'invalid-input', message: 'options object is required.' });
+  }
+  if (typeof opts.toolName !== 'string' || opts.toolName.trim().length === 0) {
+    return makeFailure({ endpoint: '', reason: 'invalid-input', message: 'toolName is required and must be a non-empty string.' });
+  }
+  const hasUrl = typeof opts.url === 'string' && opts.url.length > 0;
+  const hasProjectDir = typeof opts.projectDir === 'string' && opts.projectDir.trim().length > 0;
+  if (!hasUrl && !hasProjectDir) {
+    return makeFailure({ endpoint: '', reason: 'invalid-input', message: 'Either projectDir or url must be provided.' });
+  }
+  return null;
+}
+
+function serializeInput(input: unknown): { json: string } | { error: Error } {
+  if (input === undefined || input === null) return { json: '{}' };
+  if (typeof input === 'string') {
+    try {
+      JSON.parse(input);
+      return { json: input };
+    } catch (err) {
+      return { error: new Error(`input string is not valid JSON: ${err instanceof Error ? err.message : String(err)}`) };
+    }
+  }
+  if (typeof input !== 'object') {
+    return { error: new Error('input must be a plain object, JSON string, undefined, or null.') };
+  }
+  try {
+    return { json: JSON.stringify(input) };
+  } catch (err) {
+    return { error: new Error(`input could not be serialized to JSON: ${err instanceof Error ? err.message : String(err)}`) };
+  }
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return '';
+  }
+}
+
+function parseJsonOrText(text: string): unknown {
+  if (text.length === 0) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function classifyFetchError(err: unknown, endpoint: string, timeoutMs: number): RunToolFailure {
+  if (err instanceof Error && err.name === 'AbortError') {
+    return makeFailure({ endpoint, reason: 'timeout', message: `Tool call timed out after ${timeoutMs}ms.`, error: err });
+  }
+  const error = err instanceof Error ? err : new Error(String(err));
+  const cause = err instanceof Error && 'cause' in err ? (err.cause as { code?: string } | undefined) : undefined;
+  let reason: RunToolFailureReason = 'unknown';
+  if (cause?.code === 'ECONNREFUSED') reason = 'connection-refused';
+  else if (cause?.code === 'ECONNRESET') reason = 'connection-reset';
+  else if (cause?.code === 'ENOTFOUND' || cause?.code === 'EAI_AGAIN') reason = 'network-error';
+  return makeFailure({ endpoint, reason, message: error.message, error });
+}
+
+function makeFailure(fields: Omit<RunToolFailure, 'kind' | 'success'>): RunToolFailure {
+  return { kind: 'failure', success: false, ...fields };
+}

--- a/cli/src/lib/setup-mcp.ts
+++ b/cli/src/lib/setup-mcp.ts
@@ -2,8 +2,10 @@
 // so it can reach the project's local Unreal MCP server. Library-safe.
 //
 // Each agent has a project-relative config file and a merge strategy that
-// preserves any existing `mcpServers` entries. The snippet shape follows
-// the MCP client convention shared by the Unity/Godot CLIs.
+// preserves any existing server entries under the agent's top-level key
+// (`mcpServers` for Claude Code / Cursor, `servers` for VS Code). The
+// snippet shape follows the MCP client convention shared by the Unity/Godot
+// CLIs.
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -41,12 +43,18 @@ interface AgentDef {
   relConfigPath: string;
   /** Display label. */
   label: string;
+  /**
+   * Top-level key the agent nests its MCP servers under. Claude Code and
+   * Cursor use `mcpServers`; VS Code's `.vscode/mcp.json` uses `servers`
+   * (writing `mcpServers` there is silently ignored by VS Code).
+   */
+  bodyKey: 'mcpServers' | 'servers';
 }
 
 const AGENTS: AgentDef[] = [
-  { id: 'claude-code', relConfigPath: '.mcp.json', label: 'Claude Code' },
-  { id: 'cursor', relConfigPath: path.join('.cursor', 'mcp.json'), label: 'Cursor' },
-  { id: 'vscode', relConfigPath: path.join('.vscode', 'mcp.json'), label: 'VS Code' },
+  { id: 'claude-code', relConfigPath: '.mcp.json', label: 'Claude Code', bodyKey: 'mcpServers' },
+  { id: 'cursor', relConfigPath: path.join('.cursor', 'mcp.json'), label: 'Cursor', bodyKey: 'mcpServers' },
+  { id: 'vscode', relConfigPath: path.join('.vscode', 'mcp.json'), label: 'VS Code', bodyKey: 'servers' },
 ];
 
 /** Valid agent ids accepted by `setupMcp`. Pure. */
@@ -129,11 +137,11 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
         warnings.push(`Existing ${configPath} is not valid JSON — it will be replaced.`);
       }
     }
-    const servers = (config['mcpServers'] && typeof config['mcpServers'] === 'object'
-      ? (config['mcpServers'] as Record<string, unknown>)
+    const servers = (config[agent.bodyKey] && typeof config[agent.bodyKey] === 'object'
+      ? (config[agent.bodyKey] as Record<string, unknown>)
       : {});
     servers[SERVER_KEY] = serverEntry;
-    config['mcpServers'] = servers;
+    config[agent.bodyKey] = servers;
 
     const snippet = JSON.stringify(config, null, 2) + '\n';
 

--- a/cli/src/lib/setup-mcp.ts
+++ b/cli/src/lib/setup-mcp.ts
@@ -7,11 +7,33 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { platform } from 'os';
 import { resolveConnection } from '../utils/config.js';
+import { generatePortFromDirectory } from '../utils/port.js';
+import { ridForPlatform } from './bootstrap-local.js';
 import { emitProgress } from './progress.js';
 import type { McpTransport, SetupMcpOptions, SetupMcpResult } from './types.js';
 
 const SERVER_KEY = 'unreal-mcp';
+
+/** Stdio launch parameters for the local `unreal-mcp-server` binary (§6). */
+interface StdioServer {
+  /** Absolute path to the published server binary. */
+  serverPath: string;
+  /** Deterministic localhost port for the project's editor (§1.1). */
+  port: number;
+}
+
+/**
+ * Absolute path to the local server binary under the §6 install layout:
+ * `<project>/Intermediate/UnrealMCP/server/<platform>/unreal-mcp-server(.exe)`.
+ * Pure.
+ */
+export function resolveServerBinaryPath(projectDir: string, os: NodeJS.Platform): string {
+  const rid = ridForPlatform(os);
+  const ext = os === 'win32' ? '.exe' : '';
+  return path.join(projectDir, 'Intermediate', 'UnrealMCP', 'server', rid, `unreal-mcp-server${ext}`);
+}
 
 interface AgentDef {
   id: string;
@@ -35,26 +57,37 @@ export function listAgentIds(): string[] {
 /**
  * Build the `mcpServers` entry for the given transport. HTTP points the
  * client at the running server; stdio launches the local `unreal-mcp-server`
- * binary on demand. Pure — exported for tests.
+ * binary (the §6 install path) on demand, passing the deterministic port,
+ * auth mode, and token as args (the thin host's CLI contract, shared with
+ * unity-mcp-server). Pure — exported for tests.
  */
 export function buildServerEntry(
   transport: McpTransport,
   url: string,
   token: string | undefined,
+  stdio?: StdioServer,
 ): Record<string, unknown> {
   if (transport === 'http') {
     const entry: Record<string, unknown> = { type: 'http', url: `${url}/mcp` };
     if (token) entry['headers'] = { Authorization: `Bearer ${token}` };
     return entry;
   }
-  // stdio
-  const entry: Record<string, unknown> = {
+  // stdio — a bare binary name is not on PATH (the server lands under the
+  // project's Intermediate/ per §6), so an absolute command + port/token
+  // args are required for the entry to actually launch a working server.
+  if (!stdio) {
+    throw new Error('stdio transport requires a resolved server path + port.');
+  }
+  return {
     type: 'stdio',
-    command: 'unreal-mcp-server',
-    args: [],
+    command: stdio.serverPath,
+    args: [
+      `port=${stdio.port}`,
+      'client-transport=stdio',
+      `authorization=${token ? 'required' : 'none'}`,
+      `token=${token ?? ''}`,
+    ],
   };
-  if (token) entry['env'] = { UNREAL_MCP_TOKEN: token };
-  return entry;
 }
 
 export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
@@ -71,7 +104,14 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
     const projectDir = path.resolve(opts.projectDir ?? process.cwd());
 
     const conn = resolveConnection({ projectDir, url: opts.url, token: opts.token });
-    const serverEntry = buildServerEntry(transport, conn.url, conn.token);
+    const stdio: StdioServer | undefined =
+      transport === 'stdio'
+        ? {
+            serverPath: resolveServerBinaryPath(projectDir, platform() as NodeJS.Platform),
+            port: generatePortFromDirectory(projectDir),
+          }
+        : undefined;
+    const serverEntry = buildServerEntry(transport, conn.url, conn.token, stdio);
 
     const configPath = path.join(projectDir, agent.relConfigPath);
     emitProgress(opts.onProgress, {

--- a/cli/src/lib/setup-mcp.ts
+++ b/cli/src/lib/setup-mcp.ts
@@ -1,0 +1,136 @@
+// `setup-mcp` — write an MCP client config snippet for a supported agent
+// so it can reach the project's local Unreal MCP server. Library-safe.
+//
+// Each agent has a project-relative config file and a merge strategy that
+// preserves any existing `mcpServers` entries. The snippet shape follows
+// the MCP client convention shared by the Unity/Godot CLIs.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { resolveConnection } from '../utils/config.js';
+import { emitProgress } from './progress.js';
+import type { McpTransport, SetupMcpOptions, SetupMcpResult } from './types.js';
+
+const SERVER_KEY = 'unreal-mcp';
+
+interface AgentDef {
+  id: string;
+  /** Config file path relative to the project dir. */
+  relConfigPath: string;
+  /** Display label. */
+  label: string;
+}
+
+const AGENTS: AgentDef[] = [
+  { id: 'claude-code', relConfigPath: '.mcp.json', label: 'Claude Code' },
+  { id: 'cursor', relConfigPath: path.join('.cursor', 'mcp.json'), label: 'Cursor' },
+  { id: 'vscode', relConfigPath: path.join('.vscode', 'mcp.json'), label: 'VS Code' },
+];
+
+/** Valid agent ids accepted by `setupMcp`. Pure. */
+export function listAgentIds(): string[] {
+  return AGENTS.map((a) => a.id);
+}
+
+/**
+ * Build the `mcpServers` entry for the given transport. HTTP points the
+ * client at the running server; stdio launches the local `unreal-mcp-server`
+ * binary on demand. Pure — exported for tests.
+ */
+export function buildServerEntry(
+  transport: McpTransport,
+  url: string,
+  token: string | undefined,
+): Record<string, unknown> {
+  if (transport === 'http') {
+    const entry: Record<string, unknown> = { type: 'http', url: `${url}/mcp` };
+    if (token) entry['headers'] = { Authorization: `Bearer ${token}` };
+    return entry;
+  }
+  // stdio
+  const entry: Record<string, unknown> = {
+    type: 'stdio',
+    command: 'unreal-mcp-server',
+    args: [],
+  };
+  if (token) entry['env'] = { UNREAL_MCP_TOKEN: token };
+  return entry;
+}
+
+export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
+  const warnings: string[] = [];
+  const nextSteps: string[] = [];
+  try {
+    const agent = AGENTS.find((a) => a.id === opts.agentId);
+    if (!agent) {
+      throw new Error(
+        `Unknown agent "${opts.agentId}". Valid agents: ${listAgentIds().join(', ')}.`,
+      );
+    }
+    const transport: McpTransport = opts.transport ?? 'http';
+    const projectDir = path.resolve(opts.projectDir ?? process.cwd());
+
+    const conn = resolveConnection({ projectDir, url: opts.url, token: opts.token });
+    const serverEntry = buildServerEntry(transport, conn.url, conn.token);
+
+    const configPath = path.join(projectDir, agent.relConfigPath);
+    emitProgress(opts.onProgress, {
+      phase: 'start',
+      message: `Configuring ${agent.label} MCP for ${transport} transport`,
+    });
+
+    // Merge into any existing config, preserving other servers.
+    let config: Record<string, unknown> = {};
+    if (fs.existsSync(configPath)) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+        if (parsed && typeof parsed === 'object') config = parsed as Record<string, unknown>;
+      } catch {
+        warnings.push(`Existing ${configPath} is not valid JSON — it will be replaced.`);
+      }
+    }
+    const servers = (config['mcpServers'] && typeof config['mcpServers'] === 'object'
+      ? (config['mcpServers'] as Record<string, unknown>)
+      : {});
+    servers[SERVER_KEY] = serverEntry;
+    config['mcpServers'] = servers;
+
+    const snippet = JSON.stringify(config, null, 2) + '\n';
+
+    if (opts.dryRun) {
+      emitProgress(opts.onProgress, { phase: 'done', message: 'Dry run — config not written.' });
+    } else {
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, snippet, 'utf-8');
+      emitProgress(opts.onProgress, {
+        phase: 'file-written',
+        message: `Wrote ${configPath}`,
+        filePath: configPath,
+      });
+    }
+
+    nextSteps.push(`Restart ${agent.label} to pick up the new MCP server.`);
+    if (transport === 'http') {
+      nextSteps.push('Ensure the Unreal Editor (and its MCP server) is running — see `unreal-cli status`.');
+    }
+
+    return {
+      kind: 'success',
+      success: true,
+      agentId: agent.id,
+      configPath,
+      transport,
+      snippet,
+      warnings,
+      nextSteps,
+    };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      nextSteps,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}

--- a/cli/src/lib/setup-skills.ts
+++ b/cli/src/lib/setup-skills.ts
@@ -1,0 +1,91 @@
+// `setup-skills` — write a Claude-Code skill stub into a project so an
+// agent knows how to reach the project's Unreal MCP server. Mirrors the
+// Unity/Godot CLIs' skill-bootstrap step. Library-safe.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { resolveConnection } from '../utils/config.js';
+import { emitProgress } from './progress.js';
+import type { ProgressCallback } from './types.js';
+
+export interface SetupSkillsOptions {
+  projectDir?: string;
+  url?: string;
+  token?: string;
+  force?: boolean;
+  onProgress?: ProgressCallback;
+}
+
+export interface SetupSkillsSuccess {
+  kind: 'success';
+  success: true;
+  skillPath: string;
+  written: boolean;
+  warnings: string[];
+}
+
+export interface SetupSkillsFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  error: Error;
+}
+
+export type SetupSkillsResult = SetupSkillsSuccess | SetupSkillsFailure;
+
+const SKILL_REL_PATH = path.join('.claude', 'skills', 'unreal-mcp', 'SKILL.md');
+
+/** Render the skill markdown. Pure — exported for tests. */
+export function renderSkill(url: string): string {
+  return `---
+name: unreal-mcp
+description: Drive the Unreal Editor for this project through the Unreal-MCP server. Use when the user wants to create/modify actors, blueprints, levels, or run editor tools in Unreal.
+---
+
+# Unreal-MCP
+
+This project is wired to a local Unreal-MCP server at \`${url}\`.
+
+- Probe readiness: \`unreal-cli status\`
+- Invoke a tool: \`unreal-cli run-tool <tool-name> --input '{...}'\`
+- The editor must be running with the UnrealMCP plugin enabled (see \`unreal-cli open\`).
+`;
+}
+
+export async function setupSkills(opts: SetupSkillsOptions = {}): Promise<SetupSkillsResult> {
+  const warnings: string[] = [];
+  try {
+    const projectDir = path.resolve(opts.projectDir ?? process.cwd());
+    if (!fs.existsSync(projectDir)) throw new Error(`Project directory does not exist: ${projectDir}`);
+
+    let url = opts.url ?? '';
+    if (!url) {
+      try {
+        url = resolveConnection({ projectDir, url: opts.url, token: opts.token }).url;
+      } catch {
+        url = 'http://localhost:<deterministic-port>';
+        warnings.push('Could not resolve a connection URL — wrote a placeholder into the skill.');
+      }
+    }
+
+    const skillPath = path.join(projectDir, SKILL_REL_PATH);
+    emitProgress(opts.onProgress, { phase: 'start', message: `Writing skill to ${skillPath}` });
+
+    if (fs.existsSync(skillPath) && !opts.force) {
+      emitProgress(opts.onProgress, { phase: 'done', message: 'Skill already exists (use --force to overwrite).' });
+      return { kind: 'success', success: true, skillPath, written: false, warnings };
+    }
+
+    fs.mkdirSync(path.dirname(skillPath), { recursive: true });
+    fs.writeFileSync(skillPath, renderSkill(url), 'utf-8');
+    emitProgress(opts.onProgress, { phase: 'done', message: 'Skill written.' });
+    return { kind: 'success', success: true, skillPath, written: true, warnings };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}

--- a/cli/src/lib/status.ts
+++ b/cli/src/lib/status.ts
@@ -29,9 +29,13 @@ export async function getStatus(opts: StatusOptions = {}): Promise<StatusReport>
     projectDir = path.resolve(opts.projectDir);
     const uproject = readUProject(projectDir);
     if (uproject) {
-      const pluginInstalled =
-        fs.existsSync(path.join(projectDir, 'Plugins', 'UnrealMCP', 'UnrealMCP.uplugin')) ||
-        fs.existsSync(path.join(projectDir, 'Plugins', 'UnrealMCP'));
+      // Key on the `.uplugin` descriptor, not the directory: a bare
+      // `Plugins/UnrealMCP/` folder without the descriptor is not a usable
+      // install (the OR'd dir-exists check was a strict superset and so
+      // degenerated to dir-exists).
+      const pluginInstalled = fs.existsSync(
+        path.join(projectDir, 'Plugins', 'UnrealMCP', 'UnrealMCP.uplugin'),
+      );
       report.project = {
         projectDir: uproject.projectDir,
         projectName: uproject.projectName,

--- a/cli/src/lib/status.ts
+++ b/cli/src/lib/status.ts
@@ -1,20 +1,66 @@
-// Side-effect-free library implementation backing the `status` command.
+// Side-effect-free `status` implementation: report package identity,
+// resolved project + plugin state, the resolved connection, and an
+// optional live reachability probe.
+
+import * as fs from 'fs';
+import * as path from 'path';
 import { PACKAGE_NAME, PACKAGE_VERSION } from '../version.js';
+import { readUProject } from '../utils/project.js';
+import { resolveConnection } from '../utils/config.js';
+import { probePing } from '../utils/probe.js';
+import type { StatusOptions, StatusReport } from './types.js';
 
-export interface CliStatus {
-  kind: 'success';
-  success: true;
-  name: string;
-  version: string;
-  stage: 'pre-alpha scaffold';
-}
-
-export function getStatus(): CliStatus {
-  return {
+/**
+ * Gather status for an optional project. With no `projectDir`/`url`, returns
+ * just package identity. With a project, resolves project + connection info
+ * and (unless `noProbe`) probes the local MCP server. Never throws.
+ */
+export async function getStatus(opts: StatusOptions = {}): Promise<StatusReport> {
+  const report: StatusReport = {
     kind: 'success',
     success: true,
     name: PACKAGE_NAME,
     version: PACKAGE_VERSION,
-    stage: 'pre-alpha scaffold',
+    connection: { url: '', source: 'none', hasToken: false },
   };
+
+  let projectDir: string | undefined;
+  if (opts.projectDir) {
+    projectDir = path.resolve(opts.projectDir);
+    const uproject = readUProject(projectDir);
+    if (uproject) {
+      const pluginInstalled =
+        fs.existsSync(path.join(projectDir, 'Plugins', 'UnrealMCP', 'UnrealMCP.uplugin')) ||
+        fs.existsSync(path.join(projectDir, 'Plugins', 'UnrealMCP'));
+      report.project = {
+        projectDir: uproject.projectDir,
+        projectName: uproject.projectName,
+        engineAssociation: uproject.engineAssociation || '(none)',
+        pluginInstalled,
+      };
+    }
+  }
+
+  // Resolve a connection when we have either a project or an explicit URL.
+  if (projectDir || opts.url) {
+    try {
+      const conn = resolveConnection({ projectDir, url: opts.url, token: opts.token });
+      report.connection = { url: conn.url, source: conn.source, hasToken: conn.token !== undefined };
+
+      if (!opts.noProbe) {
+        const probe = await probePing(conn.url, {
+          token: conn.token,
+          timeoutMs: opts.probeTimeoutMs,
+          fetchImpl: opts.fetchImpl,
+        });
+        report.reachable = probe.ok;
+        report.probeReason = probe.ok ? undefined : probe.reason;
+      }
+    } catch (err) {
+      report.connection = { url: '', source: 'unresolved', hasToken: false };
+      report.probeReason = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  return report;
 }

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -1,0 +1,478 @@
+// Shared public types for the `unreal-cli` library API.
+//
+// Re-exported from `lib.ts` — consumers import from `unreal-cli` (the
+// package root), never from deep paths.
+//
+// Contract (same as unity-mcp-cli / godot-cli):
+// - Every result is a discriminated union keyed on `kind`. Successes are
+//   `{ kind: 'success', success: true, ... }`; failures are
+//   `{ kind: 'failure', success: false, error }`. `success === (kind ===
+//   'success')` always holds for wire compatibility.
+// - Errors are never thrown past the public boundary.
+// - Progress is surfaced via an optional `onProgress` callback.
+//
+// No top-level side effects; no runtime deps beyond TypeScript types.
+
+export type ResultKind = 'success' | 'failure';
+
+// ---------------------------------------------------------------------------
+// Progress events
+// ---------------------------------------------------------------------------
+
+export type ProgressEvent =
+  | { phase: 'start'; message: string }
+  | { phase: 'info'; message: string }
+  | { phase: 'file-written'; message: string; filePath: string }
+  | { phase: 'engine-resolved'; message: string; editorPath: string; engineRoot: string }
+  | { phase: 'launching'; message: string; editorPath: string; projectDir: string }
+  | { phase: 'launched'; message: string; pid?: number }
+  | { phase: 'done'; message: string };
+
+export type ProgressCallback = (event: ProgressEvent) => void;
+
+// ---------------------------------------------------------------------------
+// configure
+// ---------------------------------------------------------------------------
+
+/** Connection mode written to `UNREAL_MCP_CONNECTION_MODE`. */
+export type ConnectionMode = 'Cloud' | 'Custom';
+export type AuthOption = 'none' | 'required';
+export type McpTransport = 'stdio' | 'http';
+
+export interface ConfigureOptions {
+  /** Target Unreal project root (where `.env` / `.gitignore` live). */
+  projectDir: string;
+  connectionMode?: ConnectionMode;
+  host?: string;
+  cloudUrl?: string;
+  token?: string;
+  authOption?: AuthOption;
+  keepConnected?: boolean;
+  tools?: string;
+  startServer?: boolean;
+  transport?: McpTransport;
+  logLevel?: string;
+  /**
+   * When `true` (default), append `.env` to the project's `.gitignore`,
+   * creating it if absent. Set `false` only for tests that assert the
+   * env-write path in isolation.
+   */
+  ensureGitignore?: boolean;
+  onProgress?: ProgressCallback;
+}
+
+export interface ConfigureSuccess {
+  kind: 'success';
+  success: true;
+  /** Absolute path to the `.env` that was written. */
+  envPath: string;
+  /** Keys added / updated this run. */
+  keysWritten: string[];
+  /** Absolute path to the `.gitignore` touched (if `ensureGitignore`). */
+  gitignorePath?: string;
+  /** What happened to `.gitignore`. */
+  gitignoreAction?: 'created' | 'appended' | 'already-ignored' | 'skipped';
+  warnings: string[];
+}
+
+export interface ConfigureFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  error: Error;
+}
+
+export type ConfigureResult = ConfigureSuccess | ConfigureFailure;
+
+// ---------------------------------------------------------------------------
+// open
+// ---------------------------------------------------------------------------
+
+export interface OpenProjectOptions {
+  /** Project root or `.uproject` path; defaults to `process.cwd()`. */
+  projectDir?: string;
+  /** Explicit engine root override (source builds). */
+  engineRoot?: string;
+  /** Skip wiring MCP connection env vars onto the editor process. */
+  noConnect?: boolean;
+  host?: string;
+  token?: string;
+  auth?: AuthOption;
+  tools?: string;
+  keepConnected?: boolean;
+  transport?: McpTransport;
+  startServer?: boolean;
+  /** Test injection — installed engines (defaults to launcher manifest). */
+  enginesImpl?: () => import('../utils/launcher.js').EngineInstallation[];
+  /** Test injection — spawn (defaults to detached `child_process.spawn`). */
+  spawnImpl?: (editorPath: string, args: string[], env: NodeJS.ProcessEnv) => { pid?: number };
+  onProgress?: ProgressCallback;
+}
+
+export interface OpenProjectSuccess {
+  kind: 'success';
+  success: true;
+  editorPath: string;
+  engineRoot: string;
+  projectDir: string;
+  editorPid?: number;
+  envVars: Record<string, string>;
+  warnings: string[];
+}
+
+export interface OpenProjectFailure {
+  kind: 'failure';
+  success: false;
+  projectDir?: string;
+  warnings: string[];
+  errorMessage: string;
+  error: Error;
+}
+
+export type OpenProjectResult = OpenProjectSuccess | OpenProjectFailure;
+
+// ---------------------------------------------------------------------------
+// create-project
+// ---------------------------------------------------------------------------
+
+export interface CreateProjectOptions {
+  /** Where to create the project (the directory is created). */
+  projectDir: string;
+  /** Project / primary module name. Defaults to the directory basename. */
+  projectName?: string;
+  /** `EngineAssociation` to bake into the `.uproject` (e.g. `"5.7"`). */
+  engineAssociation?: string;
+  /** Overwrite an existing non-empty directory. Default `false`. */
+  force?: boolean;
+  onProgress?: ProgressCallback;
+}
+
+export interface CreateProjectSuccess {
+  kind: 'success';
+  success: true;
+  projectDir: string;
+  projectName: string;
+  uprojectPath: string;
+  filesWritten: string[];
+  warnings: string[];
+}
+
+export interface CreateProjectFailure {
+  kind: 'failure';
+  success: false;
+  projectDir?: string;
+  warnings: string[];
+  errorMessage: string;
+  error: Error;
+}
+
+export type CreateProjectResult = CreateProjectSuccess | CreateProjectFailure;
+
+// ---------------------------------------------------------------------------
+// install-plugin / remove-plugin
+// ---------------------------------------------------------------------------
+
+export interface InstallPluginOptions {
+  /** Target Unreal project root. */
+  projectDir: string;
+  /** Source `UnrealMCP/` plugin directory to install. */
+  pluginSourceDir: string;
+  /** Junction (dev) instead of copy. Windows only. Default `false`. */
+  junction?: boolean;
+  onProgress?: ProgressCallback;
+}
+
+export interface InstallPluginSuccess {
+  kind: 'success';
+  success: true;
+  /** Absolute path to `<project>/Plugins/UnrealMCP`. */
+  installedPath: string;
+  mode: 'copy' | 'junction';
+  warnings: string[];
+}
+
+export interface InstallPluginFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  error: Error;
+}
+
+export type InstallPluginResult = InstallPluginSuccess | InstallPluginFailure;
+
+export interface RemovePluginOptions {
+  projectDir: string;
+  onProgress?: ProgressCallback;
+}
+
+export interface RemovePluginSuccess {
+  kind: 'success';
+  success: true;
+  /** `true` when a plugin was present and removed. */
+  removed: boolean;
+  installedPath: string;
+  warnings: string[];
+}
+
+export interface RemovePluginFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  error: Error;
+}
+
+export type RemovePluginResult = RemovePluginSuccess | RemovePluginFailure;
+
+// ---------------------------------------------------------------------------
+// run-tool / run-system-tool
+// ---------------------------------------------------------------------------
+
+export type RunToolFailureReason =
+  | 'invalid-input'
+  | 'connection-refused'
+  | 'connection-reset'
+  | 'network-error'
+  | 'timeout'
+  | 'http-error'
+  | 'unknown';
+
+export interface RunToolOptions {
+  toolName: string;
+  /** Project dir — resolves URL + token. Either this or `url` is required. */
+  projectDir?: string;
+  url?: string;
+  token?: string;
+  /** Tool arguments — JSON object, JSON string, or undefined (→ `{}`). */
+  input?: unknown;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  fetchImpl?: typeof fetch;
+}
+
+export interface RunToolSuccess {
+  kind: 'success';
+  success: true;
+  endpoint: string;
+  httpStatus: number;
+  data: unknown;
+}
+
+export interface RunToolFailure {
+  kind: 'failure';
+  success: false;
+  endpoint: string;
+  reason: RunToolFailureReason;
+  httpStatus?: number;
+  data?: unknown;
+  message: string;
+  error?: Error;
+}
+
+export type RunToolResult = RunToolSuccess | RunToolFailure;
+
+// ---------------------------------------------------------------------------
+// setup-mcp
+// ---------------------------------------------------------------------------
+
+export interface SetupMcpOptions {
+  /** Agent id — use `listAgentIds()` for valid values. */
+  agentId: string;
+  /** Project dir (defaults to `process.cwd()`). */
+  projectDir?: string;
+  transport?: McpTransport;
+  url?: string;
+  token?: string;
+  /** Return the snippet instead of writing it. Default `false` (write). */
+  dryRun?: boolean;
+  onProgress?: ProgressCallback;
+}
+
+export interface SetupMcpSuccess {
+  kind: 'success';
+  success: true;
+  agentId: string;
+  /** Path the config was (or would be) written to. */
+  configPath: string;
+  transport: McpTransport;
+  /** The JSON snippet that was written. */
+  snippet: string;
+  warnings: string[];
+  nextSteps: string[];
+}
+
+export interface SetupMcpFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  nextSteps: string[];
+  error: Error;
+}
+
+export type SetupMcpResult = SetupMcpSuccess | SetupMcpFailure;
+
+// ---------------------------------------------------------------------------
+// install-engine
+// ---------------------------------------------------------------------------
+
+export interface DetectEnginesOptions {
+  /** Explicit manifest path (defaults to the platform location). */
+  manifestPath?: string;
+  os?: NodeJS.Platform;
+}
+
+export interface DetectEnginesResult {
+  kind: 'success';
+  success: true;
+  /** Path the manifest was read from (or would be, when absent). */
+  manifestPath: string | null;
+  engines: import('../utils/launcher.js').EngineInstallation[];
+}
+
+export interface PlanEngineInstallOptions {
+  /** Engine version to install, e.g. `"5.7"`. */
+  version: string;
+  manifestPath?: string;
+  os?: NodeJS.Platform;
+}
+
+/**
+ * `install-engine` never installs the engine itself — that is a multi-GB
+ * Epic-launcher operation. It detects whether the requested version is
+ * already present and otherwise hands back a launcher deep-link + a clear
+ * user-facing message.
+ */
+export interface PlanEngineInstallResult {
+  kind: 'success';
+  success: true;
+  version: string;
+  /** `true` when the requested version is already installed. */
+  alreadyInstalled: boolean;
+  /** The matching installation when `alreadyInstalled`. */
+  installation: import('../utils/launcher.js').EngineInstallation | null;
+  /** `com.epicgames.launcher://` deep link that opens the install page. */
+  launcherUrl: string;
+  /** Human-facing guidance to print. */
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// wait-for-ready
+// ---------------------------------------------------------------------------
+
+export interface WaitForReadyOptions {
+  projectDir?: string;
+  url?: string;
+  token?: string;
+  /** Overall timeout. Default 120000 ms. */
+  timeoutMs?: number;
+  /** Poll interval. Default 2000 ms. */
+  intervalMs?: number;
+  /** Per-probe timeout. Default 4000 ms. */
+  probeTimeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  /** Injectable clock for tests. */
+  nowImpl?: () => number;
+  /** Injectable sleep for tests. */
+  sleepImpl?: (ms: number) => Promise<void>;
+  onProgress?: ProgressCallback;
+}
+
+export interface WaitForReadySuccess {
+  kind: 'success';
+  success: true;
+  url: string;
+  elapsedMs: number;
+  attempts: number;
+}
+
+export interface WaitForReadyFailure {
+  kind: 'failure';
+  success: false;
+  url: string;
+  elapsedMs: number;
+  attempts: number;
+  lastReason: string;
+  error: Error;
+}
+
+export type WaitForReadyResult = WaitForReadySuccess | WaitForReadyFailure;
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+export interface StatusOptions {
+  projectDir?: string;
+  url?: string;
+  token?: string;
+  /** Skip the live HTTP probe (offline status). Default `false`. */
+  noProbe?: boolean;
+  probeTimeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export interface StatusReport {
+  kind: 'success';
+  success: true;
+  name: string;
+  version: string;
+  /** Project info, when a project dir was provided + a `.uproject` found. */
+  project?: {
+    projectDir: string;
+    projectName: string;
+    engineAssociation: string;
+    pluginInstalled: boolean;
+  };
+  connection: {
+    url: string;
+    source: string;
+    hasToken: boolean;
+  };
+  /** Live probe result; absent when `noProbe`. */
+  reachable?: boolean;
+  probeReason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// bootstrap-local
+// ---------------------------------------------------------------------------
+
+export interface BootstrapLocalOptions {
+  /** Project root — the bridge/server land under `Intermediate/UnrealMCP/`. */
+  projectDir: string;
+  /** Path to the Unreal-MCP repo root holding `bridge/` + `Unreal-MCP-Server/`. */
+  repoRoot: string;
+  os?: NodeJS.Platform;
+  /** Inject the build runner (defaults to spawning `dotnet`). */
+  buildImpl?: (step: BuildStep) => Promise<void>;
+  onProgress?: ProgressCallback;
+}
+
+export interface BuildStep {
+  label: string;
+  /** Solution/project file to publish. */
+  projectFile: string;
+  /** Output directory under the project's `Intermediate/UnrealMCP/`. */
+  outputDir: string;
+  /** Runtime identifier, e.g. `win-x64`. */
+  rid: string;
+}
+
+export interface BootstrapLocalSuccess {
+  kind: 'success';
+  success: true;
+  /** The build steps that ran (or would run). */
+  steps: BuildStep[];
+  /** `<project>/Intermediate/UnrealMCP`. */
+  outputRoot: string;
+  warnings: string[];
+}
+
+export interface BootstrapLocalFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  error: Error;
+}
+
+export type BootstrapLocalResult = BootstrapLocalSuccess | BootstrapLocalFailure;

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -233,6 +233,7 @@ export type RunToolFailureReason =
   | 'connection-reset'
   | 'network-error'
   | 'timeout'
+  | 'aborted'
   | 'http-error'
   | 'unknown';
 

--- a/cli/src/lib/update.ts
+++ b/cli/src/lib/update.ts
@@ -1,0 +1,101 @@
+// `update` — re-sync the UnrealMCP plugin installed in a project against a
+// plugin source, reporting the version delta. Reads `VersionName` from each
+// side's `UnrealMCP.uplugin` and re-copies when they differ (or always with
+// `force`). Library-safe.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { installPlugin } from './install-plugin.js';
+import { emitProgress } from './progress.js';
+import type { ProgressCallback } from './types.js';
+
+export interface UpdateOptions {
+  projectDir: string;
+  /** Plugin source to update from. */
+  pluginSourceDir: string;
+  /** Re-install even when versions match. Default `false`. */
+  force?: boolean;
+  onProgress?: ProgressCallback;
+}
+
+export interface UpdateSuccess {
+  kind: 'success';
+  success: true;
+  /** Version before the update (null when not installed). */
+  fromVersion: string | null;
+  /** Version after the update. */
+  toVersion: string | null;
+  /** `true` when files were re-copied. */
+  updated: boolean;
+  installedPath: string;
+  warnings: string[];
+}
+
+export interface UpdateFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  error: Error;
+}
+
+export type UpdateResult = UpdateSuccess | UpdateFailure;
+
+/** Read `VersionName` from a `UnrealMCP.uplugin`. Pure. Returns null on miss. */
+export function readPluginVersion(upluginPath: string): string | null {
+  if (!fs.existsSync(upluginPath)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(upluginPath, 'utf-8')) as Record<string, unknown>;
+    const v = parsed['VersionName'];
+    return typeof v === 'string' ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function update(opts: UpdateOptions): Promise<UpdateResult> {
+  const warnings: string[] = [];
+  try {
+    if (!opts?.projectDir) throw new Error('projectDir is required.');
+    if (!opts?.pluginSourceDir) throw new Error('pluginSourceDir is required.');
+    const projectDir = path.resolve(opts.projectDir);
+    const pluginSourceDir = path.resolve(opts.pluginSourceDir);
+
+    const installedUplugin = path.join(projectDir, 'Plugins', 'UnrealMCP', 'UnrealMCP.uplugin');
+    const sourceUplugin = path.join(pluginSourceDir, 'UnrealMCP.uplugin');
+    const fromVersion = readPluginVersion(installedUplugin);
+    const toVersion = readPluginVersion(sourceUplugin);
+    const installedPath = path.join(projectDir, 'Plugins', 'UnrealMCP');
+
+    emitProgress(opts.onProgress, {
+      phase: 'start',
+      message: `Updating plugin (installed=${fromVersion ?? 'none'}, source=${toVersion ?? 'unknown'})`,
+    });
+
+    const needsUpdate = opts.force === true || fromVersion !== toVersion;
+    if (!needsUpdate) {
+      emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin already up to date.' });
+      return { kind: 'success', success: true, fromVersion, toVersion, updated: false, installedPath, warnings };
+    }
+
+    const installResult = await installPlugin({
+      projectDir,
+      pluginSourceDir,
+      junction: false,
+      onProgress: opts.onProgress,
+    });
+    if (installResult.kind === 'failure') {
+      return { kind: 'failure', success: false, warnings, error: installResult.error };
+    }
+    warnings.push(...installResult.warnings);
+
+    emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin updated.' });
+    return { kind: 'success', success: true, fromVersion, toVersion, updated: true, installedPath, warnings };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}

--- a/cli/src/lib/update.ts
+++ b/cli/src/lib/update.ts
@@ -80,7 +80,19 @@ export async function update(opts: UpdateOptions): Promise<UpdateResult> {
       message: `Updating plugin (installed=${fromVersion ?? 'none'}, source=${toVersion ?? 'unknown'})`,
     });
 
-    const needsUpdate = opts.force === true || fromVersion !== toVersion;
+    // An unreadable source `.uplugin` (e.g. a typo'd `--plugin-source`) reads
+    // back as `toVersion === null`; surface that rather than silently treating
+    // it as a no-op.
+    if (toVersion === null) {
+      warnings.push(
+        'Could not read VersionName from the plugin source UnrealMCP.uplugin; proceeding with install.',
+      );
+    }
+    // A plugin that is NOT installed (`fromVersion === null`) must always be
+    // installed: `null !== null` is `false`, so without the explicit
+    // `fromVersion === null` clause an uninstalled plugin against an unreadable
+    // source would short-circuit to "already up to date" and never install.
+    const needsUpdate = opts.force === true || fromVersion === null || fromVersion !== toVersion;
     if (!needsUpdate) {
       emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin already up to date.' });
       return { kind: 'success', success: true, fromVersion, toVersion, updated: false, installedPath, warnings };

--- a/cli/src/lib/update.ts
+++ b/cli/src/lib/update.ts
@@ -40,6 +40,15 @@ export interface UpdateFailure {
 
 export type UpdateResult = UpdateSuccess | UpdateFailure;
 
+/** True when `p` is an existing symlink/junction (vs a real directory). */
+function isJunction(p: string): boolean {
+  try {
+    return fs.lstatSync(p).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
 /** Read `VersionName` from a `UnrealMCP.uplugin`. Pure. Returns null on miss. */
 export function readPluginVersion(upluginPath: string): string | null {
   if (!fs.existsSync(upluginPath)) return null;
@@ -77,10 +86,13 @@ export async function update(opts: UpdateOptions): Promise<UpdateResult> {
       return { kind: 'success', success: true, fromVersion, toVersion, updated: false, installedPath, warnings };
     }
 
+    // Preserve the existing install mode: a dev junction install must stay a
+    // junction across `update --force` rather than being silently replaced
+    // with a copy (which would detach the project from the live source).
     const installResult = await installPlugin({
       projectDir,
       pluginSourceDir,
-      junction: false,
+      junction: isJunction(installedPath),
       onProgress: opts.onProgress,
     });
     if (installResult.kind === 'failure') {

--- a/cli/src/lib/wait-for-ready.ts
+++ b/cli/src/lib/wait-for-ready.ts
@@ -1,0 +1,72 @@
+// `wait-for-ready` — poll the project's MCP server `ping` endpoint until it
+// responds 2xx or the overall timeout elapses. Clock + sleep + fetch are
+// injectable so the loop is fully unit-testable without real time or
+// sockets. Library-safe.
+
+import { resolveConnection } from '../utils/config.js';
+import { probePing } from '../utils/probe.js';
+import { emitProgress } from './progress.js';
+import type { WaitForReadyOptions, WaitForReadyResult } from './types.js';
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_INTERVAL_MS = 2_000;
+const DEFAULT_PROBE_TIMEOUT_MS = 4_000;
+
+const realSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export async function waitForReady(opts: WaitForReadyOptions = {}): Promise<WaitForReadyResult> {
+  const now = opts.nowImpl ?? Date.now;
+  const sleep = opts.sleepImpl ?? realSleep;
+  const timeoutMs = positive(opts.timeoutMs, DEFAULT_TIMEOUT_MS);
+  const intervalMs = positive(opts.intervalMs, DEFAULT_INTERVAL_MS);
+  const probeTimeoutMs = positive(opts.probeTimeoutMs, DEFAULT_PROBE_TIMEOUT_MS);
+
+  let url = '';
+  let token: string | undefined;
+  try {
+    const conn = resolveConnection({ projectDir: opts.projectDir, url: opts.url, token: opts.token });
+    url = conn.url;
+    token = conn.token;
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    return { kind: 'failure', success: false, url, elapsedMs: 0, attempts: 0, lastReason: error.message, error };
+  }
+
+  const start = now();
+  const deadline = start + timeoutMs;
+  let attempts = 0;
+  let lastReason = 'no attempts made';
+
+  emitProgress(opts.onProgress, { phase: 'start', message: `Waiting for ${url} to become ready` });
+
+  while (now() < deadline) {
+    attempts += 1;
+    const probe = await probePing(url, { token, timeoutMs: probeTimeoutMs, fetchImpl: opts.fetchImpl });
+    if (probe.ok) {
+      const elapsedMs = now() - start;
+      emitProgress(opts.onProgress, { phase: 'done', message: `Ready after ${elapsedMs}ms (${attempts} attempt(s))` });
+      return { kind: 'success', success: true, url, elapsedMs, attempts };
+    }
+    lastReason = probe.reason;
+    emitProgress(opts.onProgress, { phase: 'info', message: `Not ready (${probe.reason}) — retrying` });
+
+    const remaining = deadline - now();
+    if (remaining <= 0) break;
+    await sleep(Math.min(intervalMs, remaining));
+  }
+
+  const elapsedMs = now() - start;
+  return {
+    kind: 'failure',
+    success: false,
+    url,
+    elapsedMs,
+    attempts,
+    lastReason,
+    error: new Error(`Timed out after ${elapsedMs}ms waiting for ${url} (last: ${lastReason}).`),
+  };
+}
+
+function positive(v: number | undefined, fallback: number): number {
+  return typeof v === 'number' && v > 0 ? v : fallback;
+}

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -40,9 +40,10 @@ export interface ResolveConnectionOptions {
  */
 export function resolveConnection(opts: ResolveConnectionOptions): ResolvedConnection {
   const env = opts.processEnv ?? process.env;
+  const envToken = nonEmpty(env['UNREAL_MCP_TOKEN']);
 
   if (opts.url && opts.url.trim().length > 0) {
-    return { url: stripTrailingSlash(opts.url), token: opts.token, source: 'override' };
+    return { url: stripTrailingSlash(opts.url), token: opts.token ?? envToken, source: 'override' };
   }
 
   if (!opts.projectDir) {
@@ -50,40 +51,35 @@ export function resolveConnection(opts: ResolveConnectionOptions): ResolvedConne
   }
   const projectDir = path.resolve(opts.projectDir);
 
+  const fileEnv = readEnvFile(path.join(projectDir, '.env'));
+  const fileToken = nonEmpty(fileEnv['UNREAL_MCP_TOKEN']);
+
+  // Token precedence is layered independently of which layer supplied the
+  // URL (§8: explicit override -> process env -> project `.env`). Resolving
+  // it once here avoids the asymmetry of, e.g., a process-env HOST ignoring a
+  // `.env` token or a `.env` HOST ignoring a process-env token.
+  const token = opts.token ?? envToken ?? fileToken;
+
   // Process env beats the file (live override, never persisted — §8).
-  const envHost = env['UNREAL_MCP_HOST'];
-  const envToken = env['UNREAL_MCP_TOKEN'];
-  if (envHost && envHost.trim().length > 0) {
-    return {
-      url: stripTrailingSlash(envHost),
-      token: opts.token ?? (envToken && envToken.length > 0 ? envToken : undefined),
-      source: 'process-env',
-    };
+  const envHost = nonEmpty(env['UNREAL_MCP_HOST']);
+  if (envHost) {
+    return { url: stripTrailingSlash(envHost), token, source: 'process-env' };
   }
 
-  const fileEnv = readEnvFile(path.join(projectDir, '.env'));
-  const fileHost = fileEnv['UNREAL_MCP_HOST'];
-  const fileToken = fileEnv['UNREAL_MCP_TOKEN'];
-  if (fileHost && fileHost.length > 0) {
-    return {
-      url: stripTrailingSlash(fileHost),
-      token: opts.token ?? (fileToken && fileToken.length > 0 ? fileToken : undefined),
-      source: 'env-file',
-    };
+  const fileHost = nonEmpty(fileEnv['UNREAL_MCP_HOST']);
+  if (fileHost) {
+    return { url: stripTrailingSlash(fileHost), token, source: 'env-file' };
   }
 
   const port = generatePortFromDirectory(projectDir);
-  return {
-    url: `http://localhost:${port}`,
-    token:
-      opts.token ??
-      (envToken && envToken.length > 0
-        ? envToken
-        : fileToken && fileToken.length > 0
-          ? fileToken
-          : undefined),
-    source: 'deterministic-port',
-  };
+  return { url: `http://localhost:${port}`, token, source: 'deterministic-port' };
+}
+
+/** Trim a value and return `undefined` when it is absent or blank. */
+function nonEmpty(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 export function stripTrailingSlash(url: string): string {

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -1,0 +1,91 @@
+// Connection resolution for the HTTP commands (`run-tool`,
+// `run-system-tool`, `status`, `wait-for-ready`).
+//
+// Precedence mirrors docs/ARCHITECTURE.md §8 (highest wins):
+//   explicit override -> process env -> project `.env` -> deterministic
+//   localhost port. Only the plugin owns the on-disk JSON config under
+//   `Saved/Config/UnrealMcp/`, so the CLI never reads it — the `.env`
+//   layer plus the deterministic port are the CLI's whole picture.
+
+import * as path from 'path';
+import { readEnvFile } from './env-file.js';
+import { generatePortFromDirectory } from './port.js';
+
+export interface ResolvedConnection {
+  /** Base URL with no trailing slash. */
+  url: string;
+  /** Bearer token, when one is configured. */
+  token: string | undefined;
+  /** Where the URL came from — for diagnostics / `status`. */
+  source: 'override' | 'process-env' | 'env-file' | 'deterministic-port';
+}
+
+export interface ResolveConnectionOptions {
+  /** Absolute project dir — used for `.env` read + deterministic port. */
+  projectDir?: string;
+  /** Explicit URL override (wins over everything). */
+  url?: string;
+  /** Explicit token override (wins over everything). */
+  token?: string;
+  /** Injectable env source (defaults to `process.env`). */
+  processEnv?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Resolve the MCP server URL + token to use for a project. Pure given an
+ * injected `processEnv`; reads the project `.env` via the filesystem.
+ *
+ * Throws only when neither a `projectDir` nor a `url` override is supplied
+ * — every other path degrades to the deterministic localhost port.
+ */
+export function resolveConnection(opts: ResolveConnectionOptions): ResolvedConnection {
+  const env = opts.processEnv ?? process.env;
+
+  if (opts.url && opts.url.trim().length > 0) {
+    return { url: stripTrailingSlash(opts.url), token: opts.token, source: 'override' };
+  }
+
+  if (!opts.projectDir) {
+    throw new Error('Either url or projectDir must be provided to resolve a connection.');
+  }
+  const projectDir = path.resolve(opts.projectDir);
+
+  // Process env beats the file (live override, never persisted — §8).
+  const envHost = env['UNREAL_MCP_HOST'];
+  const envToken = env['UNREAL_MCP_TOKEN'];
+  if (envHost && envHost.trim().length > 0) {
+    return {
+      url: stripTrailingSlash(envHost),
+      token: opts.token ?? (envToken && envToken.length > 0 ? envToken : undefined),
+      source: 'process-env',
+    };
+  }
+
+  const fileEnv = readEnvFile(path.join(projectDir, '.env'));
+  const fileHost = fileEnv['UNREAL_MCP_HOST'];
+  const fileToken = fileEnv['UNREAL_MCP_TOKEN'];
+  if (fileHost && fileHost.length > 0) {
+    return {
+      url: stripTrailingSlash(fileHost),
+      token: opts.token ?? (fileToken && fileToken.length > 0 ? fileToken : undefined),
+      source: 'env-file',
+    };
+  }
+
+  const port = generatePortFromDirectory(projectDir);
+  return {
+    url: `http://localhost:${port}`,
+    token:
+      opts.token ??
+      (envToken && envToken.length > 0
+        ? envToken
+        : fileToken && fileToken.length > 0
+          ? fileToken
+          : undefined),
+    source: 'deterministic-port',
+  };
+}
+
+export function stripTrailingSlash(url: string): string {
+  return url.trim().replace(/\/+$/, '');
+}

--- a/cli/src/utils/engine.ts
+++ b/cli/src/utils/engine.ts
@@ -1,0 +1,153 @@
+// Engine-path resolution: combine a project's `EngineAssociation`
+// (utils/project.ts) with the installed engines (utils/launcher.ts) to
+// produce the absolute `UnrealEditor` binary path for the `open` command.
+//
+// All resolution is pure given the installed-engine list + platform; the
+// only I/O is the optional `existsSync` binary check, isolated behind an
+// injectable predicate so tests run without a real engine install.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  type EngineInstallation,
+  matchEngineForAssociation,
+} from './launcher.js';
+
+/**
+ * Build the absolute path to the `UnrealEditor` binary under an engine
+ * install root, for the given platform. `cmd === true` returns the
+ * headless console binary (`UnrealEditor-Cmd`) used by `wait-for-ready`
+ * smoke paths. Pure.
+ */
+export function editorBinaryPath(
+  engineRoot: string,
+  os: NodeJS.Platform,
+  cmd = false,
+): string {
+  const exe = cmd ? 'UnrealEditor-Cmd' : 'UnrealEditor';
+  // Use the path flavor for the TARGET os, not the host — so resolving a
+  // macOS/Linux engine on a Windows host (and vice versa) yields correct
+  // separators.
+  const pj = os === 'win32' ? path.win32 : path.posix;
+  switch (os) {
+    case 'win32':
+      return pj.join(engineRoot, 'Engine', 'Binaries', 'Win64', `${exe}.exe`);
+    case 'darwin':
+      // The .app wraps the same two binaries under Contents/MacOS.
+      return pj.join(engineRoot, 'Engine', 'Binaries', 'Mac', `${exe}.app`, 'Contents', 'MacOS', exe);
+    default:
+      return pj.join(engineRoot, 'Engine', 'Binaries', 'Linux', exe);
+  }
+}
+
+export interface ResolveEngineInput {
+  /** Project's `EngineAssociation` (from utils/project.ts). */
+  engineAssociation: string;
+  /** Installed engines (from utils/launcher.ts). */
+  engines: EngineInstallation[];
+  /**
+   * Explicit engine root override. When provided, association matching is
+   * skipped entirely — this is the escape hatch for source builds whose
+   * GUID association is absent from the launcher manifest.
+   */
+  engineRootOverride?: string;
+  /** Target platform; defaults to the host. */
+  os?: NodeJS.Platform;
+  /** Injectable existence check (defaults to `fs.existsSync`). */
+  existsImpl?: (p: string) => boolean;
+}
+
+export type ResolveEngineResult =
+  | {
+      kind: 'resolved';
+      engineRoot: string;
+      editorPath: string;
+      /** The matched installation, or `null` for an explicit override. */
+      installation: EngineInstallation | null;
+    }
+  | {
+      kind: 'unresolved';
+      /** Why resolution failed — feeds a user-actionable message. */
+      reason:
+        | 'no-engines-installed'
+        | 'association-not-installed'
+        | 'source-build-needs-root'
+        | 'editor-binary-missing';
+      message: string;
+      /** Present when we got as far as a candidate root. */
+      engineRoot?: string;
+    };
+
+/**
+ * Resolve a project's engine to a concrete `UnrealEditor` binary path.
+ *
+ * Order of precedence:
+ *   1. `engineRootOverride` (skips the manifest entirely).
+ *   2. The launcher engine matching `engineAssociation`.
+ *   3. (empty association) the highest installed launcher engine.
+ *
+ * Pure given its inputs (the binary existence check is injectable).
+ */
+export function resolveEngine(input: ResolveEngineInput): ResolveEngineResult {
+  const os = input.os ?? (process.platform as NodeJS.Platform);
+  const exists = input.existsImpl ?? ((p: string) => fs.existsSync(p));
+
+  if (input.engineRootOverride && input.engineRootOverride.trim().length > 0) {
+    const engineRoot = path.resolve(input.engineRootOverride.trim());
+    const editorPath = editorBinaryPath(engineRoot, os);
+    if (!exists(editorPath)) {
+      return {
+        kind: 'unresolved',
+        reason: 'editor-binary-missing',
+        engineRoot,
+        message: `UnrealEditor binary not found under --engine-root: ${editorPath}`,
+      };
+    }
+    return { kind: 'resolved', engineRoot, editorPath, installation: null };
+  }
+
+  const assoc = input.engineAssociation.trim();
+  if (input.engines.length === 0) {
+    return {
+      kind: 'unresolved',
+      reason: 'no-engines-installed',
+      message:
+        'No Unreal Engine installations found in the Epic launcher manifest. ' +
+        'Install an engine (unreal-cli install-engine) or pass --engine-root for a source build.',
+    };
+  }
+
+  if (assoc.startsWith('{')) {
+    return {
+      kind: 'unresolved',
+      reason: 'source-build-needs-root',
+      message:
+        `EngineAssociation "${assoc}" is a registered source build (GUID), which the launcher ` +
+        'manifest does not list. Pass --engine-root pointing at your engine checkout.',
+    };
+  }
+
+  const match = matchEngineForAssociation(assoc, input.engines);
+  if (!match) {
+    const installed = input.engines.map((e) => e.engineAssociation).join(', ');
+    return {
+      kind: 'unresolved',
+      reason: 'association-not-installed',
+      message:
+        `EngineAssociation "${assoc}" is not among the installed engines (${installed}). ` +
+        'Install it (unreal-cli install-engine) or pass --engine-root.',
+    };
+  }
+
+  const engineRoot = match.installLocation;
+  const editorPath = editorBinaryPath(engineRoot, os);
+  if (!exists(editorPath)) {
+    return {
+      kind: 'unresolved',
+      reason: 'editor-binary-missing',
+      engineRoot,
+      message: `Engine ${match.appName} is registered at ${engineRoot} but its UnrealEditor binary is missing: ${editorPath}`,
+    };
+  }
+  return { kind: 'resolved', engineRoot, editorPath, installation: match };
+}

--- a/cli/src/utils/env-file.ts
+++ b/cli/src/utils/env-file.ts
@@ -1,0 +1,219 @@
+// `.env` parsing / writing + `.gitignore` append helpers.
+//
+// The C++ plugin parses `<Project>/.env` with GodotMcpEnvFile's rules
+// (docs/ARCHITECTURE.md §8): skip blanks and `#` comments, split on the
+// first `=`, trim, recognize only known keys, strip a single pair of
+// matching surrounding quotes. These helpers stay 1:1 with that parser so
+// what `unreal-cli configure` writes is exactly what the plugin reads.
+//
+// Pure where possible; the read/write functions touch the filesystem but
+// never throw past their callers' try/catch — the lib boundary owns error
+// shaping.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { EOL } from 'os';
+
+/**
+ * The recognized `UNREAL_MCP_*` environment keys (docs/ARCHITECTURE.md §8).
+ * Anything outside this set is ignored on read and rejected on write so a
+ * typo never silently lands an unrecognized key in a project's `.env`.
+ */
+export const KNOWN_ENV_KEYS = [
+  'UNREAL_MCP_CONNECTION_MODE',
+  'UNREAL_MCP_HOST',
+  'UNREAL_MCP_CLOUD_URL',
+  'UNREAL_MCP_TOKEN',
+  'UNREAL_MCP_AUTH_OPTION',
+  'UNREAL_MCP_KEEP_CONNECTED',
+  'UNREAL_MCP_TOOLS',
+  'UNREAL_MCP_START_SERVER',
+  'UNREAL_MCP_TRANSPORT',
+  'UNREAL_MCP_LOG_LEVEL',
+  'UNREAL_MCP_BRIDGE_PATH',
+] as const;
+
+export type KnownEnvKey = (typeof KNOWN_ENV_KEYS)[number];
+
+const KNOWN_ENV_KEY_SET = new Set<string>(KNOWN_ENV_KEYS);
+
+export function isKnownEnvKey(key: string): key is KnownEnvKey {
+  return KNOWN_ENV_KEY_SET.has(key);
+}
+
+/**
+ * Strip a single pair of matching surrounding quotes (single or double).
+ * `"foo"` -> `foo`, `'bar'` -> `bar`, `"unbalanced` -> `"unbalanced`.
+ * Pure.
+ */
+export function stripMatchingQuotes(value: string): string {
+  if (value.length >= 2) {
+    const first = value[0];
+    const last = value[value.length - 1];
+    if ((first === '"' || first === "'") && first === last) {
+      return value.slice(1, -1);
+    }
+  }
+  return value;
+}
+
+/**
+ * Parse `.env` text into a key/value map, applying the plugin's rules:
+ * skip blank lines and `#` comments, split on the FIRST `=`, trim both
+ * sides, keep only {@link KNOWN_ENV_KEYS}, strip matching quotes from the
+ * value. Later duplicates win. Pure / no I/O.
+ */
+export function parseEnvContent(content: string): Record<KnownEnvKey, string> {
+  const out: Partial<Record<KnownEnvKey, string>> = {};
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    if (!isKnownEnvKey(key)) continue;
+    const value = stripMatchingQuotes(line.slice(eq + 1).trim());
+    out[key] = value;
+  }
+  return out as Record<KnownEnvKey, string>;
+}
+
+/** Read + parse `<file>` if present; returns `{}` when absent or unreadable. */
+export function readEnvFile(envPath: string): Record<KnownEnvKey, string> {
+  if (!fs.existsSync(envPath)) return {} as Record<KnownEnvKey, string>;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(envPath, 'utf-8');
+  } catch {
+    return {} as Record<KnownEnvKey, string>;
+  }
+  return parseEnvContent(raw);
+}
+
+/**
+ * Quote a value for `.env` only when it needs it — i.e. it contains
+ * whitespace, `#`, or a quote character. Bare tokens stay bare so a
+ * human-edited `.env` reads cleanly. Pure.
+ */
+export function quoteEnvValueIfNeeded(value: string): string {
+  if (value.length === 0) return '""';
+  if (/[\s#"']/.test(value)) {
+    return `"${value.replace(/"/g, '\\"')}"`;
+  }
+  return value;
+}
+
+/**
+ * Merge `updates` into the `.env` at `envPath`, preserving any existing
+ * lines (comments, blank lines, unknown keys, ordering) and rewriting only
+ * the keys present in `updates`. New keys are appended in a stable block.
+ * Returns the keys that were added vs updated. Touches the filesystem.
+ *
+ * A `null`/`undefined` value in `updates` deletes that key from the file.
+ */
+export function writeEnvFile(
+  envPath: string,
+  updates: Partial<Record<KnownEnvKey, string | null | undefined>>,
+): { added: KnownEnvKey[]; updated: KnownEnvKey[]; removed: KnownEnvKey[] } {
+  const existingLines = fs.existsSync(envPath)
+    ? fs.readFileSync(envPath, 'utf-8').split(/\r?\n/)
+    : [];
+
+  const added: KnownEnvKey[] = [];
+  const updated: KnownEnvKey[] = [];
+  const removed: KnownEnvKey[] = [];
+  const handled = new Set<KnownEnvKey>();
+
+  const rewritten: string[] = [];
+  for (const line of existingLines) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith('#')) {
+      rewritten.push(line);
+      continue;
+    }
+    const eq = trimmed.indexOf('=');
+    const key = eq >= 0 ? trimmed.slice(0, eq).trim() : '';
+    if (isKnownEnvKey(key) && key in updates) {
+      handled.add(key);
+      const value = updates[key];
+      if (value === null || value === undefined) {
+        removed.push(key);
+        continue; // drop the line
+      }
+      rewritten.push(`${key}=${quoteEnvValueIfNeeded(value)}`);
+      updated.push(key);
+      continue;
+    }
+    rewritten.push(line);
+  }
+
+  // Append any keys not already present.
+  const toAppend: string[] = [];
+  for (const key of KNOWN_ENV_KEYS) {
+    if (!(key in updates) || handled.has(key)) continue;
+    const value = updates[key];
+    if (value === null || value === undefined) continue;
+    toAppend.push(`${key}=${quoteEnvValueIfNeeded(value)}`);
+    added.push(key);
+  }
+
+  // Drop a trailing empty line so we don't accumulate blank lines on each
+  // round-trip, then re-join with a single trailing newline.
+  while (rewritten.length > 0 && rewritten[rewritten.length - 1].trim() === '') {
+    rewritten.pop();
+  }
+  const body = [...rewritten, ...toAppend];
+  const text = body.join(EOL) + EOL;
+
+  fs.mkdirSync(path.dirname(envPath), { recursive: true });
+  fs.writeFileSync(envPath, text, 'utf-8');
+
+  return { added, updated, removed };
+}
+
+/**
+ * Ensure `<gitignoreDir>/.gitignore` ignores `.env`, creating the file if
+ * absent. Idempotent: a line that already ignores `.env` (`/.env`, `.env`,
+ * or `*.env`) short-circuits without a write. Returns what happened so the
+ * caller can surface an accurate progress message.
+ */
+export function ensureEnvGitignored(
+  gitignoreDir: string,
+): { gitignorePath: string; action: 'created' | 'appended' | 'already-ignored' } {
+  const gitignorePath = path.join(gitignoreDir, '.gitignore');
+
+  if (!fs.existsSync(gitignorePath)) {
+    fs.mkdirSync(gitignoreDir, { recursive: true });
+    fs.writeFileSync(
+      gitignorePath,
+      `# Added by unreal-cli configure — never commit local MCP secrets.${EOL}.env${EOL}`,
+      'utf-8',
+    );
+    return { gitignorePath, action: 'created' };
+  }
+
+  const content = fs.readFileSync(gitignorePath, 'utf-8');
+  if (gitignoreAlreadyIgnoresEnv(content)) {
+    return { gitignorePath, action: 'already-ignored' };
+  }
+
+  const needsLeadingNewline = content.length > 0 && !content.endsWith('\n');
+  const appendix = `${needsLeadingNewline ? EOL : ''}.env${EOL}`;
+  fs.appendFileSync(gitignorePath, appendix, 'utf-8');
+  return { gitignorePath, action: 'appended' };
+}
+
+/**
+ * True when a `.gitignore` body already ignores `.env` via a bare `.env`,
+ * a root-anchored `/.env`, or a `*.env` glob. Negations (`!.env`) do NOT
+ * count. Pure.
+ */
+export function gitignoreAlreadyIgnoresEnv(content: string): boolean {
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith('#') || line.startsWith('!')) continue;
+    const normalized = line.replace(/^\//, '');
+    if (normalized === '.env' || normalized === '*.env') return true;
+  }
+  return false;
+}

--- a/cli/src/utils/env-file.ts
+++ b/cli/src/utils/env-file.ts
@@ -140,6 +140,11 @@ export function writeEnvFile(
     const eq = trimmed.indexOf('=');
     const key = eq >= 0 ? trimmed.slice(0, eq).trim() : '';
     if (isKnownEnvKey(key) && key in updates) {
+      // A key may appear more than once in the file. Only the FIRST occurrence
+      // is rewritten with the new value; later duplicates are dropped so the
+      // result holds a single line per key and `updated`/`removed` are not
+      // double-counted.
+      if (handled.has(key)) continue;
       handled.add(key);
       const value = updates[key];
       if (value === null || value === undefined) {

--- a/cli/src/utils/env-file.ts
+++ b/cli/src/utils/env-file.ts
@@ -63,7 +63,7 @@ export function stripMatchingQuotes(value: string): string {
  * sides, keep only {@link KNOWN_ENV_KEYS}, strip matching quotes from the
  * value. Later duplicates win. Pure / no I/O.
  */
-export function parseEnvContent(content: string): Record<KnownEnvKey, string> {
+export function parseEnvContent(content: string): Partial<Record<KnownEnvKey, string>> {
   const out: Partial<Record<KnownEnvKey, string>> = {};
   for (const rawLine of content.split(/\r?\n/)) {
     const line = rawLine.trim();
@@ -75,17 +75,17 @@ export function parseEnvContent(content: string): Record<KnownEnvKey, string> {
     const value = stripMatchingQuotes(line.slice(eq + 1).trim());
     out[key] = value;
   }
-  return out as Record<KnownEnvKey, string>;
+  return out;
 }
 
 /** Read + parse `<file>` if present; returns `{}` when absent or unreadable. */
-export function readEnvFile(envPath: string): Record<KnownEnvKey, string> {
-  if (!fs.existsSync(envPath)) return {} as Record<KnownEnvKey, string>;
+export function readEnvFile(envPath: string): Partial<Record<KnownEnvKey, string>> {
+  if (!fs.existsSync(envPath)) return {};
   let raw: string;
   try {
     raw = fs.readFileSync(envPath, 'utf-8');
   } catch {
-    return {} as Record<KnownEnvKey, string>;
+    return {};
   }
   return parseEnvContent(raw);
 }
@@ -94,11 +94,17 @@ export function readEnvFile(envPath: string): Record<KnownEnvKey, string> {
  * Quote a value for `.env` only when it needs it — i.e. it contains
  * whitespace, `#`, or a quote character. Bare tokens stay bare so a
  * human-edited `.env` reads cleanly. Pure.
+ *
+ * The value is NOT backslash-escaped: the plugin's GodotMcpEnvFile parser
+ * (and {@link stripMatchingQuotes}) only strips a single surrounding quote
+ * pair and never unescapes, so emitting `\"` would read back corrupted.
+ * Wrapping-without-escaping round-trips correctly for embedded quotes
+ * (`a"b` -> `"a"b"` -> `a"b`).
  */
 export function quoteEnvValueIfNeeded(value: string): string {
   if (value.length === 0) return '""';
   if (/[\s#"']/.test(value)) {
-    return `"${value.replace(/"/g, '\\"')}"`;
+    return `"${value}"`;
   }
   return value;
 }

--- a/cli/src/utils/launcher.ts
+++ b/cli/src/utils/launcher.ts
@@ -141,7 +141,13 @@ export function matchEngineForAssociation(
 ): EngineInstallation | null {
   const assoc = engineAssociation.trim();
   if (assoc.length === 0) {
-    return engines.length > 0 ? engines[0] : null;
+    // Highest installed engine. `parseLauncherManifest` already sorts, but
+    // `open`'s injectable `enginesImpl` may feed an unsorted list — so sort
+    // here too rather than relying on the caller's ordering.
+    if (engines.length === 0) return null;
+    return [...engines].sort((a, b) =>
+      compareEngineVersions(b.engineAssociation, a.engineAssociation),
+    )[0];
   }
   if (assoc.startsWith('{')) {
     // GUID — a registered source build; not in the launcher manifest.

--- a/cli/src/utils/launcher.ts
+++ b/cli/src/utils/launcher.ts
@@ -1,0 +1,151 @@
+// Epic Games Launcher manifest (`LauncherInstalled.dat`) parsing.
+//
+// `LauncherInstalled.dat` is a JSON file the Epic launcher maintains. It
+// lists every artifact the launcher manages — engines, marketplace
+// content, etc. Engine entries are the ones whose `AppName` looks like
+// `UE_5.7`. The CLI reads this to (a) resolve a project's
+// `EngineAssociation` to an install path (the `open` command) and (b)
+// enumerate installed engines (the `install-engine` command).
+//
+// Platform default locations:
+//   Windows : C:\ProgramData\Epic\UnrealEngineLauncher\LauncherInstalled.dat
+//   macOS   : /Users/Shared/Epic/UnrealEngineLauncher/LauncherInstalled.dat
+//
+// All parsing is pure and defensive — a missing or malformed manifest
+// yields an empty engine list, never a throw.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** A single engine installation discovered from the launcher manifest. */
+export interface EngineInstallation {
+  /** Launcher app name, e.g. `UE_5.7`. */
+  appName: string;
+  /** Full app version string, e.g. `5.7.4-12345678+++UE5+Release-5.7`. */
+  appVersion: string;
+  /** Absolute install root, e.g. `C:\Program Files\Epic Games\UE_5.7`. */
+  installLocation: string;
+  /**
+   * The `EngineAssociation` value a `.uproject` would use to reference this
+   * engine — the `UE_` prefix stripped from `appName` (`UE_5.7` -> `5.7`).
+   */
+  engineAssociation: string;
+}
+
+const RAW_ENGINE_APPNAME_RE = /^UE_(\d+\.\d+)$/;
+
+/**
+ * Resolve the platform-default `LauncherInstalled.dat` path. Returns `null`
+ * on platforms Epic does not ship a launcher manifest for (Linux), where
+ * engine discovery falls back to an explicit `--engine-root`.
+ */
+export function getDefaultLauncherManifestPath(os: NodeJS.Platform): string | null {
+  switch (os) {
+    case 'win32': {
+      const programData = process.env['PROGRAMDATA'] ?? 'C:\\ProgramData';
+      return path.win32.join(programData, 'Epic', 'UnrealEngineLauncher', 'LauncherInstalled.dat');
+    }
+    case 'darwin':
+      return path.posix.join('/Users', 'Shared', 'Epic', 'UnrealEngineLauncher', 'LauncherInstalled.dat');
+    default:
+      return null;
+  }
+}
+
+/**
+ * Parse `LauncherInstalled.dat` text into the list of ENGINE installations
+ * (entries whose `AppName` matches `UE_<major>.<minor>`). Non-engine
+ * artifacts (marketplace plugins, templates) are filtered out. Any parse
+ * failure yields `[]`. Pure / no I/O.
+ */
+export function parseLauncherManifest(content: string): EngineInstallation[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== 'object') return [];
+
+  const list = (parsed as Record<string, unknown>)['InstallationList'];
+  if (!Array.isArray(list)) return [];
+
+  const engines: EngineInstallation[] = [];
+  for (const entry of list) {
+    if (!entry || typeof entry !== 'object') continue;
+    const rec = entry as Record<string, unknown>;
+    const appName = typeof rec['AppName'] === 'string' ? rec['AppName'] : '';
+    const installLocation = typeof rec['InstallLocation'] === 'string' ? rec['InstallLocation'] : '';
+    const appVersion = typeof rec['AppVersion'] === 'string' ? rec['AppVersion'] : '';
+
+    const m = appName.match(RAW_ENGINE_APPNAME_RE);
+    if (!m || installLocation.length === 0) continue;
+
+    engines.push({
+      appName,
+      appVersion,
+      installLocation,
+      engineAssociation: m[1],
+    });
+  }
+  // Highest version first so "no association" callers get the newest engine.
+  engines.sort((a, b) => compareEngineVersions(b.engineAssociation, a.engineAssociation));
+  return engines;
+}
+
+/** Read + parse the launcher manifest at `manifestPath`; `[]` when absent. */
+export function readLauncherManifest(manifestPath: string): EngineInstallation[] {
+  if (!fs.existsSync(manifestPath)) return [];
+  let raw: string;
+  try {
+    raw = fs.readFileSync(manifestPath, 'utf-8');
+  } catch {
+    return [];
+  }
+  return parseLauncherManifest(raw);
+}
+
+/**
+ * Compare two `major.minor` engine-association strings numerically.
+ * `"5.7"` > `"5.5"` > `"4.27"`. Tolerates extra segments and non-numeric
+ * junk (treated as 0). Pure.
+ */
+export function compareEngineVersions(a: string, b: string): number {
+  const pa = a.split('.').map((s) => parseInt(s, 10));
+  const pb = b.split('.').map((s) => parseInt(s, 10));
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const x = Number.isNaN(pa[i]) || pa[i] === undefined ? 0 : pa[i];
+    const y = Number.isNaN(pb[i]) || pb[i] === undefined ? 0 : pb[i];
+    if (x !== y) return x - y;
+  }
+  return 0;
+}
+
+/**
+ * Match a project's `EngineAssociation` against the installed engines.
+ *
+ * - A launcher version association (`"5.7"`) matches the engine with that
+ *   `engineAssociation`.
+ * - An EMPTY association (source-in-tree / not yet associated) resolves to
+ *   the highest installed engine when one exists.
+ * - A GUID association (`"{...}"`, a registered source build) is NOT found
+ *   in the launcher manifest — returns `null` so the caller can surface
+ *   "source build; pass --engine-root".
+ *
+ * Pure (operates on the supplied installation list).
+ */
+export function matchEngineForAssociation(
+  engineAssociation: string,
+  engines: EngineInstallation[],
+): EngineInstallation | null {
+  const assoc = engineAssociation.trim();
+  if (assoc.length === 0) {
+    return engines.length > 0 ? engines[0] : null;
+  }
+  if (assoc.startsWith('{')) {
+    // GUID — a registered source build; not in the launcher manifest.
+    return null;
+  }
+  return engines.find((e) => e.engineAssociation === assoc) ?? null;
+}

--- a/cli/src/utils/port.ts
+++ b/cli/src/utils/port.ts
@@ -1,0 +1,23 @@
+import { createHash } from 'crypto';
+
+const MIN_PORT = 20000;
+const MAX_PORT = 29999;
+const PORT_RANGE = MAX_PORT - MIN_PORT + 1;
+
+/**
+ * Generate a deterministic localhost port from a project directory.
+ *
+ * Mirrors the proven Unity/Godot scheme (`GeneratePortFromDirectory`):
+ * SHA-256 of the lowercased directory path, first 4 bytes read as a
+ * little-endian uint32, modulo the 20000–29999 range. The UnrealMCP
+ * plugin (when it lands) will use the same hashing so the CLI can
+ * reach a project's local MCP server without reading any config.
+ *
+ * Pure / no I/O.
+ */
+export function generatePortFromDirectory(dir: string): number {
+  const hash = createHash('sha256').update(dir.toLowerCase()).digest();
+  const int32 = hash.readInt32LE(0);
+  const uint32 = int32 >>> 0;
+  return MIN_PORT + (uint32 % PORT_RANGE);
+}

--- a/cli/src/utils/probe.ts
+++ b/cli/src/utils/probe.ts
@@ -1,0 +1,84 @@
+// HTTP readiness probe against a project's local MCP server. Used by
+// `status` and `wait-for-ready`. The `ping` system tool echoes back —
+// a 2xx means the server (and the plugin behind it) is reachable.
+
+export const PING_ENDPOINT = '/api/system-tools/ping';
+
+export interface ProbeSuccess {
+  ok: true;
+  baseUrl: string;
+  httpStatus: number;
+  data: unknown;
+}
+
+export interface ProbeFailure {
+  ok: false;
+  baseUrl: string;
+  reason: string;
+}
+
+export type ProbeResult = ProbeSuccess | ProbeFailure;
+
+export interface ProbeOptions {
+  token?: string;
+  timeoutMs?: number;
+  /** Injectable fetch (defaults to global `fetch`). */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * POST `{}` to the server's `ping` endpoint. Never throws — every failure
+ * mode (connection refused, timeout, non-2xx, malformed body) is folded
+ * into a `{ ok: false }` result with a human-readable reason.
+ */
+export async function probePing(baseUrl: string, opts: ProbeOptions = {}): Promise<ProbeResult> {
+  const endpoint = `${baseUrl}${PING_ENDPOINT}`;
+  const timeoutMs = typeof opts.timeoutMs === 'number' && opts.timeoutMs > 0 ? opts.timeoutMs : 5000;
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (opts.token) headers['Authorization'] = `Bearer ${opts.token}`;
+
+  try {
+    const response = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers,
+      body: '{}',
+      signal: controller.signal,
+    });
+    const text = await response.text().catch(() => '');
+    if (response.ok) {
+      let data: unknown;
+      try {
+        data = text.length > 0 ? JSON.parse(text) : undefined;
+      } catch {
+        data = text;
+      }
+      return { ok: true, baseUrl, httpStatus: response.status, data };
+    }
+    return { ok: false, baseUrl, reason: `HTTP ${response.status}` };
+  } catch (err) {
+    return { ok: false, baseUrl, reason: classifyError(err) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function classifyError(err: unknown): string {
+  if (err instanceof Error && err.name === 'AbortError') return 'timed out';
+  const cause =
+    err instanceof Error && 'cause' in err ? (err.cause as { code?: string } | undefined) : undefined;
+  switch (cause?.code) {
+    case 'ECONNREFUSED':
+      return 'connection refused';
+    case 'ECONNRESET':
+      return 'connection reset';
+    case 'ENOTFOUND':
+    case 'EAI_AGAIN':
+      return 'host not found';
+    default:
+      return err instanceof Error ? err.message : String(err);
+  }
+}

--- a/cli/src/utils/probe.ts
+++ b/cli/src/utils/probe.ts
@@ -2,6 +2,12 @@
 // `status` and `wait-for-ready`. The `ping` system tool echoes back —
 // a 2xx means the server (and the plugin behind it) is reachable.
 
+// NOTE (doc/code reconciliation): docs/ARCHITECTURE.md's headless-e2e runbook
+// line still cites `POST /api/tools/ping` (the Godot testbed route). This
+// client deliberately uses `/api/system-tools/ping` to match unity-mcp-cli and
+// the `run-system-tool` route. The Unreal server does not exist yet, so the
+// discrepancy is unfalsifiable today; whoever lands the server reconciles it —
+// the doc line should move to `/api/system-tools/ping`.
 export const PING_ENDPOINT = '/api/system-tools/ping';
 
 export interface ProbeSuccess {

--- a/cli/src/utils/project.ts
+++ b/cli/src/utils/project.ts
@@ -1,0 +1,104 @@
+// Unreal project resolution: locate the `.uproject`, read its
+// `EngineAssociation`, and expose small pure helpers shared by the
+// `open` / `status` / `install-plugin` command logic.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface UProjectInfo {
+  /** Absolute path to the `.uproject` file. */
+  uprojectPath: string;
+  /** Absolute path to the project root (the `.uproject`'s directory). */
+  projectDir: string;
+  /** Project name (the `.uproject` basename without extension). */
+  projectName: string;
+  /**
+   * `EngineAssociation` field verbatim. A launcher build is a version
+   * string (`"5.7"`); a source build is a GUID (`"{...}"`) or empty.
+   */
+  engineAssociation: string;
+}
+
+/**
+ * Resolve a project path argument to an absolute directory. An explicit
+ * value wins; otherwise the supplied `cwd` is used. Pure / no I/O.
+ */
+export function resolveProjectDir(
+  optionPath: string | undefined,
+  cwd: string,
+): { projectDir: string; usedCwdFallback: boolean } {
+  const explicit = optionPath;
+  const resolved = explicit ?? cwd;
+  return { projectDir: path.resolve(resolved), usedCwdFallback: explicit === undefined };
+}
+
+/**
+ * Find the single `.uproject` directly inside `projectDir`. Returns the
+ * absolute path, or `null` when none (or, deterministically, the first
+ * alphabetically when several — UE itself only supports one per folder).
+ */
+export function findUProjectFile(projectDir: string): string | null {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(projectDir);
+  } catch {
+    return null;
+  }
+  const uprojects = entries
+    .filter((e) => e.toLowerCase().endsWith('.uproject'))
+    .sort((a, b) => a.localeCompare(b));
+  if (uprojects.length === 0) return null;
+  return path.join(projectDir, uprojects[0]);
+}
+
+/** True when `projectDir` contains a `.uproject`. Pure-ish (one readdir). */
+export function isUnrealProjectDir(projectDir: string): boolean {
+  return findUProjectFile(projectDir) !== null;
+}
+
+/**
+ * Extract `EngineAssociation` from a parsed `.uproject` JSON. Tolerates the
+ * field being absent (source-in-tree builds) by returning `''`. Pure.
+ */
+export function readEngineAssociation(uprojectJson: unknown): string {
+  if (uprojectJson && typeof uprojectJson === 'object') {
+    const assoc = (uprojectJson as Record<string, unknown>)['EngineAssociation'];
+    if (typeof assoc === 'string') return assoc.trim();
+  }
+  return '';
+}
+
+/**
+ * Read + parse the `.uproject` at `projectDir` (or at an explicit
+ * `uprojectPath`). Returns structured info or `null` when there is no
+ * `.uproject` / the file is unreadable / the JSON is malformed.
+ */
+export function readUProject(projectDirOrFile: string): UProjectInfo | null {
+  let uprojectPath: string | null;
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(projectDirOrFile);
+  } catch {
+    return null;
+  }
+  if (stat.isDirectory()) {
+    uprojectPath = findUProjectFile(projectDirOrFile);
+  } else {
+    uprojectPath = projectDirOrFile.toLowerCase().endsWith('.uproject') ? projectDirOrFile : null;
+  }
+  if (!uprojectPath) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(uprojectPath, 'utf-8'));
+  } catch {
+    return null;
+  }
+
+  return {
+    uprojectPath,
+    projectDir: path.dirname(uprojectPath),
+    projectName: path.basename(uprojectPath, path.extname(uprojectPath)),
+    engineAssociation: readEngineAssociation(parsed),
+  };
+}

--- a/cli/src/utils/repo.ts
+++ b/cli/src/utils/repo.ts
@@ -1,0 +1,29 @@
+// Locate the Unreal-MCP repo root (and its `UnrealMCP/` plugin source) from
+// the installed CLI's own location, so `install-plugin` / `update` /
+// `bootstrap-local` have a sane default source without the user passing
+// `--plugin-source`. Pure-ish (filesystem existence checks only).
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Walk up from `startDir` looking for a directory that contains
+ * `UnrealMCP/UnrealMCP.uplugin` (the repo root). Returns it, or `null` when
+ * the CLI was installed outside the repo (e.g. via npm global). Pure-ish.
+ */
+export function findRepoRoot(startDir: string): string | null {
+  let dir = path.resolve(startDir);
+  for (let i = 0; i < 8; i++) {
+    if (fs.existsSync(path.join(dir, 'UnrealMCP', 'UnrealMCP.uplugin'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/** Default plugin source = `<repoRoot>/UnrealMCP`, or `null`. */
+export function defaultPluginSource(startDir: string): string | null {
+  const root = findRepoRoot(startDir);
+  return root ? path.join(root, 'UnrealMCP') : null;
+}

--- a/cli/src/utils/ui.ts
+++ b/cli/src/utils/ui.ts
@@ -1,0 +1,47 @@
+// Minimal console UI helpers for the CLI command layer. The library layer
+// (`lib/*`, `utils/*` other than this file) must NEVER import this — all
+// stdout/stderr writes live here so the library stays side-effect-free.
+
+let verboseEnabled = false;
+
+export function setVerbose(on: boolean): void {
+  verboseEnabled = on;
+}
+
+export function verbose(message: string): void {
+  if (verboseEnabled) process.stderr.write(`[verbose] ${message}\n`);
+}
+
+export function info(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+export function success(message: string): void {
+  process.stdout.write(`✓ ${message}\n`);
+}
+
+export function warn(message: string): void {
+  process.stderr.write(`! ${message}\n`);
+}
+
+export function error(message: string): void {
+  process.stderr.write(`✗ ${message}\n`);
+}
+
+export function heading(message: string): void {
+  process.stdout.write(`\n${message}\n`);
+}
+
+export function label(key: string, value: string): void {
+  process.stdout.write(`  ${key}: ${value}\n`);
+}
+
+/** Print a list of warnings (no-op when empty). */
+export function printWarnings(warnings: string[]): void {
+  for (const w of warnings) warn(w);
+}
+
+/** Pretty-print a JSON value. */
+export function json(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}

--- a/cli/tests/bootstrap-local.test.ts
+++ b/cli/tests/bootstrap-local.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as path from 'path';
+import { bootstrapLocal, planBuildSteps, ridForPlatform } from '../src/lib/bootstrap-local.js';
+import { makeTempDir, rmTempDir } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+describe('ridForPlatform', () => {
+  it('maps platforms to RIDs', () => {
+    expect(ridForPlatform('win32')).toBe('win-x64');
+    expect(ridForPlatform('darwin', 'arm64')).toBe('osx-arm64');
+    expect(ridForPlatform('darwin', 'x64')).toBe('osx-x64');
+    expect(ridForPlatform('linux')).toBe('linux-x64');
+  });
+});
+
+describe('planBuildSteps', () => {
+  it('plans bridge + server into Intermediate/UnrealMCP/<leg>/<rid>', () => {
+    const { steps, outputRoot } = planBuildSteps('/repo', '/proj', 'win32', 'x64');
+    expect(outputRoot).toBe(path.join(path.resolve('/proj'), 'Intermediate', 'UnrealMCP'));
+    expect(steps).toHaveLength(2);
+    expect(steps[0].label).toBe('bridge');
+    expect(steps[0].outputDir).toContain(path.join('Intermediate', 'UnrealMCP', 'bridge', 'win-x64'));
+    expect(steps[0].projectFile).toContain(path.join('bridge', 'src'));
+    expect(steps[1].label).toBe('server');
+    expect(steps[1].projectFile).toContain('Unreal-MCP-Server');
+  });
+});
+
+describe('bootstrapLocal', () => {
+  it('runs each build step via the injected builder', async () => {
+    const built: string[] = [];
+    const r = await bootstrapLocal({
+      projectDir: tmp(),
+      repoRoot: '/repo',
+      os: 'win32',
+      buildImpl: async (step) => {
+        built.push(step.label);
+      },
+    });
+    expect(r.kind).toBe('success');
+    expect(built).toEqual(['bridge', 'server']);
+  });
+
+  it('returns failure (no throw) when a build step throws', async () => {
+    const r = await bootstrapLocal({
+      projectDir: tmp(),
+      repoRoot: '/repo',
+      os: 'win32',
+      buildImpl: async () => {
+        throw new Error('dotnet missing');
+      },
+    });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.error.message).toContain('dotnet missing');
+  });
+});

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -2,55 +2,73 @@ import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'child_process';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { getStatus } from '../src/lib.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = path.resolve(__dirname, '..', 'bin', 'unreal-cli.js');
 
 function runCli(args: string[]): { stdout: string; exitCode: number } {
   try {
-    const stdout = execFileSync('node', [CLI_PATH, ...args], {
-      encoding: 'utf-8',
-      timeout: 15000,
-    });
+    const stdout = execFileSync('node', [CLI_PATH, ...args], { encoding: 'utf-8', timeout: 20000 });
     return { stdout, exitCode: 0 };
   } catch (err: unknown) {
-    const error = err as { stdout?: string; stderr?: string; status?: number };
-    return {
-      stdout: (error.stdout ?? '') + (error.stderr ?? ''),
-      exitCode: error.status ?? 1,
-    };
+    const e = err as { stdout?: string; stderr?: string; status?: number };
+    return { stdout: (e.stdout ?? '') + (e.stderr ?? ''), exitCode: e.status ?? 1 };
   }
 }
 
+const ALL_COMMANDS = [
+  'create-project',
+  'open',
+  'close',
+  'install-plugin',
+  'remove-plugin',
+  'configure',
+  'setup-mcp',
+  'login',
+  'status',
+  'wait-for-ready',
+  'run-tool',
+  'run-system-tool',
+  'bootstrap-local',
+  'update',
+  'install-engine',
+  'setup-skills',
+];
+
 describe('CLI integration', () => {
-  it('shows help with --help, listing the status command', () => {
+  it('--help lists every one of the 16 commands', () => {
     const { stdout, exitCode } = runCli(['--help']);
     expect(exitCode).toBe(0);
     expect(stdout).toContain('unreal-cli');
-    expect(stdout).toContain('status');
+    for (const cmd of ALL_COMMANDS) {
+      expect(stdout, `help should list ${cmd}`).toContain(cmd);
+    }
   });
 
-  it('shows the semver version with --version', () => {
+  it('--version prints semver', () => {
     const { stdout, exitCode } = runCli(['--version']);
     expect(exitCode).toBe(0);
     expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
   });
 
-  it('status prints name and version', () => {
-    const { stdout, exitCode } = runCli(['status']);
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain('unreal-cli v');
-    expect(stdout).toContain('pre-alpha scaffold');
+  it('each command exposes its own --help (is registered + invokable)', () => {
+    for (const cmd of ALL_COMMANDS) {
+      const { stdout, exitCode } = runCli([cmd, '--help']);
+      expect(exitCode, `${cmd} --help should exit 0`).toBe(0);
+      expect(stdout, `${cmd} --help should name the command`).toContain(cmd);
+    }
   });
-});
 
-describe('library export (dist/lib.js contract)', () => {
-  it('getStatus returns a success discriminated union with the package version', () => {
-    const status = getStatus();
-    expect(status.kind).toBe('success');
-    expect(status.success).toBe(true);
-    expect(status.name).toBe('unreal-cli');
-    expect(status.version).toMatch(/^\d+\.\d+\.\d+$/);
+  it('status runs and prints the package identity', () => {
+    const { stdout, exitCode } = runCli(['status', '--no-probe']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/unreal-cli v\d+\.\d+\.\d+/);
+  });
+
+  it('install-engine with no version lists installed engines (no crash)', () => {
+    const fixture = path.resolve(__dirname, 'fixtures', 'LauncherInstalled.dat');
+    const { stdout, exitCode } = runCli(['install-engine', '--manifest', fixture]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('5.7');
   });
 });

--- a/cli/tests/close.test.ts
+++ b/cli/tests/close.test.ts
@@ -31,6 +31,14 @@ describe('selectEditorProcesses', () => {
     expect(pids).not.toContain(2);
     expect(pids).not.toContain(4); // not an UnrealEditor process
   });
+
+  it('does not match a sibling directory sharing a prefix', () => {
+    const sibling: RunningProcess[] = [
+      { pid: 7, commandLine: `UnrealEditor.exe "${path.join(projectDir + '2', 'Other.uproject')}"` },
+    ];
+    const matched = selectEditorProcesses(sibling, projectDir, uproject);
+    expect(matched.map((p) => p.pid)).not.toContain(7);
+  });
 });
 
 describe('close', () => {
@@ -55,5 +63,18 @@ describe('close', () => {
     const r = await close({ projectDir: dir, listProcessesImpl: () => [], killImpl: () => {} });
     expect(r.kind).toBe('success');
     if (r.kind === 'success') expect(r.wasRunning).toBe(false);
+  });
+
+  it('refuses (no kill) when the directory has no .uproject', async () => {
+    const dir = tmp(); // empty — not an Unreal project
+    const killed: number[] = [];
+    const r = await close({
+      projectDir: dir,
+      listProcessesImpl: () => [{ pid: 1, commandLine: `UnrealEditor.exe "${dir}"` }],
+      killImpl: (pid) => killed.push(pid),
+    });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.error.message).toContain('.uproject');
+    expect(killed).toEqual([]);
   });
 });

--- a/cli/tests/close.test.ts
+++ b/cli/tests/close.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as path from 'path';
+import { close, selectEditorProcesses, type RunningProcess } from '../src/lib/close.js';
+import { makeTempDir, rmTempDir, writeUProject } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+describe('selectEditorProcesses', () => {
+  const projectDir = path.resolve('/work/MyGame');
+  const uproject = path.join(projectDir, 'MyGame.uproject');
+  const procs: RunningProcess[] = [
+    { pid: 1, commandLine: `"C:/UE/UnrealEditor.exe" "${uproject}"` },
+    { pid: 2, commandLine: 'chrome.exe --foo' },
+    { pid: 3, commandLine: `UnrealEditor.exe "C:/work/MyGame/Other.uproject"` },
+    { pid: 4, commandLine: 'notepad.exe MyGame.uproject' },
+  ];
+
+  it('matches editor processes referencing the project (.uproject or dir)', () => {
+    const matched = selectEditorProcesses(procs, projectDir, uproject);
+    const pids = matched.map((p) => p.pid).sort();
+    expect(pids).toContain(1);
+    expect(pids).toContain(3); // same dir, different uproject
+    expect(pids).not.toContain(2);
+    expect(pids).not.toContain(4); // not an UnrealEditor process
+  });
+});
+
+describe('close', () => {
+  it('terminates matched editor processes via injected kill', async () => {
+    const dir = tmp();
+    writeUProject(dir, 'MyGame', '5.7');
+    const killed: number[] = [];
+    const r = await close({
+      projectDir: dir,
+      listProcessesImpl: () => [{ pid: 99, commandLine: `UnrealEditor.exe "${path.join(dir, 'MyGame.uproject')}"` }],
+      killImpl: (pid) => killed.push(pid),
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.wasRunning).toBe(true);
+    expect(killed).toEqual([99]);
+  });
+
+  it('reports wasRunning=false when nothing matches', async () => {
+    const dir = tmp();
+    writeUProject(dir, 'MyGame', '5.7');
+    const r = await close({ projectDir: dir, listProcessesImpl: () => [], killImpl: () => {} });
+    expect(r.kind).toBe('success');
+    if (r.kind === 'success') expect(r.wasRunning).toBe(false);
+  });
+});

--- a/cli/tests/configure.test.ts
+++ b/cli/tests/configure.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { configure } from '../src/lib/configure.js';
+import { readEnvFile } from '../src/utils/env-file.js';
+import { makeTempDir, rmTempDir } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+describe('configure', () => {
+  it('writes UNREAL_MCP_* into .env AND gitignores .env (acceptance criterion)', async () => {
+    const dir = tmp();
+    const result = await configure({
+      projectDir: dir,
+      connectionMode: 'Custom',
+      host: 'http://localhost:5220',
+      token: 'sekret',
+      authOption: 'required',
+      keepConnected: true,
+    });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+
+    const env = readEnvFile(result.envPath);
+    expect(env['UNREAL_MCP_CONNECTION_MODE']).toBe('Custom');
+    expect(env['UNREAL_MCP_HOST']).toBe('http://localhost:5220');
+    expect(env['UNREAL_MCP_TOKEN']).toBe('sekret');
+    expect(env['UNREAL_MCP_AUTH_OPTION']).toBe('required');
+    expect(env['UNREAL_MCP_KEEP_CONNECTED']).toBe('true');
+
+    // .gitignore created and ignores .env
+    expect(result.gitignoreAction).toBe('created');
+    const gi = fs.readFileSync(path.join(dir, '.gitignore'), 'utf-8');
+    expect(gi).toContain('.env');
+  });
+
+  it('appends .env to an existing .gitignore', async () => {
+    const dir = tmp();
+    fs.writeFileSync(path.join(dir, '.gitignore'), 'Binaries/\n', 'utf-8');
+    const result = await configure({ projectDir: dir, host: 'http://h' });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.gitignoreAction).toBe('appended');
+    expect(fs.readFileSync(path.join(dir, '.gitignore'), 'utf-8')).toContain('.env');
+  });
+
+  it('respects ensureGitignore=false (env-only)', async () => {
+    const dir = tmp();
+    const result = await configure({ projectDir: dir, host: 'http://h', ensureGitignore: false });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.gitignoreAction).toBe('skipped');
+    expect(fs.existsSync(path.join(dir, '.gitignore'))).toBe(false);
+  });
+
+  it('updates a single key without clobbering others on a second call', async () => {
+    const dir = tmp();
+    await configure({ projectDir: dir, host: 'http://a', token: 'tok' });
+    await configure({ projectDir: dir, host: 'http://b' });
+    const env = readEnvFile(path.join(dir, '.env'));
+    expect(env['UNREAL_MCP_HOST']).toBe('http://b');
+    expect(env['UNREAL_MCP_TOKEN']).toBe('tok');
+  });
+
+  it('fails (no throw) for a missing project dir', async () => {
+    const result = await configure({ projectDir: path.join(makeTempDir(), 'does-not-exist') });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') expect(result.error).toBeInstanceOf(Error);
+  });
+});

--- a/cli/tests/configure.test.ts
+++ b/cli/tests/configure.test.ts
@@ -70,6 +70,16 @@ describe('configure', () => {
     expect(env['UNREAL_MCP_TOKEN']).toBe('tok');
   });
 
+  it('leaves .env unwritten and warns when no values are supplied', async () => {
+    const dir = tmp();
+    const result = await configure({ projectDir: dir, ensureGitignore: false });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.keysWritten).toEqual([]);
+    expect(fs.existsSync(path.join(dir, '.env'))).toBe(false);
+    expect(result.warnings.join(' ')).toContain('left unchanged');
+  });
+
   it('fails (no throw) for a missing project dir', async () => {
     const result = await configure({ projectDir: path.join(makeTempDir(), 'does-not-exist') });
     expect(result.kind).toBe('failure');

--- a/cli/tests/create-project.test.ts
+++ b/cli/tests/create-project.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createProject, renderProjectTemplate, validateModuleName } from '../src/lib/create-project.js';
+import { makeTempDir, rmTempDir } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+describe('validateModuleName', () => {
+  it('accepts valid C++ identifiers and rejects hyphens/spaces/leading digits', () => {
+    expect(validateModuleName('MyGame').ok).toBe(true);
+    expect(validateModuleName('My_Game2').ok).toBe(true);
+    expect(validateModuleName('My-Game').ok).toBe(false);
+    expect(validateModuleName('My Game').ok).toBe(false);
+    expect(validateModuleName('2Game').ok).toBe(false);
+    expect(validateModuleName('').ok).toBe(false);
+  });
+});
+
+describe('renderProjectTemplate', () => {
+  it('emits a .uproject with the right module + engine association', () => {
+    const files = renderProjectTemplate('MyGame', '5.7');
+    const uproject = files.find((f) => f.relPath === 'MyGame.uproject');
+    expect(uproject).toBeDefined();
+    const parsed = JSON.parse(uproject!.content);
+    expect(parsed.EngineAssociation).toBe('5.7');
+    expect(parsed.Modules[0].Name).toBe('MyGame');
+  });
+
+  it('emits build/target/module files and a .gitignore ignoring .env', () => {
+    const files = renderProjectTemplate('MyGame', '5.7');
+    const rels = files.map((f) => f.relPath.replace(/\\/g, '/'));
+    expect(rels).toContain('Source/MyGame/MyGame.Build.cs');
+    expect(rels).toContain('Source/MyGame.Target.cs');
+    expect(rels).toContain('Source/MyGameEditor.Target.cs');
+    const gi = files.find((f) => f.relPath === '.gitignore');
+    expect(gi!.content).toContain('.env');
+  });
+});
+
+describe('createProject', () => {
+  it('scaffolds files to disk', async () => {
+    const parent = tmp();
+    const target = path.join(parent, 'NewGame');
+    const r = await createProject({ projectDir: target, engineAssociation: '5.7' });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.projectName).toBe('NewGame');
+    expect(fs.existsSync(r.uprojectPath)).toBe(true);
+    expect(fs.existsSync(path.join(target, 'Source', 'NewGame', 'NewGame.Build.cs'))).toBe(true);
+    expect(r.filesWritten.length).toBeGreaterThan(5);
+  });
+
+  it('rejects a hyphenated directory name unless --name is given', async () => {
+    const parent = tmp();
+    const r = await createProject({ projectDir: path.join(parent, 'my-game') });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.errorMessage).toContain('valid UE module name');
+  });
+
+  it('accepts an explicit --name for a hyphenated directory', async () => {
+    const parent = tmp();
+    const r = await createProject({ projectDir: path.join(parent, 'my-game'), projectName: 'MyGame' });
+    expect(r.kind).toBe('success');
+    if (r.kind === 'success') expect(r.projectName).toBe('MyGame');
+  });
+
+  it('refuses a non-empty dir without --force', async () => {
+    const target = tmp();
+    fs.writeFileSync(path.join(target, 'existing.txt'), 'x', 'utf-8');
+    const r = await createProject({ projectDir: target, projectName: 'MyGame' });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.errorMessage).toContain('not empty');
+  });
+});

--- a/cli/tests/engine.test.ts
+++ b/cli/tests/engine.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import { editorBinaryPath, resolveEngine } from '../src/utils/engine.js';
+import { parseLauncherManifest, type EngineInstallation } from '../src/utils/launcher.js';
+import { launcherFixturePath } from './helpers.js';
+
+const engines: EngineInstallation[] = parseLauncherManifest(fs.readFileSync(launcherFixturePath(), 'utf-8'));
+
+describe('editorBinaryPath', () => {
+  it('builds the Win64 UnrealEditor path', () => {
+    expect(editorBinaryPath('C:\\Engine', 'win32')).toMatch(/Engine[\\/]Binaries[\\/]Win64[\\/]UnrealEditor\.exe$/);
+  });
+  it('builds the -Cmd variant', () => {
+    expect(editorBinaryPath('C:\\Engine', 'win32', true)).toMatch(/UnrealEditor-Cmd\.exe$/);
+  });
+  it('builds the macOS .app path', () => {
+    expect(editorBinaryPath('/Engine', 'darwin')).toContain('UnrealEditor.app/Contents/MacOS/UnrealEditor');
+  });
+  it('builds the Linux path', () => {
+    expect(editorBinaryPath('/Engine', 'linux')).toMatch(/Engine\/Binaries\/Linux\/UnrealEditor$/);
+  });
+});
+
+describe('resolveEngine', () => {
+  const existsAll = () => true;
+
+  it('resolves a launcher version association to its editor binary', () => {
+    const r = resolveEngine({ engineAssociation: '5.7', engines, os: 'win32', existsImpl: existsAll });
+    expect(r.kind).toBe('resolved');
+    if (r.kind === 'resolved') {
+      expect(r.engineRoot).toBe('C:\\Program Files\\Epic Games\\UE_5.7');
+      expect(r.editorPath).toMatch(/UnrealEditor\.exe$/);
+      expect(r.installation?.appName).toBe('UE_5.7');
+    }
+  });
+
+  it('resolves an empty association to the highest installed engine', () => {
+    const r = resolveEngine({ engineAssociation: '', engines, os: 'win32', existsImpl: existsAll });
+    expect(r.kind).toBe('resolved');
+    if (r.kind === 'resolved') expect(r.installation?.engineAssociation).toBe('5.7');
+  });
+
+  it('honors an explicit engine-root override (skips the manifest)', () => {
+    const r = resolveEngine({
+      engineAssociation: '{guid}',
+      engines: [],
+      engineRootOverride: 'C:\\Src\\UE5',
+      os: 'win32',
+      existsImpl: existsAll,
+    });
+    expect(r.kind).toBe('resolved');
+    if (r.kind === 'resolved') expect(r.installation).toBeNull();
+  });
+
+  it('reports source-build-needs-root for a GUID association', () => {
+    const r = resolveEngine({ engineAssociation: '{abc}', engines, os: 'win32', existsImpl: existsAll });
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') expect(r.reason).toBe('source-build-needs-root');
+  });
+
+  it('reports no-engines-installed when the manifest is empty', () => {
+    const r = resolveEngine({ engineAssociation: '5.7', engines: [], os: 'win32', existsImpl: existsAll });
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') expect(r.reason).toBe('no-engines-installed');
+  });
+
+  it('reports association-not-installed for an unknown version', () => {
+    const r = resolveEngine({ engineAssociation: '4.27', engines, os: 'win32', existsImpl: existsAll });
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') expect(r.reason).toBe('association-not-installed');
+  });
+
+  it('reports editor-binary-missing when the binary is absent', () => {
+    const r = resolveEngine({ engineAssociation: '5.7', engines, os: 'win32', existsImpl: () => false });
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') expect(r.reason).toBe('editor-binary-missing');
+  });
+});

--- a/cli/tests/env-file.test.ts
+++ b/cli/tests/env-file.test.ts
@@ -79,6 +79,15 @@ describe('writeEnvFile', () => {
     expect(fs.readFileSync(envPath, 'utf-8')).toContain('UNREAL_MCP_TOOLS="a b c"');
   });
 
+  it('round-trips a value containing a double-quote without corruption', () => {
+    const dir = tmp();
+    const envPath = path.join(dir, '.env');
+    writeEnvFile(envPath, { UNREAL_MCP_TOOLS: 'a"b' });
+    // No backslash escaping is emitted, so the plugin parser reads it back verbatim.
+    expect(fs.readFileSync(envPath, 'utf-8')).not.toContain('\\"');
+    expect(readEnvFile(envPath)['UNREAL_MCP_TOOLS']).toBe('a"b');
+  });
+
   it('removes a key when the value is null', () => {
     const dir = tmp();
     const envPath = path.join(dir, '.env');

--- a/cli/tests/env-file.test.ts
+++ b/cli/tests/env-file.test.ts
@@ -88,6 +88,19 @@ describe('writeEnvFile', () => {
     expect(readEnvFile(envPath)['UNREAL_MCP_TOOLS']).toBe('a"b');
   });
 
+  it('collapses duplicate key lines and counts the update once', () => {
+    // Regression: a file with the same known key twice used to rewrite BOTH
+    // lines and push the key into `updated` twice, leaving a duplicate behind.
+    const dir = tmp();
+    const envPath = path.join(dir, '.env');
+    fs.writeFileSync(envPath, 'UNREAL_MCP_HOST=old1\nMY_OWN_VAR=1\nUNREAL_MCP_HOST=old2\n', 'utf-8');
+    const r = writeEnvFile(envPath, { UNREAL_MCP_HOST: 'new' });
+    expect(r.updated).toEqual(['UNREAL_MCP_HOST']);
+    const lines = fs.readFileSync(envPath, 'utf-8').split(/\r?\n/).filter(Boolean);
+    expect(lines.filter((l) => l.startsWith('UNREAL_MCP_HOST='))).toEqual(['UNREAL_MCP_HOST=new']);
+    expect(lines).toContain('MY_OWN_VAR=1');
+  });
+
   it('removes a key when the value is null', () => {
     const dir = tmp();
     const envPath = path.join(dir, '.env');

--- a/cli/tests/env-file.test.ts
+++ b/cli/tests/env-file.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  parseEnvContent,
+  stripMatchingQuotes,
+  writeEnvFile,
+  readEnvFile,
+  ensureEnvGitignored,
+  gitignoreAlreadyIgnoresEnv,
+} from '../src/utils/env-file.js';
+import { makeTempDir, rmTempDir } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+describe('parseEnvContent (plugin parser rules)', () => {
+  it('skips blanks/comments, splits on first =, trims, strips quotes, keeps known keys', () => {
+    const parsed = parseEnvContent(
+      [
+        '# comment',
+        '',
+        '  UNREAL_MCP_HOST = http://localhost:1234  ',
+        'UNREAL_MCP_TOKEN="secret=with=eq"',
+        "UNREAL_MCP_TRANSPORT='http'",
+        'UNKNOWN_KEY=ignored',
+        'malformed-line-no-eq',
+      ].join('\n'),
+    );
+    expect(parsed['UNREAL_MCP_HOST']).toBe('http://localhost:1234');
+    expect(parsed['UNREAL_MCP_TOKEN']).toBe('secret=with=eq');
+    expect(parsed['UNREAL_MCP_TRANSPORT']).toBe('http');
+    expect((parsed as Record<string, string>)['UNKNOWN_KEY']).toBeUndefined();
+  });
+});
+
+describe('stripMatchingQuotes', () => {
+  it('strips a matching pair only', () => {
+    expect(stripMatchingQuotes('"x"')).toBe('x');
+    expect(stripMatchingQuotes("'x'")).toBe('x');
+    expect(stripMatchingQuotes('"x')).toBe('"x');
+    expect(stripMatchingQuotes('x')).toBe('x');
+  });
+});
+
+describe('writeEnvFile', () => {
+  it('creates a new .env and reports added keys', () => {
+    const dir = tmp();
+    const envPath = path.join(dir, '.env');
+    const r = writeEnvFile(envPath, { UNREAL_MCP_HOST: 'http://localhost:5000', UNREAL_MCP_TOKEN: 'tok' });
+    expect(r.added.sort()).toEqual(['UNREAL_MCP_HOST', 'UNREAL_MCP_TOKEN']);
+    expect(readEnvFile(envPath)['UNREAL_MCP_HOST']).toBe('http://localhost:5000');
+  });
+
+  it('updates an existing key in place and preserves comments + unknown lines', () => {
+    const dir = tmp();
+    const envPath = path.join(dir, '.env');
+    fs.writeFileSync(envPath, '# keep me\nUNREAL_MCP_HOST=old\nMY_OWN_VAR=1\n', 'utf-8');
+    const r = writeEnvFile(envPath, { UNREAL_MCP_HOST: 'new' });
+    expect(r.updated).toEqual(['UNREAL_MCP_HOST']);
+    const text = fs.readFileSync(envPath, 'utf-8');
+    expect(text).toContain('# keep me');
+    expect(text).toContain('MY_OWN_VAR=1');
+    expect(text).toContain('UNREAL_MCP_HOST=new');
+    expect(text).not.toContain('UNREAL_MCP_HOST=old');
+  });
+
+  it('quotes values that contain whitespace', () => {
+    const dir = tmp();
+    const envPath = path.join(dir, '.env');
+    writeEnvFile(envPath, { UNREAL_MCP_TOOLS: 'a b c' });
+    expect(fs.readFileSync(envPath, 'utf-8')).toContain('UNREAL_MCP_TOOLS="a b c"');
+  });
+
+  it('removes a key when the value is null', () => {
+    const dir = tmp();
+    const envPath = path.join(dir, '.env');
+    writeEnvFile(envPath, { UNREAL_MCP_HOST: 'x', UNREAL_MCP_TOKEN: 'y' });
+    writeEnvFile(envPath, { UNREAL_MCP_TOKEN: null });
+    const parsed = readEnvFile(envPath);
+    expect(parsed['UNREAL_MCP_HOST']).toBe('x');
+    expect(parsed['UNREAL_MCP_TOKEN']).toBeUndefined();
+  });
+});
+
+describe('ensureEnvGitignored', () => {
+  it('creates .gitignore when absent', () => {
+    const dir = tmp();
+    const r = ensureEnvGitignored(dir);
+    expect(r.action).toBe('created');
+    expect(fs.readFileSync(r.gitignorePath, 'utf-8')).toContain('.env');
+  });
+
+  it('appends .env when .gitignore exists without it', () => {
+    const dir = tmp();
+    fs.writeFileSync(path.join(dir, '.gitignore'), 'node_modules/\n', 'utf-8');
+    const r = ensureEnvGitignored(dir);
+    expect(r.action).toBe('appended');
+    const text = fs.readFileSync(r.gitignorePath, 'utf-8');
+    expect(text).toContain('node_modules/');
+    expect(text).toMatch(/\.env\s*$/);
+  });
+
+  it('is a no-op when .env is already ignored', () => {
+    const dir = tmp();
+    fs.writeFileSync(path.join(dir, '.gitignore'), 'Binaries/\n.env\n', 'utf-8');
+    const r = ensureEnvGitignored(dir);
+    expect(r.action).toBe('already-ignored');
+  });
+
+  it('does not double-append when the file has no trailing newline', () => {
+    const dir = tmp();
+    fs.writeFileSync(path.join(dir, '.gitignore'), 'Saved/', 'utf-8'); // no newline
+    const r = ensureEnvGitignored(dir);
+    expect(r.action).toBe('appended');
+    const lines = fs.readFileSync(r.gitignorePath, 'utf-8').split(/\r?\n/).filter(Boolean);
+    expect(lines).toContain('Saved/');
+    expect(lines).toContain('.env');
+  });
+});
+
+describe('gitignoreAlreadyIgnoresEnv', () => {
+  it('detects .env, /.env, and *.env (but not negations)', () => {
+    expect(gitignoreAlreadyIgnoresEnv('.env')).toBe(true);
+    expect(gitignoreAlreadyIgnoresEnv('/.env')).toBe(true);
+    expect(gitignoreAlreadyIgnoresEnv('*.env')).toBe(true);
+    expect(gitignoreAlreadyIgnoresEnv('!.env')).toBe(false);
+    expect(gitignoreAlreadyIgnoresEnv('# .env')).toBe(false);
+    expect(gitignoreAlreadyIgnoresEnv('node_modules/')).toBe(false);
+  });
+});

--- a/cli/tests/fixtures/LauncherInstalled.dat
+++ b/cli/tests/fixtures/LauncherInstalled.dat
@@ -1,0 +1,28 @@
+{
+	"InstallationList": [
+		{
+			"InstallLocation": "C:\\Program Files\\Epic Games\\UE_5.7",
+			"NamespaceId": "ue",
+			"ItemId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			"ArtifactId": "UE_5.7",
+			"AppVersion": "5.7.4-40574608+++UE5+Release-5.7",
+			"AppName": "UE_5.7"
+		},
+		{
+			"InstallLocation": "D:\\Epic\\UE_5.5",
+			"NamespaceId": "ue",
+			"ItemId": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			"ArtifactId": "UE_5.5",
+			"AppVersion": "5.5.4-12345678+++UE5+Release-5.5",
+			"AppName": "UE_5.5"
+		},
+		{
+			"InstallLocation": "C:\\Marketplace\\SomeContentPack",
+			"NamespaceId": "ue",
+			"ItemId": "cccccccccccccccccccccccccccccccc",
+			"ArtifactId": "SomeContentPack",
+			"AppVersion": "1.0.0",
+			"AppName": "SomeContentPack"
+		}
+	]
+}

--- a/cli/tests/helpers.ts
+++ b/cli/tests/helpers.ts
@@ -1,0 +1,56 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/** Create a unique temp directory and return its absolute path. */
+export function makeTempDir(prefix = 'unreal-cli-test-'): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/** Remove a temp directory tree (best-effort). */
+export function rmTempDir(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Write a minimal `.uproject` into `dir` and return its path. */
+export function writeUProject(dir: string, name: string, engineAssociation = '5.7'): string {
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${name}.uproject`);
+  fs.writeFileSync(
+    file,
+    JSON.stringify(
+      {
+        FileVersion: 3,
+        EngineAssociation: engineAssociation,
+        Modules: [{ Name: name, Type: 'Runtime', LoadingPhase: 'Default' }],
+      },
+      null,
+      '\t',
+    ),
+    'utf-8',
+  );
+  return file;
+}
+
+/** Absolute path to the committed LauncherInstalled.dat fixture. */
+export function launcherFixturePath(): string {
+  return path.resolve(HERE, 'fixtures', 'LauncherInstalled.dat');
+}
+
+/** A `Response`-like stub for injecting into `fetchImpl`. */
+export function fakeResponse(opts: { ok: boolean; status: number; body?: string; statusText?: string }): Response {
+  return {
+    ok: opts.ok,
+    status: opts.status,
+    statusText: opts.statusText ?? '',
+    text: async () => opts.body ?? '',
+    json: async () => JSON.parse(opts.body ?? '{}'),
+  } as unknown as Response;
+}

--- a/cli/tests/install-engine.test.ts
+++ b/cli/tests/install-engine.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { detectInstalledEngines, planEngineInstall, launcherInstallUrl } from '../src/lib/install-engine.js';
+import { launcherFixturePath } from './helpers.js';
+
+describe('detectInstalledEngines (fixture)', () => {
+  it('detects the engines from the manifest', () => {
+    const r = detectInstalledEngines({ manifestPath: launcherFixturePath() });
+    expect(r.success).toBe(true);
+    expect(r.engines.map((e) => e.engineAssociation).sort()).toEqual(['5.5', '5.7']);
+  });
+
+  it('returns [] for a missing manifest (no throw)', () => {
+    const r = detectInstalledEngines({ manifestPath: '/no/such/file.dat' });
+    expect(r.engines).toEqual([]);
+  });
+});
+
+describe('planEngineInstall', () => {
+  it('reports alreadyInstalled for a present version', () => {
+    const r = planEngineInstall({ version: '5.7', manifestPath: launcherFixturePath() });
+    expect(r.alreadyInstalled).toBe(true);
+    expect(r.installation?.installLocation).toContain('UE_5.7');
+    expect(r.message).toContain('already installed');
+  });
+
+  it('delegates to the Epic launcher for a missing version (never installs)', () => {
+    const r = planEngineInstall({ version: '5.9', manifestPath: launcherFixturePath() });
+    expect(r.alreadyInstalled).toBe(false);
+    expect(r.installation).toBeNull();
+    expect(r.launcherUrl).toContain('com.epicgames.launcher://');
+    expect(r.message).toContain('does not download engines');
+  });
+});
+
+describe('launcherInstallUrl', () => {
+  it('builds an encoded deep link', () => {
+    expect(launcherInstallUrl('5.7')).toBe('com.epicgames.launcher://ue/launcher/install?version=5.7');
+  });
+});

--- a/cli/tests/install-engine.test.ts
+++ b/cli/tests/install-engine.test.ts
@@ -33,7 +33,7 @@ describe('planEngineInstall', () => {
 });
 
 describe('launcherInstallUrl', () => {
-  it('builds an encoded deep link', () => {
-    expect(launcherInstallUrl('5.7')).toBe('com.epicgames.launcher://ue/launcher/install?version=5.7');
+  it('builds the plain, known-good Unreal Engine launcher deep link', () => {
+    expect(launcherInstallUrl()).toBe('com.epicgames.launcher://ue/');
   });
 });

--- a/cli/tests/install-plugin.test.ts
+++ b/cli/tests/install-plugin.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { installPlugin, removePlugin } from '../src/lib/install-plugin.js';
+import { makeTempDir, rmTempDir } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+function makePluginSource(): string {
+  const dir = tmp();
+  fs.writeFileSync(path.join(dir, 'UnrealMCP.uplugin'), JSON.stringify({ VersionName: '0.1.0' }), 'utf-8');
+  fs.mkdirSync(path.join(dir, 'Source'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'Source', 'marker.txt'), 'hello', 'utf-8');
+  return dir;
+}
+
+describe('installPlugin (copy)', () => {
+  it('copies the plugin source into <project>/Plugins/UnrealMCP', async () => {
+    const project = tmp();
+    const source = makePluginSource();
+    const r = await installPlugin({ projectDir: project, pluginSourceDir: source });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.mode).toBe('copy');
+    expect(fs.existsSync(path.join(r.installedPath, 'UnrealMCP.uplugin'))).toBe(true);
+    expect(fs.existsSync(path.join(r.installedPath, 'Source', 'marker.txt'))).toBe(true);
+  });
+
+  it('is idempotent — a second install replaces the prior one', async () => {
+    const project = tmp();
+    const source = makePluginSource();
+    await installPlugin({ projectDir: project, pluginSourceDir: source });
+    const r = await installPlugin({ projectDir: project, pluginSourceDir: source });
+    expect(r.kind).toBe('success');
+  });
+
+  it('fails (no throw) when the plugin source is missing', async () => {
+    const project = tmp();
+    const r = await installPlugin({ projectDir: project, pluginSourceDir: path.join(tmp(), 'nope') });
+    expect(r.kind).toBe('failure');
+  });
+});
+
+describe('removePlugin', () => {
+  it('removes an installed plugin', async () => {
+    const project = tmp();
+    const source = makePluginSource();
+    await installPlugin({ projectDir: project, pluginSourceDir: source });
+    const r = await removePlugin({ projectDir: project });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.removed).toBe(true);
+    expect(fs.existsSync(r.installedPath)).toBe(false);
+  });
+
+  it('reports removed=false when nothing is installed', async () => {
+    const project = tmp();
+    const r = await removePlugin({ projectDir: project });
+    expect(r.kind).toBe('success');
+    if (r.kind === 'success') expect(r.removed).toBe(false);
+  });
+});

--- a/cli/tests/integration.test.ts
+++ b/cli/tests/integration.test.ts
@@ -1,0 +1,51 @@
+// Optional integration test — runs end-to-end against a real local Unreal
+// project ONLY when UNREAL_CLI_INTEGRATION is set. It is NOT part of the
+// default `vitest run` gate (acceptance criterion: "gated behind an env
+// flag, not required for the default test run").
+//
+//   UNREAL_CLI_INTEGRATION=1 \
+//   UNREAL_CLI_INTEGRATION_PROJECT=/abs/path/to/SomeProject \
+//   npm test
+//
+// Without UNREAL_CLI_INTEGRATION_PROJECT it scaffolds a throwaway project
+// in a temp dir, configures it, and probes status offline — no editor
+// binary required.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createProject } from '../src/lib/create-project.js';
+import { configure } from '../src/lib/configure.js';
+import { getStatus } from '../src/lib/status.js';
+import { makeTempDir, rmTempDir } from './helpers.js';
+
+const RUN = process.env['UNREAL_CLI_INTEGRATION'] === '1' || process.env['UNREAL_CLI_INTEGRATION'] === 'true';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+
+describe.skipIf(!RUN)('integration (env-gated)', () => {
+  it('scaffolds, configures, and reports status for a real-ish project', async () => {
+    const explicit = process.env['UNREAL_CLI_INTEGRATION_PROJECT'];
+    let projectDir: string;
+    if (explicit) {
+      projectDir = explicit;
+    } else {
+      const parent = makeTempDir();
+      dirs.push(parent);
+      projectDir = path.join(parent, 'IntegrationGame');
+      const created = await createProject({ projectDir, engineAssociation: '5.7' });
+      expect(created.kind).toBe('success');
+    }
+
+    const cfg = await configure({ projectDir, host: 'http://localhost:5220', token: 'integ' });
+    expect(cfg.kind).toBe('success');
+    expect(fs.existsSync(path.join(projectDir, '.env'))).toBe(true);
+
+    const status = await getStatus({ projectDir, noProbe: true });
+    expect(status.project?.engineAssociation).toBe('5.7');
+    expect(status.connection.url).toContain('localhost:5220');
+  });
+});

--- a/cli/tests/launcher.test.ts
+++ b/cli/tests/launcher.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import {
+  parseLauncherManifest,
+  readLauncherManifest,
+  matchEngineForAssociation,
+  compareEngineVersions,
+  getDefaultLauncherManifestPath,
+} from '../src/utils/launcher.js';
+import { launcherFixturePath } from './helpers.js';
+
+describe('parseLauncherManifest (fixture)', () => {
+  const content = fs.readFileSync(launcherFixturePath(), 'utf-8');
+
+  it('extracts only the UE_* engine entries, dropping marketplace content', () => {
+    const engines = parseLauncherManifest(content);
+    expect(engines).toHaveLength(2);
+    expect(engines.map((e) => e.engineAssociation).sort()).toEqual(['5.5', '5.7']);
+    expect(engines.some((e) => e.appName === 'SomeContentPack')).toBe(false);
+  });
+
+  it('maps AppName UE_5.7 -> engineAssociation 5.7 and keeps the install location', () => {
+    const engines = parseLauncherManifest(content);
+    const ue57 = engines.find((e) => e.engineAssociation === '5.7');
+    expect(ue57).toBeDefined();
+    expect(ue57!.installLocation).toBe('C:\\Program Files\\Epic Games\\UE_5.7');
+    expect(ue57!.appVersion).toContain('5.7.4');
+  });
+
+  it('sorts highest version first', () => {
+    const engines = parseLauncherManifest(content);
+    expect(engines[0].engineAssociation).toBe('5.7');
+  });
+
+  it('returns [] on malformed JSON', () => {
+    expect(parseLauncherManifest('not json')).toEqual([]);
+    expect(parseLauncherManifest('{"InstallationList": "nope"}')).toEqual([]);
+    expect(parseLauncherManifest('{}')).toEqual([]);
+  });
+
+  it('readLauncherManifest reads the fixture file from disk', () => {
+    const engines = readLauncherManifest(launcherFixturePath());
+    expect(engines).toHaveLength(2);
+  });
+
+  it('readLauncherManifest returns [] for a missing file', () => {
+    expect(readLauncherManifest('/no/such/LauncherInstalled.dat')).toEqual([]);
+  });
+});
+
+describe('matchEngineForAssociation', () => {
+  const engines = parseLauncherManifest(fs.readFileSync(launcherFixturePath(), 'utf-8'));
+
+  it('matches a launcher version association', () => {
+    expect(matchEngineForAssociation('5.7', engines)?.installLocation).toBe('C:\\Program Files\\Epic Games\\UE_5.7');
+    expect(matchEngineForAssociation('5.5', engines)?.engineAssociation).toBe('5.5');
+  });
+
+  it('an empty association resolves to the highest installed engine', () => {
+    expect(matchEngineForAssociation('', engines)?.engineAssociation).toBe('5.7');
+  });
+
+  it('a GUID association (source build) is not found in the manifest', () => {
+    expect(matchEngineForAssociation('{0a1b2c3d-...}', engines)).toBeNull();
+  });
+
+  it('an uninstalled version is not found', () => {
+    expect(matchEngineForAssociation('4.27', engines)).toBeNull();
+  });
+});
+
+describe('compareEngineVersions', () => {
+  it('orders numerically', () => {
+    expect(compareEngineVersions('5.7', '5.5')).toBeGreaterThan(0);
+    expect(compareEngineVersions('4.27', '5.0')).toBeLessThan(0);
+    expect(compareEngineVersions('5.7', '5.7')).toBe(0);
+  });
+});
+
+describe('getDefaultLauncherManifestPath', () => {
+  it('returns a Windows ProgramData path', () => {
+    expect(getDefaultLauncherManifestPath('win32')).toMatch(/Epic[\\/]UnrealEngineLauncher[\\/]LauncherInstalled\.dat$/);
+  });
+  it('returns a macOS shared path', () => {
+    expect(getDefaultLauncherManifestPath('darwin')).toContain('/Users/Shared/Epic');
+  });
+  it('returns null on linux (no launcher manifest)', () => {
+    expect(getDefaultLauncherManifestPath('linux')).toBeNull();
+  });
+});

--- a/cli/tests/login.test.ts
+++ b/cli/tests/login.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as path from 'path';
+import { login } from '../src/lib/login.js';
+import { readEnvFile } from '../src/utils/env-file.js';
+import { makeTempDir, rmTempDir, fakeResponse } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+function deviceFlowFetch(pendingCount: number): typeof fetch {
+  let tokenCalls = 0;
+  return (async (url: string) => {
+    if (String(url).endsWith('/code')) {
+      return fakeResponse({
+        ok: true,
+        status: 200,
+        body: JSON.stringify({
+          device_code: 'dev123',
+          user_code: 'WXYZ-1234',
+          verification_uri: 'https://ai-game.dev/activate',
+          interval: 1,
+        }),
+      });
+    }
+    // token endpoint
+    tokenCalls += 1;
+    if (tokenCalls <= pendingCount) {
+      return fakeResponse({ ok: false, status: 400, body: JSON.stringify({ error: 'authorization_pending' }) });
+    }
+    return fakeResponse({ ok: true, status: 200, body: JSON.stringify({ access_token: 'final-token' }) });
+  }) as unknown as typeof fetch;
+}
+
+describe('login (device flow)', () => {
+  it('polls past authorization_pending and returns the token', async () => {
+    const r = await login({
+      fetchImpl: deviceFlowFetch(2),
+      sleepImpl: async () => {},
+      nowImpl: () => 0,
+      timeoutMs: 100000,
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind === 'success') expect(r.token).toBe('final-token');
+  });
+
+  it('persists the token into a project .env when projectDir is given', async () => {
+    const dir = tmp();
+    const r = await login({
+      projectDir: dir,
+      fetchImpl: deviceFlowFetch(0),
+      sleepImpl: async () => {},
+      nowImpl: () => 0,
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.persisted).toBe(true);
+    const env = readEnvFile(path.join(dir, '.env'));
+    expect(env['UNREAL_MCP_TOKEN']).toBe('final-token');
+    expect(env['UNREAL_MCP_CONNECTION_MODE']).toBe('Cloud');
+  });
+
+  it('fails on access_denied', async () => {
+    const fetchImpl = (async (url: string) => {
+      if (String(url).endsWith('/code')) {
+        return fakeResponse({ ok: true, status: 200, body: JSON.stringify({ device_code: 'd', user_code: 'u', verification_uri: 'v', interval: 1 }) });
+      }
+      return fakeResponse({ ok: false, status: 400, body: JSON.stringify({ error: 'access_denied' }) });
+    }) as unknown as typeof fetch;
+    const r = await login({ fetchImpl, sleepImpl: async () => {}, nowImpl: () => 0 });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.reason).toBe('access_denied');
+  });
+
+  it('times out when the user never authorizes', async () => {
+    let clock = 0;
+    const fetchImpl = (async (url: string) => {
+      if (String(url).endsWith('/code')) {
+        return fakeResponse({ ok: true, status: 200, body: JSON.stringify({ device_code: 'd', user_code: 'u', verification_uri: 'v', interval: 1 }) });
+      }
+      return fakeResponse({ ok: false, status: 400, body: JSON.stringify({ error: 'authorization_pending' }) });
+    }) as unknown as typeof fetch;
+    const r = await login({ fetchImpl, sleepImpl: async (ms) => { clock += ms; }, nowImpl: () => clock, timeoutMs: 3000 });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.reason).toBe('timeout');
+  });
+});

--- a/cli/tests/login.test.ts
+++ b/cli/tests/login.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
 import * as path from 'path';
 import { login } from '../src/lib/login.js';
 import { readEnvFile } from '../src/utils/env-file.js';
@@ -64,6 +65,8 @@ describe('login (device flow)', () => {
     const env = readEnvFile(path.join(dir, '.env'));
     expect(env['UNREAL_MCP_TOKEN']).toBe('final-token');
     expect(env['UNREAL_MCP_CONNECTION_MODE']).toBe('Cloud');
+    // The persisted token must be gitignored (§8) so it can't be committed.
+    expect(fs.readFileSync(path.join(dir, '.gitignore'), 'utf-8')).toContain('.env');
   });
 
   it('fails on access_denied', async () => {

--- a/cli/tests/login.test.ts
+++ b/cli/tests/login.test.ts
@@ -69,6 +69,27 @@ describe('login (device flow)', () => {
     expect(fs.readFileSync(path.join(dir, '.gitignore'), 'utf-8')).toContain('.env');
   });
 
+  it('increases the poll interval persistently after slow_down (RFC 8628)', async () => {
+    let tokenCalls = 0;
+    const fetchImpl = (async (url: string) => {
+      if (String(url).endsWith('/code')) {
+        return fakeResponse({ ok: true, status: 200, body: JSON.stringify({ device_code: 'd', user_code: 'u', verification_uri: 'v', interval: 1 }) });
+      }
+      tokenCalls += 1;
+      if (tokenCalls === 1) {
+        return fakeResponse({ ok: false, status: 400, body: JSON.stringify({ error: 'slow_down' }) });
+      }
+      return fakeResponse({ ok: true, status: 200, body: JSON.stringify({ access_token: 'final-token' }) });
+    }) as unknown as typeof fetch;
+    const sleeps: number[] = [];
+    const r = await login({ fetchImpl, sleepImpl: async (ms) => { sleeps.push(ms); }, nowImpl: () => 0, timeoutMs: 100000 });
+    expect(r.kind).toBe('success');
+    // One sleep per poll (at the top of the loop): 1000ms before the first
+    // (slow_down) poll, then a PERSISTENTLY increased 6000ms before the retry —
+    // not a one-shot extra sleep at the old 1000ms cadence.
+    expect(sleeps).toEqual([1000, 6000]);
+  });
+
   it('fails on access_denied', async () => {
     const fetchImpl = (async (url: string) => {
       if (String(url).endsWith('/code')) {

--- a/cli/tests/open.test.ts
+++ b/cli/tests/open.test.ts
@@ -74,6 +74,23 @@ describe('openProject', () => {
     expect(spawnedWith!.env['UNREAL_MCP_HOST']).toBe('http://localhost:5220');
   });
 
+  it('warns that connection options are ignored under --no-connect', async () => {
+    const dir = tmp();
+    writeUProject(dir, 'MyGame', '5.7');
+    const r = await openProject({
+      projectDir: dir,
+      noConnect: true,
+      host: 'http://h',
+      auth: 'required',
+      enginesImpl: () => [fakeEngine('5.7')],
+      spawnImpl: () => ({ pid: 7 }),
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.envVars).toEqual({}); // nothing propagated under --no-connect
+    expect(r.warnings.some((w) => /ignored under --no-connect/.test(w))).toBe(true);
+  });
+
   it('fails when no .uproject is present', async () => {
     const dir = tmp();
     const r = await openProject({ projectDir: dir, enginesImpl: () => [fakeEngine('5.7')] });

--- a/cli/tests/open.test.ts
+++ b/cli/tests/open.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { openProject, buildOpenEnv } from '../src/lib/open.js';
+import { editorBinaryPath } from '../src/utils/engine.js';
+import type { EngineInstallation } from '../src/utils/launcher.js';
+import * as fs from 'fs';
+import * as path from 'path';
+import { makeTempDir, rmTempDir, writeUProject } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+/**
+ * Build a fake engine install whose UnrealEditor binary actually exists on
+ * disk (for the host platform), so resolveEngine's existence check passes
+ * deterministically regardless of what is installed on the test machine.
+ */
+function fakeEngine(association: string): EngineInstallation {
+  const root = tmp();
+  const bin = editorBinaryPath(root, process.platform);
+  fs.mkdirSync(path.dirname(bin), { recursive: true });
+  fs.writeFileSync(bin, '', 'utf-8');
+  return { appName: `UE_${association}`, appVersion: `${association}.0`, installLocation: root, engineAssociation: association };
+}
+
+describe('buildOpenEnv', () => {
+  it('maps options to UNREAL_MCP_* vars', () => {
+    const env = buildOpenEnv({ host: 'http://h', token: 't', keepConnected: true, auth: 'required', transport: 'http' });
+    expect(env).toEqual({
+      UNREAL_MCP_HOST: 'http://h',
+      UNREAL_MCP_TOKEN: 't',
+      UNREAL_MCP_KEEP_CONNECTED: 'true',
+      UNREAL_MCP_AUTH_OPTION: 'required',
+      UNREAL_MCP_TRANSPORT: 'http',
+    });
+  });
+
+  it('returns undefined for --no-connect', () => {
+    expect(buildOpenEnv({ noConnect: true, host: 'http://h' })).toBeUndefined();
+  });
+
+  it('throws on bad auth/transport enums', () => {
+    expect(() => buildOpenEnv({ auth: 'bogus' as never })).toThrow();
+    expect(() => buildOpenEnv({ transport: 'bogus' as never })).toThrow();
+  });
+});
+
+describe('openProject', () => {
+  it('resolves the engine and spawns the editor (injected engines + spawn)', async () => {
+    const dir = tmp();
+    writeUProject(dir, 'MyGame', '5.7');
+    let spawnedWith: { editorPath: string; args: string[]; env: NodeJS.ProcessEnv } | null = null;
+    const r = await openProject({
+      projectDir: dir,
+      host: 'http://localhost:5220',
+      enginesImpl: () => [fakeEngine('5.7')],
+      spawnImpl: (editorPath, args, env) => {
+        spawnedWith = { editorPath, args, env };
+        return { pid: 4242 };
+      },
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.editorPid).toBe(4242);
+    expect(r.editorPath).toContain('UnrealEditor');
+    expect(r.envVars['UNREAL_MCP_HOST']).toBe('http://localhost:5220');
+    expect(spawnedWith).not.toBeNull();
+    expect(spawnedWith!.env['UNREAL_MCP_HOST']).toBe('http://localhost:5220');
+  });
+
+  it('fails when no .uproject is present', async () => {
+    const dir = tmp();
+    const r = await openProject({ projectDir: dir, enginesImpl: () => [fakeEngine('5.7')] });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.errorMessage).toContain('.uproject');
+  });
+
+  it('fails when the engine association is not installed', async () => {
+    const dir = tmp();
+    writeUProject(dir, 'MyGame', '4.27');
+    const r = await openProject({ projectDir: dir, enginesImpl: () => [fakeEngine('5.7')], spawnImpl: () => ({ pid: 1 }) });
+    expect(r.kind).toBe('failure');
+  });
+});

--- a/cli/tests/port.test.ts
+++ b/cli/tests/port.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { generatePortFromDirectory } from '../src/utils/port.js';
+
+describe('generatePortFromDirectory', () => {
+  it('is deterministic and in the 20000-29999 range', () => {
+    const a = generatePortFromDirectory('C:\\Projects\\MyGame');
+    const b = generatePortFromDirectory('C:\\Projects\\MyGame');
+    expect(a).toBe(b);
+    expect(a).toBeGreaterThanOrEqual(20000);
+    expect(a).toBeLessThanOrEqual(29999);
+  });
+
+  it('is case-insensitive (lowercases the path)', () => {
+    expect(generatePortFromDirectory('/Foo/Bar')).toBe(generatePortFromDirectory('/foo/bar'));
+  });
+
+  it('differs for different directories', () => {
+    expect(generatePortFromDirectory('/a')).not.toBe(generatePortFromDirectory('/b'));
+  });
+});

--- a/cli/tests/project.test.ts
+++ b/cli/tests/project.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as path from 'path';
+import { readUProject, readEngineAssociation, findUProjectFile, resolveProjectDir } from '../src/utils/project.js';
+import { makeTempDir, rmTempDir, writeUProject } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+describe('project utils', () => {
+  it('finds the .uproject and reads its EngineAssociation', () => {
+    const dir = tmp();
+    writeUProject(dir, 'MyGame', '5.7');
+    const found = findUProjectFile(dir);
+    expect(found).not.toBeNull();
+    const info = readUProject(dir);
+    expect(info?.projectName).toBe('MyGame');
+    expect(info?.engineAssociation).toBe('5.7');
+    expect(info?.projectDir).toBe(path.resolve(dir));
+  });
+
+  it('returns null when no .uproject exists', () => {
+    const dir = tmp();
+    expect(findUProjectFile(dir)).toBeNull();
+    expect(readUProject(dir)).toBeNull();
+  });
+
+  it('readEngineAssociation tolerates a missing field', () => {
+    expect(readEngineAssociation({})).toBe('');
+    expect(readEngineAssociation({ EngineAssociation: ' 5.5 ' })).toBe('5.5');
+    expect(readEngineAssociation(null)).toBe('');
+  });
+
+  it('resolveProjectDir falls back to cwd', () => {
+    const r = resolveProjectDir(undefined, '/work');
+    expect(r.usedCwdFallback).toBe(true);
+    expect(r.projectDir).toBe(path.resolve('/work'));
+    const r2 = resolveProjectDir('/explicit', '/work');
+    expect(r2.usedCwdFallback).toBe(false);
+  });
+});

--- a/cli/tests/run-tool.test.ts
+++ b/cli/tests/run-tool.test.ts
@@ -56,6 +56,23 @@ describe('runTool', () => {
     if (r.kind === 'failure') expect(r.reason).toBe('invalid-input');
   });
 
+  it('reports reason "aborted" (not "timeout") when the caller aborts', async () => {
+    const ac = new AbortController();
+    const fetchImpl = (async (_url: string, init: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init.signal?.addEventListener('abort', () => {
+          const e = new Error('aborted');
+          e.name = 'AbortError';
+          reject(e);
+        });
+      })) as unknown as typeof fetch;
+    const p = runTool({ toolName: 'ping', url: 'http://h', fetchImpl, signal: ac.signal, timeoutMs: 10000 });
+    ac.abort();
+    const r = await p;
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.reason).toBe('aborted');
+  });
+
   it('classifies a connection-refused cause', async () => {
     const fetchImpl = (async () => {
       const err = new Error('fetch failed');

--- a/cli/tests/run-tool.test.ts
+++ b/cli/tests/run-tool.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { runTool, runSystemTool } from '../src/lib/run-tool.js';
+import { fakeResponse } from './helpers.js';
+
+describe('runTool', () => {
+  it('POSTs to /api/tools/<name> against an explicit url and returns parsed data', async () => {
+    let calledUrl = '';
+    let calledBody = '';
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+      calledUrl = String(url);
+      calledBody = String(init.body);
+      return fakeResponse({ ok: true, status: 200, body: JSON.stringify({ status: 'success', structured: { pong: true } }) });
+    }) as unknown as typeof fetch;
+
+    const r = await runTool({ toolName: 'ping', url: 'http://localhost:5220/', input: { x: 1 }, fetchImpl });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(calledUrl).toBe('http://localhost:5220/api/tools/ping');
+    expect(calledBody).toBe('{"x":1}');
+    expect((r.data as { structured: { pong: boolean } }).structured.pong).toBe(true);
+  });
+
+  it('run-system-tool hits /api/system-tools/<name>', async () => {
+    let calledUrl = '';
+    const fetchImpl = (async (url: string) => {
+      calledUrl = String(url);
+      return fakeResponse({ ok: true, status: 200, body: '{}' });
+    }) as unknown as typeof fetch;
+    await runSystemTool({ toolName: 'ping', url: 'http://h', fetchImpl });
+    expect(calledUrl).toBe('http://h/api/system-tools/ping');
+  });
+
+  it('surfaces an http-error with status + body', async () => {
+    const fetchImpl = (async () =>
+      fakeResponse({ ok: false, status: 500, statusText: 'Server Error', body: '{"error":"boom"}' })) as unknown as typeof fetch;
+    const r = await runTool({ toolName: 'ping', url: 'http://h', fetchImpl });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') {
+      expect(r.reason).toBe('http-error');
+      expect(r.httpStatus).toBe(500);
+    }
+  });
+
+  it('rejects a missing toolName / missing url+projectDir without throwing', async () => {
+    const r1 = await runTool({ toolName: '', url: 'http://h' });
+    expect(r1.kind).toBe('failure');
+    if (r1.kind === 'failure') expect(r1.reason).toBe('invalid-input');
+    const r2 = await runTool({ toolName: 'ping' });
+    expect(r2.kind).toBe('failure');
+    if (r2.kind === 'failure') expect(r2.reason).toBe('invalid-input');
+  });
+
+  it('rejects malformed JSON input', async () => {
+    const r = await runTool({ toolName: 'ping', url: 'http://h', input: '{not json' });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.reason).toBe('invalid-input');
+  });
+
+  it('classifies a connection-refused cause', async () => {
+    const fetchImpl = (async () => {
+      const err = new Error('fetch failed');
+      (err as Error & { cause?: unknown }).cause = { code: 'ECONNREFUSED' };
+      throw err;
+    }) as unknown as typeof fetch;
+    const r = await runTool({ toolName: 'ping', url: 'http://h', fetchImpl });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.reason).toBe('connection-refused');
+  });
+});

--- a/cli/tests/setup-mcp.test.ts
+++ b/cli/tests/setup-mcp.test.ts
@@ -75,6 +75,17 @@ describe('setupMcp', () => {
     expect(entry.args.some((a: string) => /^port=\d+$/.test(a))).toBe(true);
   });
 
+  it('writes vscode config under the top-level `servers` key (not `mcpServers`)', async () => {
+    const dir = tmp();
+    const r = await setupMcp({ agentId: 'vscode', projectDir: dir, transport: 'http', url: 'http://localhost:5220' });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
+    // VS Code's .vscode/mcp.json uses `servers`; `mcpServers` is ignored.
+    expect(written.servers['unreal-mcp'].url).toBe('http://localhost:5220/mcp');
+    expect(written.mcpServers).toBeUndefined();
+  });
+
   it('dry-run returns the snippet without writing', async () => {
     const dir = tmp();
     const r = await setupMcp({ agentId: 'cursor', projectDir: dir, dryRun: true, url: 'http://h' });

--- a/cli/tests/setup-mcp.test.ts
+++ b/cli/tests/setup-mcp.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { setupMcp, listAgentIds, buildServerEntry } from '../src/lib/setup-mcp.js';
+import { makeTempDir, rmTempDir } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+describe('listAgentIds', () => {
+  it('includes the known agents', () => {
+    expect(listAgentIds()).toEqual(expect.arrayContaining(['claude-code', 'cursor', 'vscode']));
+  });
+});
+
+describe('buildServerEntry', () => {
+  it('builds an http entry with bearer header', () => {
+    const e = buildServerEntry('http', 'http://localhost:5220', 'tok');
+    expect(e).toMatchObject({ type: 'http', url: 'http://localhost:5220/mcp', headers: { Authorization: 'Bearer tok' } });
+  });
+  it('builds a stdio entry launching unreal-mcp-server', () => {
+    const e = buildServerEntry('stdio', 'http://x', undefined);
+    expect(e).toMatchObject({ type: 'stdio', command: 'unreal-mcp-server' });
+  });
+});
+
+describe('setupMcp', () => {
+  it('writes .mcp.json for claude-code and merges with existing servers', async () => {
+    const dir = tmp();
+    fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({ mcpServers: { other: { type: 'stdio' } } }), 'utf-8');
+    const r = await setupMcp({ agentId: 'claude-code', projectDir: dir, transport: 'http', url: 'http://localhost:5220' });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
+    expect(written.mcpServers.other).toBeDefined();
+    expect(written.mcpServers['unreal-mcp'].url).toBe('http://localhost:5220/mcp');
+  });
+
+  it('dry-run returns the snippet without writing', async () => {
+    const dir = tmp();
+    const r = await setupMcp({ agentId: 'cursor', projectDir: dir, dryRun: true, url: 'http://h' });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(fs.existsSync(r.configPath)).toBe(false);
+    expect(r.snippet).toContain('unreal-mcp');
+  });
+
+  it('fails for an unknown agent', async () => {
+    const r = await setupMcp({ agentId: 'emacs', projectDir: tmp() });
+    expect(r.kind).toBe('failure');
+  });
+});

--- a/cli/tests/setup-mcp.test.ts
+++ b/cli/tests/setup-mcp.test.ts
@@ -25,9 +25,27 @@ describe('buildServerEntry', () => {
     const e = buildServerEntry('http', 'http://localhost:5220', 'tok');
     expect(e).toMatchObject({ type: 'http', url: 'http://localhost:5220/mcp', headers: { Authorization: 'Bearer tok' } });
   });
-  it('builds a stdio entry launching unreal-mcp-server', () => {
-    const e = buildServerEntry('stdio', 'http://x', undefined);
-    expect(e).toMatchObject({ type: 'stdio', command: 'unreal-mcp-server' });
+  it('builds a stdio entry launching the absolute server binary with port + auth args', () => {
+    const e = buildServerEntry('stdio', 'http://x', 'tok', {
+      serverPath: '/abs/Intermediate/UnrealMCP/server/win-x64/unreal-mcp-server.exe',
+      port: 5220,
+    });
+    expect(e).toMatchObject({
+      type: 'stdio',
+      command: '/abs/Intermediate/UnrealMCP/server/win-x64/unreal-mcp-server.exe',
+    });
+    expect(e.args).toEqual(
+      expect.arrayContaining(['port=5220', 'client-transport=stdio', 'authorization=required', 'token=tok']),
+    );
+  });
+
+  it('stdio uses authorization=none when there is no token', () => {
+    const e = buildServerEntry('stdio', 'http://x', undefined, { serverPath: '/abs/srv', port: 1 });
+    expect(e.args).toEqual(expect.arrayContaining(['authorization=none', 'token=']));
+  });
+
+  it('stdio without resolved server params throws (a bare PATH command would not launch)', () => {
+    expect(() => buildServerEntry('stdio', 'http://x', undefined)).toThrow();
   });
 });
 
@@ -41,6 +59,20 @@ describe('setupMcp', () => {
     const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
     expect(written.mcpServers.other).toBeDefined();
     expect(written.mcpServers['unreal-mcp'].url).toBe('http://localhost:5220/mcp');
+  });
+
+  it('writes a stdio entry with an absolute §6 server path and a port arg', async () => {
+    const dir = tmp();
+    const r = await setupMcp({ agentId: 'claude-code', projectDir: dir, transport: 'stdio' });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
+    const entry = written.mcpServers['unreal-mcp'];
+    expect(entry.type).toBe('stdio');
+    expect(path.isAbsolute(entry.command)).toBe(true);
+    expect(entry.command).toContain(path.join('Intermediate', 'UnrealMCP', 'server'));
+    expect(entry.command).toMatch(/unreal-mcp-server(\.exe)?$/);
+    expect(entry.args.some((a: string) => /^port=\d+$/.test(a))).toBe(true);
   });
 
   it('dry-run returns the snippet without writing', async () => {

--- a/cli/tests/setup-skills.test.ts
+++ b/cli/tests/setup-skills.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { setupSkills, renderSkill } from '../src/lib/setup-skills.js';
+import { makeTempDir, rmTempDir, writeUProject } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+describe('renderSkill', () => {
+  it('embeds the server URL and a frontmatter name', () => {
+    const md = renderSkill('http://localhost:5220');
+    expect(md).toContain('name: unreal-mcp');
+    expect(md).toContain('http://localhost:5220');
+  });
+});
+
+describe('setupSkills', () => {
+  it('writes .claude/skills/unreal-mcp/SKILL.md', async () => {
+    const dir = tmp();
+    writeUProject(dir, 'MyGame', '5.7');
+    const r = await setupSkills({ projectDir: dir, url: 'http://h' });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.written).toBe(true);
+    expect(r.skillPath.replace(/\\/g, '/')).toContain('.claude/skills/unreal-mcp/SKILL.md');
+    expect(fs.existsSync(r.skillPath)).toBe(true);
+  });
+
+  it('does not overwrite without --force', async () => {
+    const dir = tmp();
+    const skillPath = path.join(dir, '.claude', 'skills', 'unreal-mcp', 'SKILL.md');
+    fs.mkdirSync(path.dirname(skillPath), { recursive: true });
+    fs.writeFileSync(skillPath, 'existing', 'utf-8');
+    const r = await setupSkills({ projectDir: dir, url: 'http://h' });
+    expect(r.kind).toBe('success');
+    if (r.kind === 'success') expect(r.written).toBe(false);
+    expect(fs.readFileSync(skillPath, 'utf-8')).toBe('existing');
+  });
+});

--- a/cli/tests/status.test.ts
+++ b/cli/tests/status.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { getStatus } from '../src/lib/status.js';
+import { makeTempDir, rmTempDir, writeUProject, fakeResponse } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+describe('getStatus', () => {
+  it('returns package identity with no project', async () => {
+    const r = await getStatus({ noProbe: true });
+    expect(r.name).toBe('unreal-cli');
+    expect(r.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(r.project).toBeUndefined();
+  });
+
+  it('reports project + plugin state and resolves a deterministic-port connection', async () => {
+    const dir = tmp();
+    writeUProject(dir, 'MyGame', '5.7');
+    fs.mkdirSync(path.join(dir, 'Plugins', 'UnrealMCP'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'Plugins', 'UnrealMCP', 'UnrealMCP.uplugin'), '{}', 'utf-8');
+
+    const r = await getStatus({ projectDir: dir, noProbe: true });
+    expect(r.project?.projectName).toBe('MyGame');
+    expect(r.project?.engineAssociation).toBe('5.7');
+    expect(r.project?.pluginInstalled).toBe(true);
+    expect(r.connection.source).toBe('deterministic-port');
+    expect(r.connection.url).toMatch(/^http:\/\/localhost:\d+$/);
+  });
+
+  it('probes reachability when not disabled', async () => {
+    const dir = tmp();
+    writeUProject(dir, 'MyGame', '5.7');
+    const fetchImpl = (async () => fakeResponse({ ok: true, status: 200, body: '{}' })) as unknown as typeof fetch;
+    const r = await getStatus({ projectDir: dir, fetchImpl, probeTimeoutMs: 1000 });
+    expect(r.reachable).toBe(true);
+  });
+
+  it('reports unreachable on connection refused', async () => {
+    const dir = tmp();
+    writeUProject(dir, 'MyGame', '5.7');
+    const fetchImpl = (async () => {
+      const err = new Error('refused');
+      (err as Error & { cause?: unknown }).cause = { code: 'ECONNREFUSED' };
+      throw err;
+    }) as unknown as typeof fetch;
+    const r = await getStatus({ projectDir: dir, fetchImpl, probeTimeoutMs: 1000 });
+    expect(r.reachable).toBe(false);
+    expect(r.probeReason).toBe('connection refused');
+  });
+});

--- a/cli/tests/update.test.ts
+++ b/cli/tests/update.test.ts
@@ -50,6 +50,24 @@ describe('update', () => {
     if (r.kind === 'success') expect(r.updated).toBe(false);
   });
 
+  it('installs when not present even if the source version is unreadable', async () => {
+    // Regression: a not-installed plugin (fromVersion === null) against a
+    // source whose UnrealMCP.uplugin is unreadable (toVersion === null) must
+    // still install — `null !== null` is false, so the old guard short-
+    // circuited to "already up to date" and never copied anything.
+    const project = tmp();
+    const source = tmp(); // a real dir, but with no UnrealMCP.uplugin
+    fs.writeFileSync(path.join(source, 'README.md'), 'plugin contents', 'utf-8');
+    const r = await update({ projectDir: project, pluginSourceDir: source });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.fromVersion).toBeNull();
+    expect(r.toVersion).toBeNull();
+    expect(r.updated).toBe(true);
+    expect(r.warnings.some((w) => /could not read versionname/i.test(w))).toBe(true);
+    expect(fs.existsSync(path.join(project, 'Plugins', 'UnrealMCP', 'README.md'))).toBe(true);
+  });
+
   it('re-installs when versions differ', async () => {
     const project = tmp();
     await update({ projectDir: project, pluginSourceDir: makeSource('0.1.0') });

--- a/cli/tests/update.test.ts
+++ b/cli/tests/update.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { update, readPluginVersion } from '../src/lib/update.js';
+import { makeTempDir, rmTempDir } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+function makeSource(version: string): string {
+  const dir = tmp();
+  fs.writeFileSync(path.join(dir, 'UnrealMCP.uplugin'), JSON.stringify({ VersionName: version }), 'utf-8');
+  return dir;
+}
+
+describe('readPluginVersion', () => {
+  it('reads VersionName, null on miss', () => {
+    const dir = makeSource('0.2.0');
+    expect(readPluginVersion(path.join(dir, 'UnrealMCP.uplugin'))).toBe('0.2.0');
+    expect(readPluginVersion(path.join(dir, 'nope.uplugin'))).toBeNull();
+  });
+});
+
+describe('update', () => {
+  it('installs when not already present', async () => {
+    const project = tmp();
+    const source = makeSource('0.1.0');
+    const r = await update({ projectDir: project, pluginSourceDir: source });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.updated).toBe(true);
+    expect(r.fromVersion).toBeNull();
+    expect(r.toVersion).toBe('0.1.0');
+    expect(fs.existsSync(path.join(project, 'Plugins', 'UnrealMCP', 'UnrealMCP.uplugin'))).toBe(true);
+  });
+
+  it('is a no-op when versions match', async () => {
+    const project = tmp();
+    const source = makeSource('0.1.0');
+    await update({ projectDir: project, pluginSourceDir: source });
+    const r = await update({ projectDir: project, pluginSourceDir: source });
+    expect(r.kind).toBe('success');
+    if (r.kind === 'success') expect(r.updated).toBe(false);
+  });
+
+  it('re-installs when versions differ', async () => {
+    const project = tmp();
+    await update({ projectDir: project, pluginSourceDir: makeSource('0.1.0') });
+    const r = await update({ projectDir: project, pluginSourceDir: makeSource('0.2.0') });
+    expect(r.kind).toBe('success');
+    if (r.kind === 'success') {
+      expect(r.fromVersion).toBe('0.1.0');
+      expect(r.toVersion).toBe('0.2.0');
+      expect(r.updated).toBe(true);
+    }
+  });
+});

--- a/cli/tests/wait-for-ready.test.ts
+++ b/cli/tests/wait-for-ready.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { waitForReady } from '../src/lib/wait-for-ready.js';
+import { fakeResponse } from './helpers.js';
+
+describe('waitForReady', () => {
+  it('succeeds once the probe returns 2xx', async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls += 1;
+      if (calls < 3) {
+        const err = new Error('refused');
+        (err as Error & { cause?: unknown }).cause = { code: 'ECONNREFUSED' };
+        throw err;
+      }
+      return fakeResponse({ ok: true, status: 200, body: '{}' });
+    }) as unknown as typeof fetch;
+
+    let clock = 0;
+    const r = await waitForReady({
+      url: 'http://localhost:5220',
+      timeoutMs: 100000,
+      intervalMs: 1000,
+      fetchImpl,
+      nowImpl: () => clock,
+      sleepImpl: async (ms) => {
+        clock += ms;
+      },
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind === 'success') expect(r.attempts).toBe(3);
+  });
+
+  it('fails on timeout with the last reason', async () => {
+    const fetchImpl = (async () => {
+      const err = new Error('refused');
+      (err as Error & { cause?: unknown }).cause = { code: 'ECONNREFUSED' };
+      throw err;
+    }) as unknown as typeof fetch;
+
+    let clock = 0;
+    const r = await waitForReady({
+      url: 'http://localhost:5220',
+      timeoutMs: 5000,
+      intervalMs: 1000,
+      fetchImpl,
+      nowImpl: () => clock,
+      sleepImpl: async (ms) => {
+        clock += ms;
+      },
+    });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') {
+      expect(r.lastReason).toBe('connection refused');
+      expect(r.attempts).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Implement the full `unreal-cli` command surface (docs/ARCHITECTURE.md §9.1) — 16 commander commands adapted to Unreal's project/engine/plugin conventions, extending the existing `cli/` skeleton. Stays `private: true` @ `0.1.0`, no publish.
- Engine resolution via `.uproject` `EngineAssociation` cross-referenced against the Epic launcher `LauncherInstalled.dat` manifest; `install-engine` detects installed engines and links to the Epic launcher for missing versions (never installs directly).
- `configure` writes `UNREAL_MCP_*` into `<project>/.env` and appends `.env` to the project `.gitignore` (creating it if absent) — §8 token-commit guard.
- Side-effect-free `dist/lib.js` library export (discriminated-union results, never throws past the boundary) mirroring the Unity CLI shape.

## Test plan

- [x] `npm run build` (tsc) — 0 errors
- [x] `npm test` (vitest) — 112 passed, 1 skipped (env-gated integration test); fixtures: `LauncherInstalled.dat`, fake project dirs, `.env`/`.gitignore`, engine resolution
- [x] Manual smoke: `configure` writes `.env` + `.gitignore`; `install-engine` detects from manifest; `dist/lib.js` exports resolve
- Note: the repo has no `.github/workflows/` yet — local full-suite green is the gate (CI lands with the ci-workflows task).

Closes #2