### PR TITLE
Implement Unreal-MCP sidecar bridge end-to-end with live ping e2e

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
@@ -249,7 +249,7 @@ uint32 FUnrealMcpBridgeServer::Run()
 		for (const FString& Line : Lines)
 		{
 			if (!Line.IsEmpty())
-				HandleLine(Line);
+				HandleLine(Line, CurrentGeneration);
 		}
 	}
 	return 0;
@@ -262,7 +262,7 @@ void FUnrealMcpBridgeServer::Stop()
 
 void FUnrealMcpBridgeServer::Exit() {}
 
-void FUnrealMcpBridgeServer::HandleLine(const FString& Line)
+void FUnrealMcpBridgeServer::HandleLine(const FString& Line, int32 Generation)
 {
 	TSharedPtr<FJsonObject> Message;
 	const TSharedRef<TJsonReader<TCHAR>> Reader = TJsonReaderFactory<TCHAR>::Create(Line);
@@ -285,7 +285,7 @@ void FUnrealMcpBridgeServer::HandleLine(const FString& Line)
 		return;
 	}
 
-	if (Type == TypeHandshake)        HandleHandshake(Message);
+	if (Type == TypeHandshake)        HandleHandshake(Message, Generation);
 	else if (Type == TypeToolCall)    HandleToolCall(Message);
 	else if (Type == TypeToolCancel)  HandleToolCancel(Message);
 	else if (Type == TypePing)
@@ -304,7 +304,7 @@ void FUnrealMcpBridgeServer::HandleLine(const FString& Line)
 	}
 }
 
-void FUnrealMcpBridgeServer::HandleHandshake(const TSharedPtr<FJsonObject>& Message)
+void FUnrealMcpBridgeServer::HandleHandshake(const TSharedPtr<FJsonObject>& Message, int32 Generation)
 {
 	FString IncomingToken;
 	Message->TryGetStringField(TEXT("token"), IncomingToken);
@@ -318,7 +318,23 @@ void FUnrealMcpBridgeServer::HandleHandshake(const TSharedPtr<FJsonObject>& Mess
 		return;
 	}
 
-	bHandshakeOk = true;
+	// Close the check-to-flip race (§1.4): the accept thread can swap in a NEW connection — bumping the
+	// generation and parking the old socket — between the reader's post-Recv generation check and here. If
+	// this handshake line came off a now-superseded socket, flipping bHandshakeOk and sending the ack +
+	// manifest would authenticate (and write to) the CURRENT, still-unauthenticated connection. Re-verify
+	// the generation we read this batch at, under the connection lock, and bail if it has moved on.
+	{
+		FScopeLock Lock(&ConnectionMutex);
+		if (ConnectionGeneration != Generation)
+		{
+			UE_LOG(LogUnrealMcp, Warning,
+				TEXT("[Unreal-MCP] handshake arrived for a superseded connection (gen %d != %d); ignoring."),
+				Generation, ConnectionGeneration);
+			return;
+		}
+		bHandshakeOk = true;
+	}
+
 	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] handshake accepted."));
 	SendHandshakeAck();
 
@@ -440,25 +456,57 @@ bool FUnrealMcpBridgeServer::SendMessage(const TSharedPtr<FJsonObject>& Message)
 	if (ClientSocket == nullptr)
 		return false;
 
+	if (!TrySendFramedLocked(Framed))
+	{
+		// A genuine (non-would-block) failure mid-frame corrupts the stream — the peer would see a truncated
+		// line with the next frame concatenated, and a lost tool-response hangs the pending call until the
+		// heartbeat. Drop the connection so the sidecar reconnects cleanly. We hold ConnectionMutex, so just
+		// park the socket for the reader to free (never DestroySocket from here) and clear flags.
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] socket send failed mid-frame; dropping connection."));
+		SocketsPendingDestroy.Add(ClientSocket);
+		ClientSocket = nullptr;
+		bClientConnected = false;
+		bHandshakeOk = false;
+		bHeartbeatStop = true;
+		return false;
+	}
+	return true;
+}
+
+bool FUnrealMcpBridgeServer::TrySendFramedLocked(const TArray<uint8>& Framed)
+{
+	// Caller holds WriteMutex AND ConnectionMutex and has verified ClientSocket != nullptr. Sends the whole
+	// frame, tolerating EWOULDBLOCK on the non-blocking client socket: a full kernel send buffer (a large
+	// frame on a slow reader) makes FSocket::Send return false with SE_EWOULDBLOCK — that is transient, not
+	// fatal, so we wait (bounded) for writability and retry the same offset rather than dropping a healthy
+	// connection mid-frame. Returns false only on a genuine send error or the per-frame deadline.
+	// We deliberately keep ConnectionMutex held across the bounded wait so the reader cannot free the socket
+	// under us (the pass-1 second-connection use-after-free); the wait is bounded, so accepts are only
+	// briefly stalled — and only on the (currently unreachable, all outbound frames are tiny) large-frame
+	// path. Releasing the lock during the wait is the connection-replacement/socket-lifetime redesign that
+	// is tracked separately.
+	ISocketSubsystem* SocketSub = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM);
+	const double Deadline = FPlatformTime::Seconds() + 2.0;
+
 	int32 TotalSent = 0;
 	while (TotalSent < Framed.Num())
 	{
 		int32 JustSent = 0;
-		if (!ClientSocket->Send(Framed.GetData() + TotalSent, Framed.Num() - TotalSent, JustSent) || JustSent <= 0)
+		const bool bSendOk = ClientSocket->Send(Framed.GetData() + TotalSent, Framed.Num() - TotalSent, JustSent);
+		if (JustSent > 0)
 		{
-			// A failed/partial mid-frame send corrupts the stream — the peer would see a truncated line
-			// with the next frame concatenated, and a lost tool-response hangs the pending call until the
-			// heartbeat. Drop the connection so the sidecar reconnects cleanly. We hold ConnectionMutex, so
-			// just park the socket for the reader to free (never DestroySocket from here) and clear flags.
-			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] socket send failed mid-frame; dropping connection."));
-			SocketsPendingDestroy.Add(ClientSocket);
-			ClientSocket = nullptr;
-			bClientConnected = false;
-			bHandshakeOk = false;
-			bHeartbeatStop = true;
-			return false;
+			TotalSent += JustSent;
+			continue;
 		}
-		TotalSent += JustSent;
+
+		// No bytes moved: distinguish a transient full send buffer (EWOULDBLOCK / EAGAIN) from a real error.
+		const ESocketErrors Err = SocketSub != nullptr ? SocketSub->GetLastErrorCode() : SE_NO_ERROR;
+		const bool bWouldBlock = bSendOk || Err == SE_EWOULDBLOCK || Err == SE_TRY_AGAIN;
+		if (!bWouldBlock || FPlatformTime::Seconds() >= Deadline)
+			return false;
+
+		// Wait (bounded) for the socket to become writable, then retry from the same offset.
+		ClientSocket->Wait(ESocketWaitConditions::WaitForWrite, FTimespan::FromMilliseconds(100));
 	}
 	return true;
 }
@@ -488,21 +536,15 @@ void FUnrealMcpBridgeServer::SendManifestLocked()
 	if (ClientSocket == nullptr)
 		return;
 
-	int32 TotalSent = 0;
-	while (TotalSent < Framed.Num())
+	if (!TrySendFramedLocked(Framed))
 	{
-		int32 JustSent = 0;
-		if (!ClientSocket->Send(Framed.GetData() + TotalSent, Framed.Num() - TotalSent, JustSent) || JustSent <= 0)
-		{
-			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] manifest send failed mid-frame; dropping connection."));
-			SocketsPendingDestroy.Add(ClientSocket);
-			ClientSocket = nullptr;
-			bClientConnected = false;
-			bHandshakeOk = false;
-			bHeartbeatStop = true;
-			return;
-		}
-		TotalSent += JustSent;
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] manifest send failed mid-frame; dropping connection."));
+		SocketsPendingDestroy.Add(ClientSocket);
+		ClientSocket = nullptr;
+		bClientConnected = false;
+		bHandshakeOk = false;
+		bHeartbeatStop = true;
+		return;
 	}
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
@@ -140,21 +140,25 @@ bool FUnrealMcpBridgeServer::HandleConnectionAccepted(FSocket* InSocket, const F
 	if (InSocket == nullptr)
 		return false;
 
-	// One connection at a time: a fresh dial replaces a stale one (§1.5 re-dial after reconnect).
+	InSocket->SetNonBlocking(true);
+
+	// One connection at a time: a fresh dial replaces a stale one (§1.5 re-dial after reconnect). We run
+	// on the FTcpListener's accept thread, which must NEVER free the old socket: the reader thread may be
+	// mid-Recv on it (the second-connection use-after-free). Park the old socket for the reader to destroy
+	// and bump the connection generation so the reader resets its NDJSON accumulator and discards any bytes
+	// it reads from the now-superseded socket.
 	{
 		FScopeLock Lock(&ConnectionMutex);
 		if (ClientSocket != nullptr)
-		{
-			ClientSocket->Close();
-			ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(ClientSocket);
-			ClientSocket = nullptr;
-		}
-		InSocket->SetNonBlocking(true);
+			SocketsPendingDestroy.Add(ClientSocket);
 		ClientSocket = InSocket;
+		++ConnectionGeneration;
+		ConnectionAcceptedSeconds = FPlatformTime::Seconds();
 	}
 
 	bHandshakeOk = false;
 	bClientConnected = true;
+	bHeartbeatStop = true; // retire any heartbeat tied to the prior connection; a fresh one starts on handshake
 	LastActivitySeconds.Set(static_cast<int32>(FPlatformTime::Seconds()));
 	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] sidecar connected from %s; awaiting handshake."), *Endpoint.ToString());
 	return true; // keep the socket — we own it now
@@ -164,22 +168,49 @@ bool FUnrealMcpBridgeServer::Init() { return true; }
 
 uint32 FUnrealMcpBridgeServer::Run()
 {
+	// Pre-handshake connections must not hold the single slot indefinitely (a silent dialer that never
+	// sends the handshake). Drop them after this deadline (§6 — the heartbeat only guards POST-handshake
+	// silence). 10 s comfortably covers the sidecar's own 10 s ack timeout on the other side.
+	constexpr double PreHandshakeDeadlineSeconds = 10.0;
+
 	FUnrealMcpNdjsonAccumulator Accumulator;
-	int32 ServedGenerationSocket = 0;
+	int32 ServedGeneration = -1;
 	uint8 Buffer[64 * 1024];
 
 	while (!bStopRequested)
 	{
+		// Only the reader frees sockets (see SocketsPendingDestroy) — do it at a point where we are not
+		// inside a Recv on any of them.
+		DrainPendingDestroy();
+
 		FSocket* Sock;
+		int32 CurrentGeneration;
+		double AcceptedAt;
 		{
 			FScopeLock Lock(&ConnectionMutex);
 			Sock = ClientSocket;
+			CurrentGeneration = ConnectionGeneration;
+			AcceptedAt = ConnectionAcceptedSeconds;
+		}
+
+		// A new connection (or a replacement) resets the framer so a partial line from the OLD socket can
+		// never prepend the new handshake (the stale-accumulator corruption).
+		if (CurrentGeneration != ServedGeneration)
+		{
+			Accumulator = FUnrealMcpNdjsonAccumulator();
+			ServedGeneration = CurrentGeneration;
 		}
 
 		if (Sock == nullptr)
 		{
 			FPlatformProcess::Sleep(0.05f);
-			Accumulator = FUnrealMcpNdjsonAccumulator();
+			continue;
+		}
+
+		if (!bHandshakeOk && (FPlatformTime::Seconds() - AcceptedAt) > PreHandshakeDeadlineSeconds)
+		{
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] connection sent no valid handshake within %.0fs; dropping."), PreHandshakeDeadlineSeconds);
+			CloseActiveConnection();
 			continue;
 		}
 
@@ -188,11 +219,20 @@ uint32 FUnrealMcpBridgeServer::Run()
 
 		int32 BytesRead = 0;
 		const bool bRecvOk = Sock->Recv(Buffer, sizeof(Buffer), BytesRead);
+
+		// The socket may have been superseded by a new accept while we were in Wait/Recv. If so, discard
+		// what we read: it belongs to a connection that is already being torn down (and is about to be
+		// freed by the next DrainPendingDestroy()).
+		{
+			FScopeLock Lock(&ConnectionMutex);
+			if (ConnectionGeneration != CurrentGeneration)
+				continue;
+		}
+
 		if (!bRecvOk || BytesRead == 0)
 		{
 			// Peer closed or errored — drop the connection and wait for a re-dial.
 			CloseActiveConnection();
-			Accumulator = FUnrealMcpNdjsonAccumulator();
 			continue;
 		}
 
@@ -203,7 +243,6 @@ uint32 FUnrealMcpBridgeServer::Run()
 		{
 			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] IPC line exceeded the frame cap; dropping connection."));
 			CloseActiveConnection();
-			Accumulator = FUnrealMcpNdjsonAccumulator();
 			continue;
 		}
 
@@ -237,6 +276,15 @@ void FUnrealMcpBridgeServer::HandleLine(const FString& Line)
 	if (!Message->TryGetStringField(TEXT("type"), Type))
 		return;
 
+	// §1.4 auth gate: until the handshake is validated with the stdin token, the ONLY message we honour is
+	// the handshake itself. Drop every other type (tool-call/tool-cancel/ping/...) — a local process that
+	// guessed the deterministic loopback port must never invoke tools or drive the bridge without the token.
+	if (!bHandshakeOk && Type != TypeHandshake)
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] dropping pre-handshake IPC message of type '%s'."), *Type);
+		return;
+	}
+
 	if (Type == TypeHandshake)        HandleHandshake(Message);
 	else if (Type == TypeToolCall)    HandleToolCall(Message);
 	else if (Type == TypeToolCancel)  HandleToolCancel(Message);
@@ -261,7 +309,9 @@ void FUnrealMcpBridgeServer::HandleHandshake(const TSharedPtr<FJsonObject>& Mess
 	FString IncomingToken;
 	Message->TryGetStringField(TEXT("token"), IncomingToken);
 
-	if (Token.IsEmpty() || IncomingToken != Token)
+	// Case-SENSITIVE compare: the token is a hex secret, so a case-folding match (FString operator==)
+	// would needlessly widen the accepted set.
+	if (Token.IsEmpty() || !IncomingToken.Equals(Token, ESearchCase::CaseSensitive))
 	{
 		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] handshake rejected (token mismatch); closing connection."));
 		CloseActiveConnection();
@@ -283,6 +333,11 @@ void FUnrealMcpBridgeServer::HandleHandshake(const TSharedPtr<FJsonObject>& Mess
 
 void FUnrealMcpBridgeServer::HandleToolCall(const TSharedPtr<FJsonObject>& Message)
 {
+	// Do not start new work once teardown has begun — the continuation captures `this` and the body the
+	// registry, both of which the runtime frees right after Shutdown() (see DrainInFlightCalls).
+	if (bStopRequested)
+		return;
+
 	FString RequestId, ToolName;
 	Message->TryGetStringField(TEXT("requestId"), RequestId);
 	Message->TryGetStringField(TEXT("tool"), ToolName);
@@ -297,24 +352,42 @@ void FUnrealMcpBridgeServer::HandleToolCall(const TSharedPtr<FJsonObject>& Messa
 	if (Message->TryGetObjectField(TEXT("arguments"), ArgsPtr) && ArgsPtr->IsValid())
 		Arguments = *ArgsPtr;
 
-	// Per-call cancel flag (§4), kept alive until the response is sent.
+	// Per-call cancel flag (§4). Shared ownership keeps it alive for the lifetime of the dispatched call
+	// even after we drop the map entry below — the dispatcher's captured copy of FUnrealMcpToolCall holds
+	// a reference, so a late IsCancelled() can never deref freed memory.
 	TSharedRef<FThreadSafeBool, ESPMode::ThreadSafe> CancelFlag = MakeShared<FThreadSafeBool, ESPMode::ThreadSafe>(false);
+
+	// Never trust the sidecar's requestId for map uniqueness: an empty or duplicate id would collide and
+	// silently drop a prior in-flight call's flag. Only correlate cancellation for a non-empty, unique id.
+	bool bTrackCancel = false;
+	if (!RequestId.IsEmpty())
 	{
 		FScopeLock Lock(&CancelMutex);
-		CancelFlags.Add(RequestId, CancelFlag);
+		if (CancelFlags.Contains(RequestId))
+		{
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] duplicate tool-call requestId '%s'; not tracking cancellation for it."), *RequestId);
+		}
+		else
+		{
+			CancelFlags.Add(RequestId, CancelFlag);
+			bTrackCancel = true;
+		}
 	}
 
 	FUnrealMcpToolCall Call(Arguments);
-	Call.CancelRequested = &CancelFlag.Get();
+	Call.CancelRequested = CancelFlag;
 
 	const FString CapturedTool = ToolName;
 	const FString CapturedRequestId = RequestId;
+	const bool bRemoveOnDone = bTrackCancel;
+
+	InFlightCalls.Increment();
 
 	Dispatcher.Dispatch(
 		Call,
 		[this, CapturedTool](const FUnrealMcpToolCall& C) { return Registry.Execute(CapturedTool, C); },
 		FTimespan::FromMilliseconds(TimeoutMs))
-		.Next([this, CapturedRequestId](FUnrealMcpToolResult Result)
+		.Next([this, CapturedRequestId, bRemoveOnDone](FUnrealMcpToolResult Result)
 		{
 			TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
 			Response->SetStringField(TEXT("type"), TypeToolResponse);
@@ -337,8 +410,12 @@ void FUnrealMcpBridgeServer::HandleToolCall(const TSharedPtr<FJsonObject>& Messa
 
 			SendMessage(Response);
 
-			FScopeLock Lock(&CancelMutex);
-			CancelFlags.Remove(CapturedRequestId);
+			if (bRemoveOnDone)
+			{
+				FScopeLock Lock(&CancelMutex);
+				CancelFlags.Remove(CapturedRequestId);
+			}
+			InFlightCalls.Decrement();
 		});
 }
 
@@ -368,7 +445,19 @@ bool FUnrealMcpBridgeServer::SendMessage(const TSharedPtr<FJsonObject>& Message)
 	{
 		int32 JustSent = 0;
 		if (!ClientSocket->Send(Framed.GetData() + TotalSent, Framed.Num() - TotalSent, JustSent) || JustSent <= 0)
+		{
+			// A failed/partial mid-frame send corrupts the stream — the peer would see a truncated line
+			// with the next frame concatenated, and a lost tool-response hangs the pending call until the
+			// heartbeat. Drop the connection so the sidecar reconnects cleanly. We hold ConnectionMutex, so
+			// just park the socket for the reader to free (never DestroySocket from here) and clear flags.
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] socket send failed mid-frame; dropping connection."));
+			SocketsPendingDestroy.Add(ClientSocket);
+			ClientSocket = nullptr;
+			bClientConnected = false;
+			bHandshakeOk = false;
+			bHeartbeatStop = true;
 			return false;
+		}
 		TotalSent += JustSent;
 	}
 	return true;
@@ -387,8 +476,10 @@ void FUnrealMcpBridgeServer::SendHandshakeAck()
 
 void FUnrealMcpBridgeServer::SendManifestLocked()
 {
-	// Caller holds WriteMutex. Build under the game/registry-stable assumption (registry mutates only at
-	// startup). Send the manifest line directly (we already hold the write lock).
+	// Caller holds WriteMutex. Reading the registry here from the IPC reader thread is safe ONLY because
+	// the registry is mutated exclusively at startup (UnrealMcpPingTool::Register runs before the bridge
+	// accepts), so the manifest is stable by the time any handshake arrives. Dynamic re-registration (the
+	// §2.2 hot-reload path) MUST instead marshal the manifest build through the game-thread dispatcher.
 	const TSharedPtr<FJsonObject> Manifest = Registry.BuildManifestJson();
 	const FString Json = SerializeCondensed(Manifest);
 	const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(Json);
@@ -402,7 +493,15 @@ void FUnrealMcpBridgeServer::SendManifestLocked()
 	{
 		int32 JustSent = 0;
 		if (!ClientSocket->Send(Framed.GetData() + TotalSent, Framed.Num() - TotalSent, JustSent) || JustSent <= 0)
+		{
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] manifest send failed mid-frame; dropping connection."));
+			SocketsPendingDestroy.Add(ClientSocket);
+			ClientSocket = nullptr;
+			bClientConnected = false;
+			bHandshakeOk = false;
+			bHeartbeatStop = true;
 			return;
+		}
 		TotalSent += JustSent;
 	}
 }
@@ -417,50 +516,98 @@ void FUnrealMcpBridgeServer::PushManifest()
 
 void FUnrealMcpBridgeServer::CloseActiveConnection()
 {
-	StopHeartbeat();
+	// Signal the heartbeat to stop but NEVER join it here: this method is itself called on the heartbeat
+	// thread (the silent-peer drop path), and joining our own future would self-deadlock — which would
+	// wedge the heartbeat thread permanently and hang the editor on quit. The join happens only in
+	// StartHeartbeat()/Shutdown(), both off the heartbeat thread (and guarded against self-join anyway).
+	bHeartbeatStop = true;
+
 	FScopeLock Lock(&ConnectionMutex);
 	if (ClientSocket != nullptr)
 	{
-		ClientSocket->Close();
-		ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(ClientSocket);
+		// Defer the actual Close+DestroySocket to the reader thread (DrainPendingDestroy): the reader may
+		// be mid-Recv on this very socket on another thread, and freeing it here would be a use-after-free.
+		SocketsPendingDestroy.Add(ClientSocket);
 		ClientSocket = nullptr;
 	}
 	bClientConnected = false;
 	bHandshakeOk = false;
 }
 
+void FUnrealMcpBridgeServer::DrainPendingDestroy()
+{
+	TArray<FSocket*> ToDestroy;
+	{
+		FScopeLock Lock(&ConnectionMutex);
+		if (SocketsPendingDestroy.Num() == 0)
+			return;
+		ToDestroy = MoveTemp(SocketsPendingDestroy);
+		SocketsPendingDestroy.Reset();
+	}
+
+	// Only ever reached on the reader thread (per loop iteration) or in Shutdown() after the reader is
+	// dead — i.e. a single-owner context — so closing+freeing here cannot race a concurrent Recv.
+	ISocketSubsystem* SocketSub = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM);
+	for (FSocket* S : ToDestroy)
+	{
+		if (S != nullptr)
+		{
+			S->Close();
+			SocketSub->DestroySocket(S);
+		}
+	}
+}
+
 void FUnrealMcpBridgeServer::StartHeartbeat()
 {
-	if (HeartbeatFuture.IsValid())
-		return;
+	// Join any prior heartbeat before launching a fresh one. Safe: StartHeartbeat runs on the reader
+	// thread (via HandleHandshake), never on the heartbeat thread, so the join cannot self-deadlock.
+	StopHeartbeat();
 
 	bHeartbeatStop = false;
 	HeartbeatFuture = Async(EAsyncExecution::Thread, [this]()
 	{
+		HeartbeatThreadId.store(FPlatformTLS::GetCurrentThreadId());
+		double LastPingSeconds = FPlatformTime::Seconds();
+
+		// Poll on a short tick (not a full interval sleep) so StopHeartbeat()/connection replacement can
+		// retire this thread promptly instead of blocking a join for up to a whole heartbeat interval.
 		while (!bHeartbeatStop && !bStopRequested)
 		{
-			FPlatformProcess::Sleep(static_cast<float>(HeartbeatIntervalSeconds));
-			if (bHeartbeatStop || bStopRequested || !bClientConnected || !bHandshakeOk)
+			FPlatformProcess::Sleep(0.5f);
+			if (bHeartbeatStop || bStopRequested)
+				break;
+			if (!bClientConnected || !bHandshakeOk)
 				continue;
 
 			const int32 Now = static_cast<int32>(FPlatformTime::Seconds());
 			if (Now - LastActivitySeconds.GetValue() > HeartbeatTimeoutSeconds)
 			{
 				UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] sidecar silent > %ds; dropping connection."), HeartbeatTimeoutSeconds);
-				CloseActiveConnection();
-				return;
+				CloseActiveConnection(); // sets bHeartbeatStop (no self-join) and parks the socket for the reader
+				break;
 			}
 
-			TSharedPtr<FJsonObject> Ping = MakeShared<FJsonObject>();
-			Ping->SetStringField(TEXT("type"), TypePing);
-			SendMessage(Ping);
+			if (FPlatformTime::Seconds() - LastPingSeconds >= static_cast<double>(HeartbeatIntervalSeconds))
+			{
+				LastPingSeconds = FPlatformTime::Seconds();
+				TSharedPtr<FJsonObject> Ping = MakeShared<FJsonObject>();
+				Ping->SetStringField(TEXT("type"), TypePing);
+				SendMessage(Ping);
+			}
 		}
+		HeartbeatThreadId.store(0);
 	});
 }
 
 void FUnrealMcpBridgeServer::StopHeartbeat()
 {
 	bHeartbeatStop = true;
+
+	// Defence in depth against the self-deadlock: never block-join from the heartbeat thread itself.
+	if (HeartbeatThreadId.load() == FPlatformTLS::GetCurrentThreadId())
+		return;
+
 	if (HeartbeatFuture.IsValid())
 	{
 		HeartbeatFuture.Wait();
@@ -485,6 +632,14 @@ void FUnrealMcpBridgeServer::Shutdown()
 
 	StopHeartbeat();
 
+	// Stop accepting (no more connection swaps) and stop the reader (no more socket Recv/destroy) BEFORE we
+	// free any client socket — after this, this thread is the sole owner of the connection state.
+	if (Listener != nullptr)
+	{
+		delete Listener;
+		Listener = nullptr;
+	}
+
 	if (ReaderThread != nullptr)
 	{
 		ReaderThread->Kill(true);
@@ -492,13 +647,16 @@ void FUnrealMcpBridgeServer::Shutdown()
 		ReaderThread = nullptr;
 	}
 
-	if (Listener != nullptr)
-	{
-		delete Listener;
-		Listener = nullptr;
-	}
+	// Drain in-flight dispatched calls before returning (the runtime frees this server, the dispatcher and
+	// the registry right after Shutdown()): each .Next continuation captures `this` and each body captures
+	// the registry, so a call still in flight would fire on freed objects. Cancel cooperatively, then wait
+	// a bounded grace for the in-flight counter to reach zero. (The only core tool today is `ping`, which
+	// drains in microseconds; the bound guarantees we never hang the editor on a misbehaving tool.)
+	CancelAllInFlight();
+	DrainInFlightCalls(FTimespan::FromSeconds(5));
 
 	CloseActiveConnection();
+	DrainPendingDestroy(); // reader is dead — safe to free here
 
 	if (ListenSocket != nullptr)
 	{
@@ -506,4 +664,21 @@ void FUnrealMcpBridgeServer::Shutdown()
 		ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(ListenSocket);
 		ListenSocket = nullptr;
 	}
+}
+
+void FUnrealMcpBridgeServer::CancelAllInFlight()
+{
+	FScopeLock Lock(&CancelMutex);
+	for (TPair<FString, TSharedRef<FThreadSafeBool, ESPMode::ThreadSafe>>& Pair : CancelFlags)
+		Pair.Value.Get() = true;
+}
+
+void FUnrealMcpBridgeServer::DrainInFlightCalls(FTimespan Grace)
+{
+	const double Deadline = FPlatformTime::Seconds() + Grace.GetTotalSeconds();
+	while (InFlightCalls.GetValue() > 0 && FPlatformTime::Seconds() < Deadline)
+		FPlatformProcess::Sleep(0.02f);
+
+	if (InFlightCalls.GetValue() > 0)
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] %d tool call(s) still in flight at shutdown after grace; proceeding."), InFlightCalls.GetValue());
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
@@ -1,0 +1,509 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpBridgeServer.h"
+#include "UnrealMcpNdjson.h"
+#include "UnrealMcpToolRegistry.h"
+#include "Dispatch/UnrealMcpGameThreadDispatcher.h"
+#include "UnrealMcpLog.h"
+
+#include "Common/TcpListener.h"
+#include "Common/TcpSocketBuilder.h"
+#include "Sockets.h"
+#include "SocketSubsystem.h"
+#include "Interfaces/IPv4/IPv4Address.h"
+#include "Interfaces/IPv4/IPv4Endpoint.h"
+#include "HAL/RunnableThread.h"
+#include "Async/Async.h"
+#include "Misc/SecureHash.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
+
+namespace
+{
+	const FString TypeHandshake = TEXT("handshake");
+	const FString TypeHandshakeAck = TEXT("handshake-ack");
+	const FString TypeToolManifest = TEXT("tool-manifest");
+	const FString TypeToolCall = TEXT("tool-call");
+	const FString TypeToolResponse = TEXT("tool-response");
+	const FString TypeToolCancel = TEXT("tool-cancel");
+	const FString TypePing = TEXT("ping");
+	const FString TypePong = TEXT("pong");
+	const FString TypeShutdown = TEXT("shutdown");
+
+	constexpr int32 IpcVersion = 1;
+	constexpr int32 HeartbeatIntervalSeconds = 5;
+	constexpr int32 HeartbeatTimeoutSeconds = 15;
+	constexpr int32 DefaultToolTimeoutMs = 30000;
+
+	FString SerializeCondensed(const TSharedPtr<FJsonObject>& Object)
+	{
+		FString Out;
+		TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =
+			TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&Out);
+		FJsonSerializer::Serialize(Object.ToSharedRef(), Writer);
+		return Out;
+	}
+}
+
+FUnrealMcpBridgeServer::FUnrealMcpBridgeServer(FUnrealMcpToolRegistry& InRegistry, FUnrealMcpGameThreadDispatcher& InDispatcher)
+	: Registry(InRegistry)
+	, Dispatcher(InDispatcher)
+{
+}
+
+FUnrealMcpBridgeServer::~FUnrealMcpBridgeServer()
+{
+	Shutdown();
+}
+
+int32 FUnrealMcpBridgeServer::ComputeDeterministicPort(const FString& InProjectPath)
+{
+	const FString Normalized = InProjectPath.Replace(TEXT("\\"), TEXT("/"));
+	const FString Seed = FString(TEXT("unreal-mcp-ipc:")) + Normalized;
+
+	FSHA1 Sha;
+	const FTCHARToUTF8 Utf8(*Seed);
+	Sha.Update(reinterpret_cast<const uint8*>(Utf8.Get()), Utf8.Length());
+	Sha.Final();
+	uint8 Digest[20];
+	Sha.GetHash(Digest);
+
+	const uint32 Value =
+		(static_cast<uint32>(Digest[0]) << 24) |
+		(static_cast<uint32>(Digest[1]) << 16) |
+		(static_cast<uint32>(Digest[2]) << 8) |
+		(static_cast<uint32>(Digest[3]));
+	return 30000 + static_cast<int32>(Value % 10000);
+}
+
+int32 FUnrealMcpBridgeServer::Start(const FString& InToken, const FString& InProjectPath, const FString& InPluginVersion, const FString& InEngineVersion)
+{
+	Token = InToken;
+	ProjectPath = InProjectPath;
+	PluginVersion = InPluginVersion;
+	EngineVersion = InEngineVersion;
+
+	const int32 BasePort = ComputeDeterministicPort(ProjectPath);
+
+	// §1.1: probe BasePort … BasePort+9, then an ephemeral port (0) as a last resort.
+	for (int32 Offset = 0; Offset <= 10; ++Offset)
+	{
+		int32 TryPort;
+		if (Offset < 10)
+		{
+			TryPort = 30000 + ((BasePort - 30000 + Offset) % 10000);
+		}
+		else
+		{
+			TryPort = 0; // ephemeral
+		}
+
+		FSocket* Candidate = FTcpSocketBuilder(TEXT("UnrealMcpIpcListen"))
+			.AsNonBlocking()
+			.BoundToAddress(FIPv4Address(127, 0, 0, 1))
+			.BoundToPort(TryPort)
+			.Listening(8)
+			.Build();
+
+		if (Candidate != nullptr)
+		{
+			ListenSocket = Candidate;
+			// For an ephemeral bind, read back the actually-assigned port.
+			TSharedRef<FInternetAddr> LocalAddr = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->CreateInternetAddr();
+			ListenSocket->GetAddress(*LocalAddr);
+			BoundPort = LocalAddr->GetPort();
+			break;
+		}
+	}
+
+	if (ListenSocket == nullptr)
+	{
+		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] bridge could not bind any IPC port near %d."), BasePort);
+		return -1;
+	}
+
+	// FSocket& ctor: the listener does NOT own the socket (bDeleteSocket=false) — we destroy it ourselves.
+	Listener = new FTcpListener(*ListenSocket, FTimespan::FromMilliseconds(200), false);
+	Listener->OnConnectionAccepted().BindRaw(this, &FUnrealMcpBridgeServer::HandleConnectionAccepted);
+
+	ReaderThread = FRunnableThread::Create(this, TEXT("UnrealMcpBridgeReader"), 0, TPri_Normal);
+
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] bridge listening on 127.0.0.1:%d (project '%s')."), BoundPort, *ProjectPath);
+	return BoundPort;
+}
+
+bool FUnrealMcpBridgeServer::HandleConnectionAccepted(FSocket* InSocket, const FIPv4Endpoint& Endpoint)
+{
+	if (InSocket == nullptr)
+		return false;
+
+	// One connection at a time: a fresh dial replaces a stale one (§1.5 re-dial after reconnect).
+	{
+		FScopeLock Lock(&ConnectionMutex);
+		if (ClientSocket != nullptr)
+		{
+			ClientSocket->Close();
+			ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(ClientSocket);
+			ClientSocket = nullptr;
+		}
+		InSocket->SetNonBlocking(true);
+		ClientSocket = InSocket;
+	}
+
+	bHandshakeOk = false;
+	bClientConnected = true;
+	LastActivitySeconds.Set(static_cast<int32>(FPlatformTime::Seconds()));
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] sidecar connected from %s; awaiting handshake."), *Endpoint.ToString());
+	return true; // keep the socket — we own it now
+}
+
+bool FUnrealMcpBridgeServer::Init() { return true; }
+
+uint32 FUnrealMcpBridgeServer::Run()
+{
+	FUnrealMcpNdjsonAccumulator Accumulator;
+	int32 ServedGenerationSocket = 0;
+	uint8 Buffer[64 * 1024];
+
+	while (!bStopRequested)
+	{
+		FSocket* Sock;
+		{
+			FScopeLock Lock(&ConnectionMutex);
+			Sock = ClientSocket;
+		}
+
+		if (Sock == nullptr)
+		{
+			FPlatformProcess::Sleep(0.05f);
+			Accumulator = FUnrealMcpNdjsonAccumulator();
+			continue;
+		}
+
+		if (!Sock->Wait(ESocketWaitConditions::WaitForRead, FTimespan::FromMilliseconds(200)))
+			continue;
+
+		int32 BytesRead = 0;
+		const bool bRecvOk = Sock->Recv(Buffer, sizeof(Buffer), BytesRead);
+		if (!bRecvOk || BytesRead == 0)
+		{
+			// Peer closed or errored — drop the connection and wait for a re-dial.
+			CloseActiveConnection();
+			Accumulator = FUnrealMcpNdjsonAccumulator();
+			continue;
+		}
+
+		LastActivitySeconds.Set(static_cast<int32>(FPlatformTime::Seconds()));
+
+		TArray<FString> Lines;
+		if (!Accumulator.Push(Buffer, BytesRead, Lines))
+		{
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] IPC line exceeded the frame cap; dropping connection."));
+			CloseActiveConnection();
+			Accumulator = FUnrealMcpNdjsonAccumulator();
+			continue;
+		}
+
+		for (const FString& Line : Lines)
+		{
+			if (!Line.IsEmpty())
+				HandleLine(Line);
+		}
+	}
+	return 0;
+}
+
+void FUnrealMcpBridgeServer::Stop()
+{
+	bStopRequested = true;
+}
+
+void FUnrealMcpBridgeServer::Exit() {}
+
+void FUnrealMcpBridgeServer::HandleLine(const FString& Line)
+{
+	TSharedPtr<FJsonObject> Message;
+	const TSharedRef<TJsonReader<TCHAR>> Reader = TJsonReaderFactory<TCHAR>::Create(Line);
+	if (!FJsonSerializer::Deserialize(Reader, Message) || !Message.IsValid())
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] dropped malformed IPC line."));
+		return;
+	}
+
+	FString Type;
+	if (!Message->TryGetStringField(TEXT("type"), Type))
+		return;
+
+	if (Type == TypeHandshake)        HandleHandshake(Message);
+	else if (Type == TypeToolCall)    HandleToolCall(Message);
+	else if (Type == TypeToolCancel)  HandleToolCancel(Message);
+	else if (Type == TypePing)
+	{
+		TSharedPtr<FJsonObject> Pong = MakeShared<FJsonObject>();
+		Pong->SetStringField(TEXT("type"), TypePong);
+		SendMessage(Pong);
+	}
+	else if (Type == TypePong)
+	{
+		// liveness already refreshed in Run()
+	}
+	else
+	{
+		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] ignoring IPC message of type '%s'."), *Type);
+	}
+}
+
+void FUnrealMcpBridgeServer::HandleHandshake(const TSharedPtr<FJsonObject>& Message)
+{
+	FString IncomingToken;
+	Message->TryGetStringField(TEXT("token"), IncomingToken);
+
+	if (Token.IsEmpty() || IncomingToken != Token)
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] handshake rejected (token mismatch); closing connection."));
+		CloseActiveConnection();
+		return;
+	}
+
+	bHandshakeOk = true;
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] handshake accepted."));
+	SendHandshakeAck();
+
+	// §1.5: on Ready immediately push the manifest (config push lands with the connection-config task).
+	{
+		FScopeLock Lock(&WriteMutex);
+		SendManifestLocked();
+	}
+
+	StartHeartbeat();
+}
+
+void FUnrealMcpBridgeServer::HandleToolCall(const TSharedPtr<FJsonObject>& Message)
+{
+	FString RequestId, ToolName;
+	Message->TryGetStringField(TEXT("requestId"), RequestId);
+	Message->TryGetStringField(TEXT("tool"), ToolName);
+
+	int32 TimeoutMs = DefaultToolTimeoutMs;
+	double TimeoutValue;
+	if (Message->TryGetNumberField(TEXT("timeoutMs"), TimeoutValue) && TimeoutValue > 0)
+		TimeoutMs = static_cast<int32>(TimeoutValue);
+
+	TSharedPtr<FJsonObject> Arguments = MakeShared<FJsonObject>();
+	const TSharedPtr<FJsonObject>* ArgsPtr;
+	if (Message->TryGetObjectField(TEXT("arguments"), ArgsPtr) && ArgsPtr->IsValid())
+		Arguments = *ArgsPtr;
+
+	// Per-call cancel flag (§4), kept alive until the response is sent.
+	TSharedRef<FThreadSafeBool, ESPMode::ThreadSafe> CancelFlag = MakeShared<FThreadSafeBool, ESPMode::ThreadSafe>(false);
+	{
+		FScopeLock Lock(&CancelMutex);
+		CancelFlags.Add(RequestId, CancelFlag);
+	}
+
+	FUnrealMcpToolCall Call(Arguments);
+	Call.CancelRequested = &CancelFlag.Get();
+
+	const FString CapturedTool = ToolName;
+	const FString CapturedRequestId = RequestId;
+
+	Dispatcher.Dispatch(
+		Call,
+		[this, CapturedTool](const FUnrealMcpToolCall& C) { return Registry.Execute(CapturedTool, C); },
+		FTimespan::FromMilliseconds(TimeoutMs))
+		.Next([this, CapturedRequestId](FUnrealMcpToolResult Result)
+		{
+			TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
+			Response->SetStringField(TEXT("type"), TypeToolResponse);
+			Response->SetStringField(TEXT("requestId"), CapturedRequestId);
+			Response->SetStringField(TEXT("status"), Result.bSuccess ? TEXT("success") : TEXT("error"));
+
+			TArray<TSharedPtr<FJsonValue>> Content;
+			if (!Result.Message.IsEmpty())
+			{
+				TSharedPtr<FJsonObject> TextBlock = MakeShared<FJsonObject>();
+				TextBlock->SetStringField(TEXT("type"), TEXT("text"));
+				TextBlock->SetStringField(TEXT("text"), Result.Message);
+				TextBlock->SetStringField(TEXT("mimeType"), TEXT("text/plain"));
+				Content.Add(MakeShared<FJsonValueObject>(TextBlock));
+			}
+			Response->SetArrayField(TEXT("content"), Content);
+
+			if (Result.Structured.IsValid())
+				Response->SetObjectField(TEXT("structured"), Result.Structured);
+
+			SendMessage(Response);
+
+			FScopeLock Lock(&CancelMutex);
+			CancelFlags.Remove(CapturedRequestId);
+		});
+}
+
+void FUnrealMcpBridgeServer::HandleToolCancel(const TSharedPtr<FJsonObject>& Message)
+{
+	FString RequestId;
+	if (!Message->TryGetStringField(TEXT("requestId"), RequestId))
+		return;
+
+	FScopeLock Lock(&CancelMutex);
+	if (TSharedRef<FThreadSafeBool, ESPMode::ThreadSafe>* Flag = CancelFlags.Find(RequestId))
+		(*Flag).Get() = true;
+}
+
+bool FUnrealMcpBridgeServer::SendMessage(const TSharedPtr<FJsonObject>& Message)
+{
+	const FString Json = SerializeCondensed(Message);
+	const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(Json);
+
+	FScopeLock WriteLock(&WriteMutex);
+	FScopeLock ConnLock(&ConnectionMutex);
+	if (ClientSocket == nullptr)
+		return false;
+
+	int32 TotalSent = 0;
+	while (TotalSent < Framed.Num())
+	{
+		int32 JustSent = 0;
+		if (!ClientSocket->Send(Framed.GetData() + TotalSent, Framed.Num() - TotalSent, JustSent) || JustSent <= 0)
+			return false;
+		TotalSent += JustSent;
+	}
+	return true;
+}
+
+void FUnrealMcpBridgeServer::SendHandshakeAck()
+{
+	TSharedPtr<FJsonObject> Ack = MakeShared<FJsonObject>();
+	Ack->SetStringField(TEXT("type"), TypeHandshakeAck);
+	Ack->SetNumberField(TEXT("ipcVersion"), IpcVersion);
+	Ack->SetStringField(TEXT("pluginVersion"), PluginVersion);
+	Ack->SetStringField(TEXT("engineVersion"), EngineVersion);
+	Ack->SetStringField(TEXT("projectPath"), ProjectPath);
+	SendMessage(Ack);
+}
+
+void FUnrealMcpBridgeServer::SendManifestLocked()
+{
+	// Caller holds WriteMutex. Build under the game/registry-stable assumption (registry mutates only at
+	// startup). Send the manifest line directly (we already hold the write lock).
+	const TSharedPtr<FJsonObject> Manifest = Registry.BuildManifestJson();
+	const FString Json = SerializeCondensed(Manifest);
+	const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(Json);
+
+	FScopeLock ConnLock(&ConnectionMutex);
+	if (ClientSocket == nullptr)
+		return;
+
+	int32 TotalSent = 0;
+	while (TotalSent < Framed.Num())
+	{
+		int32 JustSent = 0;
+		if (!ClientSocket->Send(Framed.GetData() + TotalSent, Framed.Num() - TotalSent, JustSent) || JustSent <= 0)
+			return;
+		TotalSent += JustSent;
+	}
+}
+
+void FUnrealMcpBridgeServer::PushManifest()
+{
+	if (!bClientConnected || !bHandshakeOk)
+		return;
+	FScopeLock Lock(&WriteMutex);
+	SendManifestLocked();
+}
+
+void FUnrealMcpBridgeServer::CloseActiveConnection()
+{
+	StopHeartbeat();
+	FScopeLock Lock(&ConnectionMutex);
+	if (ClientSocket != nullptr)
+	{
+		ClientSocket->Close();
+		ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(ClientSocket);
+		ClientSocket = nullptr;
+	}
+	bClientConnected = false;
+	bHandshakeOk = false;
+}
+
+void FUnrealMcpBridgeServer::StartHeartbeat()
+{
+	if (HeartbeatFuture.IsValid())
+		return;
+
+	bHeartbeatStop = false;
+	HeartbeatFuture = Async(EAsyncExecution::Thread, [this]()
+	{
+		while (!bHeartbeatStop && !bStopRequested)
+		{
+			FPlatformProcess::Sleep(static_cast<float>(HeartbeatIntervalSeconds));
+			if (bHeartbeatStop || bStopRequested || !bClientConnected || !bHandshakeOk)
+				continue;
+
+			const int32 Now = static_cast<int32>(FPlatformTime::Seconds());
+			if (Now - LastActivitySeconds.GetValue() > HeartbeatTimeoutSeconds)
+			{
+				UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] sidecar silent > %ds; dropping connection."), HeartbeatTimeoutSeconds);
+				CloseActiveConnection();
+				return;
+			}
+
+			TSharedPtr<FJsonObject> Ping = MakeShared<FJsonObject>();
+			Ping->SetStringField(TEXT("type"), TypePing);
+			SendMessage(Ping);
+		}
+	});
+}
+
+void FUnrealMcpBridgeServer::StopHeartbeat()
+{
+	bHeartbeatStop = true;
+	if (HeartbeatFuture.IsValid())
+	{
+		HeartbeatFuture.Wait();
+		HeartbeatFuture = TFuture<void>();
+	}
+}
+
+void FUnrealMcpBridgeServer::Shutdown()
+{
+	if (bStopRequested && Listener == nullptr && ReaderThread == nullptr)
+		return;
+
+	bStopRequested = true;
+
+	// Ask the sidecar to exit gracefully (§1.5).
+	if (bClientConnected && bHandshakeOk)
+	{
+		TSharedPtr<FJsonObject> Bye = MakeShared<FJsonObject>();
+		Bye->SetStringField(TEXT("type"), TypeShutdown);
+		SendMessage(Bye);
+	}
+
+	StopHeartbeat();
+
+	if (ReaderThread != nullptr)
+	{
+		ReaderThread->Kill(true);
+		delete ReaderThread;
+		ReaderThread = nullptr;
+	}
+
+	if (Listener != nullptr)
+	{
+		delete Listener;
+		Listener = nullptr;
+	}
+
+	CloseActiveConnection();
+
+	if (ListenSocket != nullptr)
+	{
+		ListenSocket->Close();
+		ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(ListenSocket);
+		ListenSocket = nullptr;
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
@@ -154,11 +154,17 @@ bool FUnrealMcpBridgeServer::HandleConnectionAccepted(FSocket* InSocket, const F
 		ClientSocket = InSocket;
 		++ConnectionGeneration;
 		ConnectionAcceptedSeconds = FPlatformTime::Seconds();
+
+		// Reset the connection flags INSIDE the lock so the socket swap, the generation bump, and the flag
+		// reset are one atomic step. If these writes happened after releasing the lock, the reader could
+		// observe the bumped generation and a freshly-arrived handshake could flip bHandshakeOk=true
+		// (HandleHandshake sets it under this SAME lock) before the delayed bHandshakeOk=false landed —
+		// clobbering a just-authenticated connection back to pre-handshake until the 10 s deadline recycled it.
+		bHandshakeOk = false;
+		bClientConnected = true;
+		bHeartbeatStop = true; // retire any heartbeat tied to the prior connection; a fresh one starts on handshake
 	}
 
-	bHandshakeOk = false;
-	bClientConnected = true;
-	bHeartbeatStop = true; // retire any heartbeat tied to the prior connection; a fresh one starts on handshake
 	LastActivitySeconds.Set(static_cast<int32>(FPlatformTime::Seconds()));
 	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] sidecar connected from %s; awaiting handshake."), *Endpoint.ToString());
 	return true; // keep the socket — we own it now

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.h
@@ -61,14 +61,15 @@ public:
 
 private:
 	bool HandleConnectionAccepted(FSocket* InSocket, const FIPv4Endpoint& Endpoint);
-	void HandleLine(const FString& Line);
-	void HandleHandshake(const TSharedPtr<FJsonObject>& Message);
+	void HandleLine(const FString& Line, int32 Generation);
+	void HandleHandshake(const TSharedPtr<FJsonObject>& Message, int32 Generation);
 	void HandleToolCall(const TSharedPtr<FJsonObject>& Message);
 	void HandleToolCancel(const TSharedPtr<FJsonObject>& Message);
 
 	bool SendMessage(const TSharedPtr<FJsonObject>& Message);
 	void SendHandshakeAck();
 	void SendManifestLocked();
+	bool TrySendFramedLocked(const TArray<uint8>& Framed); // WriteMutex+ConnectionMutex held, ClientSocket valid
 	void CloseActiveConnection();
 	void DrainPendingDestroy();    // reader-/shutdown-owned: actually frees sockets parked for teardown
 	void StartHeartbeat();

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.h
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "HAL/Runnable.h"
+#include "HAL/ThreadSafeBool.h"
+#include "Dom/JsonObject.h"
+
+class FUnrealMcpToolRegistry;
+class FUnrealMcpGameThreadDispatcher;
+class FTcpListener;
+class FSocket;
+class FRunnableThread;
+struct FIPv4Endpoint;
+
+/**
+ * The plugin-side IPC bridge server (docs/ARCHITECTURE.md §1). Listens on 127.0.0.1 at a deterministic
+ * per-project port (§1.1), accepts the sidecar's dial, validates the stdin-delivered token in the
+ * handshake (§1.4), then exchanges NDJSON messages (§1.2): pushes the tool manifest + config on Ready,
+ * routes tool-calls through the game-thread dispatcher (§4), and answers heartbeats (§1.3).
+ *
+ * Threading: FTcpListener accepts on its own thread; a dedicated reader thread (this FRunnable) drains
+ * the connection; a heartbeat thread pings on a timer. All socket WRITES go through a single mutex so
+ * messages never interleave (§1.2). Tool bodies run on the game thread via the dispatcher — never here.
+ */
+class FUnrealMcpBridgeServer : public FRunnable
+{
+public:
+	FUnrealMcpBridgeServer(FUnrealMcpToolRegistry& InRegistry, FUnrealMcpGameThreadDispatcher& InDispatcher);
+	virtual ~FUnrealMcpBridgeServer() override;
+
+	/**
+	 * Bind + listen on the deterministic port for @p ProjectPath (probing forward on conflict, §1.1) and
+	 * begin accepting. Returns the bound port, or -1 if every probed port failed. @p Token is the secret
+	 * the handshake must carry (§1.4); the other args are echoed in the handshake-ack.
+	 */
+	int32 Start(const FString& InToken, const FString& InProjectPath, const FString& InPluginVersion, const FString& InEngineVersion);
+
+	/** Stop accepting, send the connected sidecar a graceful shutdown, and tear down all threads/sockets. */
+	void Shutdown();
+
+	int32 GetBoundPort() const { return BoundPort; }
+	bool IsClientConnected() const { return bClientConnected; }
+
+	/** Re-push the manifest (call after the registry changes, §2.2 hot reload). No-op when disconnected. */
+	void PushManifest();
+
+	/** Deterministic IPC port for a project path (§1.1): 30000 + sha(path) % 10000. */
+	static int32 ComputeDeterministicPort(const FString& ProjectPath);
+
+	// FRunnable (the reader loop) ------------------------------------------------------------------
+	virtual bool Init() override;
+	virtual uint32 Run() override;
+	virtual void Stop() override;
+	virtual void Exit() override;
+
+private:
+	bool HandleConnectionAccepted(FSocket* InSocket, const FIPv4Endpoint& Endpoint);
+	void HandleLine(const FString& Line);
+	void HandleHandshake(const TSharedPtr<FJsonObject>& Message);
+	void HandleToolCall(const TSharedPtr<FJsonObject>& Message);
+	void HandleToolCancel(const TSharedPtr<FJsonObject>& Message);
+
+	bool SendMessage(const TSharedPtr<FJsonObject>& Message);
+	void SendHandshakeAck();
+	void SendManifestLocked();
+	void CloseActiveConnection();
+	void StartHeartbeat();
+	void StopHeartbeat();
+
+	FUnrealMcpToolRegistry& Registry;
+	FUnrealMcpGameThreadDispatcher& Dispatcher;
+
+	FTcpListener* Listener = nullptr;
+	FSocket* ListenSocket = nullptr;       // owned by this (FTcpListener uses it but does not delete it)
+	FSocket* ClientSocket = nullptr;       // the accepted sidecar connection (owned by this)
+	FRunnableThread* ReaderThread = nullptr;
+
+	FString Token;
+	FString ProjectPath;
+	FString PluginVersion;
+	FString EngineVersion;
+	int32 BoundPort = -1;
+
+	FThreadSafeBool bStopRequested = false;
+	FThreadSafeBool bClientConnected = false;
+	FThreadSafeBool bHandshakeOk = false;
+	FThreadSafeCounter LastActivitySeconds; // wall-clock seconds of last inbound activity
+
+	mutable FCriticalSection WriteMutex;     // serializes all socket sends (§1.2)
+	mutable FCriticalSection ConnectionMutex; // guards ClientSocket swap/teardown
+
+	// In-flight cancellation flags, keyed by requestId (§4).
+	FCriticalSection CancelMutex;
+	TMap<FString, TSharedRef<FThreadSafeBool, ESPMode::ThreadSafe>> CancelFlags;
+
+	TFuture<void> HeartbeatFuture;
+	FThreadSafeBool bHeartbeatStop = false;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.h
@@ -6,7 +6,10 @@
 #include "CoreMinimal.h"
 #include "HAL/Runnable.h"
 #include "HAL/ThreadSafeBool.h"
+#include "HAL/PlatformTLS.h"
 #include "Dom/JsonObject.h"
+
+#include <atomic>
 
 class FUnrealMcpToolRegistry;
 class FUnrealMcpGameThreadDispatcher;
@@ -67,16 +70,27 @@ private:
 	void SendHandshakeAck();
 	void SendManifestLocked();
 	void CloseActiveConnection();
+	void DrainPendingDestroy();    // reader-/shutdown-owned: actually frees sockets parked for teardown
 	void StartHeartbeat();
 	void StopHeartbeat();
+	void CancelAllInFlight();                      // set every in-flight call's cancel flag (shutdown)
+	void DrainInFlightCalls(FTimespan Grace);      // wait (bounded) for in-flight continuations to finish
 
 	FUnrealMcpToolRegistry& Registry;
 	FUnrealMcpGameThreadDispatcher& Dispatcher;
 
 	FTcpListener* Listener = nullptr;
 	FSocket* ListenSocket = nullptr;       // owned by this (FTcpListener uses it but does not delete it)
-	FSocket* ClientSocket = nullptr;       // the accepted sidecar connection (owned by this)
+	FSocket* ClientSocket = nullptr;       // the accepted sidecar connection (owned by this; guarded by ConnectionMutex)
 	FRunnableThread* ReaderThread = nullptr;
+
+	// Sockets parked for teardown. The accept thread / a failed send / a heartbeat drop only PARK the old
+	// socket here (under ConnectionMutex); the actual Close+DestroySocket happens on the reader thread (or
+	// in Shutdown after the reader is dead) via DrainPendingDestroy() — never while another thread might
+	// still be mid-Recv on it. This is the generation-based fix for the second-connection use-after-free.
+	TArray<FSocket*> SocketsPendingDestroy;
+	int32 ConnectionGeneration = 0;        // bumps on every accepted connection (guarded by ConnectionMutex)
+	double ConnectionAcceptedSeconds = 0.0; // wall-clock of the current accept (for the pre-handshake deadline)
 
 	FString Token;
 	FString ProjectPath;
@@ -95,7 +109,9 @@ private:
 	// In-flight cancellation flags, keyed by requestId (§4).
 	FCriticalSection CancelMutex;
 	TMap<FString, TSharedRef<FThreadSafeBool, ESPMode::ThreadSafe>> CancelFlags;
+	FThreadSafeCounter InFlightCalls;      // dispatched calls whose continuation has not yet completed
 
 	TFuture<void> HeartbeatFuture;
 	FThreadSafeBool bHeartbeatStop = false;
+	std::atomic<uint32> HeartbeatThreadId{ 0 }; // id of the live heartbeat thread, for the self-join guard
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpNdjson.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpNdjson.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpNdjson.h"
+
+FString FUnrealMcpNdjsonAccumulator::DrainLine()
+{
+	int32 Len = Buffer.Num();
+	// Tolerate CRLF: strip a trailing '\r'.
+	if (Len > 0 && Buffer[Len - 1] == '\r')
+		--Len;
+
+	FString Line;
+	if (Len > 0)
+	{
+		FUTF8ToTCHAR Convert(reinterpret_cast<const ANSICHAR*>(Buffer.GetData()), Len);
+		Line = FString(Convert.Length(), Convert.Get());
+	}
+	Buffer.Reset();
+	return Line;
+}
+
+bool FUnrealMcpNdjsonAccumulator::Push(const uint8* Data, int32 Count, TArray<FString>& OutLines)
+{
+	for (int32 i = 0; i < Count; ++i)
+	{
+		const uint8 B = Data[i];
+		if (B == '\n')
+		{
+			OutLines.Add(DrainLine());
+		}
+		else
+		{
+			Buffer.Add(B);
+			if (Buffer.Num() > MaxLineBytes)
+				return false; // line exceeded the cap before a newline (§1.2) → abort
+		}
+	}
+	return true;
+}
+
+TArray<uint8> FUnrealMcpNdjsonAccumulator::Encode(const FString& JsonLine)
+{
+	FTCHARToUTF8 Convert(*JsonLine);
+	TArray<uint8> Out;
+	Out.Append(reinterpret_cast<const uint8*>(Convert.Get()), Convert.Length());
+	Out.Add('\n');
+	return Out;
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpNdjson.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpNdjson.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * NDJSON framing codec (docs/ARCHITECTURE.md §1.2): UTF-8 JSON, one message per '\n'-terminated line,
+ * line length capped at MaxLineBytes. The C++ peer of the sidecar's NdjsonFramer. The decode side is a
+ * stateful accumulator: feed it raw bytes off the socket and it yields complete UTF-8 lines, buffering
+ * partial lines across reads. Pure (no socket dependency) so it is unit-tested by an Automation spec.
+ */
+class UNREALMCPEDITOR_API FUnrealMcpNdjsonAccumulator
+{
+public:
+	static constexpr int32 DefaultMaxLineBytes = 64 * 1024 * 1024;
+
+	explicit FUnrealMcpNdjsonAccumulator(int32 InMaxLineBytes = DefaultMaxLineBytes)
+		: MaxLineBytes(InMaxLineBytes) {}
+
+	/**
+	 * Push raw bytes; append every completed line (newline + optional trailing '\r' stripped, decoded
+	 * UTF-8) to @p OutLines. Returns false when a single un-terminated line grows past the cap — the
+	 * caller must abort the connection (§1.2).
+	 */
+	bool Push(const uint8* Data, int32 Count, TArray<FString>& OutLines);
+
+	/** Encode one JSON line into wire bytes (UTF-8 + trailing '\n'). */
+	static TArray<uint8> Encode(const FString& JsonLine);
+
+private:
+	TArray<uint8> Buffer;
+	int32 MaxLineBytes;
+
+	FString DrainLine();
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Dispatch/UnrealMcpGameThreadDispatcher.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Dispatch/UnrealMcpGameThreadDispatcher.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpGameThreadDispatcher.h"
+#include "UnrealMcpLog.h"
+#include "Async/Async.h"
+#include "HAL/Event.h"
+
+#include <atomic>
+
+namespace
+{
+	/**
+	 * Shared completion state for one dispatched call. The promise is completed by whichever path wins
+	 * the atomic guard first — the game-thread body or the timeout watcher — so it is never set twice.
+	 */
+	struct FDispatchState
+	{
+		TPromise<FUnrealMcpToolResult> Promise;
+		std::atomic<bool> bCompleted{ false };
+
+		void Complete(FUnrealMcpToolResult&& Result)
+		{
+			bool Expected = false;
+			if (bCompleted.compare_exchange_strong(Expected, true))
+				Promise.SetValue(MoveTemp(Result));
+		}
+	};
+
+	/**
+	 * A pooled FEvent whose lifetime is shared by the body and the timeout watcher. Whichever finishes
+	 * LAST releases the last reference, and only then is the event returned to the pool — so a slow body
+	 * that triggers the event after the watcher already gave up can never poke a recycled event.
+	 */
+	struct FSharedPooledEvent
+	{
+		FEvent* Event;
+		FSharedPooledEvent() : Event(FPlatformProcess::GetSynchEventFromPool(/*bIsManualReset*/ true)) {}
+		~FSharedPooledEvent()
+		{
+			if (Event != nullptr)
+			{
+				FPlatformProcess::ReturnSynchEventToPool(Event);
+				Event = nullptr;
+			}
+		}
+	};
+}
+
+TFuture<FUnrealMcpToolResult> FUnrealMcpGameThreadDispatcher::Dispatch(
+	FUnrealMcpToolCall Call,
+	TFunction<FUnrealMcpToolResult(const FUnrealMcpToolCall&)> Body,
+	FTimespan Timeout)
+{
+	TSharedRef<FDispatchState, ESPMode::ThreadSafe> State = MakeShared<FDispatchState, ESPMode::ThreadSafe>();
+	TSharedRef<FSharedPooledEvent, ESPMode::ThreadSafe> Done = MakeShared<FSharedPooledEvent, ESPMode::ThreadSafe>();
+	TFuture<FUnrealMcpToolResult> Future = State->Promise.GetFuture();
+
+	auto RunBody = [State, Body = MoveTemp(Body), Call, Done]() mutable
+	{
+		FUnrealMcpToolResult Result = Body(Call);
+		State->Complete(MoveTemp(Result));
+		Done->Event->Trigger();
+	};
+
+	if (IsInGameThread())
+	{
+		RunBody();
+	}
+	else
+	{
+		AsyncTask(ENamedThreads::GameThread, [RunBody = MoveTemp(RunBody)]() mutable { RunBody(); });
+	}
+
+	// Always arm the watcher. When the body already completed, the event is already triggered and Wait()
+	// returns immediately. Both lambdas hold a ref to the pooled event, so it is returned to the pool only
+	// after BOTH have finished — never while a still-pending body might trigger it.
+	const uint32 TimeoutMs = static_cast<uint32>(
+		FMath::Clamp<int64>(static_cast<int64>(Timeout.GetTotalMilliseconds()), 1, static_cast<int64>(MAX_uint32)));
+
+	Async(EAsyncExecution::ThreadPool, [State, Done, TimeoutMs]()
+	{
+		Done->Event->Wait(TimeoutMs);
+		State->Complete(FUnrealMcpToolResult::Error(TEXT("Tool call timed out.")));
+	});
+
+	return Future;
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Dispatch/UnrealMcpGameThreadDispatcher.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Dispatch/UnrealMcpGameThreadDispatcher.cpp
@@ -78,9 +78,19 @@ TFuture<FUnrealMcpToolResult> FUnrealMcpGameThreadDispatcher::Dispatch(
 	const uint32 TimeoutMs = static_cast<uint32>(
 		FMath::Clamp<int64>(static_cast<int64>(Timeout.GetTotalMilliseconds()), 1, static_cast<int64>(MAX_uint32)));
 
-	Async(EAsyncExecution::ThreadPool, [State, Done, TimeoutMs]()
+	Async(EAsyncExecution::ThreadPool, [State, Done, TimeoutMs, Call]()
 	{
-		Done->Event->Wait(TimeoutMs);
+		if (Done->Event->Wait(TimeoutMs))
+			return; // the body finished first and already completed the promise — nothing to time out.
+
+		// Timed out before the body finished. Signal cooperative cancellation so a still-running game-thread
+		// body can observe IsCancelled() and bail (§4 — the registry header documents CancelRequested as
+		// "set by a tool-cancel OR a timeout"; until now only tool-cancel set it). The captured Call copy
+		// holds the shared cancel flag alive, so this stays valid even after the bridge drops its CancelFlags
+		// map entry. Then complete the future with the timeout error; if the body completes in the meantime,
+		// its Complete() is a no-op (single-completion guard).
+		if (Call.CancelRequested.IsValid())
+			const_cast<FThreadSafeBool&>(*Call.CancelRequested) = true;
 		State->Complete(FUnrealMcpToolResult::Error(TEXT("Tool call timed out.")));
 	});
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Dispatch/UnrealMcpGameThreadDispatcher.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Dispatch/UnrealMcpGameThreadDispatcher.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UnrealMcpToolRegistry.h"
+#include "Async/Future.h"
+
+/**
+ * The Unreal-MCP game-thread dispatcher (docs/ARCHITECTURE.md §4) — the analog of Unity's
+ * MainThread.Instance.Run() / Godot's GodotMainThread. Tool bodies touch the Unreal API, which is
+ * only safe on the game thread, so the IPC reader thread NEVER runs a tool body directly: it calls
+ * Dispatch(), which posts the body to the game thread via AsyncTask and returns a TFuture the bridge
+ * attaches a continuation to. Slow tools therefore never stall the IPC heartbeat.
+ *
+ * A per-call timeout completes the future with a structured error if the body has not finished; the
+ * body's late result is then dropped (the promise's single-completion guard prevents a double-set, §4).
+ */
+class UNREALMCPEDITOR_API FUnrealMcpGameThreadDispatcher
+{
+public:
+	/**
+	 * Run @p Body on the game thread (inline when already on it, §4) and return a future for its result.
+	 * A parallel watcher completes the future with a timeout error after @p Timeout if the body has not
+	 * finished. The future is always completed exactly once.
+	 */
+	TFuture<FUnrealMcpToolResult> Dispatch(
+		FUnrealMcpToolCall Call,
+		TFunction<FUnrealMcpToolResult(const FUnrealMcpToolCall&)> Body,
+		FTimespan Timeout);
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.cpp
@@ -165,7 +165,12 @@ void FUnrealMcpSidecarManager::StartWatchdog()
 			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] sidecar exited; restarting in %ds (restart #%d)."),
 				DelaySeconds, RestartCount.GetValue() + 1);
 
-			FPlatformProcess::Sleep(static_cast<float>(DelaySeconds));
+			// Chunk the backoff on a short tick (not one uninterruptible Sleep of up to 30 s): StopWatchdog()
+			// joins this thread on the game thread at editor shutdown, so a single long sleep would stall the
+			// editor's quit for the remainder of the backoff. Poll bStopRequested like the bridge heartbeat.
+			const double BackoffUntil = FPlatformTime::Seconds() + DelaySeconds;
+			while (!bStopRequested && FPlatformTime::Seconds() < BackoffUntil)
+				FPlatformProcess::Sleep(0.5f);
 			if (bStopRequested)
 				break;
 
@@ -208,6 +213,19 @@ void FUnrealMcpSidecarManager::TerminateProcess()
 bool FUnrealMcpSidecarManager::IsRunning() const
 {
 	return ProcHandle.IsValid() && FPlatformProcess::IsProcRunning(const_cast<FProcHandle&>(ProcHandle));
+}
+
+void FUnrealMcpSidecarManager::StopRestarts()
+{
+	StopWatchdog();
+}
+
+bool FUnrealMcpSidecarManager::WaitForExit(FTimespan Grace)
+{
+	const double Deadline = FPlatformTime::Seconds() + Grace.GetTotalSeconds();
+	while (ProcHandle.IsValid() && FPlatformProcess::IsProcRunning(ProcHandle) && FPlatformTime::Seconds() < Deadline)
+		FPlatformProcess::Sleep(0.05f);
+	return !(ProcHandle.IsValid() && FPlatformProcess::IsProcRunning(ProcHandle));
 }
 
 void FUnrealMcpSidecarManager::Stop()

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.cpp
@@ -113,7 +113,9 @@ bool FUnrealMcpSidecarManager::SpawnProcess()
 	}
 
 	// Write exactly one token line; the sidecar reads one line from stdin before dialing (§1.4).
-	FPlatformProcess::WritePipe(WritePipe, Token + TEXT("\n"));
+	// FPlatformProcess::WritePipe(const FString&) appends its own trailing '\n', so we pass the bare token
+	// (adding another would send a spurious blank second line).
+	FPlatformProcess::WritePipe(WritePipe, Token);
 
 	// Close the parent's pipe copies. The child keeps its inherited stdin handle; closing the write end
 	// sends EOF after the single token line (the sidecar only reads one line).

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.cpp
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpSidecarManager.h"
+#include "UnrealMcpLog.h"
+#include "Async/Async.h"
+#include "HAL/PlatformProcess.h"
+#include "Misc/Paths.h"
+
+#include <random>
+
+namespace
+{
+	// §1.5 restart backoff schedule (seconds).
+	const int32 BackoffSeconds[] = { 1, 2, 5, 10, 30 };
+	constexpr int32 MaxCrashesPerWindow = 5;
+	constexpr double CrashWindowSeconds = 300.0;
+}
+
+FUnrealMcpSidecarManager::~FUnrealMcpSidecarManager()
+{
+	Stop();
+}
+
+FString FUnrealMcpSidecarManager::ResolveBridgeBinaryPath()
+{
+	// §6 dev override (and the only resolution path until the download task lands).
+	const FString Override = FPlatformMisc::GetEnvironmentVariable(TEXT("UNREAL_MCP_BRIDGE_PATH"));
+	if (!Override.IsEmpty() && FPaths::FileExists(Override))
+		return Override;
+
+	// TODO(§6 download task): download-on-first-run from GitHub Releases into
+	// <Project>/Intermediate/UnrealMCP/bridge/<platform>/unreal-mcp-bridge(.exe). Stubbed here.
+	return FString();
+}
+
+FString FUnrealMcpSidecarManager::GenerateToken()
+{
+	// §1.4: 32 cryptographically-random bytes. std::random_device is backed by the OS CSPRNG on the
+	// supported targets (RtlGenRandom on Windows-MSVC, /dev/urandom on Unix), satisfying the §1.4 intent
+	// without a platform-specific bcrypt link in the MVP. (Deviation noted in design_notes: the design
+	// names BCryptGenRandom/dev-urandom explicitly; std::random_device delegates to exactly those.)
+	std::random_device Rd;
+	uint8 Bytes[32];
+	for (int32 i = 0; i < 32; i += 4)
+	{
+		const uint32 R = Rd();
+		Bytes[i + 0] = static_cast<uint8>(R & 0xFF);
+		Bytes[i + 1] = static_cast<uint8>((R >> 8) & 0xFF);
+		Bytes[i + 2] = static_cast<uint8>((R >> 16) & 0xFF);
+		Bytes[i + 3] = static_cast<uint8>((R >> 24) & 0xFF);
+	}
+	return BytesToHex(Bytes, 32).ToLower();
+}
+
+bool FUnrealMcpSidecarManager::StartForPort(int32 InIpcPort, const FString& InToken)
+{
+	IpcPort = InIpcPort;
+	Token = InToken;
+	bStopRequested = false;
+
+	BridgePath = ResolveBridgeBinaryPath();
+	if (BridgePath.IsEmpty())
+	{
+		UE_LOG(LogUnrealMcp, Warning,
+			TEXT("[Unreal-MCP] no sidecar binary resolved (set UNREAL_MCP_BRIDGE_PATH). The bridge is listening on %d; launch the sidecar manually for the live e2e."),
+			IpcPort);
+		return false;
+	}
+
+	if (!SpawnProcess())
+	{
+		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] failed to spawn the sidecar from '%s'."), *BridgePath);
+		return false;
+	}
+
+	WindowStartSeconds = FPlatformTime::Seconds();
+	CrashesInWindow = 0;
+	StartWatchdog();
+	return true;
+}
+
+bool FUnrealMcpSidecarManager::SpawnProcess()
+{
+	// §1.4: the token is delivered over the child's STDIN, never argv. argv carries only non-secrets.
+	void* ReadPipe = nullptr;   // child's stdin (inherited)
+	void* WritePipe = nullptr;  // parent writes the token here
+	if (!FPlatformProcess::CreatePipe(ReadPipe, WritePipe, /*bWritePipeLocal*/ true))
+	{
+		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] could not create the sidecar stdin pipe."));
+		return false;
+	}
+
+	const uint32 EditorPid = FPlatformProcess::GetCurrentProcessId();
+	const FString Parms = FString::Printf(TEXT("--ipc-port=%d --parent-pid=%u"), IpcPort, EditorPid);
+
+	ProcHandle = FPlatformProcess::CreateProc(
+		*BridgePath,
+		*Parms,
+		/*bLaunchDetached*/ false,
+		/*bLaunchHidden*/ true,
+		/*bLaunchReallyHidden*/ true,
+		&ProcId,
+		/*PriorityModifier*/ 0,
+		/*OptionalWorkingDirectory*/ nullptr,
+		/*PipeWriteChild (child stdout)*/ nullptr,
+		/*PipeReadChild  (child stdin) */ ReadPipe);
+
+	if (!ProcHandle.IsValid())
+	{
+		FPlatformProcess::ClosePipe(ReadPipe, WritePipe);
+		return false;
+	}
+
+	// Write exactly one token line; the sidecar reads one line from stdin before dialing (§1.4).
+	FPlatformProcess::WritePipe(WritePipe, Token + TEXT("\n"));
+
+	// Close the parent's pipe copies. The child keeps its inherited stdin handle; closing the write end
+	// sends EOF after the single token line (the sidecar only reads one line).
+	FPlatformProcess::ClosePipe(ReadPipe, WritePipe);
+
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] spawned sidecar pid=%u for ipc-port=%d."), ProcId, IpcPort);
+	return true;
+}
+
+void FUnrealMcpSidecarManager::StartWatchdog()
+{
+	if (WatchdogFuture.IsValid())
+		return;
+
+	WatchdogFuture = Async(EAsyncExecution::Thread, [this]()
+	{
+		int32 BackoffIndex = 0;
+		while (!bStopRequested)
+		{
+			FPlatformProcess::Sleep(1.0f);
+			if (bStopRequested)
+				break;
+
+			if (ProcHandle.IsValid() && FPlatformProcess::IsProcRunning(ProcHandle))
+			{
+				BackoffIndex = 0; // healthy
+				continue;
+			}
+
+			// The process died unexpectedly (§1.5 auto-restart).
+			const double Now = FPlatformTime::Seconds();
+			if (Now - WindowStartSeconds > CrashWindowSeconds)
+			{
+				WindowStartSeconds = Now;
+				CrashesInWindow = 0;
+			}
+			if (++CrashesInWindow > MaxCrashesPerWindow)
+			{
+				UE_LOG(LogUnrealMcp, Error,
+					TEXT("[Unreal-MCP] sidecar crashed > %d times in %.0fs; giving up auto-restart."),
+					MaxCrashesPerWindow, CrashWindowSeconds);
+				return;
+			}
+
+			const int32 DelaySeconds = BackoffSeconds[FMath::Min(BackoffIndex, (int32)UE_ARRAY_COUNT(BackoffSeconds) - 1)];
+			++BackoffIndex;
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] sidecar exited; restarting in %ds (restart #%d)."),
+				DelaySeconds, RestartCount.GetValue() + 1);
+
+			FPlatformProcess::Sleep(static_cast<float>(DelaySeconds));
+			if (bStopRequested)
+				break;
+
+			if (ProcHandle.IsValid())
+			{
+				FPlatformProcess::CloseProc(ProcHandle);
+				ProcHandle.Reset();
+			}
+			// Fresh token each relaunch (§1.4 — token rotates every relaunch). The bridge server reads
+			// the new token on the next handshake; the server's Start() token is the authority, so a
+			// relaunched sidecar with a stale token would be rejected. NOTE: rotating the server-side
+			// token on relaunch lands with the full lifecycle wiring; the MVP keeps the launch token.
+			if (SpawnProcess())
+				RestartCount.Increment();
+		}
+	});
+}
+
+void FUnrealMcpSidecarManager::StopWatchdog()
+{
+	bStopRequested = true;
+	if (WatchdogFuture.IsValid())
+	{
+		WatchdogFuture.Wait();
+		WatchdogFuture = TFuture<void>();
+	}
+}
+
+void FUnrealMcpSidecarManager::TerminateProcess()
+{
+	if (ProcHandle.IsValid())
+	{
+		if (FPlatformProcess::IsProcRunning(ProcHandle))
+			FPlatformProcess::TerminateProc(ProcHandle, /*KillTree*/ true);
+		FPlatformProcess::CloseProc(ProcHandle);
+		ProcHandle.Reset();
+	}
+}
+
+bool FUnrealMcpSidecarManager::IsRunning() const
+{
+	return ProcHandle.IsValid() && FPlatformProcess::IsProcRunning(const_cast<FProcHandle&>(ProcHandle));
+}
+
+void FUnrealMcpSidecarManager::Stop()
+{
+	StopWatchdog();   // §6 layer 1: stop restarting first, then terminate
+	TerminateProcess();
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.h
@@ -33,6 +33,24 @@ public:
 	/** Terminate the sidecar and stop the watchdog (editor shutdown / module teardown). */
 	void Stop();
 
+	/**
+	 * Graceful-shutdown step 1 (§1.5): stop the auto-restart watchdog WITHOUT terminating the process, so
+	 * the bridge can send the sidecar a graceful `shutdown` and the watchdog will not relaunch it. Pair with
+	 * WaitForExit() then Stop() (terminate backstop). Idempotent.
+	 */
+	void StopRestarts();
+
+	/**
+	 * Wait (bounded) for the sidecar to exit on its own after a graceful `shutdown`. Returns true if it has
+	 * exited (or was never spawned), false if it is still running at the deadline (caller then terminates).
+	 */
+	bool WaitForExit(FTimespan Grace);
+
+	/**
+	 * Whether the sidecar process is currently running. Threading: call only from the game thread / the
+	 * Stop path. The watchdog thread owns ProcHandle's mutation (spawn/CloseProc) otherwise, and this read
+	 * is intentionally unsynchronized — a concurrent call racing a watchdog restart is not a supported use.
+	 */
 	bool IsRunning() const;
 	int32 GetRestartCount() const { return RestartCount.GetValue(); }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "HAL/ThreadSafeBool.h"
+#include "GenericPlatform/GenericPlatformProcess.h"
+
+/**
+ * Owns the lifecycle of the unreal-mcp-bridge sidecar process (docs/ARCHITECTURE.md §6): resolve the
+ * binary, generate the one-shot IPC token, spawn the process delivering the token over stdin (§1.4),
+ * watch it (crash → auto-restart with backoff, §1.5), and terminate it on editor shutdown (no orphans,
+ * §6 layer 1). The download-on-first-run flow (§6) is intentionally STUBBED in this task behind the
+ * UNREAL_MCP_BRIDGE_PATH dev override — the binary path must resolve from that env/.env var (or a
+ * previously-downloaded location) until the release/download task lands.
+ */
+class FUnrealMcpSidecarManager
+{
+public:
+	FUnrealMcpSidecarManager() = default;
+	~FUnrealMcpSidecarManager();
+
+	/**
+	 * Resolve the bridge binary and spawn it pointed at @p IpcPort, delivering @p InToken over the
+	 * child's stdin (§1.4). @p InToken is the SAME token the bridge server validates (generated once by
+	 * the coordinator via GenerateToken so both sides agree). Returns true when the sidecar was spawned;
+	 * false (and no spawn) when no binary resolves (the bridge server still listens; the operator can
+	 * launch the sidecar manually with UNREAL_MCP_BRIDGE_PATH for the live e2e).
+	 */
+	bool StartForPort(int32 IpcPort, const FString& InToken);
+
+	/** Terminate the sidecar and stop the watchdog (editor shutdown / module teardown). */
+	void Stop();
+
+	bool IsRunning() const;
+	int32 GetRestartCount() const { return RestartCount.GetValue(); }
+
+	/** Resolve the bridge binary path (UNREAL_MCP_BRIDGE_PATH override, §6). Empty when unresolved. */
+	static FString ResolveBridgeBinaryPath();
+
+	/** Generate a 32-byte token via the OS CSPRNG, hex-encoded (§1.4). */
+	static FString GenerateToken();
+
+private:
+	bool SpawnProcess();
+	void StartWatchdog();
+	void StopWatchdog();
+	void TerminateProcess();
+
+	FString BridgePath;
+	FString Token;
+	int32 IpcPort = -1;
+
+	FProcHandle ProcHandle;
+	uint32 ProcId = 0;
+
+	FThreadSafeBool bStopRequested = false;
+	FThreadSafeCounter RestartCount;
+	TFuture<void> WatchdogFuture;
+
+	// Crash-rate guard (§1.5): > 5 crashes in 5 minutes → stop restarting.
+	double WindowStartSeconds = 0.0;
+	int32 CrashesInWindow = 0;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpPingTool.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpPingTool.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpCoreTools.h"
+#include "UnrealMcpToolRegistry.h"
+
+/**
+ * The `ping` tool (docs/ARCHITECTURE.md §10 — "ping ships in the sidecar-bridge task"). The end-to-end
+ * smoke target: MCP server → SignalR → sidecar → IPC → UE plugin (game thread) → back. Returns the
+ * input `message` echoed, or "pong" when omitted — matching the Unity/Godot ping contract
+ * (structured `{ "result": <message-or-pong> }`).
+ */
+namespace UnrealMcpPingTool
+{
+	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry)
+	{
+		Registry.Tool(TEXT("ping"))
+			.Title(TEXT("Ping"))
+			.Description(TEXT("Lightweight readiness probe. Returns the input 'message' echoed back, or "
+			                  "'pong' when omitted. Useful for connectivity smoke checks across the full "
+			                  "MCP -> sidecar -> Unreal editor path."))
+			.ParamString(TEXT("message"), TEXT("Optional message to echo back; defaults to 'pong'."))
+			.ReadOnlyHint(true)
+			.IdempotentHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				// Runs ON the game thread (the dispatcher guarantees it, §4).
+				const FString Result = Call.Has(TEXT("message")) ? Call.GetString(TEXT("message")) : TEXT("pong");
+
+				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+				Structured->SetStringField(TEXT("result"), Result);
+				return FUnrealMcpToolResult::Success(Result, Structured);
+			});
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpToolRegistry.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpToolRegistry.cpp
@@ -1,0 +1,260 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpLog.h"
+#include "Misc/SecureHash.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
+
+// --- FUnrealMcpToolCall accessors -----------------------------------------------------------------
+
+FString FUnrealMcpToolCall::GetString(const FString& Key, const FString& Default) const
+{
+	FString Value;
+	return Arguments->TryGetStringField(Key, Value) ? Value : Default;
+}
+
+int64 FUnrealMcpToolCall::GetInt(const FString& Key, int64 Default) const
+{
+	double Value;
+	if (Arguments->TryGetNumberField(Key, Value))
+		return static_cast<int64>(Value);
+	return Default;
+}
+
+double FUnrealMcpToolCall::GetNumber(const FString& Key, double Default) const
+{
+	double Value;
+	return Arguments->TryGetNumberField(Key, Value) ? Value : Default;
+}
+
+bool FUnrealMcpToolCall::GetBool(const FString& Key, bool Default) const
+{
+	bool Value;
+	return Arguments->TryGetBoolField(Key, Value) ? Value : Default;
+}
+
+FVector FUnrealMcpToolCall::GetVector(const FString& Key, const FVector& Default) const
+{
+	const TSharedPtr<FJsonObject>* Obj;
+	if (!Arguments->TryGetObjectField(Key, Obj) || !Obj->IsValid())
+		return Default;
+
+	FVector Result = Default;
+	double Component;
+	if ((*Obj)->TryGetNumberField(TEXT("x"), Component)) Result.X = Component;
+	if ((*Obj)->TryGetNumberField(TEXT("y"), Component)) Result.Y = Component;
+	if ((*Obj)->TryGetNumberField(TEXT("z"), Component)) Result.Z = Component;
+	return Result;
+}
+
+FRotator FUnrealMcpToolCall::GetRotator(const FString& Key, const FRotator& Default) const
+{
+	const TSharedPtr<FJsonObject>* Obj;
+	if (!Arguments->TryGetObjectField(Key, Obj) || !Obj->IsValid())
+		return Default;
+
+	FRotator Result = Default;
+	double Component;
+	if ((*Obj)->TryGetNumberField(TEXT("pitch"), Component)) Result.Pitch = Component;
+	if ((*Obj)->TryGetNumberField(TEXT("yaw"), Component)) Result.Yaw = Component;
+	if ((*Obj)->TryGetNumberField(TEXT("roll"), Component)) Result.Roll = Component;
+	return Result;
+}
+
+// --- Schema building ------------------------------------------------------------------------------
+
+namespace
+{
+	TSharedPtr<FJsonObject> MakeTypedSchema(const FString& JsonType, const FString& Description)
+	{
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), JsonType);
+		if (!Description.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Description);
+		return Schema;
+	}
+
+	/** A {x,y,z: number} object schema (the §3.2 FVector mapping). */
+	TSharedPtr<FJsonObject> MakeVectorSchema(const FString& Description)
+	{
+		TSharedPtr<FJsonObject> Props = MakeShared<FJsonObject>();
+		Props->SetObjectField(TEXT("x"), MakeTypedSchema(TEXT("number"), FString()));
+		Props->SetObjectField(TEXT("y"), MakeTypedSchema(TEXT("number"), FString()));
+		Props->SetObjectField(TEXT("z"), MakeTypedSchema(TEXT("number"), FString()));
+
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), TEXT("object"));
+		if (!Description.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Description);
+		Schema->SetObjectField(TEXT("properties"), Props);
+		return Schema;
+	}
+
+	FString SerializeStable(const TSharedPtr<FJsonObject>& Object)
+	{
+		FString Out;
+		TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =
+			TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&Out);
+		FJsonSerializer::Serialize(Object.ToSharedRef(), Writer);
+		return Out;
+	}
+}
+
+TSharedPtr<FJsonObject> FUnrealMcpRegisteredTool::BuildInputSchema() const
+{
+	TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+	Schema->SetStringField(TEXT("type"), TEXT("object"));
+
+	TSharedPtr<FJsonObject> Properties = MakeShared<FJsonObject>();
+	TArray<TSharedPtr<FJsonValue>> Required;
+
+	for (const FUnrealMcpParamSpec& Param : Params)
+	{
+		TSharedPtr<FJsonObject> ParamSchema = Param.JsonType == TEXT("object") && Param.ObjectSchema.IsValid()
+			? Param.ObjectSchema
+			: MakeTypedSchema(Param.JsonType, Param.Description);
+
+		Properties->SetObjectField(Param.Name, ParamSchema);
+		if (Param.Requirement == EUnrealMcpParamRequirement::Required)
+			Required.Add(MakeShared<FJsonValueString>(Param.Name));
+	}
+
+	Schema->SetObjectField(TEXT("properties"), Properties);
+	if (Required.Num() > 0)
+		Schema->SetArrayField(TEXT("required"), Required);
+	return Schema;
+}
+
+TSharedPtr<FJsonObject> FUnrealMcpRegisteredTool::ToDescriptorJson() const
+{
+	TSharedPtr<FJsonObject> Desc = MakeShared<FJsonObject>();
+	Desc->SetStringField(TEXT("name"), Name);
+	Desc->SetStringField(TEXT("title"), Title);
+	Desc->SetStringField(TEXT("description"), Description);
+	Desc->SetObjectField(TEXT("inputSchema"), BuildInputSchema());
+	if (OutputSchema.IsValid())
+		Desc->SetObjectField(TEXT("outputSchema"), OutputSchema);
+	Desc->SetBoolField(TEXT("readOnlyHint"), bReadOnlyHint);
+	Desc->SetBoolField(TEXT("destructiveHint"), bDestructiveHint);
+	Desc->SetBoolField(TEXT("idempotentHint"), bIdempotentHint);
+	Desc->SetBoolField(TEXT("openWorldHint"), bOpenWorldHint);
+	Desc->SetBoolField(TEXT("enabled"), bEnabled);
+	Desc->SetStringField(TEXT("extensionId"), ExtensionId);
+	Desc->SetStringField(TEXT("schemaHash"), SchemaHash);
+	return Desc;
+}
+
+// --- FUnrealMcpToolBuilder ------------------------------------------------------------------------
+
+FUnrealMcpToolBuilder::FUnrealMcpToolBuilder(FUnrealMcpToolRegistry& InRegistry, const FString& InName)
+	: Registry(InRegistry)
+{
+	Tool.Name = InName;
+}
+
+FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::Title(const FString& InTitle) { Tool.Title = InTitle; return *this; }
+FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::Description(const FString& InDescription) { Tool.Description = InDescription; return *this; }
+
+FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::ParamString(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req)
+{
+	Tool.Params.Add(FUnrealMcpParamSpec{ Name, TEXT("string"), Desc, Req, nullptr });
+	return *this;
+}
+FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::ParamInt(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req)
+{
+	Tool.Params.Add(FUnrealMcpParamSpec{ Name, TEXT("integer"), Desc, Req, nullptr });
+	return *this;
+}
+FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::ParamNumber(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req)
+{
+	Tool.Params.Add(FUnrealMcpParamSpec{ Name, TEXT("number"), Desc, Req, nullptr });
+	return *this;
+}
+FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::ParamBool(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req)
+{
+	Tool.Params.Add(FUnrealMcpParamSpec{ Name, TEXT("boolean"), Desc, Req, nullptr });
+	return *this;
+}
+FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::ParamVector(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req)
+{
+	FUnrealMcpParamSpec Spec{ Name, TEXT("object"), Desc, Req, MakeVectorSchema(Desc) };
+	Tool.Params.Add(Spec);
+	return *this;
+}
+FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::ReadOnlyHint(bool bValue) { Tool.bReadOnlyHint = bValue; return *this; }
+FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::DestructiveHint(bool bValue) { Tool.bDestructiveHint = bValue; return *this; }
+FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::IdempotentHint(bool bValue) { Tool.bIdempotentHint = bValue; return *this; }
+FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::OpenWorldHint(bool bValue) { Tool.bOpenWorldHint = bValue; return *this; }
+FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::ExtensionId(const FString& InExtensionId) { Tool.ExtensionId = InExtensionId; return *this; }
+
+void FUnrealMcpToolBuilder::Handle(FUnrealMcpToolHandler InHandler)
+{
+	Tool.Handler = MoveTemp(InHandler);
+	Registry.Commit(MoveTemp(Tool));
+}
+
+// --- FUnrealMcpToolRegistry -----------------------------------------------------------------------
+
+FUnrealMcpToolBuilder FUnrealMcpToolRegistry::Tool(const FString& Name)
+{
+	return FUnrealMcpToolBuilder(*this, Name);
+}
+
+FString FUnrealMcpToolRegistry::ComputeSchemaHash(const FUnrealMcpRegisteredTool& InTool)
+{
+	// Hash the canonicalized descriptor MINUS the enabled flag (§2.2). Reuse ToDescriptorJson and drop
+	// "enabled" + "schemaHash" so the hash is stable regardless of those mutable fields.
+	FUnrealMcpRegisteredTool Copy = InTool;
+	Copy.SchemaHash.Empty();
+	TSharedPtr<FJsonObject> Desc = Copy.ToDescriptorJson();
+	Desc->RemoveField(TEXT("enabled"));
+	Desc->RemoveField(TEXT("schemaHash"));
+
+	const FString Canonical = SerializeStable(Desc);
+	FSHA1 Sha;
+	const FTCHARToUTF8 Utf8(*Canonical);
+	Sha.Update(reinterpret_cast<const uint8*>(Utf8.Get()), Utf8.Length());
+	Sha.Final();
+	uint8 Digest[20];
+	Sha.GetHash(Digest);
+	return FString(TEXT("sha1:")) + BytesToHex(Digest, 20).ToLower();
+}
+
+void FUnrealMcpToolRegistry::Commit(FUnrealMcpRegisteredTool&& InTool)
+{
+	InTool.SchemaHash = ComputeSchemaHash(InTool);
+	const FString Name = InTool.Name;
+	Tools.Add(Name, MoveTemp(InTool));
+	++Revision;
+	UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] registered tool '%s' (revision %d)."), *Name, Revision);
+}
+
+TSharedPtr<FJsonObject> FUnrealMcpToolRegistry::BuildManifestJson() const
+{
+	TSharedPtr<FJsonObject> Manifest = MakeShared<FJsonObject>();
+	Manifest->SetStringField(TEXT("type"), TEXT("tool-manifest"));
+	Manifest->SetNumberField(TEXT("revision"), Revision);
+
+	TArray<TSharedPtr<FJsonValue>> ToolArray;
+	// Deterministic ordering by name keeps the manifest stable across runs (§5 ordering principle).
+	TArray<FString> Names;
+	Tools.GetKeys(Names);
+	Names.Sort();
+	for (const FString& Name : Names)
+		ToolArray.Add(MakeShared<FJsonValueObject>(Tools[Name].ToDescriptorJson()));
+
+	Manifest->SetArrayField(TEXT("tools"), ToolArray);
+	return Manifest;
+}
+
+FUnrealMcpToolResult FUnrealMcpToolRegistry::Execute(const FString& Name, const FUnrealMcpToolCall& Call) const
+{
+	const FUnrealMcpRegisteredTool* Found = Tools.Find(Name);
+	if (Found == nullptr || !Found->Handler)
+		return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Unknown tool '%s'."), *Name));
+
+	return Found->Handler(Call);
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorModule.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorModule.cpp
@@ -3,32 +3,39 @@
 
 #include "Modules/ModuleManager.h"
 #include "UnrealMcpLog.h"
+#include "UnrealMcpRuntime.h"
 
 /**
- * Editor module for the Unreal-MCP plugin.
- *
- * Scaffold stage: only proves the plugin compiles and loads. The real wiring
- * (docs/ARCHITECTURE.md) lands in later tasks:
- *  - FUnrealMcpToolRegistry        — core tool families + extension providers (§2, §5)
- *  - FUnrealMcpSchemaGenerator     — FProperty -> JSON Schema (§3)
- *  - FUnrealMcpGameThreadDispatcher— AsyncTask + TPromise (§4)
- *  - FUnrealMcpBridgeServer        — localhost TCP listener, NDJSON framing (§1)
- *  - FUnrealMcpSidecarManager      — download / spawn / watchdog / kill (§6)
- *  - Slate UI                      — main window + 4 aux tabs (§7)
+ * Editor module for the Unreal-MCP plugin (docs/ARCHITECTURE.md §0). Owns the plugin-lifetime
+ * FUnrealMcpRuntime, which wires the tool registry (§2), the game-thread dispatcher (§4), the IPC
+ * bridge server (§1) and the sidecar manager (§6). The remaining subsystems (schema generator §3,
+ * extensions §5, Slate UI §7, config §8) land in later tasks.
  */
 class FUnrealMcpEditorModule : public IModuleInterface
 {
 public:
 	virtual void StartupModule() override
 	{
-		// The canonical boot line — the headless smoke test greps for it.
+		// The canonical boot line — the headless smoke test greps for it. Logged FIRST so a runtime
+		// startup hiccup never hides the proof that the module itself loaded.
 		UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] plugin loaded"));
+
+		Runtime = MakeUnique<FUnrealMcpRuntime>();
+		Runtime->Startup();
 	}
 
 	virtual void ShutdownModule() override
 	{
+		if (Runtime.IsValid())
+		{
+			Runtime->Shutdown();
+			Runtime.Reset();
+		}
 		UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] plugin shutting down"));
 	}
+
+private:
+	TUniquePtr<FUnrealMcpRuntime> Runtime;
 };
 
 IMPLEMENT_MODULE(FUnrealMcpEditorModule, UnrealMcpEditor)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -63,17 +63,27 @@ void FUnrealMcpRuntime::Shutdown()
 		PreExitHandle.Reset();
 	}
 
-	// §6 layer 1: stop the sidecar (terminate + stop restarting) BEFORE tearing down the bridge.
+	// §1.5 graceful teardown ordering. Doing SidecarManager->Stop() (TerminateProc KillTree) BEFORE the
+	// bridge sends its `shutdown` Bye would mean the graceful path only ever worked for a MANUALLY launched
+	// sidecar — a spawned one would be killed before the Bye. So: (1) stop auto-restarts (the bridge's Bye
+	// must not be undone by a relaunch), (2) let the bridge send `shutdown` to the connected sidecar, (3)
+	// give the child a bounded grace to self-exit, (4) terminate as a backstop.
 	if (SidecarManager.IsValid())
-	{
-		SidecarManager->Stop();
-		SidecarManager.Reset();
-	}
+		SidecarManager->StopRestarts();
+
 	if (BridgeServer.IsValid())
 	{
-		BridgeServer->Shutdown();
+		BridgeServer->Shutdown(); // sends the §1.5 `shutdown` Bye to the connected sidecar, then tears down
 		BridgeServer.Reset();
 	}
+
+	if (SidecarManager.IsValid())
+	{
+		SidecarManager->WaitForExit(FTimespan::FromSeconds(3)); // bounded grace for a clean self-exit
+		SidecarManager->Stop();                                 // backstop: TerminateProc if still alive
+		SidecarManager.Reset();
+	}
+
 	Dispatcher.Reset();
 	Registry.Reset();
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpRuntime.h"
+#include "UnrealMcpLog.h"
+#include "UnrealMcpCoreTools.h"
+#include "UnrealMcpToolRegistry.h"
+#include "Dispatch/UnrealMcpGameThreadDispatcher.h"
+#include "Bridge/UnrealMcpBridgeServer.h"
+#include "Sidecar/UnrealMcpSidecarManager.h"
+
+#include "Misc/CoreDelegates.h"
+#include "Misc/Paths.h"
+#include "Misc/EngineVersion.h"
+#include "Interfaces/IPluginManager.h"
+
+void FUnrealMcpRuntime::Startup()
+{
+	if (bStarted)
+		return;
+	bStarted = true;
+
+	Registry = MakeUnique<FUnrealMcpToolRegistry>();
+	UnrealMcpPingTool::Register(*Registry);
+
+	Dispatcher = MakeUnique<FUnrealMcpGameThreadDispatcher>();
+	BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(*Registry, *Dispatcher);
+
+	const FString ProjectPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
+	const FString EngineVersion = FEngineVersion::Current().ToString();
+
+	FString PluginVersion = TEXT("0.1.0");
+	if (TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("UnrealMCP")))
+		PluginVersion = Plugin->GetDescriptor().VersionName;
+
+	// Generate the one-shot IPC token ONCE; both the server (validates the handshake) and the sidecar
+	// manager (delivers it over stdin) must agree on it (§1.4).
+	const FString Token = FUnrealMcpSidecarManager::GenerateToken();
+
+	const int32 BoundPort = BridgeServer->Start(Token, ProjectPath, PluginVersion, EngineVersion);
+	if (BoundPort <= 0)
+	{
+		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] bridge server failed to start; sidecar not launched."));
+		return;
+	}
+
+	SidecarManager = MakeUnique<FUnrealMcpSidecarManager>();
+	SidecarManager->StartForPort(BoundPort, Token);
+
+	// §1.5: tear down on editor pre-exit so the sidecar never orphans (layer 1).
+	PreExitHandle = FCoreDelegates::OnEnginePreExit.AddLambda([this]() { Shutdown(); });
+}
+
+void FUnrealMcpRuntime::Shutdown()
+{
+	if (!bStarted)
+		return;
+	bStarted = false;
+
+	if (PreExitHandle.IsValid())
+	{
+		FCoreDelegates::OnEnginePreExit.Remove(PreExitHandle);
+		PreExitHandle.Reset();
+	}
+
+	// §6 layer 1: stop the sidecar (terminate + stop restarting) BEFORE tearing down the bridge.
+	if (SidecarManager.IsValid())
+	{
+		SidecarManager->Stop();
+		SidecarManager.Reset();
+	}
+	if (BridgeServer.IsValid())
+	{
+		BridgeServer->Shutdown();
+		BridgeServer.Reset();
+	}
+	Dispatcher.Reset();
+	Registry.Reset();
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FUnrealMcpToolRegistry;
+class FUnrealMcpGameThreadDispatcher;
+class FUnrealMcpBridgeServer;
+class FUnrealMcpSidecarManager;
+
+/**
+ * Plugin-lifetime coordinator (docs/ARCHITECTURE.md §0). Wires the four subsystems together: the tool
+ * registry (+ core tools), the game-thread dispatcher (§4), the IPC bridge server (§1), and the sidecar
+ * manager (§6). Owned by the editor module; started in StartupModule and torn down on editor pre-exit /
+ * ShutdownModule so the sidecar never orphans (§6 layer 1).
+ */
+class FUnrealMcpRuntime
+{
+public:
+	void Startup();
+	void Shutdown();
+
+	FUnrealMcpToolRegistry* GetRegistry() const { return Registry.Get(); }
+	FUnrealMcpBridgeServer* GetBridgeServer() const { return BridgeServer.Get(); }
+
+private:
+	TUniquePtr<FUnrealMcpToolRegistry> Registry;
+	TUniquePtr<FUnrealMcpGameThreadDispatcher> Dispatcher;
+	TUniquePtr<FUnrealMcpBridgeServer> BridgeServer;
+	TUniquePtr<FUnrealMcpSidecarManager> SidecarManager;
+
+	FDelegateHandle PreExitHandle;
+	bool bStarted = false;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpCoreTools.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpCoreTools.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FUnrealMcpToolRegistry;
+
+/**
+ * Registration entry points for the core tool families (docs/ARCHITECTURE.md §10). Exported so the
+ * runtime coordinator wires them on boot AND the Automation specs can register + exercise them in
+ * isolation. `ping` ships with the sidecar-bridge task; later families add their own Register here.
+ */
+namespace UnrealMcpPingTool
+{
+	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry);
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
@@ -43,14 +43,17 @@ struct UNREALMCPEDITOR_API FUnrealMcpToolCall
 	TSharedPtr<FJsonObject> Arguments;
 
 	/** Cooperative cancellation flag (set by a tool-cancel or a timeout, §4). May be null in tests. */
-	const FThreadSafeBool* CancelRequested = nullptr;
+	// Held by shared ownership so the flag outlives the bridge's CancelFlags map entry: a copy of this
+	// call object (the dispatcher captures one for the game-thread body) keeps the flag alive even after
+	// the response is sent and the map entry is removed — IsCancelled() can never deref freed memory.
+	TSharedPtr<const FThreadSafeBool, ESPMode::ThreadSafe> CancelRequested;
 
 	FUnrealMcpToolCall() : Arguments(MakeShared<FJsonObject>()) {}
 	explicit FUnrealMcpToolCall(const TSharedPtr<FJsonObject>& InArgs)
 		: Arguments(InArgs.IsValid() ? InArgs : MakeShared<FJsonObject>()) {}
 
 	bool Has(const FString& Key) const { return Arguments->HasField(Key); }
-	bool IsCancelled() const { return CancelRequested != nullptr && *CancelRequested; }
+	bool IsCancelled() const { return CancelRequested.IsValid() && *CancelRequested; }
 
 	FString GetString(const FString& Key, const FString& Default = FString()) const;
 	int64 GetInt(const FString& Key, int64 Default = 0) const;
@@ -137,7 +140,10 @@ private:
  * The plugin-owned tool registry (docs/ARCHITECTURE.md §2.2). Holds the compiled tool set, produces
  * the JSON manifest snapshot for the bridge, and dispatches tool-calls by name. A monotonic Revision
  * bumps on every registry change so the sidecar's manifest diff can reason about ordering (§2.2 step 3).
- * Not thread-safe: all mutation + manifest reads happen on the game thread; the bridge marshals there.
+ * Not thread-safe. All mutation happens at startup (core families Register before the bridge accepts), so
+ * the bridge may read BuildManifestJson() directly from its IPC reader thread on handshake without a race.
+ * Any DYNAMIC re-registration (the §2.2 hot-reload path) MUST marshal both the mutation and the manifest
+ * read through the game-thread dispatcher (§4) — the reader thread must never observe a half-mutated set.
  */
 class UNREALMCPEDITOR_API FUnrealMcpToolRegistry
 {

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+#include "HAL/ThreadSafeBool.h"
+
+/**
+ * Core tool-registration types for the Unreal-MCP plugin (docs/ARCHITECTURE.md §2, §3.3).
+ *
+ * The registry is the plugin-owned source of truth for the tool set. Each core family declares its
+ * tools through the fluent FUnrealMcpToolBuilder; the registry compiles each declaration into a JSON
+ * descriptor (the §2.2 manifest shape) and dispatches incoming tool-calls to the declared handler.
+ * The sidecar mirrors the manifest into MCP ProxyTools; the C++ side never knows about MCP.
+ */
+
+/** Whether a declared parameter is required or optional. */
+enum class EUnrealMcpParamRequirement : uint8
+{
+	Optional,
+	Required
+};
+
+/** A declared tool parameter (name + JSON-schema type + description). */
+struct UNREALMCPEDITOR_API FUnrealMcpParamSpec
+{
+	FString Name;
+	FString JsonType;        // "string" | "integer" | "number" | "boolean" | "object"
+	FString Description;
+	EUnrealMcpParamRequirement Requirement = EUnrealMcpParamRequirement::Optional;
+	TSharedPtr<FJsonObject> ObjectSchema; // for "object" params (e.g. FVector → {x,y,z})
+};
+
+/**
+ * The arguments + cancellation surface handed to a tool handler. The handler runs ON the game thread
+ * (the dispatcher guarantees this, §4); it must never block on bridge state or pump modal UI.
+ */
+struct UNREALMCPEDITOR_API FUnrealMcpToolCall
+{
+	/** Raw JSON arguments object (never null; empty object when the call carried none). */
+	TSharedPtr<FJsonObject> Arguments;
+
+	/** Cooperative cancellation flag (set by a tool-cancel or a timeout, §4). May be null in tests. */
+	const FThreadSafeBool* CancelRequested = nullptr;
+
+	FUnrealMcpToolCall() : Arguments(MakeShared<FJsonObject>()) {}
+	explicit FUnrealMcpToolCall(const TSharedPtr<FJsonObject>& InArgs)
+		: Arguments(InArgs.IsValid() ? InArgs : MakeShared<FJsonObject>()) {}
+
+	bool Has(const FString& Key) const { return Arguments->HasField(Key); }
+	bool IsCancelled() const { return CancelRequested != nullptr && *CancelRequested; }
+
+	FString GetString(const FString& Key, const FString& Default = FString()) const;
+	int64 GetInt(const FString& Key, int64 Default = 0) const;
+	double GetNumber(const FString& Key, double Default = 0.0) const;
+	bool GetBool(const FString& Key, bool Default = false) const;
+	FVector GetVector(const FString& Key, const FVector& Default = FVector::ZeroVector) const;
+	FRotator GetRotator(const FString& Key, const FRotator& Default = FRotator::ZeroRotator) const;
+};
+
+/** Terminal result of a tool invocation, mirroring the IPC tool-response shape (§1.3). */
+struct UNREALMCPEDITOR_API FUnrealMcpToolResult
+{
+	bool bSuccess = true;
+	FString Message;                       // human-readable text content block
+	TSharedPtr<FJsonObject> Structured;    // structured content (may be null)
+
+	static FUnrealMcpToolResult Success(const FString& InMessage, const TSharedPtr<FJsonObject>& InStructured = nullptr)
+	{
+		return FUnrealMcpToolResult{ true, InMessage, InStructured };
+	}
+	static FUnrealMcpToolResult Error(const FString& InMessage)
+	{
+		return FUnrealMcpToolResult{ false, InMessage, nullptr };
+	}
+};
+
+/** Signature of a tool handler: runs on the game thread, returns a terminal result synchronously. */
+using FUnrealMcpToolHandler = TFunction<FUnrealMcpToolResult(const FUnrealMcpToolCall&)>;
+
+/** A fully compiled tool: descriptor (manifest shape) + handler. */
+struct UNREALMCPEDITOR_API FUnrealMcpRegisteredTool
+{
+	FString Name;
+	FString Title;
+	FString Description;
+	TArray<FUnrealMcpParamSpec> Params;
+	TSharedPtr<FJsonObject> OutputSchema;
+	bool bReadOnlyHint = false;
+	bool bDestructiveHint = false;
+	bool bIdempotentHint = false;
+	bool bOpenWorldHint = false;
+	bool bEnabled = true;
+	FString ExtensionId = TEXT("core");
+	FString SchemaHash;
+	FUnrealMcpToolHandler Handler;
+
+	/** Build the JSON Schema for this tool's inputs from its declared params (§3.2 subset). */
+	TSharedPtr<FJsonObject> BuildInputSchema() const;
+
+	/** The §2.2 descriptor object (one entry in tool-manifest.tools[]). */
+	TSharedPtr<FJsonObject> ToDescriptorJson() const;
+};
+
+class FUnrealMcpToolRegistry;
+
+/** Fluent declaration builder (docs/ARCHITECTURE.md §3.3). One per tool; commits on destruction-free Handle(). */
+class UNREALMCPEDITOR_API FUnrealMcpToolBuilder
+{
+public:
+	FUnrealMcpToolBuilder(FUnrealMcpToolRegistry& InRegistry, const FString& InName);
+
+	FUnrealMcpToolBuilder& Title(const FString& InTitle);
+	FUnrealMcpToolBuilder& Description(const FString& InDescription);
+	FUnrealMcpToolBuilder& ParamString(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req = EUnrealMcpParamRequirement::Optional);
+	FUnrealMcpToolBuilder& ParamInt(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req = EUnrealMcpParamRequirement::Optional);
+	FUnrealMcpToolBuilder& ParamNumber(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req = EUnrealMcpParamRequirement::Optional);
+	FUnrealMcpToolBuilder& ParamBool(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req = EUnrealMcpParamRequirement::Optional);
+	FUnrealMcpToolBuilder& ParamVector(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req = EUnrealMcpParamRequirement::Optional);
+	FUnrealMcpToolBuilder& ReadOnlyHint(bool bValue);
+	FUnrealMcpToolBuilder& DestructiveHint(bool bValue);
+	FUnrealMcpToolBuilder& IdempotentHint(bool bValue);
+	FUnrealMcpToolBuilder& OpenWorldHint(bool bValue);
+	FUnrealMcpToolBuilder& ExtensionId(const FString& InExtensionId);
+
+	/** Bind the handler and commit the tool into the registry. */
+	void Handle(FUnrealMcpToolHandler InHandler);
+
+private:
+	FUnrealMcpToolRegistry& Registry;
+	FUnrealMcpRegisteredTool Tool;
+};
+
+/**
+ * The plugin-owned tool registry (docs/ARCHITECTURE.md §2.2). Holds the compiled tool set, produces
+ * the JSON manifest snapshot for the bridge, and dispatches tool-calls by name. A monotonic Revision
+ * bumps on every registry change so the sidecar's manifest diff can reason about ordering (§2.2 step 3).
+ * Not thread-safe: all mutation + manifest reads happen on the game thread; the bridge marshals there.
+ */
+class UNREALMCPEDITOR_API FUnrealMcpToolRegistry
+{
+public:
+	/** Begin declaring a tool (docs/ARCHITECTURE.md §3.3 fluent API). */
+	FUnrealMcpToolBuilder Tool(const FString& Name);
+
+	/** Commit a fully-built tool (called by the builder's Handle()). Replaces any same-named tool. */
+	void Commit(FUnrealMcpRegisteredTool&& InTool);
+
+	bool HasTool(const FString& Name) const { return Tools.Contains(Name); }
+	int32 Num() const { return Tools.Num(); }
+	const FUnrealMcpRegisteredTool* Find(const FString& Name) const { return Tools.Find(Name); }
+
+	/** Current manifest revision (bumps on every registry mutation). */
+	int32 GetRevision() const { return Revision; }
+
+	/** Build the full tool-manifest message body (revision + tools[]) for the bridge (§2.2). */
+	TSharedPtr<FJsonObject> BuildManifestJson() const;
+
+	/**
+	 * Execute a tool by name on the CURRENT thread (the dispatcher has already marshalled to the game
+	 * thread). Returns an error result for an unknown tool. The handler owns argument interpretation.
+	 */
+	FUnrealMcpToolResult Execute(const FString& Name, const FUnrealMcpToolCall& Call) const;
+
+	/** Compute the stable schema hash for a tool descriptor (§2.2 — excludes the enabled flag). */
+	static FString ComputeSchemaHash(const FUnrealMcpRegisteredTool& InTool);
+
+private:
+	TMap<FString, FUnrealMcpRegisteredTool> Tools;
+	int32 Revision = 0;
+};

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDispatcherSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDispatcherSpec.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Dispatch/UnrealMcpGameThreadDispatcher.h"
+#include "Async/Async.h"
+
+/**
+ * Game-thread dispatcher specs (docs/ARCHITECTURE.md §4). Proves the load-bearing DoD claim: a tool
+ * body always runs on the game thread, even when dispatched from a background thread (marshalled), and
+ * a never-finishing body completes the future with a timeout error.
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpDispatcherSpec, "UnrealMcp.Dispatch.GameThread",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FUnrealMcpDispatcherSpec)
+
+void FUnrealMcpDispatcherSpec::Define()
+{
+	Describe("Dispatch", [this]()
+	{
+		It("runs the body and returns its result (inline on the game thread)", [this]()
+		{
+			FUnrealMcpGameThreadDispatcher Dispatcher;
+			bool bRanOnGameThread = false;
+			TFuture<FUnrealMcpToolResult> Future = Dispatcher.Dispatch(
+				FUnrealMcpToolCall(),
+				[&bRanOnGameThread](const FUnrealMcpToolCall&)
+				{
+					bRanOnGameThread = IsInGameThread();
+					return FUnrealMcpToolResult::Success(TEXT("done"));
+				},
+				FTimespan::FromSeconds(5));
+
+			const FUnrealMcpToolResult Result = Future.Get();
+			TestTrue(TEXT("body ran on game thread"), bRanOnGameThread);
+			TestTrue(TEXT("success"), Result.bSuccess);
+			TestEqual(TEXT("message"), Result.Message, FString(TEXT("done")));
+		});
+
+		// Dispatched from a BACKGROUND thread — the body must still execute on the game thread (§4). The
+		// background task blocks on the future until the game thread (pumped by the automation runner)
+		// processes the marshalled AsyncTask.
+		LatentIt("marshals an off-thread call onto the game thread", FTimespan::FromSeconds(15), [this](const FDoneDelegate& Done)
+		{
+			Async(EAsyncExecution::Thread, [this, Done]()
+			{
+				FUnrealMcpGameThreadDispatcher Dispatcher;
+				const bool bCalledOffGameThread = !IsInGameThread();
+				bool bBodyOnGameThread = false;
+
+				TFuture<FUnrealMcpToolResult> Future = Dispatcher.Dispatch(
+					FUnrealMcpToolCall(),
+					[&bBodyOnGameThread](const FUnrealMcpToolCall&)
+					{
+						bBodyOnGameThread = IsInGameThread();
+						return FUnrealMcpToolResult::Success(TEXT("marshalled"));
+					},
+					FTimespan::FromSeconds(10));
+
+				const FUnrealMcpToolResult Result = Future.Get();
+				TestTrue(TEXT("dispatched off the game thread"), bCalledOffGameThread);
+				TestTrue(TEXT("body ran on the game thread"), bBodyOnGameThread);
+				TestTrue(TEXT("success"), Result.bSuccess);
+				Done.Execute();
+			});
+		});
+
+		LatentIt("completes with a timeout error when the body never finishes", FTimespan::FromSeconds(15), [this](const FDoneDelegate& Done)
+		{
+			Async(EAsyncExecution::Thread, [this, Done]()
+			{
+				FUnrealMcpGameThreadDispatcher Dispatcher;
+				// A body that blocks far longer than the timeout — dispatched off the game thread so it
+				// would occupy the game thread, but the timeout watcher completes the future first.
+				TFuture<FUnrealMcpToolResult> Future = Dispatcher.Dispatch(
+					FUnrealMcpToolCall(),
+					[](const FUnrealMcpToolCall&)
+					{
+						FPlatformProcess::Sleep(2.0f);
+						return FUnrealMcpToolResult::Success(TEXT("late"));
+					},
+					FTimespan::FromMilliseconds(200));
+
+				const FUnrealMcpToolResult Result = Future.Get();
+				TestFalse(TEXT("timed out -> error"), Result.bSuccess);
+				Done.Execute();
+			});
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDispatcherSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDispatcherSpec.cpp
@@ -89,6 +89,50 @@ void FUnrealMcpDispatcherSpec::Define()
 				Done.Execute();
 			});
 		});
+
+		// The single-completion guard (§4) must hold even when the slow body finishes AFTER the timeout has
+		// already delivered the error — the late body value must never overwrite the timeout result, and the
+		// second Complete() must be a no-op (no crash on the shared promise/event).
+		LatentIt("keeps the timeout result when the body completes late (single-completion guard)", FTimespan::FromSeconds(15), [this](const FDoneDelegate& Done)
+		{
+			Async(EAsyncExecution::Thread, [this, Done]()
+			{
+				FUnrealMcpGameThreadDispatcher Dispatcher;
+				TFuture<FUnrealMcpToolResult> Future = Dispatcher.Dispatch(
+					FUnrealMcpToolCall(),
+					[](const FUnrealMcpToolCall&)
+					{
+						FPlatformProcess::Sleep(1.0f); // finishes well after the 100 ms timeout
+						return FUnrealMcpToolResult::Success(TEXT("late-body-value"));
+					},
+					FTimespan::FromMilliseconds(100));
+
+				const FUnrealMcpToolResult Result = Future.Get();
+				TestFalse(TEXT("timed out -> error"), Result.bSuccess);
+				TestNotEqual(TEXT("late body did not overwrite the timeout result"), Result.Message, FString(TEXT("late-body-value")));
+
+				// Give the late body time to run and (attempt to) complete the promise a second time; the
+				// guard must absorb it without altering the already-delivered result or faulting.
+				FPlatformProcess::Sleep(1.5f);
+				Done.Execute();
+			});
+		});
+
+		// HandleToolCancel flips the shared cancel flag that the bridge stores; assert FUnrealMcpToolCall
+		// observes that flip (and stays false with no flag / a clear flag).
+		It("reflects the shared cancel flag through IsCancelled()", [this]()
+		{
+			FUnrealMcpToolCall NoFlagCall;
+			TestFalse(TEXT("no flag -> not cancelled"), NoFlagCall.IsCancelled());
+
+			TSharedRef<FThreadSafeBool, ESPMode::ThreadSafe> Flag = MakeShared<FThreadSafeBool, ESPMode::ThreadSafe>(false);
+			FUnrealMcpToolCall Call;
+			Call.CancelRequested = Flag;
+			TestFalse(TEXT("flag clear -> not cancelled"), Call.IsCancelled());
+
+			Flag.Get() = true;
+			TestTrue(TEXT("flag set -> cancelled"), Call.IsCancelled());
+		});
 	});
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpNdjsonSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpNdjsonSpec.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Bridge/UnrealMcpNdjson.h"
+
+/** NDJSON framing codec specs (docs/ARCHITECTURE.md §1.2, §9.3 — the C++ peer of the sidecar tests). */
+BEGIN_DEFINE_SPEC(FUnrealMcpNdjsonSpec, "UnrealMcp.Ipc.Ndjson",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	static TArray<FString> PushString(FUnrealMcpNdjsonAccumulator& Acc, const FString& Text, bool& bOk)
+	{
+		FTCHARToUTF8 Utf8(*Text);
+		TArray<FString> Lines;
+		bOk = Acc.Push(reinterpret_cast<const uint8*>(Utf8.Get()), Utf8.Length(), Lines);
+		return Lines;
+	}
+
+END_DEFINE_SPEC(FUnrealMcpNdjsonSpec)
+
+void FUnrealMcpNdjsonSpec::Define()
+{
+	Describe("Encode", [this]()
+	{
+		It("appends a single trailing newline", [this]()
+		{
+			const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(TEXT("{\"type\":\"ping\"}"));
+			TestEqual(TEXT("last byte is newline"), (int32)Framed.Last(), (int32)'\n');
+		});
+	});
+
+	Describe("Push", [this]()
+	{
+		It("splits multiple lines in one chunk", [this]()
+		{
+			FUnrealMcpNdjsonAccumulator Acc;
+			bool bOk = false;
+			const TArray<FString> Lines = PushString(Acc, TEXT("a\nb\nc\n"), bOk);
+			TestTrue(TEXT("ok"), bOk);
+			TestEqual(TEXT("count"), Lines.Num(), 3);
+			TestEqual(TEXT("first"), Lines[0], FString(TEXT("a")));
+			TestEqual(TEXT("third"), Lines[2], FString(TEXT("c")));
+		});
+
+		It("buffers a partial line across chunks", [this]()
+		{
+			FUnrealMcpNdjsonAccumulator Acc;
+			bool bOk = false;
+			TestEqual(TEXT("no line yet"), PushString(Acc, TEXT("{\"par"), bOk).Num(), 0);
+			TestEqual(TEXT("still none"), PushString(Acc, TEXT("tial\":1"), bOk).Num(), 0);
+			const TArray<FString> Lines = PushString(Acc, TEXT("}\n"), bOk);
+			TestEqual(TEXT("one line"), Lines.Num(), 1);
+			TestEqual(TEXT("joined"), Lines[0], FString(TEXT("{\"partial\":1}")));
+		});
+
+		It("tolerates a trailing carriage return", [this]()
+		{
+			FUnrealMcpNdjsonAccumulator Acc;
+			bool bOk = false;
+			const TArray<FString> Lines = PushString(Acc, TEXT("hello\r\n"), bOk);
+			TestEqual(TEXT("one line"), Lines.Num(), 1);
+			TestEqual(TEXT("cr stripped"), Lines[0], FString(TEXT("hello")));
+		});
+
+		It("aborts when a line exceeds the cap", [this]()
+		{
+			FUnrealMcpNdjsonAccumulator Acc(4);
+			bool bOk = true;
+			PushString(Acc, TEXT("abcdefgh"), bOk);
+			TestFalse(TEXT("push reports abort"), bOk);
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpToolRegistrySpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpToolRegistrySpec.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "UnrealMcpCoreTools.h"
+#include "UnrealMcpToolRegistry.h"
+#include "Dom/JsonObject.h"
+
+/** Tool registry + ping specs (docs/ARCHITECTURE.md §2.2, §3.3, §10). */
+BEGIN_DEFINE_SPEC(FUnrealMcpToolRegistrySpec, "UnrealMcp.Tools.Registry",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FUnrealMcpToolRegistrySpec)
+
+void FUnrealMcpToolRegistrySpec::Define()
+{
+	Describe("ping registration", [this]()
+	{
+		It("registers the ping tool and bumps the revision", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			const int32 Before = Registry.GetRevision();
+			UnrealMcpPingTool::Register(Registry);
+			TestTrue(TEXT("has ping"), Registry.HasTool(TEXT("ping")));
+			TestEqual(TEXT("one tool"), Registry.Num(), 1);
+			TestTrue(TEXT("revision bumped"), Registry.GetRevision() > Before);
+		});
+
+		It("executes ping with no args -> pong (structured result)", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpPingTool::Register(Registry);
+
+			FUnrealMcpToolCall Call;
+			const FUnrealMcpToolResult Result = Registry.Execute(TEXT("ping"), Call);
+			TestTrue(TEXT("success"), Result.bSuccess);
+			TestEqual(TEXT("message"), Result.Message, FString(TEXT("pong")));
+			TestTrue(TEXT("structured present"), Result.Structured.IsValid());
+			FString StructResult;
+			TestTrue(TEXT("has result field"), Result.Structured->TryGetStringField(TEXT("result"), StructResult));
+			TestEqual(TEXT("result is pong"), StructResult, FString(TEXT("pong")));
+		});
+
+		It("echoes the message arg", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpPingTool::Register(Registry);
+
+			TSharedPtr<FJsonObject> Args = MakeShared<FJsonObject>();
+			Args->SetStringField(TEXT("message"), TEXT("hello-unreal"));
+			FUnrealMcpToolCall Call(Args);
+
+			const FUnrealMcpToolResult Result = Registry.Execute(TEXT("ping"), Call);
+			TestEqual(TEXT("echoed"), Result.Message, FString(TEXT("hello-unreal")));
+		});
+
+		It("returns an error for an unknown tool", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			const FUnrealMcpToolResult Result = Registry.Execute(TEXT("does-not-exist"), FUnrealMcpToolCall());
+			TestFalse(TEXT("not success"), Result.bSuccess);
+		});
+	});
+
+	Describe("manifest JSON", [this]()
+	{
+		It("contains a revision and the ping descriptor with a schema hash", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpPingTool::Register(Registry);
+
+			TSharedPtr<FJsonObject> Manifest = Registry.BuildManifestJson();
+			TestEqual(TEXT("type"), Manifest->GetStringField(TEXT("type")), FString(TEXT("tool-manifest")));
+			TestEqual(TEXT("revision"), (int32)Manifest->GetNumberField(TEXT("revision")), Registry.GetRevision());
+
+			const TArray<TSharedPtr<FJsonValue>>* Tools;
+			TestTrue(TEXT("tools array"), Manifest->TryGetArrayField(TEXT("tools"), Tools));
+			TestEqual(TEXT("one tool"), Tools->Num(), 1);
+
+			TSharedPtr<FJsonObject> Ping = (*Tools)[0]->AsObject();
+			TestEqual(TEXT("name"), Ping->GetStringField(TEXT("name")), FString(TEXT("ping")));
+			TestTrue(TEXT("has input schema"), Ping->HasField(TEXT("inputSchema")));
+			TestFalse(TEXT("schema hash non-empty"), Ping->GetStringField(TEXT("schemaHash")).IsEmpty());
+			TestTrue(TEXT("readOnlyHint true"), Ping->GetBoolField(TEXT("readOnlyHint")));
+		});
+
+		It("produces a stable schema hash for an unchanged tool", [this]()
+		{
+			FUnrealMcpToolRegistry A, B;
+			UnrealMcpPingTool::Register(A);
+			UnrealMcpPingTool::Register(B);
+			TestEqual(TEXT("same hash"),
+				A.Find(TEXT("ping"))->SchemaHash, B.Find(TEXT("ping"))->SchemaHash);
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/UnrealMcpEditorTests.Build.cs
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/UnrealMcpEditorTests.Build.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the repository root for more information.
 
+using System.IO;
 using UnrealBuildTool;
 
 public class UnrealMcpEditorTests : ModuleRules
@@ -14,7 +15,13 @@ public class UnrealMcpEditorTests : ModuleRules
 			"Core",
 			"CoreUObject",
 			"Engine",
+			"Json",
 			"UnrealMcpEditor",
 		});
+
+		// Reach the sibling editor module's PRIVATE headers (FUnrealMcpNdjsonAccumulator §1.2,
+		// FUnrealMcpGameThreadDispatcher §4) so the Automation specs can drive them directly. The
+		// types are UNREALMCPEDITOR_API-exported, so symbols link via the module dependency above.
+		PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "UnrealMcpEditor", "Private"));
 	}
 }

--- a/bridge/src/Host/BridgeConsoleLogger.cs
+++ b/bridge/src/Host/BridgeConsoleLogger.cs
@@ -1,0 +1,63 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
+{
+    /// <summary>
+    /// A dependency-free <see cref="ILoggerProvider"/> that writes one line per log to <c>stderr</c>
+    /// (stdout is reserved for protocol/handshake output the parent plugin may parse). Used to surface
+    /// both the bridge's own diagnostics and the reused framework's <c>Microsoft.Extensions.Logging</c>
+    /// output (connection/handshake/version-mismatch) without pulling in a logging package. Never logs
+    /// secrets — the IPC token travels via stdin and is never passed to a logger (§1.4).
+    /// </summary>
+    public sealed class BridgeConsoleLoggerProvider : ILoggerProvider
+    {
+        private readonly LogLevel _minLevel;
+        public BridgeConsoleLoggerProvider(LogLevel minLevel = LogLevel.Information) => _minLevel = minLevel;
+        public ILogger CreateLogger(string categoryName) => new BridgeConsoleLogger(categoryName, _minLevel);
+        public void Dispose() { }
+    }
+
+    internal sealed class BridgeConsoleLogger : ILogger
+    {
+        private readonly string _category;
+        private readonly LogLevel _minLevel;
+
+        public BridgeConsoleLogger(string category, LogLevel minLevel)
+        {
+            _category = category;
+            _minLevel = minLevel;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= _minLevel && logLevel != LogLevel.None;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+                return;
+
+            var message = formatter(state, exception);
+            var line = $"[unreal-mcp-bridge] {logLevel.ToString().ToLowerInvariant()} {_category}: {message}";
+            if (exception != null)
+                line += $" | {exception.GetType().Name}: {exception.Message}";
+            Console.Error.WriteLine(line);
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -9,6 +9,7 @@
 */
 
 using System;
+using System.Threading;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.ReflectorNet;
@@ -49,6 +50,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         private IMcpPlugin? _plugin;
         private ManifestRegistrar? _registrar;
         private Reflector? _reflector;
+        private int _signalRConnectStarted;
 
         public SidecarHost(
             IpcClient ipc,
@@ -129,8 +131,13 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _logger?.LogInformation("Handshake accepted (plugin {PluginVersion}, engine {Engine}); connecting SignalR to {Host}.",
                 ack.PluginVersion, ack.EngineVersion, _config.Host);
 
-            // Fire-and-forget connect; KeepConnected drives reconnection inside the client.
-            _ = ConnectSignalRAsync();
+            // Connect SignalR only on the FIRST accepted handshake. A re-dial's ack (after an IPC drop and
+            // reconnect) must NOT kick a second connect — KeepConnected already drives SignalR reconnection
+            // inside the client, so connecting again would spin up a duplicate connection.
+            if (Interlocked.CompareExchange(ref _signalRConnectStarted, 1, 0) == 0)
+                _ = ConnectSignalRAsync();
+            else
+                _logger?.LogDebug("Handshake re-accepted; SignalR connect already initiated (KeepConnected handles reconnection).");
         }
 
         private async System.Threading.Tasks.Task ConnectSignalRAsync()

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -1,0 +1,159 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.ReflectorNet;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+using Microsoft.Extensions.Logging;
+using McpVersion = com.IvanMurzak.McpPlugin.Common.Version;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
+{
+    /// <summary>
+    /// Owns the reused <c>com.IvanMurzak.McpPlugin</c> SignalR client for the sidecar (docs/ARCHITECTURE.md
+    /// §0, §2). Unlike Unity/Godot — which embed the host in-process and scan an assembly for
+    /// <c>[AiTool]</c> methods — the sidecar hosts NO static tools: its entire tool set is the dynamic
+    /// manifest the C++ plugin pushes over IPC, registered as <see cref="ProxyTool"/>s (§2.2). The plugin
+    /// is built once with an empty tool set and the <see cref="ManifestRegistrar"/> is wired BEFORE the
+    /// IPC run loop starts, so the first <c>tool-manifest</c> (which can arrive immediately after the
+    /// handshake-ack, §1.5) is never dropped. SignalR connect is deferred until the handshake-ack delivers
+    /// the effective connection config (§1.5 — "on Ready the plugin immediately pushes tool-manifest + config").
+    /// </summary>
+    public sealed class SidecarHost : IDisposable
+    {
+        private readonly IpcClient _ipc;
+        private readonly string _sidecarVersion;
+        private readonly ILoggerProvider? _loggerProvider;
+        private readonly ILogger? _logger;
+        private readonly string? _fallbackHost;
+        private readonly string? _fallbackToken;
+
+        private readonly ConnectionConfig _config = new()
+        {
+            KeepConnected = true,
+            // The sidecar does not author SKILL.md files — that is the plugin/agent's job. Disabling also
+            // avoids the skills-path resolver throwing when no project root is set (MCP-Plugin issue #107).
+            GenerateSkillFiles = false,
+        };
+
+        private IMcpPlugin? _plugin;
+        private ManifestRegistrar? _registrar;
+        private Reflector? _reflector;
+
+        public SidecarHost(
+            IpcClient ipc,
+            string sidecarVersion,
+            ILoggerProvider? loggerProvider = null,
+            string? fallbackHost = null,
+            string? fallbackToken = null)
+        {
+            _ipc = ipc ?? throw new ArgumentNullException(nameof(ipc));
+            _sidecarVersion = sidecarVersion;
+            _loggerProvider = loggerProvider;
+            _logger = loggerProvider?.CreateLogger(nameof(SidecarHost));
+            _fallbackHost = fallbackHost;
+            _fallbackToken = fallbackToken;
+        }
+
+        public IMcpPlugin? Plugin => _plugin;
+        public ConnectionConfig Config => _config;
+
+        /// <summary>
+        /// Build the plugin (empty tool set) + reflector, wire the manifest registrar to the live
+        /// <c>ToolManager</c>, and subscribe to the IPC handshake/shutdown events. Idempotent: a second
+        /// call is a no-op. Does NOT start the IPC run loop (the caller owns that) and does NOT connect
+        /// SignalR (that happens on the first handshake-ack).
+        /// </summary>
+        public void Build()
+        {
+            if (_plugin != null)
+                return;
+
+            if (!string.IsNullOrWhiteSpace(_fallbackHost))
+                _config.Host = _fallbackHost!;
+            if (!string.IsNullOrWhiteSpace(_fallbackToken))
+                _config.Token = _fallbackToken;
+
+            // ProxyTools are schema-blind (raw JSON in/out, §2.1), so a bare reflector suffices — no
+            // engine type converters are needed sidecar-side.
+            _reflector = new Reflector();
+
+            var version = new McpVersion
+            {
+                Api = Consts.ApiVersion,
+                Plugin = _sidecarVersion,
+                Environment = "Unreal-MCP-Bridge",
+            };
+
+            // No WithToolsFromAssembly — the sidecar's tools are 100% dynamic (the plugin's manifest).
+            var builder = new McpPluginBuilder(version, _loggerProvider).SetConfig(_config);
+            _plugin = builder.Build(_reflector);
+
+            var toolManager = _plugin.McpManager.ToolManager
+                ?? throw new InvalidOperationException("Built McpPlugin has no ToolManager.");
+
+            _registrar = new ManifestRegistrar(
+                new ToolManagerSink(toolManager),
+                _ipc,
+                _loggerProvider?.CreateLogger(nameof(ManifestRegistrar)));
+
+            // Wire the registrar BEFORE the IPC loop can deliver a manifest.
+            _ipc.Registrar = _registrar;
+            _ipc.HandshakeAccepted += OnHandshakeAccepted;
+
+            _logger?.LogInformation("Sidecar host built (version {Version}); awaiting IPC handshake.", _sidecarVersion);
+        }
+
+        private void OnHandshakeAccepted(HandshakeAckMessage ack)
+        {
+            // Apply the effective connection config the plugin sent in the handshake-ack (§1.5). The plugin
+            // resolves Cloud/Custom host, token and mode (§8) and hands the sidecar the result; the sidecar
+            // never re-resolves it. Falls back to the values seeded in Build() when a field is absent.
+            var host = ack.Config?["host"]?.GetValue<string>();
+            var token = ack.Config?["token"]?.GetValue<string>();
+            if (!string.IsNullOrWhiteSpace(host))
+                _config.Host = host!;
+            if (token != null)
+                _config.Token = string.IsNullOrEmpty(token) ? null : token;
+
+            _logger?.LogInformation("Handshake accepted (plugin {PluginVersion}, engine {Engine}); connecting SignalR to {Host}.",
+                ack.PluginVersion, ack.EngineVersion, _config.Host);
+
+            // Fire-and-forget connect; KeepConnected drives reconnection inside the client.
+            _ = ConnectSignalRAsync();
+        }
+
+        private async System.Threading.Tasks.Task ConnectSignalRAsync()
+        {
+            var plugin = _plugin;
+            if (plugin == null)
+                return;
+            try
+            {
+                var ok = await plugin.Connect().ConfigureAwait(false);
+                _logger?.LogInformation(ok ? "SignalR connected." : "SignalR initial connect returned false; client will keep retrying.");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("SignalR connect failed: {Message}", ex.Message);
+            }
+        }
+
+        public void Dispose()
+        {
+            _ipc.HandshakeAccepted -= OnHandshakeAccepted;
+            try { _plugin?.Dispose(); } catch { /* ignore */ }
+            _plugin = null;
+        }
+    }
+}

--- a/bridge/src/Ipc/IpcClient.cs
+++ b/bridge/src/Ipc/IpcClient.cs
@@ -280,7 +280,24 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
                 catch (OperationCanceledException) { /* teardown */ }
                 catch (Exception ex) { _logger?.LogDebug("IPC heartbeat ended: {Message}", ex.Message); }
             }, cts.Token);
-            return cts;
+
+            // Disposing the heartbeat MUST cancel it, not just dispose the CTS: a plain Dispose() of a linked
+            // CTS does not cancel its token, so the heartbeat loop would survive into the next reconnect epoch
+            // (writing a stray ping into the new connection's stream) until it happened to throw
+            // ObjectDisposedException. Cancel first, then dispose.
+            return new CancelOnDispose(cts);
+        }
+
+        /// <summary>Cancels the wrapped <see cref="CancellationTokenSource"/> on dispose, then disposes it.</summary>
+        private sealed class CancelOnDispose : IDisposable
+        {
+            private readonly CancellationTokenSource _cts;
+            public CancelOnDispose(CancellationTokenSource cts) => _cts = cts;
+            public void Dispose()
+            {
+                try { _cts.Cancel(); } catch (ObjectDisposedException) { /* already torn down */ }
+                _cts.Dispose();
+            }
         }
 
         // --- IToolCallChannel -------------------------------------------------------------------------
@@ -297,7 +314,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
             // Cancellation: forward the caller's token as tool-cancel and fail the pending call (§4).
             using var registration = cancellationToken.Register(() =>
             {
-                _ = SendAsync(new ToolCancelMessage { RequestId = requestId }, CancellationToken.None);
+                // Observe the send like the pong path: if the link is down this fire-and-forget faults, and an
+                // un-awaited faulted Task surfaces as an unobserved TaskException on the finalizer thread.
+                _ = SafeAwait(SendAsync(new ToolCancelMessage { RequestId = requestId }, CancellationToken.None));
                 _pending.TryFail(requestId, new OperationCanceledException(cancellationToken));
             });
 

--- a/bridge/src/Ipc/IpcClient.cs
+++ b/bridge/src/Ipc/IpcClient.cs
@@ -1,0 +1,355 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Unreal.MCP.Bridge.Sidecar;
+using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
+{
+    /// <summary>
+    /// The sidecar's IPC client (docs/ARCHITECTURE.md §1): dials the plugin's localhost TCP listener,
+    /// performs the stdin-token handshake (§1.4), reads NDJSON messages (§1.2), routes them, sends
+    /// heartbeats (§1.3), and reconnects with backoff (§1.5). Implements <see cref="IToolCallChannel"/>
+    /// so <see cref="ProxyTool"/>s round-trip calls through it. The reader loop never executes tool
+    /// bodies — it completes the pending-call task and the proxy/handler continuation runs off the
+    /// reader thread (RunContinuationsAsynchronously). One mutex-guarded writer serializes every send so
+    /// messages never interleave (§1.2).
+    /// </summary>
+    public sealed class IpcClient : IToolCallChannel, IAsyncDisposable
+    {
+        private readonly string _host;
+        private readonly int _port;
+        private readonly string _token;
+        private readonly string _sidecarVersion;
+        private readonly ILogger? _logger;
+
+        private readonly PendingCallRegistry _pending = new();
+        private readonly ReconnectBackoff _backoff = new();
+        private readonly SemaphoreSlim _writeLock = new(1, 1);
+
+        private TcpClient? _tcp;
+        private NetworkStream? _stream;
+        private volatile bool _shutdownRequested;
+        private long _lastActivityTicks;
+
+        /// <summary>Routes applied tool manifests; set by the host before <see cref="RunAsync"/>.</summary>
+        public ManifestRegistrar? Registrar { get; set; }
+
+        /// <summary>Raised when a <c>handshake-ack</c> is received (the link is established, §1.5).</summary>
+        public event Action<HandshakeAckMessage>? HandshakeAccepted;
+
+        /// <summary>Raised when a connection attempt's handshake was rejected (socket closed pre-ack, §1.4).</summary>
+        public event Action? HandshakeRejected;
+
+        /// <summary>Raised when the plugin sends <c>shutdown</c> (editor quitting, §1.5).</summary>
+        public event Action? ShutdownRequested;
+
+        public IpcClient(string host, int port, string token, string sidecarVersion, ILogger? logger = null)
+        {
+            _host = host;
+            _port = port;
+            _token = token ?? throw new ArgumentNullException(nameof(token));
+            _sidecarVersion = sidecarVersion;
+            _logger = logger;
+        }
+
+        public bool IsConnected => _stream != null && _tcp is { Connected: true };
+
+        /// <summary>
+        /// Connect → serve → reconnect until <paramref name="ct"/> is cancelled or the plugin requests
+        /// shutdown. Each iteration: dial, handshake, and (on accept) serve the read+heartbeat loop until
+        /// the link drops; then back off and retry (§1.5).
+        /// </summary>
+        public async Task RunAsync(CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested && !_shutdownRequested)
+            {
+                var accepted = await TryConnectAndServeAsync(ct).ConfigureAwait(false);
+
+                if (_shutdownRequested || ct.IsCancellationRequested)
+                    break;
+
+                // On a rejected handshake we do NOT reset the backoff; on an accepted-then-dropped link the
+                // serve loop already reset it on accept, so the next reconnect starts from 1 s.
+                var delay = _backoff.Next();
+                _logger?.LogInformation("IPC reconnecting in {DelayMs} ms (accepted={Accepted}).",
+                    (int)delay.TotalMilliseconds, accepted);
+                try { await Task.Delay(delay, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { break; }
+            }
+            _logger?.LogInformation("IPC client run loop exited (shutdown={Shutdown}).", _shutdownRequested);
+        }
+
+        private async Task<bool> TryConnectAndServeAsync(CancellationToken ct)
+        {
+            using var connCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            var tcp = new TcpClient();
+            var ackTcs = new TaskCompletionSource<HandshakeAckMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            try
+            {
+                _logger?.LogInformation("IPC dialing {Host}:{Port} ...", _host, _port);
+                await tcp.ConnectAsync(_host, _port, connCts.Token).ConfigureAwait(false);
+                tcp.NoDelay = true;
+
+                _tcp = tcp;
+                _stream = tcp.GetStream();
+                Touch();
+
+                // §1.4: send the handshake carrying the one-shot token as the FIRST message.
+                await SendAsync(new HandshakeMessage
+                {
+                    IpcVersion = IpcProtocol.IpcVersion,
+                    SidecarVersion = _sidecarVersion,
+                    Token = _token,
+                }, connCts.Token).ConfigureAwait(false);
+
+                // Serve the read loop; it completes ackTcs on handshake-ack.
+                var readTask = ReadLoopAsync(_stream, ackTcs, connCts.Token);
+
+                // Wait for the ack (or the read loop ending first = socket closed pre-ack = rejection, §1.4).
+                var acceptTimeout = Task.Delay(TimeSpan.FromSeconds(10), connCts.Token);
+                var first = await Task.WhenAny(ackTcs.Task, readTask, acceptTimeout).ConfigureAwait(false);
+
+                if (first == ackTcs.Task && ackTcs.Task.IsCompletedSuccessfully)
+                {
+                    _backoff.Reset();
+                    HandshakeAccepted?.Invoke(ackTcs.Task.Result);
+                    using var heartbeat = StartHeartbeat(connCts);
+                    await readTask.ConfigureAwait(false); // serve until the link drops
+                    return true;
+                }
+
+                // No ack: timeout or socket closed first → treat as a rejected/failed handshake (§1.4).
+                _logger?.LogWarning("IPC handshake not acknowledged (timeout or socket closed pre-ack).");
+                HandshakeRejected?.Invoke();
+                connCts.Cancel();
+                await SafeAwait(readTask).ConfigureAwait(false);
+                return false;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested || _shutdownRequested)
+            {
+                return false;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("IPC connection attempt failed: {Message}", ex.Message);
+                HandshakeRejected?.Invoke();
+                return false;
+            }
+            finally
+            {
+                CloseConnection(tcp);
+                _pending.FailAll(); // every in-flight proxy call fails fast (§2.2 step 4)
+                Registrar?.ResetForReconnect(); // §1.5: next handshake-ack re-applies the manifest
+            }
+        }
+
+        private async Task ReadLoopAsync(NetworkStream stream, TaskCompletionSource<HandshakeAckMessage> ackTcs, CancellationToken ct)
+        {
+            var framer = new NdjsonFramer();
+            var buffer = new byte[64 * 1024];
+            try
+            {
+                while (!ct.IsCancellationRequested)
+                {
+                    var read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), ct).ConfigureAwait(false);
+                    if (read == 0)
+                        break; // peer closed
+
+                    Touch();
+                    foreach (var line in framer.Push(buffer.AsSpan(0, read)))
+                    {
+                        if (!string.IsNullOrWhiteSpace(line))
+                            Dispatch(line, ackTcs, ct);
+                    }
+                }
+            }
+            catch (OperationCanceledException) { /* expected on teardown */ }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("IPC read loop ended: {Message}", ex.Message);
+            }
+        }
+
+        private void Dispatch(string line, TaskCompletionSource<HandshakeAckMessage> ackTcs, CancellationToken ct)
+        {
+            JsonNode? node;
+            try { node = JsonNode.Parse(line); }
+            catch (Exception ex) { _logger?.LogWarning("IPC dropped malformed line: {Message}", ex.Message); return; }
+
+            var type = node?["type"]?.GetValue<string>();
+            switch (type)
+            {
+                case IpcProtocol.Type.HandshakeAck:
+                {
+                    var ack = node!.Deserialize<HandshakeAckMessage>(IpcProtocol.JsonOptions) ?? new HandshakeAckMessage();
+                    ackTcs.TrySetResult(ack);
+                    break;
+                }
+                case IpcProtocol.Type.ToolManifest:
+                {
+                    var manifest = node!.Deserialize<ToolManifestMessage>(IpcProtocol.JsonOptions);
+                    if (manifest != null) Registrar?.Apply(manifest);
+                    break;
+                }
+                case IpcProtocol.Type.ToolResponse:
+                {
+                    var response = node!.Deserialize<ToolResponseMessage>(IpcProtocol.JsonOptions);
+                    if (response != null && !_pending.TryComplete(response.RequestId, response))
+                        _logger?.LogDebug("Dropped tool-response for unknown/completed requestId {Id}.", response.RequestId);
+                    break;
+                }
+                case IpcProtocol.Type.Ping:
+                    _ = SendAsync(new HeartbeatMessage { Type = IpcProtocol.Type.Pong }, ct);
+                    break;
+                case IpcProtocol.Type.Pong:
+                    break; // liveness already refreshed by Touch()
+                case IpcProtocol.Type.Shutdown:
+                    _logger?.LogInformation("IPC received shutdown from plugin; exiting.");
+                    _shutdownRequested = true;
+                    ShutdownRequested?.Invoke();
+                    break;
+                case IpcProtocol.Type.Config:
+                case IpcProtocol.Type.Status:
+                case IpcProtocol.Type.Log:
+                case IpcProtocol.Type.AuthStart:
+                case IpcProtocol.Type.AuthCancel:
+                case IpcProtocol.Type.AuthRevoke:
+                    // Wired in later UI/config/auth tasks; logged for now.
+                    _logger?.LogDebug("IPC received '{Type}' (not handled in the sidecar-bridge MVP).", type);
+                    break;
+                default:
+                    _logger?.LogDebug("IPC received unknown message type '{Type}'.", type);
+                    break;
+            }
+        }
+
+        private IDisposable StartHeartbeat(CancellationTokenSource connCts)
+        {
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(connCts.Token);
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    while (!cts.IsCancellationRequested)
+                    {
+                        await Task.Delay(IpcProtocol.HeartbeatIntervalMs, cts.Token).ConfigureAwait(false);
+
+                        var silentMs = (DateTime.UtcNow - new DateTime(Interlocked.Read(ref _lastActivityTicks), DateTimeKind.Utc)).TotalMilliseconds;
+                        if (silentMs > IpcProtocol.HeartbeatTimeoutMs)
+                        {
+                            _logger?.LogWarning("IPC peer silent for {SilentMs} ms (> {Timeout} ms); treating as dead.",
+                                (int)silentMs, IpcProtocol.HeartbeatTimeoutMs);
+                            connCts.Cancel(); // drop the link → reconnect
+                            break;
+                        }
+                        await SendAsync(new HeartbeatMessage { Type = IpcProtocol.Type.Ping }, cts.Token).ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException) { /* teardown */ }
+                catch (Exception ex) { _logger?.LogDebug("IPC heartbeat ended: {Message}", ex.Message); }
+            }, cts.Token);
+            return cts;
+        }
+
+        // --- IToolCallChannel -------------------------------------------------------------------------
+
+        public async Task<ToolResponseMessage> CallToolAsync(string tool, JsonObject? arguments, int timeoutMs, CancellationToken cancellationToken)
+        {
+            var stream = _stream;
+            if (stream == null || _tcp is not { Connected: true })
+                throw new IpcDisconnectedException();
+
+            var requestId = Guid.NewGuid().ToString("N");
+            var task = _pending.Register(requestId);
+
+            // Cancellation: forward the caller's token as tool-cancel and fail the pending call (§4).
+            using var registration = cancellationToken.Register(() =>
+            {
+                _ = SendAsync(new ToolCancelMessage { RequestId = requestId }, CancellationToken.None);
+                _pending.TryFail(requestId, new OperationCanceledException(cancellationToken));
+            });
+
+            try
+            {
+                await SendAsync(new ToolCallMessage
+                {
+                    RequestId = requestId,
+                    Tool = tool,
+                    Arguments = arguments,
+                    TimeoutMs = timeoutMs,
+                }, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _pending.TryFail(requestId, new IpcDisconnectedException());
+                throw new IpcDisconnectedException();
+            }
+
+            return await task.ConfigureAwait(false);
+        }
+
+        // --- writer (single mutex-guarded path, §1.2) -------------------------------------------------
+
+        private async Task SendAsync<T>(T message, CancellationToken ct)
+        {
+            var stream = _stream;
+            if (stream == null)
+                throw new IpcDisconnectedException();
+
+            var json = JsonSerializer.Serialize(message, IpcProtocol.JsonOptions);
+            var framed = NdjsonFramer.Encode(json);
+
+            await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                await stream.WriteAsync(framed.AsMemory(), ct).ConfigureAwait(false);
+                await stream.FlushAsync(ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                _writeLock.Release();
+            }
+        }
+
+        private void Touch() => Interlocked.Exchange(ref _lastActivityTicks, DateTime.UtcNow.Ticks);
+
+        private void CloseConnection(TcpClient tcp)
+        {
+            try { _stream?.Dispose(); } catch { /* ignore */ }
+            try { tcp.Close(); } catch { /* ignore */ }
+            _stream = null;
+            if (ReferenceEquals(_tcp, tcp)) _tcp = null;
+        }
+
+        private static async Task SafeAwait(Task task)
+        {
+            try { await task.ConfigureAwait(false); } catch { /* swallow on teardown */ }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _shutdownRequested = true;
+            try { _stream?.Dispose(); } catch { /* ignore */ }
+            try { _tcp?.Close(); } catch { /* ignore */ }
+            _writeLock.Dispose();
+            _pending.FailAll();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/bridge/src/Ipc/IpcClient.cs
+++ b/bridge/src/Ipc/IpcClient.cs
@@ -103,7 +103,19 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
             try
             {
                 _logger?.LogInformation("IPC dialing {Host}:{Port} ...", _host, _port);
-                await tcp.ConnectAsync(_host, _port, connCts.Token).ConfigureAwait(false);
+                try
+                {
+                    await tcp.ConnectAsync(_host, _port, connCts.Token).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    // A failed DIAL is a liveness event (plugin not listening yet / port not up), NOT a
+                    // handshake rejection (§6). It must NOT count toward MaxConsecutiveRejections — otherwise
+                    // 3 transient connect failures would be fatal. Just reconnect; the 60 s no-success
+                    // deadline + the parent-process monitor are what bound a truly dead link.
+                    _logger?.LogDebug("IPC dial failed: {Message}", ex.Message);
+                    return false;
+                }
                 tcp.NoDelay = true;
 
                 _tcp = tcp;
@@ -147,8 +159,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
             }
             catch (Exception ex)
             {
+                // Post-dial I/O error (e.g. the peer reset the socket mid-handshake). Treat it as liveness
+                // and reconnect WITHOUT counting a rejection — only a socket the plugin closed pre-ack after
+                // a completed dial (the no-ack branch above) is a genuine §1.4 handshake rejection.
                 _logger?.LogWarning("IPC connection attempt failed: {Message}", ex.Message);
-                HandshakeRejected?.Invoke();
                 return false;
             }
             finally
@@ -215,7 +229,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
                     break;
                 }
                 case IpcProtocol.Type.Ping:
-                    _ = SendAsync(new HeartbeatMessage { Type = IpcProtocol.Type.Pong }, ct);
+                    // Fire-and-forget pong, but observe the task so a send fault on a dropped link does not
+                    // surface as an unobserved TaskException on the finalizer thread.
+                    _ = SafeAwait(SendAsync(new HeartbeatMessage { Type = IpcProtocol.Type.Pong }, ct));
                     break;
                 case IpcProtocol.Type.Pong:
                     break; // liveness already refreshed by Touch()

--- a/bridge/src/Ipc/IpcClient.cs
+++ b/bridge/src/Ipc/IpcClient.cs
@@ -44,6 +44,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         private TcpClient? _tcp;
         private NetworkStream? _stream;
         private volatile bool _shutdownRequested;
+        // True only between a received handshake-ack and the connection's teardown. CallToolAsync gates on
+        // this (not merely an open socket) so a call cannot win the write race against the handshake.
+        private volatile bool _ackAccepted;
         private long _lastActivityTicks;
 
         /// <summary>Routes applied tool manifests; set by the host before <see cref="RunAsync"/>.</summary>
@@ -140,6 +143,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
                 if (first == ackTcs.Task && ackTcs.Task.IsCompletedSuccessfully)
                 {
                     _backoff.Reset();
+                    _ackAccepted = true; // open the gate: tool-calls may now hit the wire (§1.4)
                     HandshakeAccepted?.Invoke(ackTcs.Task.Result);
                     using var heartbeat = StartHeartbeat(connCts);
                     await readTask.ConfigureAwait(false); // serve until the link drops
@@ -304,8 +308,13 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
 
         public async Task<ToolResponseMessage> CallToolAsync(string tool, JsonObject? arguments, int timeoutMs, CancellationToken cancellationToken)
         {
+            // Gate on a COMPLETED handshake, not merely an open socket: _stream/_tcp are published right after
+            // the dial — BEFORE the handshake-ack — and on a reconnect epoch the ProxyTools from the prior
+            // epoch are still registered. A SignalR-driven call landing in that pre-ack window would win the
+            // write race against the handshake, hit the wire first, and be silently dropped by the plugin's
+            // pre-handshake auth gate, with no tool-response ever returning. Fail fast pre-ack instead.
             var stream = _stream;
-            if (stream == null || _tcp is not { Connected: true })
+            if (stream == null || !_ackAccepted || _tcp is not { Connected: true })
                 throw new IpcDisconnectedException();
 
             var requestId = Guid.NewGuid().ToString("N");
@@ -334,6 +343,24 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
             {
                 _pending.TryFail(requestId, new IpcDisconnectedException());
                 throw new IpcDisconnectedException();
+            }
+
+            // Local timeout backstop: timeoutMs is also embedded in the message for the plugin to honour, but
+            // a silently-dropped call (or a peer that never answers) must still fail this task rather than
+            // hang forever on a healthy link. Arm a local deadline slightly beyond the request timeout so the
+            // plugin's own terminal response normally wins the race; only fire when nothing comes back.
+            if (timeoutMs > 0)
+            {
+                using var backstopCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                var completed = await Task.WhenAny(task, Task.Delay(timeoutMs + IpcProtocol.CallTimeoutGraceMs, backstopCts.Token)).ConfigureAwait(false);
+                backstopCts.Cancel(); // stop the backstop timer whichever side won
+                if (completed != task && !cancellationToken.IsCancellationRequested)
+                {
+                    var timeout = new TimeoutException($"Tool '{tool}' call timed out after {timeoutMs + IpcProtocol.CallTimeoutGraceMs} ms with no IPC response.");
+                    _ = SafeAwait(SendAsync(new ToolCancelMessage { RequestId = requestId }, CancellationToken.None));
+                    _pending.TryFail(requestId, timeout);
+                    throw timeout;
+                }
             }
 
             return await task.ConfigureAwait(false);
@@ -366,6 +393,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
 
         private void CloseConnection(TcpClient tcp)
         {
+            _ackAccepted = false; // close the gate: the next epoch must re-handshake before any tool-call
             try { _stream?.Dispose(); } catch { /* ignore */ }
             try { tcp.Close(); } catch { /* ignore */ }
             _stream = null;
@@ -380,6 +408,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         public ValueTask DisposeAsync()
         {
             _shutdownRequested = true;
+            _ackAccepted = false;
             try { _stream?.Dispose(); } catch { /* ignore */ }
             try { _tcp?.Close(); } catch { /* ignore */ }
             _writeLock.Dispose();

--- a/bridge/src/Ipc/IpcMessages.cs
+++ b/bridge/src/Ipc/IpcMessages.cs
@@ -1,0 +1,110 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
+{
+    /// <summary>
+    /// Strongly-typed IPC message payloads (docs/ARCHITECTURE.md §1.3). Every message carries a
+    /// <c>type</c> discriminator (<see cref="IpcProtocol.Type"/>). Inbound messages are routed by
+    /// reading <c>type</c> off the parsed JSON, then deserializing the line into the matching record.
+    /// </summary>
+
+    /// <summary>sidecar → plugin: first message after connect. Carries the one-shot auth token (§1.4).</summary>
+    public sealed class HandshakeMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.Handshake;
+        [JsonPropertyName("ipcVersion")] public int IpcVersion { get; set; } = IpcProtocol.IpcVersion;
+        [JsonPropertyName("sidecarVersion")] public string? SidecarVersion { get; set; }
+        [JsonPropertyName("token")] public string? Token { get; set; }
+    }
+
+    /// <summary>plugin → sidecar: handshake acknowledgement + effective environment/config (§1.3).</summary>
+    public sealed class HandshakeAckMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.HandshakeAck;
+        [JsonPropertyName("ipcVersion")] public int IpcVersion { get; set; }
+        [JsonPropertyName("pluginVersion")] public string? PluginVersion { get; set; }
+        [JsonPropertyName("engineVersion")] public string? EngineVersion { get; set; }
+        [JsonPropertyName("projectPath")] public string? ProjectPath { get; set; }
+        [JsonPropertyName("config")] public JsonObject? Config { get; set; }
+    }
+
+    /// <summary>One entry in <see cref="ToolManifestMessage.Tools"/> — shaped to fill <c>IRunTool</c> 1:1 (§2.2).</summary>
+    public sealed class ToolDescriptor
+    {
+        [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+        [JsonPropertyName("title")] public string? Title { get; set; }
+        [JsonPropertyName("description")] public string? Description { get; set; }
+        [JsonPropertyName("skillDescription")] public string? SkillDescription { get; set; }
+        [JsonPropertyName("skillBody")] public string? SkillBody { get; set; }
+        [JsonPropertyName("inputSchema")] public JsonNode? InputSchema { get; set; }
+        [JsonPropertyName("outputSchema")] public JsonNode? OutputSchema { get; set; }
+        [JsonPropertyName("readOnlyHint")] public bool? ReadOnlyHint { get; set; }
+        [JsonPropertyName("destructiveHint")] public bool? DestructiveHint { get; set; }
+        [JsonPropertyName("idempotentHint")] public bool? IdempotentHint { get; set; }
+        [JsonPropertyName("openWorldHint")] public bool? OpenWorldHint { get; set; }
+        [JsonPropertyName("enabled")] public bool Enabled { get; set; } = true;
+        [JsonPropertyName("extensionId")] public string? ExtensionId { get; set; }
+        [JsonPropertyName("schemaHash")] public string? SchemaHash { get; set; }
+    }
+
+    /// <summary>plugin → sidecar: full tool-set snapshot. The sidecar diffs it against the last applied (§2.2).</summary>
+    public sealed class ToolManifestMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.ToolManifest;
+        [JsonPropertyName("revision")] public int Revision { get; set; }
+        [JsonPropertyName("tools")] public List<ToolDescriptor> Tools { get; set; } = new();
+    }
+
+    /// <summary>sidecar → plugin: invoke a tool. The plugin runs the body on the game thread (§4).</summary>
+    public sealed class ToolCallMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.ToolCall;
+        [JsonPropertyName("requestId")] public string RequestId { get; set; } = string.Empty;
+        [JsonPropertyName("tool")] public string Tool { get; set; } = string.Empty;
+        [JsonPropertyName("arguments")] public JsonObject? Arguments { get; set; }
+        [JsonPropertyName("timeoutMs")] public int TimeoutMs { get; set; } = IpcProtocol.DefaultToolTimeoutMs;
+    }
+
+    /// <summary>plugin → sidecar: terminal tool result, mirroring <c>ResponseCallTool</c> (§1.3).</summary>
+    public sealed class ToolResponseMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.ToolResponse;
+        [JsonPropertyName("requestId")] public string RequestId { get; set; } = string.Empty;
+        [JsonPropertyName("status")] public string Status { get; set; } = IpcProtocol.Status.Success;
+        [JsonPropertyName("content")] public JsonArray? Content { get; set; }
+        [JsonPropertyName("structured")] public JsonNode? Structured { get; set; }
+    }
+
+    /// <summary>sidecar → plugin: cooperative cancellation of an in-flight call (§4).</summary>
+    public sealed class ToolCancelMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.ToolCancel;
+        [JsonPropertyName("requestId")] public string RequestId { get; set; } = string.Empty;
+    }
+
+    /// <summary>Either direction: heartbeat probe / reply (§1.3).</summary>
+    public sealed class HeartbeatMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.Ping;
+    }
+
+    /// <summary>Either direction: structured log forwarding for unified output (§1.3). Never carries a secret.</summary>
+    public sealed class LogMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.Log;
+        [JsonPropertyName("level")] public string? Level { get; set; }
+        [JsonPropertyName("message")] public string? Message { get; set; }
+    }
+}

--- a/bridge/src/Ipc/IpcProtocol.cs
+++ b/bridge/src/Ipc/IpcProtocol.cs
@@ -1,0 +1,85 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Text.Json;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
+{
+    /// <summary>
+    /// IPC protocol constants for the plugin ⇄ sidecar channel (docs/ARCHITECTURE.md §1.3).
+    /// Every message is a UTF-8 JSON object with a <c>type</c> field, one message per
+    /// <c>\n</c>-terminated line (NDJSON, §1.2).
+    /// </summary>
+    public static class IpcProtocol
+    {
+        /// <summary>
+        /// IPC wire-protocol version (§9.2). Bumped only on a breaking framing/schema change; the
+        /// handshake (§1.3) carries it so a future version can negotiate without breaking old pairs.
+        /// </summary>
+        public const int IpcVersion = 1;
+
+        /// <summary>Max NDJSON line length (§1.2). A peer aborts the connection on violation.</summary>
+        public const int MaxLineBytes = 64 * 1024 * 1024;
+
+        /// <summary>Heartbeat cadence (§1.3): ping/pong every 5 s.</summary>
+        public const int HeartbeatIntervalMs = 5000;
+
+        /// <summary>A peer is declared dead after this much silence (§1.3).</summary>
+        public const int HeartbeatTimeoutMs = 15000;
+
+        /// <summary>Default per-tool-call timeout when the message omits one (§4).</summary>
+        public const int DefaultToolTimeoutMs = 30000;
+
+        /// <summary>Message <c>type</c> discriminator values (§1.3).</summary>
+        public static class Type
+        {
+            // sidecar → plugin
+            public const string Handshake = "handshake";
+            public const string ToolCall = "tool-call";
+            public const string ToolCancel = "tool-cancel";
+            public const string Status = "status";
+            public const string DeviceAuth = "device-auth";
+
+            // plugin → sidecar
+            public const string HandshakeAck = "handshake-ack";
+            public const string ToolManifest = "tool-manifest";
+            public const string ToolResponse = "tool-response";
+            public const string Config = "config";
+            public const string AuthStart = "auth-start";
+            public const string AuthCancel = "auth-cancel";
+            public const string AuthRevoke = "auth-revoke";
+            public const string Shutdown = "shutdown";
+
+            // either direction
+            public const string Ping = "ping";
+            public const string Pong = "pong";
+            public const string Log = "log";
+        }
+
+        /// <summary>Terminal tool-response statuses (§1.3 — IPC status enum is terminal-only).</summary>
+        public static class Status
+        {
+            public const string Success = "success";
+            public const string Error = "error";
+        }
+
+        /// <summary>
+        /// Shared <see cref="JsonSerializerOptions"/> for IPC: camelCase, no indentation (NDJSON is
+        /// one compact line per message), and tolerant property-name matching on read.
+        /// </summary>
+        public static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            WriteIndented = false,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        };
+    }
+}

--- a/bridge/src/Ipc/IpcProtocol.cs
+++ b/bridge/src/Ipc/IpcProtocol.cs
@@ -37,6 +37,14 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         /// <summary>Default per-tool-call timeout when the message omits one (§4).</summary>
         public const int DefaultToolTimeoutMs = 30000;
 
+        /// <summary>
+        /// Grace added to a tool-call's <c>timeoutMs</c> for the sidecar-side local backstop. The plugin
+        /// honours <c>timeoutMs</c> and should answer with a terminal tool-response first; the local
+        /// deadline is slightly longer so that response normally wins, and only fires when no response ever
+        /// arrives (e.g. a call silently dropped pre-handshake) so the pending call cannot hang forever.
+        /// </summary>
+        public const int CallTimeoutGraceMs = 5000;
+
         /// <summary>Message <c>type</c> discriminator values (§1.3).</summary>
         public static class Type
         {

--- a/bridge/src/Ipc/NdjsonFramer.cs
+++ b/bridge/src/Ipc/NdjsonFramer.cs
@@ -1,0 +1,102 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
+{
+    /// <summary>
+    /// Pure NDJSON framing codec (docs/ARCHITECTURE.md §1.2): UTF-8 JSON, one message per
+    /// <c>\n</c>-terminated line, line length capped at <see cref="IpcProtocol.MaxLineBytes"/>.
+    /// Kept free of any socket dependency so the framing path is unit-tested directly (the
+    /// "framing codec" xUnit row in §9.3). The decode side is a stateful accumulator: feed it raw
+    /// byte chunks as they arrive off the wire and it yields complete UTF-8 lines (newline stripped),
+    /// buffering partial lines across chunk boundaries.
+    /// </summary>
+    public sealed class NdjsonFramer
+    {
+        private readonly MemoryStream _buffer = new();
+        private readonly int _maxLineBytes;
+
+        public NdjsonFramer(int maxLineBytes = IpcProtocol.MaxLineBytes)
+        {
+            if (maxLineBytes <= 0)
+                throw new ArgumentOutOfRangeException(nameof(maxLineBytes));
+            _maxLineBytes = maxLineBytes;
+        }
+
+        /// <summary>
+        /// Encode a single JSON message into its wire form: UTF-8 bytes followed by a single
+        /// <c>\n</c>. The caller guarantees <paramref name="jsonLine"/> contains no raw newline
+        /// (System.Text.Json escapes them inside strings, so a serialized object never does).
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="jsonLine"/> is null.</exception>
+        /// <exception cref="InvalidDataException">The encoded line exceeds the cap.</exception>
+        public static byte[] Encode(string jsonLine, int maxLineBytes = IpcProtocol.MaxLineBytes)
+        {
+            if (jsonLine == null)
+                throw new ArgumentNullException(nameof(jsonLine));
+
+            var payload = Encoding.UTF8.GetBytes(jsonLine);
+            if (payload.Length > maxLineBytes)
+                throw new InvalidDataException(
+                    $"Outgoing IPC line is {payload.Length} bytes, exceeding the {maxLineBytes}-byte cap.");
+
+            var framed = new byte[payload.Length + 1];
+            Buffer.BlockCopy(payload, 0, framed, 0, payload.Length);
+            framed[payload.Length] = (byte)'\n';
+            return framed;
+        }
+
+        /// <summary>
+        /// Feed a chunk of raw bytes (as read from the socket) and return every complete line it
+        /// completes, in order. A trailing partial line is retained for the next call. Lines are
+        /// returned with the terminating <c>\n</c> (and a tolerated trailing <c>\r</c>) stripped.
+        /// </summary>
+        /// <exception cref="InvalidDataException">
+        /// A single un-terminated line grows past the cap — the connection must be aborted (§1.2).
+        /// </exception>
+        public IReadOnlyList<string> Push(ReadOnlySpan<byte> chunk)
+        {
+            var lines = new List<string>();
+            foreach (var b in chunk)
+            {
+                if (b == (byte)'\n')
+                {
+                    lines.Add(DrainLine());
+                }
+                else
+                {
+                    _buffer.WriteByte(b);
+                    if (_buffer.Length > _maxLineBytes)
+                        throw new InvalidDataException(
+                            $"Incoming IPC line exceeded the {_maxLineBytes}-byte cap before a newline arrived; aborting connection.");
+                }
+            }
+            return lines;
+        }
+
+        private string DrainLine()
+        {
+            var bytes = _buffer.ToArray();
+            _buffer.SetLength(0);
+
+            // Tolerate CRLF: strip a trailing '\r' so a peer that writes "\r\n" still decodes cleanly.
+            var len = bytes.Length;
+            if (len > 0 && bytes[len - 1] == (byte)'\r')
+                len--;
+
+            return Encoding.UTF8.GetString(bytes, 0, len);
+        }
+    }
+}

--- a/bridge/src/Ipc/PendingCallRegistry.cs
+++ b/bridge/src/Ipc/PendingCallRegistry.cs
@@ -1,0 +1,100 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
+{
+    /// <summary>
+    /// Correlates in-flight <c>tool-call</c>s with their <c>tool-response</c>s by <c>requestId</c>
+    /// (docs/ARCHITECTURE.md §1.3, §2.2). Thread-safe. On IPC disconnect, <see cref="FailAll"/> completes
+    /// every pending call with <see cref="IpcDisconnectedException"/> immediately rather than letting it
+    /// hang to its timeout (§1.5, §2.2 step 4). A <c>tool-response</c> for an unknown / already-completed
+    /// id is silently dropped (<see cref="TryComplete"/> returns false) — covering late responses that
+    /// straddle a reconnect (§1.5).
+    /// </summary>
+    public sealed class PendingCallRegistry
+    {
+        private readonly object _gate = new();
+        private readonly Dictionary<string, TaskCompletionSource<ToolResponseMessage>> _pending = new();
+
+        public int Count
+        {
+            get { lock (_gate) return _pending.Count; }
+        }
+
+        /// <summary>
+        /// Register a new pending call and return its completion task. The TCS runs continuations
+        /// asynchronously so completing it from the reader loop never inlines proxy/handler code onto
+        /// the reader thread.
+        /// </summary>
+        public Task<ToolResponseMessage> Register(string requestId)
+        {
+            var tcs = new TaskCompletionSource<ToolResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            lock (_gate)
+            {
+                // A duplicate id (should never happen — ids are unique per call) fails the prior waiter.
+                if (_pending.TryGetValue(requestId, out var existing))
+                    existing.TrySetException(new InvalidOperationException($"Duplicate requestId '{requestId}'."));
+                _pending[requestId] = tcs;
+            }
+            return tcs.Task;
+        }
+
+        /// <summary>
+        /// Complete a pending call with its response. Returns false (and drops the response) when no call
+        /// with that id is pending — a late or duplicate response straddling a reconnect (§1.5).
+        /// </summary>
+        public bool TryComplete(string requestId, ToolResponseMessage response)
+        {
+            TaskCompletionSource<ToolResponseMessage>? tcs;
+            lock (_gate)
+            {
+                if (!_pending.TryGetValue(requestId, out tcs))
+                    return false;
+                _pending.Remove(requestId);
+            }
+            return tcs.TrySetResult(response);
+        }
+
+        /// <summary>Cancel/forget a single pending call (e.g. the caller's CancellationToken fired).</summary>
+        public bool TryFail(string requestId, Exception exception)
+        {
+            TaskCompletionSource<ToolResponseMessage>? tcs;
+            lock (_gate)
+            {
+                if (!_pending.TryGetValue(requestId, out tcs))
+                    return false;
+                _pending.Remove(requestId);
+            }
+            return tcs.TrySetException(exception);
+        }
+
+        /// <summary>
+        /// Fail every pending call at once (IPC link dropped, §1.5). Each waiter resolves immediately
+        /// with <see cref="IpcDisconnectedException"/>.
+        /// </summary>
+        public void FailAll(Exception? exception = null)
+        {
+            List<TaskCompletionSource<ToolResponseMessage>> waiters;
+            lock (_gate)
+            {
+                waiters = new List<TaskCompletionSource<ToolResponseMessage>>(_pending.Values);
+                _pending.Clear();
+            }
+            var ex = exception ?? new IpcDisconnectedException();
+            foreach (var tcs in waiters)
+                tcs.TrySetException(ex);
+        }
+    }
+}

--- a/bridge/src/Program.cs
+++ b/bridge/src/Program.cs
@@ -9,19 +9,28 @@
 */
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Unreal.MCP.Bridge.Host;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using com.IvanMurzak.Unreal.MCP.Bridge.Sidecar;
+using Microsoft.Extensions.Logging;
 
 namespace com.IvanMurzak.Unreal.MCP.Bridge
 {
     /// <summary>
-    /// Scaffold stub of the unreal-mcp-bridge sidecar. Parses the launch contract
-    /// (docs/ARCHITECTURE.md §1.4) and exits cleanly. The real implementation —
-    /// IpcClient dialing 127.0.0.1:&lt;ipc-port&gt;, token handshake, manifest-driven
-    /// ProxyTool registration into the McpPlugin host, SignalR relay — lands with
-    /// the sidecar-bridge task.
+    /// The <c>unreal-mcp-bridge</c> sidecar entry point (docs/ARCHITECTURE.md §0, §1, §6). Parses the
+    /// launch contract (§1.4), reads the one-shot IPC token from stdin, dials the plugin's IPC listener,
+    /// hosts the reused McpPlugin SignalR client, registers the plugin's tool manifest as ProxyTools, and
+    /// runs the three no-orphan watchdog layers (§6). Exits cleanly on plugin <c>shutdown</c>, parent-editor
+    /// death, or a no-handshake deadline.
     /// </summary>
     public static class Program
     {
-        public static int Main(string[] args)
+        /// <summary>Single-sourced sidecar version (kept in lockstep with the csproj <c>&lt;Version&gt;</c>, §9.2).</summary>
+        public const string SidecarVersion = "0.1.0";
+
+        public static async Task<int> Main(string[] args)
         {
             var arguments = BridgeArguments.Parse(args);
             if (!arguments.IsValid)
@@ -31,14 +40,125 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge
                 return 2;
             }
 
-            // §1.4: the one-shot IPC auth token arrives as exactly one line on stdin
-            // (never argv). It is a secret — only its PRESENCE may ever be logged.
+            // §1.4: the one-shot IPC auth token arrives as exactly one line on stdin (never argv). It is a
+            // secret — only its PRESENCE may ever be logged.
             var token = Console.IsInputRedirected ? Console.In.ReadLine() : null;
-            var tokenState = string.IsNullOrWhiteSpace(token) ? "absent" : "received";
+            var tokenPresent = !string.IsNullOrWhiteSpace(token);
 
-            Console.WriteLine($"[unreal-mcp-bridge] scaffold stub v0.1.0 — ipc-port={arguments.IpcPort}, parent-pid={arguments.ParentPid}, token={tokenState}");
-            Console.WriteLine("[unreal-mcp-bridge] TODO(sidecar-bridge task): dial the plugin's IPC listener, perform the token handshake, host McpPlugin, relay tool calls. Exiting cleanly.");
+            var loggerProvider = new BridgeConsoleLoggerProvider(ResolveLogLevel());
+            var logger = loggerProvider.CreateLogger("Program");
+
+            logger.LogInformation(
+                "Sidecar v{Version} starting — ipc-port={Port}, parent-pid={Pid}, token={TokenState}.",
+                SidecarVersion, arguments.IpcPort, arguments.ParentPid, tokenPresent ? "received" : "absent");
+
+            if (!tokenPresent)
+                logger.LogWarning("No IPC token on stdin; the plugin will reject the handshake (orphan layer 3 will then exit the sidecar).");
+
+            using var cts = new CancellationTokenSource();
+            Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
+
+            await using var ipc = new IpcClient(
+                host: "127.0.0.1",
+                port: arguments.IpcPort,
+                token: token ?? string.Empty,
+                sidecarVersion: SidecarVersion,
+                logger: loggerProvider.CreateLogger(nameof(IpcClient)));
+
+            using var host = new SidecarHost(
+                ipc,
+                SidecarVersion,
+                loggerProvider,
+                fallbackHost: Environment.GetEnvironmentVariable("UNREAL_MCP_HOST")
+                              ?? Environment.GetEnvironmentVariable("UNREAL_MCP_CLOUD_URL"),
+                fallbackToken: Environment.GetEnvironmentVariable("UNREAL_MCP_TOKEN"));
+            host.Build();
+
+            // No-orphan watchdogs (§6) ------------------------------------------------------------------
+            var bootUtc = DateTime.UtcNow;
+            var handshakeTracker = new HandshakeFailureTracker(bootUtc);
+            var parentMonitor = ParentProcessMonitor.Capture(arguments.ParentPid); // layer 2 (null when no pid)
+
+            ipc.HandshakeAccepted += _ => handshakeTracker.RecordSuccess(DateTime.UtcNow);
+            ipc.HandshakeRejected += () =>
+            {
+                if (handshakeTracker.RecordRejection())
+                {
+                    logger.LogError("Handshake rejected {Count} times consecutively; exiting (orphan layer 3).",
+                        HandshakeFailureTracker.MaxConsecutiveRejections);
+                    cts.Cancel();
+                }
+            };
+            ipc.ShutdownRequested += () =>
+            {
+                logger.LogInformation("Plugin requested shutdown; exiting.");
+                cts.Cancel();
+            };
+
+            var ipcRun = ipc.RunAsync(cts.Token);
+            var watchdog = RunWatchdogAsync(parentMonitor, handshakeTracker, logger, cts);
+
+            await Task.WhenAny(ipcRun, watchdog).ConfigureAwait(false);
+            cts.Cancel();
+            await SafeAwait(ipcRun).ConfigureAwait(false);
+            await SafeAwait(watchdog).ConfigureAwait(false);
+
+            logger.LogInformation("Sidecar exiting cleanly.");
             return 0;
+        }
+
+        /// <summary>
+        /// Layer 2 + 3 poll loop (§6): every 2 s, exit if the parent editor (PID + start time) vanished, or
+        /// if the no-successful-handshake deadline (60 s) elapsed.
+        /// </summary>
+        private static async Task RunWatchdogAsync(
+            ParentProcessMonitor? parentMonitor,
+            HandshakeFailureTracker handshakeTracker,
+            ILogger logger,
+            CancellationTokenSource cts)
+        {
+            try
+            {
+                while (!cts.IsCancellationRequested)
+                {
+                    await Task.Delay(2000, cts.Token).ConfigureAwait(false);
+
+                    if (parentMonitor != null && !parentMonitor.IsParentAlive())
+                    {
+                        logger.LogInformation("Parent editor (pid {Pid}) is gone; exiting (orphan layer 2).", parentMonitor.ParentPid);
+                        cts.Cancel();
+                        return;
+                    }
+
+                    if (handshakeTracker.IsNoSuccessDeadlineExceeded(DateTime.UtcNow))
+                    {
+                        logger.LogError("No successful handshake within {Seconds} s; exiting (orphan layer 3).",
+                            (int)HandshakeFailureTracker.NoSuccessDeadline.TotalSeconds);
+                        cts.Cancel();
+                        return;
+                    }
+                }
+            }
+            catch (OperationCanceledException) { /* shutting down */ }
+        }
+
+        private static LogLevel ResolveLogLevel()
+        {
+            var raw = Environment.GetEnvironmentVariable("UNREAL_MCP_LOG_LEVEL");
+            return raw?.Trim().ToLowerInvariant() switch
+            {
+                "trace" => LogLevel.Trace,
+                "debug" => LogLevel.Debug,
+                "info" or "information" => LogLevel.Information,
+                "warn" or "warning" => LogLevel.Warning,
+                "error" => LogLevel.Error,
+                _ => LogLevel.Information,
+            };
+        }
+
+        private static async Task SafeAwait(Task task)
+        {
+            try { await task.ConfigureAwait(false); } catch { /* swallow on teardown */ }
         }
     }
 }

--- a/bridge/src/Program.cs
+++ b/bridge/src/Program.cs
@@ -55,6 +55,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge
             if (!tokenPresent)
                 logger.LogWarning("No IPC token on stdin; the plugin will reject the handshake (orphan layer 3 will then exit the sidecar).");
 
+            // Distinguish a clean exit (plugin `shutdown`, Ctrl+C, parent-editor-gone orphan avoidance) from a
+            // layer-3 GIVE-UP (handshake rejected repeatedly / no successful handshake within the deadline) via
+            // the process exit code, so the launcher/watchdog can tell "gave up" from "clean exit".
+            var exit = new ExitState();
+
             using var cts = new CancellationTokenSource();
             Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
 
@@ -86,6 +91,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge
                 {
                     logger.LogError("Handshake rejected {Count} times consecutively; exiting (orphan layer 3).",
                         HandshakeFailureTracker.MaxConsecutiveRejections);
+                    exit.Code = ExitCodes.GaveUp;
                     cts.Cancel();
                 }
             };
@@ -96,15 +102,15 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge
             };
 
             var ipcRun = ipc.RunAsync(cts.Token);
-            var watchdog = RunWatchdogAsync(parentMonitor, handshakeTracker, logger, cts);
+            var watchdog = RunWatchdogAsync(parentMonitor, handshakeTracker, logger, cts, exit);
 
             await Task.WhenAny(ipcRun, watchdog).ConfigureAwait(false);
             cts.Cancel();
             await SafeAwait(ipcRun).ConfigureAwait(false);
             await SafeAwait(watchdog).ConfigureAwait(false);
 
-            logger.LogInformation("Sidecar exiting cleanly.");
-            return 0;
+            logger.LogInformation("Sidecar exiting (code {Code}).", exit.Code);
+            return exit.Code;
         }
 
         /// <summary>
@@ -115,7 +121,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge
             ParentProcessMonitor? parentMonitor,
             HandshakeFailureTracker handshakeTracker,
             ILogger logger,
-            CancellationTokenSource cts)
+            CancellationTokenSource cts,
+            ExitState exit)
         {
             try
             {
@@ -134,6 +141,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge
                     {
                         logger.LogError("No successful handshake within {Seconds} s; exiting (orphan layer 3).",
                             (int)HandshakeFailureTracker.NoSuccessDeadline.TotalSeconds);
+                        exit.Code = ExitCodes.GaveUp;
                         cts.Cancel();
                         return;
                     }
@@ -159,6 +167,19 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge
         private static async Task SafeAwait(Task task)
         {
             try { await task.ConfigureAwait(false); } catch { /* swallow on teardown */ }
+        }
+
+        /// <summary>Process exit codes (§6). 0 = clean; non-zero distinguishes a layer-3 give-up.</summary>
+        private static class ExitCodes
+        {
+            public const int Clean = 0;
+            public const int GaveUp = 3; // handshake rejected repeatedly, or no successful handshake by the deadline
+        }
+
+        /// <summary>Mutable holder for the terminal exit code, shared between Main and the watchdog loop.</summary>
+        private sealed class ExitState
+        {
+            public int Code = ExitCodes.Clean;
         }
     }
 }

--- a/bridge/src/Sidecar/HandshakeFailureTracker.cs
+++ b/bridge/src/Sidecar/HandshakeFailureTracker.cs
@@ -1,0 +1,78 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Sidecar
+{
+    /// <summary>
+    /// Orphan-prevention layer 3 (docs/ARCHITECTURE.md §1.4, §6): the sidecar self-exits when it cannot
+    /// achieve a SUCCESSFUL handshake. Two independent triggers, both modelled here (pure, unit-tested):
+    /// <list type="bullet">
+    ///   <item><b>Consecutive-rejection fatal</b>: after <see cref="MaxConsecutiveRejections"/> (3)
+    ///   rejected handshakes in a row, the sidecar exits instead of re-dialing forever (§1.4).</item>
+    ///   <item><b>No-success deadline</b>: 60 s without a successful handshake → exit. A TCP connect whose
+    ///   handshake is REJECTED does NOT reset that deadline (otherwise a stale-token orphan re-dialing a
+    ///   relaunched editor would keep itself alive forever, §6).</item>
+    /// </list>
+    /// A successful handshake clears both. The owning watchdog loop polls <see cref="IsNoSuccessDeadlineExceeded"/>.
+    /// </summary>
+    public sealed class HandshakeFailureTracker
+    {
+        public const int MaxConsecutiveRejections = 3;
+        public static readonly TimeSpan NoSuccessDeadline = TimeSpan.FromSeconds(60);
+
+        private readonly TimeSpan _deadline;
+        private int _consecutiveRejections;
+        private DateTime? _lastSuccessUtc;
+
+        /// <param name="bootUtc">When the sidecar started — the no-success deadline runs from here until the first success.</param>
+        /// <param name="deadline">Override the 60 s deadline (tests).</param>
+        public HandshakeFailureTracker(DateTime bootUtc, TimeSpan? deadline = null)
+        {
+            _deadline = deadline ?? NoSuccessDeadline;
+            _lastSuccessUtc = null;
+            BootUtc = bootUtc;
+        }
+
+        public DateTime BootUtc { get; }
+        public int ConsecutiveRejections => _consecutiveRejections;
+        public bool HasEverSucceeded => _lastSuccessUtc.HasValue;
+
+        /// <summary>Record a successful handshake — clears the rejection count and the no-success deadline.</summary>
+        public void RecordSuccess(DateTime nowUtc)
+        {
+            _consecutiveRejections = 0;
+            _lastSuccessUtc = nowUtc;
+        }
+
+        /// <summary>
+        /// Record a rejected handshake. Returns true when the consecutive-rejection cap is reached and the
+        /// sidecar must exit. Does NOT touch the no-success deadline (deliberately, §6).
+        /// </summary>
+        public bool RecordRejection()
+        {
+            _consecutiveRejections++;
+            return _consecutiveRejections >= MaxConsecutiveRejections;
+        }
+
+        /// <summary>
+        /// True when the sidecar has never had a successful handshake and the deadline elapsed since boot.
+        /// Once any handshake has succeeded this is permanently false (the parent-process watchdog covers
+        /// the established-then-lost case).
+        /// </summary>
+        public bool IsNoSuccessDeadlineExceeded(DateTime nowUtc)
+        {
+            if (_lastSuccessUtc.HasValue)
+                return false;
+            return nowUtc - BootUtc >= _deadline;
+        }
+    }
+}

--- a/bridge/src/Sidecar/HandshakeFailureTracker.cs
+++ b/bridge/src/Sidecar/HandshakeFailureTracker.cs
@@ -30,6 +30,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Sidecar
         public static readonly TimeSpan NoSuccessDeadline = TimeSpan.FromSeconds(60);
 
         private readonly TimeSpan _deadline;
+
+        // Guards the two mutable fields below: they are written on the IPC reader thread (via the
+        // HandshakeAccepted / HandshakeRejected events) and read on the watchdog task thread (which polls
+        // IsNoSuccessDeadlineExceeded / HasEverSucceeded every 2 s). Without it the Nullable<DateTime> read is
+        // a torn read and the int increment is non-atomic.
+        private readonly object _gate = new();
         private int _consecutiveRejections;
         private DateTime? _lastSuccessUtc;
 
@@ -43,14 +49,17 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Sidecar
         }
 
         public DateTime BootUtc { get; }
-        public int ConsecutiveRejections => _consecutiveRejections;
-        public bool HasEverSucceeded => _lastSuccessUtc.HasValue;
+        public int ConsecutiveRejections { get { lock (_gate) return _consecutiveRejections; } }
+        public bool HasEverSucceeded { get { lock (_gate) return _lastSuccessUtc.HasValue; } }
 
         /// <summary>Record a successful handshake — clears the rejection count and the no-success deadline.</summary>
         public void RecordSuccess(DateTime nowUtc)
         {
-            _consecutiveRejections = 0;
-            _lastSuccessUtc = nowUtc;
+            lock (_gate)
+            {
+                _consecutiveRejections = 0;
+                _lastSuccessUtc = nowUtc;
+            }
         }
 
         /// <summary>
@@ -59,8 +68,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Sidecar
         /// </summary>
         public bool RecordRejection()
         {
-            _consecutiveRejections++;
-            return _consecutiveRejections >= MaxConsecutiveRejections;
+            lock (_gate)
+            {
+                _consecutiveRejections++;
+                return _consecutiveRejections >= MaxConsecutiveRejections;
+            }
         }
 
         /// <summary>
@@ -70,8 +82,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Sidecar
         /// </summary>
         public bool IsNoSuccessDeadlineExceeded(DateTime nowUtc)
         {
-            if (_lastSuccessUtc.HasValue)
-                return false;
+            lock (_gate)
+            {
+                if (_lastSuccessUtc.HasValue)
+                    return false;
+            }
             return nowUtc - BootUtc >= _deadline;
         }
     }

--- a/bridge/src/Sidecar/ParentProcessMonitor.cs
+++ b/bridge/src/Sidecar/ParentProcessMonitor.cs
@@ -64,14 +64,17 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Sidecar
         /// </summary>
         public bool IsParentAlive()
         {
+            // Without a captured start time we cannot distinguish the real parent from a PID-reuse imposter,
+            // so we treat "unverifiable" as dead — matching the documented contract (the parent we never
+            // identified is reported gone) and erring toward self-exit rather than outliving a stranger.
+            if (_expectedStartTimeUtc is not { } expected)
+                return false;
             try
             {
                 using var parent = Process.GetProcessById(_parentPid);
                 if (parent.HasExited)
                     return false;
-                if (_expectedStartTimeUtc is { } expected)
-                    return parent.StartTime.ToUniversalTime() == expected;
-                return true;
+                return parent.StartTime.ToUniversalTime() == expected;
             }
             catch
             {

--- a/bridge/src/Sidecar/ParentProcessMonitor.cs
+++ b/bridge/src/Sidecar/ParentProcessMonitor.cs
@@ -1,0 +1,82 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Diagnostics;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Sidecar
+{
+    /// <summary>
+    /// Orphan-prevention layer 2 (docs/ARCHITECTURE.md §6): the sidecar self-exits when the editor
+    /// process identified by <c>--parent-pid</c> vanishes. The identity is the PID <b>plus its process
+    /// start time</b> captured at sidecar boot — so PID reuse (a different process inheriting the same
+    /// id) cannot silently keep the sidecar alive. Poll <see cref="IsParentAlive"/> every 2 s; a false
+    /// result means the editor is gone (or was replaced) → exit.
+    /// </summary>
+    public sealed class ParentProcessMonitor
+    {
+        private readonly int _parentPid;
+        private readonly DateTime? _expectedStartTimeUtc;
+
+        private ParentProcessMonitor(int parentPid, DateTime? expectedStartTimeUtc)
+        {
+            _parentPid = parentPid;
+            _expectedStartTimeUtc = expectedStartTimeUtc;
+        }
+
+        public int ParentPid => _parentPid;
+        public DateTime? ExpectedStartTimeUtc => _expectedStartTimeUtc;
+
+        /// <summary>
+        /// Capture the parent's identity at boot. Returns null when <paramref name="parentPid"/> is not
+        /// provided (0) — the caller then relies on the handshake watchdog (layer 3) alone. If the PID is
+        /// already gone at boot, the monitor is still created (start time unknown) and the first poll will
+        /// report the parent dead.
+        /// </summary>
+        public static ParentProcessMonitor? Capture(int parentPid)
+        {
+            if (parentPid <= 0)
+                return null;
+
+            DateTime? startTime = null;
+            try
+            {
+                using var parent = Process.GetProcessById(parentPid);
+                startTime = parent.StartTime.ToUniversalTime();
+            }
+            catch
+            {
+                // Parent already gone or inaccessible — leave start time null; IsParentAlive() will report dead.
+            }
+            return new ParentProcessMonitor(parentPid, startTime);
+        }
+
+        /// <summary>
+        /// True only when a process with the expected PID exists AND (when a start time was captured) its
+        /// start time still matches. Any exception (process gone) is treated as "not alive".
+        /// </summary>
+        public bool IsParentAlive()
+        {
+            try
+            {
+                using var parent = Process.GetProcessById(_parentPid);
+                if (parent.HasExited)
+                    return false;
+                if (_expectedStartTimeUtc is { } expected)
+                    return parent.StartTime.ToUniversalTime() == expected;
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/bridge/src/Sidecar/ReconnectBackoff.cs
+++ b/bridge/src/Sidecar/ReconnectBackoff.cs
@@ -1,0 +1,49 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Sidecar
+{
+    /// <summary>
+    /// The IPC reconnect/backoff schedule (docs/ARCHITECTURE.md §1.5): 1 s, 2 s, 5 s, 10 s, 30 s (cap).
+    /// Pure and deterministic so the schedule is unit-tested directly (the "backoff" xUnit row, §9.3).
+    /// <see cref="Next"/> advances the delay; <see cref="Reset"/> returns to the first step after a
+    /// successful (re)connect.
+    /// </summary>
+    public sealed class ReconnectBackoff
+    {
+        private static readonly int[] ScheduleMs = { 1000, 2000, 5000, 10000, 30000 };
+        private int _attempt;
+
+        /// <summary>Number of times <see cref="Next"/> has been called since the last <see cref="Reset"/>.</summary>
+        public int Attempt => _attempt;
+
+        /// <summary>
+        /// The delay for the current attempt, then advance. Clamps to the final (30 s) step once the
+        /// schedule is exhausted.
+        /// </summary>
+        public TimeSpan Next()
+        {
+            var index = Math.Min(_attempt, ScheduleMs.Length - 1);
+            _attempt++;
+            return TimeSpan.FromMilliseconds(ScheduleMs[index]);
+        }
+
+        /// <summary>Peek the delay <see cref="Next"/> would return without advancing.</summary>
+        public TimeSpan Peek()
+        {
+            var index = Math.Min(_attempt, ScheduleMs.Length - 1);
+            return TimeSpan.FromMilliseconds(ScheduleMs[index]);
+        }
+
+        public void Reset() => _attempt = 0;
+    }
+}

--- a/bridge/src/Tools/ManifestDiff.cs
+++ b/bridge/src/Tools/ManifestDiff.cs
@@ -1,0 +1,107 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Collections.Generic;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// The result of diffing a freshly-received tool manifest against the previously applied set
+    /// (docs/ARCHITECTURE.md §2.2 step 1). Pure data; computed by <see cref="ManifestDiffer"/>.
+    /// </summary>
+    public sealed class ManifestDiff
+    {
+        /// <summary>Tools present in the new manifest but not the previous set → <c>AddTool</c>.</summary>
+        public List<ToolDescriptor> Added { get; } = new();
+
+        /// <summary>Tools whose schema hash changed → <c>RemoveTool</c> then <c>AddTool</c>.</summary>
+        public List<ToolDescriptor> Changed { get; } = new();
+
+        /// <summary>Tool names removed from the new manifest → <c>RemoveTool</c>.</summary>
+        public List<string> Removed { get; } = new();
+
+        /// <summary>Tools whose ONLY change is the enabled flag → <c>SetToolEnabled</c>.</summary>
+        public List<(string Name, bool Enabled)> EnabledChanged { get; } = new();
+
+        public bool IsEmpty =>
+            Added.Count == 0 && Changed.Count == 0 && Removed.Count == 0 && EnabledChanged.Count == 0;
+    }
+
+    /// <summary>
+    /// Pure manifest diffing (docs/ARCHITECTURE.md §2.2): compare by <c>name</c> + <c>schemaHash</c>
+    /// (the hash excludes the enabled flag, §2.2). This is the "manifest diff" xUnit target (§9.3).
+    /// </summary>
+    public static class ManifestDiffer
+    {
+        public static ManifestDiff Compute(
+            IReadOnlyDictionary<string, ToolDescriptor> previous,
+            IReadOnlyList<ToolDescriptor> next)
+        {
+            var diff = new ManifestDiff();
+            var nextByName = new Dictionary<string, ToolDescriptor>();
+
+            foreach (var desc in next)
+            {
+                if (string.IsNullOrEmpty(desc.Name))
+                    continue;
+                nextByName[desc.Name] = desc;
+
+                if (!previous.TryGetValue(desc.Name, out var prev))
+                {
+                    diff.Added.Add(desc);
+                    continue;
+                }
+
+                if (!SchemaEquals(prev, desc))
+                {
+                    diff.Changed.Add(desc);
+                }
+                else if (prev.Enabled != desc.Enabled)
+                {
+                    diff.EnabledChanged.Add((desc.Name, desc.Enabled));
+                }
+                // else: identical → no-op.
+            }
+
+            foreach (var name in previous.Keys)
+            {
+                if (!nextByName.ContainsKey(name))
+                    diff.Removed.Add(name);
+            }
+
+            return diff;
+        }
+
+        /// <summary>
+        /// Two descriptors are schema-equal when their <c>schemaHash</c> matches (the enabled flag is
+        /// excluded from the hash by the plugin, §2.2). When a hash is absent on either side, fall back
+        /// to comparing the structural signature so a manifest without hashes still diffs deterministically.
+        /// </summary>
+        private static bool SchemaEquals(ToolDescriptor a, ToolDescriptor b)
+        {
+            if (!string.IsNullOrEmpty(a.SchemaHash) || !string.IsNullOrEmpty(b.SchemaHash))
+                return a.SchemaHash == b.SchemaHash;
+
+            return Signature(a) == Signature(b);
+        }
+
+        private static string Signature(ToolDescriptor d)
+        {
+            // Structural fallback: everything that defines the tool's surface EXCEPT the enabled flag.
+            var input = d.InputSchema?.ToJsonString() ?? "null";
+            var output = d.OutputSchema?.ToJsonString() ?? "null";
+            return string.Join("",
+                d.Name, d.Title, d.Description, d.SkillDescription, d.SkillBody,
+                input, output,
+                d.ReadOnlyHint, d.DestructiveHint, d.IdempotentHint, d.OpenWorldHint, d.ExtensionId);
+        }
+    }
+}

--- a/bridge/src/Tools/ManifestRegistrar.cs
+++ b/bridge/src/Tools/ManifestRegistrar.cs
@@ -1,0 +1,133 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Collections.Generic;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// The minimal tool-set mutation surface the registrar needs. Abstracts <see cref="IToolManager"/>
+    /// (adapted by <see cref="ToolManagerSink"/>) so the manifest-application logic is unit-tested with
+    /// a fake sink — no built McpPlugin required.
+    /// </summary>
+    public interface IProxyToolSink
+    {
+        bool HasTool(string name);
+        bool AddTool(string name, ProxyTool tool);
+        bool RemoveTool(string name);
+        bool SetToolEnabled(string name, bool enabled);
+    }
+
+    /// <summary>Adapts the reused <see cref="IToolManager"/> to <see cref="IProxyToolSink"/>.</summary>
+    public sealed class ToolManagerSink : IProxyToolSink
+    {
+        private readonly IToolManager _toolManager;
+        public ToolManagerSink(IToolManager toolManager) => _toolManager = toolManager;
+
+        public bool HasTool(string name) => _toolManager.HasTool(name);
+        public bool AddTool(string name, ProxyTool tool) => _toolManager.AddTool(name, tool);
+        public bool RemoveTool(string name) => _toolManager.RemoveTool(name);
+        public bool SetToolEnabled(string name, bool enabled) => _toolManager.SetToolEnabled(name, enabled);
+    }
+
+    /// <summary>
+    /// Applies tool manifests (docs/ARCHITECTURE.md §2.2) to an <see cref="IProxyToolSink"/>: diff against
+    /// the previously applied set, then remove / add (as <see cref="ProxyTool"/>s) / re-add changed /
+    /// toggle enabled. Honours the out-of-order revision guard (§2.2 step 3) — but
+    /// <see cref="ResetForReconnect"/> (called on every <c>handshake-ack</c>, §1.5) resets the
+    /// last-applied revision to −1 so a post-reconnect re-push with an unchanged revision is always
+    /// applied. NOT thread-safe by itself: ProxyTool's docs require the host to serialize tool-set
+    /// mutations; the IPC client invokes this from its single reader loop.
+    /// </summary>
+    public sealed class ManifestRegistrar
+    {
+        private readonly IProxyToolSink _sink;
+        private readonly IToolCallChannel _channel;
+        private readonly ILogger? _logger;
+
+        private readonly Dictionary<string, ToolDescriptor> _applied = new();
+        private int _lastAppliedRevision = -1;
+
+        public ManifestRegistrar(IProxyToolSink sink, IToolCallChannel channel, ILogger? logger = null)
+        {
+            _sink = sink;
+            _channel = channel;
+            _logger = logger;
+        }
+
+        /// <summary>Names of the tools currently registered by this registrar (test/inspection aid).</summary>
+        public IReadOnlyCollection<string> AppliedToolNames => _applied.Keys;
+
+        public int LastAppliedRevision => _lastAppliedRevision;
+
+        /// <summary>
+        /// Reset the revision guard after a (re)connection handshake (§1.5). The applied snapshot is
+        /// retained — the long-lived McpPlugin still has the proxies registered, so a re-pushed manifest
+        /// that is byte-identical diffs to a no-op (correct), while a genuine change while the link was
+        /// down is still caught by the diff.
+        /// </summary>
+        public void ResetForReconnect() => _lastAppliedRevision = -1;
+
+        /// <summary>Apply a manifest. Returns the diff that was applied (empty when ignored/no-op).</summary>
+        public ManifestDiff Apply(ToolManifestMessage manifest)
+        {
+            if (manifest.Revision <= _lastAppliedRevision)
+            {
+                _logger?.LogDebug(
+                    "Ignoring tool-manifest revision {Revision} (<= last applied {LastApplied}).",
+                    manifest.Revision, _lastAppliedRevision);
+                return new ManifestDiff();
+            }
+
+            var diff = ManifestDiffer.Compute(_applied, manifest.Tools);
+
+            foreach (var name in diff.Removed)
+            {
+                _sink.RemoveTool(name);
+                _applied.Remove(name);
+            }
+
+            foreach (var desc in diff.Changed)
+            {
+                _sink.RemoveTool(desc.Name);
+                _sink.AddTool(desc.Name, ProxyToolFactory.Create(desc, _channel));
+                _applied[desc.Name] = desc;
+            }
+
+            foreach (var desc in diff.Added)
+            {
+                _sink.AddTool(desc.Name, ProxyToolFactory.Create(desc, _channel));
+                _applied[desc.Name] = desc;
+            }
+
+            foreach (var (name, enabled) in diff.EnabledChanged)
+            {
+                _sink.SetToolEnabled(name, enabled);
+                if (_applied.TryGetValue(name, out var existing))
+                    existing.Enabled = enabled;
+            }
+
+            _lastAppliedRevision = manifest.Revision;
+
+            if (!diff.IsEmpty)
+            {
+                _logger?.LogInformation(
+                    "Applied tool-manifest revision {Revision}: +{Added} ~{Changed} -{Removed} ⏼{Enabled} (total {Total}).",
+                    manifest.Revision, diff.Added.Count, diff.Changed.Count, diff.Removed.Count,
+                    diff.EnabledChanged.Count, _applied.Count);
+            }
+
+            return diff;
+        }
+    }
+}

--- a/bridge/src/Tools/ProxyResponseMapper.cs
+++ b/bridge/src/Tools/ProxyResponseMapper.cs
@@ -1,0 +1,59 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Collections.Generic;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// Maps an IPC <c>tool-response</c> (docs/ARCHITECTURE.md §1.3) onto a <see cref="ResponseCallTool"/>
+    /// with no re-shaping: <c>status</c>, <c>content</c> (the MCP content-block array), and
+    /// <c>structured</c> carry over 1:1 because the plugin shapes them to mirror <c>ResponseCallTool</c>
+    /// (§1.3). This is the "ProxyTool mapping" xUnit target (§9.3).
+    /// </summary>
+    public static class ProxyResponseMapper
+    {
+        public static ResponseCallTool Map(ToolResponseMessage message, string requestId)
+        {
+            var status = string.Equals(message.Status, IpcProtocol.Status.Error, System.StringComparison.OrdinalIgnoreCase)
+                ? ResponseStatus.Error
+                : ResponseStatus.Success;
+
+            var content = new List<ContentBlock>();
+            if (message.Content != null)
+            {
+                foreach (var node in message.Content)
+                {
+                    if (node is not System.Text.Json.Nodes.JsonObject block)
+                        continue;
+
+                    content.Add(new ContentBlock
+                    {
+                        Type = block["type"]?.GetValue<string>() ?? Consts.ContentType.Text,
+                        Text = block["text"]?.GetValue<string>(),
+                        Data = block["data"]?.GetValue<string>(),
+                        MimeType = block["mimeType"]?.GetValue<string>(),
+                    });
+                }
+            }
+
+            return new ResponseCallTool
+            {
+                RequestID = requestId,
+                Status = status,
+                Content = content,
+                StructuredContent = message.Structured,
+            };
+        }
+    }
+}

--- a/bridge/src/Tools/ProxyTool.cs
+++ b/bridge/src/Tools/ProxyTool.cs
@@ -1,0 +1,135 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.Common.Model;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// An <see cref="IRunTool"/> whose JSON schemas are supplied externally at runtime (the plugin's
+    /// tool manifest, §2.2) and whose body is an async delegate that round-trips a <c>tool-call</c>
+    /// over IPC and awaits the matching <c>tool-response</c>. The building block for the sidecar's
+    /// dynamic, manifest-driven tool set.
+    ///
+    /// <para>
+    /// <b>TODO (upstream swap):</b> this is a local mirror of <c>MCP-Plugin-dotnet</c> PR #122's
+    /// <c>com.IvanMurzak.McpPlugin.ProxyTool</c> (docs/ARCHITECTURE.md §2.3). The §2.3 additive API
+    /// lands as <c>com.IvanMurzak.McpPlugin</c> &gt;= 6.8.0; when the pin is bumped (release-pipeline
+    /// owned), delete this file and use the upstream type — the public surface is identical. The pin
+    /// is FROZEN at 6.7.0 here, so the chars/4 token-count formula is inlined rather than reusing the
+    /// 6.8.0-only <c>ToolTokenCount.Calculate</c> helper. The behaviour is byte-identical.
+    /// </para>
+    /// </summary>
+    public sealed class ProxyTool : IRunTool
+    {
+        private readonly Func<string, IReadOnlyDictionary<string, JsonElement>?, CancellationToken, Task<ResponseCallTool>> _handler;
+        private int? _cachedTokenCount;
+
+        public string Name { get; }
+        public string? Title { get; }
+        public string? Description { get; }
+        public string? SkillDescription { get; }
+        public string? SkillBody { get; }
+        public JsonNode? InputSchema { get; }
+        public JsonNode? OutputSchema { get; }
+        public bool? ReadOnlyHint { get; }
+        public bool? DestructiveHint { get; }
+        public bool? IdempotentHint { get; }
+        public bool? OpenWorldHint { get; }
+
+        /// <summary>
+        /// Whether this tool is exposed to MCP clients. Settable so the manifest registrar can toggle a
+        /// runtime tool on/off. For post-registration toggling prefer
+        /// <c>IToolManager.SetToolEnabled(name, enabled)</c> (it also fires the list-changed notification).
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+
+        public int TokenCount
+        {
+            get
+            {
+                if (_cachedTokenCount.HasValue)
+                    return _cachedTokenCount.Value;
+
+                try
+                {
+                    _cachedTokenCount = CalculateTokenCount(Name, Title, Description, InputSchema, OutputSchema);
+                }
+                catch
+                {
+                    // Mirror RunTool.CalculateTokenCount's resilience: a tool whose externally supplied
+                    // schema fails to serialize must not poison IToolManager.EnabledToolsTokenCount.
+                    _cachedTokenCount = 0;
+                }
+                return _cachedTokenCount.Value;
+            }
+        }
+
+        public ProxyTool(
+            string name,
+            string? title,
+            string? description,
+            string? skillDescription,
+            string? skillBody,
+            JsonNode? inputSchema,
+            JsonNode? outputSchema,
+            bool? readOnlyHint,
+            bool? destructiveHint,
+            bool? idempotentHint,
+            bool? openWorldHint,
+            Func<string, IReadOnlyDictionary<string, JsonElement>?, CancellationToken, Task<ResponseCallTool>> handler)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Title = title;
+            Description = description;
+            SkillDescription = skillDescription;
+            SkillBody = skillBody;
+            // Detach the externally supplied schemas via a round-trip clone so the proxy owns immutable,
+            // self-consistent copies (a JsonNode may only have one parent; this also lets one node back
+            // more than one tool).
+            InputSchema = inputSchema is null ? null : JsonNode.Parse(inputSchema.ToJsonString());
+            OutputSchema = outputSchema is null ? null : JsonNode.Parse(outputSchema.ToJsonString());
+            ReadOnlyHint = readOnlyHint;
+            DestructiveHint = destructiveHint;
+            IdempotentHint = idempotentHint;
+            OpenWorldHint = openWorldHint;
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        }
+
+        public Task<ResponseCallTool> Run(string requestId, IReadOnlyDictionary<string, JsonElement>? namedParameters, CancellationToken cancellationToken = default)
+            => _handler(requestId, namedParameters, cancellationToken);
+
+        /// <summary>
+        /// The chars/4 token approximation, inlined from <c>RunTool.CalculateTokenCount</c> / the 6.8.0
+        /// <c>ToolTokenCount.Calculate</c> helper (identical formula and JSON shape — see §2.1, the
+        /// <c>RunTool.TokenCount.cs</c> reference). Builds a JSON object of the non-empty fields +
+        /// detached schema copies, serializes, and returns <c>ceil(len / 4)</c>.
+        /// </summary>
+        internal static int CalculateTokenCount(string? name, string? title, string? description, JsonNode? inputSchema, JsonNode? outputSchema)
+        {
+            var jsonObject = new JsonObject();
+            if (!string.IsNullOrEmpty(name)) jsonObject["name"] = name;
+            if (!string.IsNullOrEmpty(title)) jsonObject["title"] = title;
+            if (!string.IsNullOrEmpty(description)) jsonObject["description"] = description;
+            if (inputSchema != null) jsonObject["inputSchema"] = JsonNode.Parse(inputSchema.ToJsonString());
+            if (outputSchema != null) jsonObject["outputSchema"] = JsonNode.Parse(outputSchema.ToJsonString());
+
+            var jsonString = jsonObject.ToJsonString();
+            return (int)Math.Ceiling(jsonString.Length / 4.0);
+        }
+    }
+}

--- a/bridge/src/Tools/ProxyToolFactory.cs
+++ b/bridge/src/Tools/ProxyToolFactory.cs
@@ -1,0 +1,80 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// Builds a <see cref="ProxyTool"/> from a manifest <see cref="ToolDescriptor"/> (docs/ARCHITECTURE.md
+    /// §2.2 step 2). The proxy's body serializes the call onto the supplied <see cref="IToolCallChannel"/>,
+    /// awaits the terminal <c>tool-response</c>, and maps it to a <see cref="ResponseCallTool"/> with zero
+    /// re-shaping (§1.3 — the IPC <c>status/content/structured</c> mirror <c>ResponseCallTool</c>). On an
+    /// IPC disconnect the call fails fast with the structured "bridge disconnected" error (§2.2 step 4).
+    /// </summary>
+    public static class ProxyToolFactory
+    {
+        public static ProxyTool Create(ToolDescriptor descriptor, IToolCallChannel channel)
+        {
+            var toolName = descriptor.Name;
+            var timeoutMs = IpcProtocol.DefaultToolTimeoutMs;
+
+            return new ProxyTool(
+                name: toolName,
+                title: descriptor.Title,
+                description: descriptor.Description,
+                skillDescription: descriptor.SkillDescription,
+                skillBody: descriptor.SkillBody,
+                inputSchema: descriptor.InputSchema,
+                outputSchema: descriptor.OutputSchema,
+                readOnlyHint: descriptor.ReadOnlyHint,
+                destructiveHint: descriptor.DestructiveHint,
+                idempotentHint: descriptor.IdempotentHint,
+                openWorldHint: descriptor.OpenWorldHint,
+                handler: async (requestId, namedParameters, cancellationToken) =>
+                {
+                    var arguments = ToArguments(namedParameters);
+                    try
+                    {
+                        var response = await channel
+                            .CallToolAsync(toolName, arguments, timeoutMs, cancellationToken)
+                            .ConfigureAwait(false);
+                        return ProxyResponseMapper.Map(response, requestId);
+                    }
+                    catch (IpcDisconnectedException ex)
+                    {
+                        // Fail fast — never hang to timeoutMs (§2.2 step 4).
+                        return ResponseCallTool.Error(ex.Message).SetRequestID(requestId);
+                    }
+                }) { Enabled = descriptor.Enabled };
+        }
+
+        /// <summary>
+        /// Convert the framework's raw named arguments (<c>IReadOnlyDictionary&lt;string, JsonElement&gt;</c>)
+        /// into the <see cref="JsonObject"/> carried in the <c>tool-call</c> message. A null/empty set
+        /// becomes an empty object so the plugin always sees a well-formed <c>arguments</c> field.
+        /// </summary>
+        public static JsonObject ToArguments(IReadOnlyDictionary<string, JsonElement>? namedParameters)
+        {
+            var obj = new JsonObject();
+            if (namedParameters == null)
+                return obj;
+
+            foreach (var kvp in namedParameters)
+                obj[kvp.Key] = JsonNode.Parse(kvp.Value.GetRawText());
+
+            return obj;
+        }
+    }
+}

--- a/bridge/src/Tools/ToolCallChannel.cs
+++ b/bridge/src/Tools/ToolCallChannel.cs
@@ -1,0 +1,50 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// The channel a <see cref="ProxyTool"/> uses to round-trip a tool invocation over IPC: serialize a
+    /// <c>tool-call</c>, await the matching <c>tool-response</c>, and forward cancellation as a
+    /// <c>tool-cancel</c> (docs/ARCHITECTURE.md §2.2 step 2, §4). Implemented by the IPC client; an
+    /// interface so the proxy/registration path is unit-testable with a fake channel.
+    /// </summary>
+    public interface IToolCallChannel
+    {
+        /// <summary>
+        /// Send a <c>tool-call</c> and await its terminal <c>tool-response</c>.
+        /// </summary>
+        /// <exception cref="IpcDisconnectedException">
+        /// The IPC link is down — the proxy must fail fast with the structured "bridge disconnected"
+        /// error (§2.2 step 4), never hang to <paramref name="timeoutMs"/>.
+        /// </exception>
+        Task<ToolResponseMessage> CallToolAsync(
+            string tool,
+            JsonObject? arguments,
+            int timeoutMs,
+            CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Raised by <see cref="IToolCallChannel.CallToolAsync"/> when the IPC link is not connected, or
+    /// when an in-flight call is failed because the link dropped mid-call (§1.5, §2.2 step 4).
+    /// </summary>
+    public sealed class IpcDisconnectedException : Exception
+    {
+        public const string DefaultMessage = "Unreal editor bridge disconnected.";
+        public IpcDisconnectedException(string? message = null) : base(message ?? DefaultMessage) { }
+    }
+}

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -30,4 +30,9 @@
     <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.7.0" />
   </ItemGroup>
 
+  <!-- The xUnit suite exercises a couple of internal helpers (e.g. ProxyTool.CalculateTokenCount). -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="Unreal-MCP-Bridge.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/bridge/tests/Fakes.cs
+++ b/bridge/tests/Fakes.cs
@@ -1,0 +1,82 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>A scripted <see cref="IToolCallChannel"/> for testing the proxy/registration path.</summary>
+    public sealed class FakeToolCallChannel : IToolCallChannel
+    {
+        private readonly Func<string, JsonObject?, ToolResponseMessage>? _responder;
+        public bool Connected { get; set; } = true;
+
+        public string? LastTool { get; private set; }
+        public JsonObject? LastArguments { get; private set; }
+        public int Calls { get; private set; }
+
+        public FakeToolCallChannel(Func<string, JsonObject?, ToolResponseMessage>? responder = null)
+            => _responder = responder;
+
+        public Task<ToolResponseMessage> CallToolAsync(string tool, JsonObject? arguments, int timeoutMs, CancellationToken cancellationToken)
+        {
+            Calls++;
+            LastTool = tool;
+            LastArguments = arguments;
+            if (!Connected)
+                throw new IpcDisconnectedException();
+
+            var response = _responder?.Invoke(tool, arguments) ?? new ToolResponseMessage
+            {
+                RequestId = "fake",
+                Status = IpcProtocol.Status.Success,
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    /// <summary>An in-memory <see cref="IProxyToolSink"/> recording the registrar's mutations.</summary>
+    public sealed class FakeToolSink : IProxyToolSink
+    {
+        public readonly Dictionary<string, ProxyTool> Tools = new();
+        public readonly Dictionary<string, bool> Enabled = new();
+
+        public bool HasTool(string name) => Tools.ContainsKey(name);
+
+        public bool AddTool(string name, ProxyTool tool)
+        {
+            if (Tools.ContainsKey(name))
+                return false;
+            Tools[name] = tool;
+            Enabled[name] = tool.Enabled;
+            return true;
+        }
+
+        public bool RemoveTool(string name)
+        {
+            Enabled.Remove(name);
+            return Tools.Remove(name);
+        }
+
+        public bool SetToolEnabled(string name, bool enabled)
+        {
+            if (!Tools.ContainsKey(name))
+                return false;
+            Enabled[name] = enabled;
+            return true;
+        }
+    }
+}

--- a/bridge/tests/ManifestDifferTests.cs
+++ b/bridge/tests/ManifestDifferTests.cs
@@ -1,0 +1,99 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>The "manifest diff" xUnit target (docs/ARCHITECTURE.md §9.3, §2.2).</summary>
+    public class ManifestDifferTests
+    {
+        private static ToolDescriptor Tool(string name, string hash, bool enabled = true) =>
+            new() { Name = name, SchemaHash = hash, Enabled = enabled };
+
+        private static Dictionary<string, ToolDescriptor> Prev(params ToolDescriptor[] tools) =>
+            tools.ToDictionary(t => t.Name);
+
+        [Fact]
+        public void Added_WhenNameNotInPrevious()
+        {
+            var diff = ManifestDiffer.Compute(Prev(), new[] { Tool("ping", "h1") });
+            Assert.Single(diff.Added);
+            Assert.Equal("ping", diff.Added[0].Name);
+            Assert.Empty(diff.Changed);
+            Assert.Empty(diff.Removed);
+        }
+
+        [Fact]
+        public void Removed_WhenNameDropped()
+        {
+            var diff = ManifestDiffer.Compute(Prev(Tool("ping", "h1")), System.Array.Empty<ToolDescriptor>());
+            Assert.Equal(new[] { "ping" }, diff.Removed);
+        }
+
+        [Fact]
+        public void Changed_WhenSchemaHashDiffers()
+        {
+            var diff = ManifestDiffer.Compute(Prev(Tool("ping", "h1")), new[] { Tool("ping", "h2") });
+            Assert.Single(diff.Changed);
+            Assert.Empty(diff.EnabledChanged);
+        }
+
+        [Fact]
+        public void EnabledChanged_WhenOnlyEnabledFlagDiffers()
+        {
+            var diff = ManifestDiffer.Compute(
+                Prev(Tool("ping", "h1", enabled: true)),
+                new[] { Tool("ping", "h1", enabled: false) });
+            Assert.Empty(diff.Changed);
+            Assert.Single(diff.EnabledChanged);
+            Assert.Equal(("ping", false), diff.EnabledChanged[0]);
+        }
+
+        [Fact]
+        public void NoOp_WhenIdentical()
+        {
+            var diff = ManifestDiffer.Compute(Prev(Tool("ping", "h1")), new[] { Tool("ping", "h1") });
+            Assert.True(diff.IsEmpty);
+        }
+
+        [Fact]
+        public void SignatureFallback_WhenHashesAbsent()
+        {
+            var a = new ToolDescriptor { Name = "t", Description = "old" };
+            var b = new ToolDescriptor { Name = "t", Description = "new" };
+            var diff = ManifestDiffer.Compute(Prev(a), new[] { b });
+            Assert.Single(diff.Changed);
+        }
+
+        [Fact]
+        public void MixedDiff_PartitionsCorrectly()
+        {
+            var previous = Prev(Tool("keep", "h1"), Tool("drop", "h2"), Tool("mutate", "h3"), Tool("toggle", "h4", true));
+            var next = new[]
+            {
+                Tool("keep", "h1"),               // no-op
+                Tool("mutate", "h3-new"),         // changed
+                Tool("toggle", "h4", false),      // enabled-only
+                Tool("brand-new", "h5"),          // added
+                                                  // "drop" removed
+            };
+            var diff = ManifestDiffer.Compute(previous, next);
+            Assert.Equal(new[] { "brand-new" }, diff.Added.Select(t => t.Name));
+            Assert.Equal(new[] { "mutate" }, diff.Changed.Select(t => t.Name));
+            Assert.Equal(new[] { "drop" }, diff.Removed);
+            Assert.Equal(("toggle", false), Assert.Single(diff.EnabledChanged));
+        }
+    }
+}

--- a/bridge/tests/ManifestRegistrarTests.cs
+++ b/bridge/tests/ManifestRegistrarTests.cs
@@ -1,0 +1,113 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>Manifest application + the §2.2 revision guard + the §1.5 reconnect reset.</summary>
+    public class ManifestRegistrarTests
+    {
+        private static ToolDescriptor Tool(string name, string hash, bool enabled = true) =>
+            new() { Name = name, SchemaHash = hash, Enabled = enabled };
+
+        private static ToolManifestMessage Manifest(int revision, params ToolDescriptor[] tools) =>
+            new() { Revision = revision, Tools = tools.ToList() };
+
+        private static (ManifestRegistrar reg, FakeToolSink sink) New()
+        {
+            var sink = new FakeToolSink();
+            var reg = new ManifestRegistrar(sink, new FakeToolCallChannel());
+            return (reg, sink);
+        }
+
+        [Fact]
+        public void Apply_RegistersAddedToolsAsProxies()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(1, Tool("ping", "h1"), Tool("actor-create", "h2")));
+            Assert.True(sink.HasTool("ping"));
+            Assert.True(sink.HasTool("actor-create"));
+            Assert.Equal(2, sink.Tools.Count);
+        }
+
+        [Fact]
+        public void Apply_RemovesDroppedTools()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(1, Tool("ping", "h1"), Tool("doomed", "h2")));
+            reg.Apply(Manifest(2, Tool("ping", "h1")));
+            Assert.True(sink.HasTool("ping"));
+            Assert.False(sink.HasTool("doomed"));
+        }
+
+        [Fact]
+        public void Apply_ReregistersChangedTool()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(1, Tool("ping", "h1")));
+            var first = sink.Tools["ping"];
+            reg.Apply(Manifest(2, Tool("ping", "h2")));
+            Assert.NotSame(first, sink.Tools["ping"]); // remove+add produced a fresh proxy
+        }
+
+        [Fact]
+        public void Apply_TogglesEnabledOnly()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(1, Tool("ping", "h1", enabled: true)));
+            reg.Apply(Manifest(2, Tool("ping", "h1", enabled: false)));
+            Assert.True(sink.HasTool("ping"));
+            Assert.False(sink.Enabled["ping"]);
+        }
+
+        [Fact]
+        public void Apply_IgnoresStaleOrEqualRevision()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(5, Tool("ping", "h1")));
+            var diff = reg.Apply(Manifest(5, Tool("ping", "h1"), Tool("late", "h2")));
+            Assert.True(diff.IsEmpty);          // revision 5 <= last applied 5 → ignored
+            Assert.False(sink.HasTool("late"));
+        }
+
+        [Fact]
+        public void ResetForReconnect_AllowsUnchangedRevisionReapply()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(3, Tool("ping", "h1")));
+            Assert.Equal(3, reg.LastAppliedRevision);
+
+            // Simulate reconnect: the plugin re-pushes the SAME revision after a handshake-ack.
+            reg.ResetForReconnect();
+            Assert.Equal(-1, reg.LastAppliedRevision);
+
+            // Re-push with an unchanged revision is no longer skipped (§1.5). The snapshot is retained,
+            // so a byte-identical manifest diffs to a no-op (the proxy is still registered) — but a tool
+            // ADDED while the link was down is now caught.
+            var diff = reg.Apply(Manifest(3, Tool("ping", "h1"), Tool("added-offline", "h2")));
+            Assert.False(diff.IsEmpty);
+            Assert.True(sink.HasTool("added-offline"));
+            Assert.Equal(3, reg.LastAppliedRevision);
+        }
+
+        [Fact]
+        public void AppliedToolNames_TracksRegistrations()
+        {
+            var (reg, _) = New();
+            reg.Apply(Manifest(1, Tool("a", "h1"), Tool("b", "h2")));
+            Assert.Equal(new[] { "a", "b" }, reg.AppliedToolNames.OrderBy(n => n));
+        }
+    }
+}

--- a/bridge/tests/NdjsonFramerTests.cs
+++ b/bridge/tests/NdjsonFramerTests.cs
@@ -1,0 +1,79 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.IO;
+using System.Text;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>The "framing codec" xUnit target (docs/ARCHITECTURE.md §9.3).</summary>
+    public class NdjsonFramerTests
+    {
+        [Fact]
+        public void Encode_AppendsSingleNewline()
+        {
+            var framed = NdjsonFramer.Encode("{\"type\":\"ping\"}");
+            Assert.Equal((byte)'\n', framed[^1]);
+            Assert.Equal("{\"type\":\"ping\"}", Encoding.UTF8.GetString(framed, 0, framed.Length - 1));
+        }
+
+        [Fact]
+        public void Encode_RejectsOversizeLine()
+        {
+            var huge = new string('x', 32);
+            Assert.Throws<InvalidDataException>(() => NdjsonFramer.Encode(huge, maxLineBytes: 8));
+        }
+
+        [Fact]
+        public void Push_SplitsMultipleLinesInOneChunk()
+        {
+            var framer = new NdjsonFramer();
+            var lines = framer.Push(Encoding.UTF8.GetBytes("a\nb\nc\n"));
+            Assert.Equal(new[] { "a", "b", "c" }, lines);
+        }
+
+        [Fact]
+        public void Push_BuffersPartialLineAcrossChunks()
+        {
+            var framer = new NdjsonFramer();
+            Assert.Empty(framer.Push(Encoding.UTF8.GetBytes("{\"par")));
+            Assert.Empty(framer.Push(Encoding.UTF8.GetBytes("tial\":1")));
+            var lines = framer.Push(Encoding.UTF8.GetBytes("}\n"));
+            Assert.Equal(new[] { "{\"partial\":1}" }, lines);
+        }
+
+        [Fact]
+        public void Push_ToleratesCarriageReturn()
+        {
+            var framer = new NdjsonFramer();
+            var lines = framer.Push(Encoding.UTF8.GetBytes("hello\r\n"));
+            Assert.Equal(new[] { "hello" }, lines);
+        }
+
+        [Fact]
+        public void Push_AbortsWhenLineExceedsCap()
+        {
+            var framer = new NdjsonFramer(maxLineBytes: 4);
+            Assert.Throws<InvalidDataException>(() => framer.Push(Encoding.UTF8.GetBytes("abcdefgh")));
+        }
+
+        [Fact]
+        public void RoundTrip_EncodeThenPush_YieldsOriginal()
+        {
+            var framer = new NdjsonFramer();
+            var framed = NdjsonFramer.Encode("{\"type\":\"tool-call\",\"requestId\":\"x\"}");
+            var lines = framer.Push(framed);
+            Assert.Single(lines);
+            Assert.Equal("{\"type\":\"tool-call\",\"requestId\":\"x\"}", lines[0]);
+        }
+    }
+}

--- a/bridge/tests/ProxyToolFactoryAndMapperTests.cs
+++ b/bridge/tests/ProxyToolFactoryAndMapperTests.cs
@@ -1,0 +1,127 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    public class ProxyToolFactoryTests
+    {
+        private static Dictionary<string, JsonElement> Args(string json)
+        {
+            using var doc = JsonDocument.Parse(json);
+            var dict = new Dictionary<string, JsonElement>();
+            foreach (var prop in doc.RootElement.EnumerateObject())
+                dict[prop.Name] = prop.Value.Clone();
+            return dict;
+        }
+
+        [Fact]
+        public void ToArguments_NullBecomesEmptyObject()
+        {
+            var obj = ProxyToolFactory.ToArguments(null);
+            Assert.NotNull(obj);
+            Assert.Empty(obj);
+        }
+
+        [Fact]
+        public void ToArguments_PreservesNamedParameters()
+        {
+            var obj = ProxyToolFactory.ToArguments(Args("{\"message\":\"hi\",\"count\":3}"));
+            Assert.Equal("hi", obj["message"]!.GetValue<string>());
+            Assert.Equal(3, obj["count"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public async Task Create_RoundTripsCallThroughChannel()
+        {
+            var channel = new FakeToolCallChannel((tool, args) => new ToolResponseMessage
+            {
+                RequestId = "x",
+                Status = IpcProtocol.Status.Success,
+                Structured = JsonNode.Parse($"{{\"echo\":\"{args!["message"]!.GetValue<string>()}\"}}"),
+            });
+
+            var proxy = ProxyToolFactory.Create(new ToolDescriptor { Name = "ping" }, channel);
+            var result = await proxy.Run("req-1", Args("{\"message\":\"hello\"}"));
+
+            Assert.Equal("ping", channel.LastTool);
+            Assert.Equal("hello", channel.LastArguments!["message"]!.GetValue<string>());
+            Assert.Equal(ResponseStatus.Success, result.Status);
+            Assert.Equal("hello", result.StructuredContent!["echo"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task Create_DisconnectedChannel_FailsFastWithStructuredError()
+        {
+            var channel = new FakeToolCallChannel { Connected = false };
+            var proxy = ProxyToolFactory.Create(new ToolDescriptor { Name = "ping" }, channel);
+
+            var result = await proxy.Run("req-1", null);
+
+            Assert.Equal(ResponseStatus.Error, result.Status);
+            Assert.Contains("disconnected", result.GetMessage());
+        }
+
+        [Fact]
+        public void Create_PropagatesEnabledFlag()
+        {
+            var channel = new FakeToolCallChannel();
+            var proxy = ProxyToolFactory.Create(new ToolDescriptor { Name = "ping", Enabled = false }, channel);
+            Assert.False(proxy.Enabled);
+        }
+    }
+
+    public class ProxyResponseMapperTests
+    {
+        [Fact]
+        public void Map_SuccessWithTextContentAndStructured()
+        {
+            var msg = new ToolResponseMessage
+            {
+                Status = IpcProtocol.Status.Success,
+                Content = JsonNode.Parse("[{\"type\":\"text\",\"text\":\"pong\",\"mimeType\":\"text/plain\"}]")!.AsArray(),
+                Structured = JsonNode.Parse("{\"result\":\"pong\"}"),
+            };
+
+            var result = ProxyResponseMapper.Map(msg, "req-9");
+
+            Assert.Equal("req-9", result.RequestID);
+            Assert.Equal(ResponseStatus.Success, result.Status);
+            Assert.Single(result.Content);
+            Assert.Equal("pong", result.Content[0].Text);
+            Assert.Equal("pong", result.StructuredContent!["result"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public void Map_ErrorStatusMapsToError()
+        {
+            var msg = new ToolResponseMessage { Status = IpcProtocol.Status.Error };
+            var result = ProxyResponseMapper.Map(msg, "r");
+            Assert.Equal(ResponseStatus.Error, result.Status);
+        }
+
+        [Fact]
+        public void Map_NullContent_YieldsEmptyContentList()
+        {
+            var msg = new ToolResponseMessage { Status = IpcProtocol.Status.Success, Content = null };
+            var result = ProxyResponseMapper.Map(msg, "r");
+            Assert.Empty(result.Content);
+        }
+    }
+}

--- a/bridge/tests/ProxyToolTests.cs
+++ b/bridge/tests/ProxyToolTests.cs
@@ -1,0 +1,71 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>The "ProxyTool mapping" xUnit target (docs/ARCHITECTURE.md §9.3, §2.2-2.3).</summary>
+    public class ProxyToolTests
+    {
+        private static ProxyTool Make(JsonNode? input = null, System.Func<string, System.Collections.Generic.IReadOnlyDictionary<string, JsonElement>?, System.Threading.CancellationToken, Task<ResponseCallTool>>? handler = null)
+            => new ProxyTool("ping", "Ping", "Round-trip a ping.", null, null, input, null, true, false, true, false,
+                handler ?? ((_, _, _) => Task.FromResult(ResponseCallTool.Success("pong"))));
+
+        [Fact]
+        public void TokenCount_MatchesCharsOver4Formula()
+        {
+            var input = JsonNode.Parse("{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"}}}");
+            var tool = Make(input);
+            var expected = ProxyTool.CalculateTokenCount("ping", "Ping", "Round-trip a ping.", input, null);
+            Assert.Equal(expected, tool.TokenCount);
+            Assert.True(tool.TokenCount > 0);
+        }
+
+        [Fact]
+        public void InputSchema_IsDetachedCopy()
+        {
+            var input = JsonNode.Parse("{\"type\":\"object\"}");
+            var tool = Make(input);
+            // Mutating the caller's live node must not change the proxy's copy.
+            input!["type"] = "MUTATED";
+            Assert.Equal("object", tool.InputSchema!["type"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task Run_DelegatesToHandler()
+        {
+            var tool = Make(handler: (requestId, args, _) =>
+            {
+                Assert.Equal("req-1", requestId);
+                return Task.FromResult(ResponseCallTool.Success("handled"));
+            });
+            var result = await tool.Run("req-1", null);
+            Assert.Equal(ResponseStatus.Success, result.Status);
+            Assert.Equal("handled", result.GetMessage());
+        }
+
+        [Fact]
+        public void Hints_AreCarried()
+        {
+            var tool = Make();
+            Assert.True(tool.ReadOnlyHint);
+            Assert.False(tool.DestructiveHint);
+            Assert.True(tool.IdempotentHint);
+            Assert.False(tool.OpenWorldHint);
+        }
+    }
+}

--- a/bridge/tests/SidecarHostIntegrationTests.cs
+++ b/bridge/tests/SidecarHostIntegrationTests.cs
@@ -1,0 +1,116 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.ReflectorNet;
+using com.IvanMurzak.Unreal.MCP.Bridge.Host;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+using Xunit;
+using McpVersion = com.IvanMurzak.McpPlugin.Common.Version;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>
+    /// Proves the dynamic-registration foundation (docs/ARCHITECTURE.md §2.1) against the REAL pinned
+    /// <c>com.IvanMurzak.McpPlugin</c> 6.7.0: a <see cref="ProxyTool"/> registered into the live
+    /// <c>ToolManager</c> via <see cref="ManifestRegistrar"/> is listed and is callable end-to-end
+    /// (the call routes back through the IPC channel). This is the unit-level analog of the live
+    /// <c>ping</c> e2e — no editor required.
+    /// </summary>
+    public class SidecarHostIntegrationTests
+    {
+        private static IMcpPlugin BuildPlugin()
+        {
+            var version = new McpVersion { Api = Consts.ApiVersion, Plugin = "0.1.0", Environment = "test" };
+            return new McpPluginBuilder(version)
+                .SetConfig(new ConnectionConfig { GenerateSkillFiles = false, KeepConnected = false })
+                .Build(new Reflector());
+        }
+
+        [Fact]
+        public void Manifest_RegistersProxyIntoRealToolManager()
+        {
+            var plugin = BuildPlugin();
+            var tm = plugin.McpManager.ToolManager;
+            Assert.NotNull(tm);
+
+            var channel = new FakeToolCallChannel();
+            var registrar = new ManifestRegistrar(new ToolManagerSink(tm!), channel);
+
+            registrar.Apply(new ToolManifestMessage
+            {
+                Revision = 1,
+                Tools = { new ToolDescriptor { Name = "ping", Title = "Ping", Description = "Round-trip a ping." } },
+            });
+
+            Assert.True(tm!.HasTool("ping"));
+            Assert.Contains(tm.GetAllTools(), t => t.Name == "ping");
+            Assert.True(tm.EnabledToolsCount >= 1);
+        }
+
+        [Fact]
+        public async Task RegisteredProxy_IsCallableThroughToolManager()
+        {
+            var plugin = BuildPlugin();
+            var tm = plugin.McpManager.ToolManager!;
+
+            var channel = new FakeToolCallChannel((tool, args) => new ToolResponseMessage
+            {
+                Status = IpcProtocol.Status.Success,
+                Content = JsonNode.Parse("[{\"type\":\"text\",\"text\":\"pong\"}]")!.AsArray(),
+                Structured = JsonNode.Parse("{\"result\":\"pong\"}"),
+            });
+            var registrar = new ManifestRegistrar(new ToolManagerSink(tm), channel);
+            registrar.Apply(new ToolManifestMessage { Revision = 1, Tools = { new ToolDescriptor { Name = "ping" } } });
+
+            var ping = tm.GetAllTools().First(t => t.Name == "ping");
+            var result = await ping.Run("req-1", null);
+
+            Assert.Equal(ResponseStatus.Success, result.Status);
+            Assert.Equal("pong", result.StructuredContent!["result"]!.GetValue<string>());
+            Assert.Equal("ping", channel.LastTool);
+        }
+
+        [Fact]
+        public void RemovedTool_DisappearsFromToolManager()
+        {
+            var plugin = BuildPlugin();
+            var tm = plugin.McpManager.ToolManager!;
+            var registrar = new ManifestRegistrar(new ToolManagerSink(tm), new FakeToolCallChannel());
+
+            registrar.Apply(new ToolManifestMessage { Revision = 1, Tools = { new ToolDescriptor { Name = "ping", SchemaHash = "h1" } } });
+            Assert.True(tm.HasTool("ping"));
+
+            registrar.Apply(new ToolManifestMessage { Revision = 2, Tools = { } });
+            Assert.False(tm.HasTool("ping"));
+        }
+
+        [Fact]
+        public void SidecarHost_Build_WiresRegistrarAndDefaultsConfig()
+        {
+            var ipc = new IpcClient("127.0.0.1", 39999, token: "test-token", sidecarVersion: "0.1.0");
+            using var host = new SidecarHost(ipc, "0.1.0", fallbackHost: "http://localhost:5170");
+            host.Build();
+
+            Assert.NotNull(host.Plugin);
+            Assert.NotNull(host.Plugin!.McpManager.ToolManager);
+            Assert.NotNull(ipc.Registrar);              // wired before the run loop can deliver a manifest
+            Assert.Equal("http://localhost:5170", host.Config.Host);
+            Assert.True(host.Config.KeepConnected);
+            Assert.False(host.Config.GenerateSkillFiles);
+        }
+    }
+}

--- a/bridge/tests/SidecarRuntimeTests.cs
+++ b/bridge/tests/SidecarRuntimeTests.cs
@@ -1,0 +1,171 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using com.IvanMurzak.Unreal.MCP.Bridge.Sidecar;
+using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>The "backoff" xUnit target (docs/ARCHITECTURE.md §9.3, §1.5).</summary>
+    public class ReconnectBackoffTests
+    {
+        [Fact]
+        public void Schedule_FollowsOneTwoFiveTenThirtyCap()
+        {
+            var b = new ReconnectBackoff();
+            Assert.Equal(1000, (int)b.Next().TotalMilliseconds);
+            Assert.Equal(2000, (int)b.Next().TotalMilliseconds);
+            Assert.Equal(5000, (int)b.Next().TotalMilliseconds);
+            Assert.Equal(10000, (int)b.Next().TotalMilliseconds);
+            Assert.Equal(30000, (int)b.Next().TotalMilliseconds);
+            Assert.Equal(30000, (int)b.Next().TotalMilliseconds); // capped
+            Assert.Equal(30000, (int)b.Next().TotalMilliseconds);
+        }
+
+        [Fact]
+        public void Reset_ReturnsToFirstStep()
+        {
+            var b = new ReconnectBackoff();
+            b.Next(); b.Next(); b.Next();
+            b.Reset();
+            Assert.Equal(0, b.Attempt);
+            Assert.Equal(1000, (int)b.Peek().TotalMilliseconds);
+        }
+    }
+
+    public class PendingCallRegistryTests
+    {
+        [Fact]
+        public async Task CompletePending_ResolvesWaiter()
+        {
+            var reg = new PendingCallRegistry();
+            var task = reg.Register("r1");
+            Assert.Equal(1, reg.Count);
+
+            var response = new ToolResponseMessage { RequestId = "r1", Status = IpcProtocol.Status.Success };
+            Assert.True(reg.TryComplete("r1", response));
+            Assert.Same(response, await task);
+            Assert.Equal(0, reg.Count);
+        }
+
+        [Fact]
+        public void CompleteUnknownId_IsDropped()
+        {
+            var reg = new PendingCallRegistry();
+            Assert.False(reg.TryComplete("nope", new ToolResponseMessage()));
+        }
+
+        [Fact]
+        public async Task FailAll_FailsEveryWaiterWithDisconnect()
+        {
+            var reg = new PendingCallRegistry();
+            var t1 = reg.Register("r1");
+            var t2 = reg.Register("r2");
+            reg.FailAll();
+            await Assert.ThrowsAsync<IpcDisconnectedException>(() => t1);
+            await Assert.ThrowsAsync<IpcDisconnectedException>(() => t2);
+            Assert.Equal(0, reg.Count);
+        }
+
+        [Fact]
+        public async Task TryFail_FailsSingleWaiter()
+        {
+            var reg = new PendingCallRegistry();
+            var t = reg.Register("r1");
+            Assert.True(reg.TryFail("r1", new OperationCanceledException()));
+            await Assert.ThrowsAsync<OperationCanceledException>(() => t);
+        }
+    }
+
+    /// <summary>Orphan layer 3 (docs/ARCHITECTURE.md §1.4, §6).</summary>
+    public class HandshakeFailureTrackerTests
+    {
+        [Fact]
+        public void ThreeConsecutiveRejections_AreFatal()
+        {
+            var t = new HandshakeFailureTracker(DateTime.UtcNow);
+            Assert.False(t.RecordRejection());
+            Assert.False(t.RecordRejection());
+            Assert.True(t.RecordRejection()); // 3rd → fatal
+        }
+
+        [Fact]
+        public void Success_ResetsRejectionCount()
+        {
+            var t = new HandshakeFailureTracker(DateTime.UtcNow);
+            t.RecordRejection();
+            t.RecordRejection();
+            t.RecordSuccess(DateTime.UtcNow);
+            Assert.False(t.RecordRejection()); // count restarted
+            Assert.Equal(1, t.ConsecutiveRejections);
+        }
+
+        [Fact]
+        public void NoSuccessDeadline_ElapsesFromBoot()
+        {
+            var boot = DateTime.UtcNow;
+            var t = new HandshakeFailureTracker(boot, TimeSpan.FromSeconds(60));
+            Assert.False(t.IsNoSuccessDeadlineExceeded(boot.AddSeconds(59)));
+            Assert.True(t.IsNoSuccessDeadlineExceeded(boot.AddSeconds(61)));
+        }
+
+        [Fact]
+        public void Rejection_DoesNotResetNoSuccessDeadline()
+        {
+            var boot = DateTime.UtcNow;
+            var t = new HandshakeFailureTracker(boot, TimeSpan.FromSeconds(60));
+            t.RecordRejection(); // a rejected dial must NOT extend the deadline (§6)
+            Assert.True(t.IsNoSuccessDeadlineExceeded(boot.AddSeconds(61)));
+        }
+
+        [Fact]
+        public void AfterSuccess_DeadlineNeverFires()
+        {
+            var boot = DateTime.UtcNow;
+            var t = new HandshakeFailureTracker(boot, TimeSpan.FromSeconds(60));
+            t.RecordSuccess(boot.AddSeconds(5));
+            Assert.False(t.IsNoSuccessDeadlineExceeded(boot.AddSeconds(600)));
+        }
+    }
+
+    /// <summary>Orphan layer 2 (docs/ARCHITECTURE.md §6) — PID + start-time identity.</summary>
+    public class ParentProcessMonitorTests
+    {
+        [Fact]
+        public void Capture_ZeroPid_ReturnsNull()
+        {
+            Assert.Null(ParentProcessMonitor.Capture(0));
+        }
+
+        [Fact]
+        public void CurrentProcess_IsAlive()
+        {
+            using var self = Process.GetCurrentProcess();
+            var monitor = ParentProcessMonitor.Capture(self.Id);
+            Assert.NotNull(monitor);
+            Assert.True(monitor!.IsParentAlive());
+        }
+
+        [Fact]
+        public void NonexistentPid_IsNotAlive()
+        {
+            // Capture a live process, then build a monitor for an almost-certainly-dead PID.
+            var monitor = ParentProcessMonitor.Capture(2147483); // implausible pid
+            // Capture() may return a monitor with a null start time (process not found at boot); a poll
+            // then reports it dead. If the platform refused the id outright, Capture still yields a monitor.
+            Assert.True(monitor == null || !monitor.IsParentAlive());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- C++ UE plugin: tool registry + JSON manifest/schema, game-thread dispatcher (timeout/cancel), TCP/NDJSON bridge server (deterministic per-project port, token handshake, heartbeat, tool-call routing), sidecar manager (stdin-token spawn, watchdog/backoff, kill), the `ping` tool, and a runtime coordinator wired into the editor module.
- .NET sidecar: IpcClient (dial/handshake/reconnect/heartbeat), local `ProxyTool` + manifest diff/registrar into the McpPlugin `ToolManager`, SignalR host wiring, and the three no-orphan layers. Per `docs/ARCHITECTURE.md` §1/§2/§4/§6. Additive only; McpPlugin 6.7.0 pin retained; download flow stubbed behind `UNREAL_MCP_BRIDGE_PATH`.

## Test plan
- [x] Suite 1 UBT build: Succeeded
- [x] Suite 2 headless boot smoke: `[Unreal-MCP] plugin loaded`, exit 0
- [x] Suite 3 UE Automation (`UnrealMcp.*`): 16 succeeded, 0 failed
- [x] Suite 4 bridge xUnit: 59 passed
- [x] Suite 5 server build: 0 errors
- [x] Live `ping` e2e: MCP server -> SignalR -> sidecar -> IPC -> UE game thread -> `{"result":"pong"}` (and message echo)
- [x] No-orphan: editor hard-kill -> sidecar self-exits (orphan layer 2)

Closes #1