### PR TITLE
feat(plugin): implement the extensions mechanism (IUnrealMcpToolProvider)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionManager.cpp
@@ -17,6 +17,56 @@
 #include "Misc/Paths.h"
 #include "HAL/FileManager.h"
 
+namespace
+{
+	/** The reserved core scope: every non-extension tool defaults to this id (UnrealMcpToolRegistry.h). */
+	const FString ReservedCoreExtensionId = TEXT("core");
+
+	/**
+	 * Validate a provider-supplied extension id before it is used as a registry scope / removal key (§5).
+	 * A provider returning the reserved "core" id (or an empty/garbage id) would otherwise have its tools
+	 * removed under that id on the NEXT rebuild's cleanup pass — for "core" that silently deletes every
+	 * core tool. Ids are reverse-DNS-style: lowercase letters/digits separated by '.' or '-', no leading/
+	 * trailing/empty separators. Returns false + a human-readable reason on the first problem.
+	 */
+	bool IsValidExtensionId(const FString& Id, FString& OutError)
+	{
+		if (Id.IsEmpty())
+		{
+			OutError = TEXT("extension id is empty");
+			return false;
+		}
+		if (Id == ReservedCoreExtensionId)
+		{
+			OutError = FString::Printf(TEXT("extension id '%s' is reserved for built-in tools"), *ReservedCoreExtensionId);
+			return false;
+		}
+
+		bool bPrevSeparator = false;
+		const int32 Len = Id.Len();
+		for (int32 i = 0; i < Len; ++i)
+		{
+			const TCHAR C = Id[i];
+			const bool bLower = (C >= TEXT('a') && C <= TEXT('z'));
+			const bool bDigit = (C >= TEXT('0') && C <= TEXT('9'));
+			const bool bSeparator = (C == TEXT('.') || C == TEXT('-'));
+			if (!bLower && !bDigit && !bSeparator)
+			{
+				OutError = FString::Printf(
+					TEXT("extension id '%s' has an invalid character (allowed: lowercase letters, digits, '.', '-')"), *Id);
+				return false;
+			}
+			if (bSeparator && (i == 0 || i == Len - 1 || bPrevSeparator))
+			{
+				OutError = FString::Printf(TEXT("extension id '%s' has a leading, trailing, or doubled '.'/'-' separator"), *Id);
+				return false;
+			}
+			bPrevSeparator = bSeparator;
+		}
+		return true;
+	}
+}
+
 FUnrealMcpExtensionManager::FUnrealMcpExtensionManager(
 	FUnrealMcpToolRegistry& InRegistry, TFunction<void()> InOnChanged, const FString& InConfigPath)
 	: Registry(InRegistry)
@@ -102,14 +152,27 @@ void FUnrealMcpExtensionManager::Rebuild(bool bNotify)
 
 void FUnrealMcpExtensionManager::RebuildFromProviders(const TArray<IUnrealMcpToolProvider*>& Providers, bool bNotify)
 {
+	// 0. Re-entrancy guard (§5): if a provider's RegisterTools synchronously (un)registers a modular
+	//    feature, OnFeatureRegistered re-enters here mid-rebuild. Defer rather than recurse — recursing
+	//    would re-open the registry's extension scope (tripping its no-nested-scope check) and could free
+	//    a provider the outer Sorted loop still holds. Record the request and let the outer pass re-run.
+	if (bRebuilding)
+	{
+		bPendingRebuild = true;
+		bPendingNotify = bPendingNotify || bNotify;
+		return;
+	}
+	bRebuilding = true;
+
 	// 1. Clear the previous extension contribution (core tools are untouched: only ids we registered).
 	for (const FString& Id : RegisteredExtensionIds)
 		Registry.RemoveToolsForExtension(Id);
 	RegisteredExtensionIds.Reset();
 	Records.Reset();
 
-	// 2. Deterministic ordering: providers sorted by ExtensionId (§5). UE's Sort on a pointer array
-	//    dereferences elements, so the predicate receives references.
+	// 2. Deterministic ordering: providers sorted by ExtensionId (§5). StableSort keeps registration
+	//    order as the tie-break so two providers sharing an id get a stable relative order run-to-run.
+	//    UE's Sort on a pointer array dereferences elements, so the predicate receives references.
 	TArray<IUnrealMcpToolProvider*> Sorted;
 	Sorted.Reserve(Providers.Num());
 	for (IUnrealMcpToolProvider* P : Providers)
@@ -117,12 +180,13 @@ void FUnrealMcpExtensionManager::RebuildFromProviders(const TArray<IUnrealMcpToo
 		if (P != nullptr)
 			Sorted.Add(P);
 	}
-	Sorted.Sort([](const IUnrealMcpToolProvider& A, const IUnrealMcpToolProvider& B)
+	Sorted.StableSort([](const IUnrealMcpToolProvider& A, const IUnrealMcpToolProvider& B)
 	{
 		return A.GetExtensionId() < B.GetExtensionId();
 	});
 
 	// 3. Register each enabled provider; build the public record either way.
+	TSet<FString> SeenIds;
 	Records.Reserve(Sorted.Num());
 	for (IUnrealMcpToolProvider* Provider : Sorted)
 	{
@@ -130,8 +194,39 @@ void FUnrealMcpExtensionManager::RebuildFromProviders(const TArray<IUnrealMcpToo
 		Record.Id = Provider->GetExtensionId();
 		Record.DisplayName = Provider->GetDisplayName();
 		Record.Version = Provider->GetExtensionVersion();
-		Record.bEnabled = !DisabledExtensions.Contains(Record.Id);
 
+		// 3a. Validate the provider-supplied id before it becomes a registry scope / removal key. An
+		//     invalid or reserved ("core") id is recorded on the record and the provider contributes
+		//     nothing — never register under it (that would let the next rebuild's cleanup delete the
+		//     core tools, or a malformed id leak into the manifest).
+		FString IdError;
+		if (!IsValidExtensionId(Record.Id, IdError))
+		{
+			Record.bEnabled = false;
+			Record.ToolCount = 0;
+			Record.Error = IdError;
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] extension rejected: %s — its tools were skipped."), *IdError);
+			Records.Add(MoveTemp(Record));
+			continue;
+		}
+
+		// 3b. Detect a duplicate extension id (an authoring error, §5). The first-sorted provider keeps
+		//     the id; later providers sharing it are skipped with an error so the manifest stays
+		//     deterministic and a second provider cannot silently shadow the first's removal key.
+		if (SeenIds.Contains(Record.Id))
+		{
+			Record.bEnabled = false;
+			Record.ToolCount = 0;
+			Record.Error = FString::Printf(
+				TEXT("duplicate extension id '%s' — another provider already registered it; this provider's tools were skipped"),
+				*Record.Id);
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] %s"), *Record.Error);
+			Records.Add(MoveTemp(Record));
+			continue;
+		}
+		SeenIds.Add(Record.Id);
+
+		Record.bEnabled = !DisabledExtensions.Contains(Record.Id);
 		if (Record.bEnabled)
 		{
 			const FUnrealMcpExtensionRegistrationResult Result = Registry.RegisterExtension(
@@ -151,6 +246,17 @@ void FUnrealMcpExtensionManager::RebuildFromProviders(const TArray<IUnrealMcpToo
 	// 4. Notify the owner to re-push the manifest (§2.2).
 	if (bNotify && OnChanged)
 		OnChanged();
+
+	// 5. Release the guard. If a provider re-entered while we were rebuilding, the feature set changed
+	//    under us — re-run once against the FRESH source so the manifest reflects the new reality.
+	bRebuilding = false;
+	if (bPendingRebuild)
+	{
+		bPendingRebuild = false;
+		const bool bDeferredNotify = bPendingNotify;
+		bPendingNotify = false;
+		Rebuild(bDeferredNotify);
+	}
 }
 
 void FUnrealMcpExtensionManager::OnFeatureRegistered(const FName& Type, IModularFeature* /*Feature*/)
@@ -183,7 +289,11 @@ void FUnrealMcpExtensionManager::LoadConfig()
 	const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
 	if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid())
 	{
-		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] extension config at '%s' is malformed; ignoring."), *ConfigPath);
+		// Loud (Error, not Warning): a malformed file means the persisted disabled set is being silently
+		// dropped, so disabled extensions will spring back enabled until the file is rewritten.
+		UE_LOG(LogUnrealMcp, Error,
+			TEXT("[Unreal-MCP] extension config at '%s' is malformed and was ignored; disabled-extension state is lost until it is next saved."),
+			*ConfigPath);
 		return;
 	}
 
@@ -215,7 +325,21 @@ void FUnrealMcpExtensionManager::SaveConfig() const
 	const TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Out);
 	FJsonSerializer::Serialize(Root.ToSharedRef(), Writer);
 
-	IFileManager::Get().MakeDirectory(*FPaths::GetPath(ConfigPath), /*Tree*/ true);
-	if (!FFileHelper::SaveStringToFile(Out, *ConfigPath))
+	IFileManager& FileManager = IFileManager::Get();
+	FileManager.MakeDirectory(*FPaths::GetPath(ConfigPath), /*Tree*/ true);
+
+	// Crash-safe write: serialize to a sibling temp file, then atomically Move it over the target. A
+	// crash mid-write leaves the temp file (discarded next run), never a half-written Extensions.json
+	// that LoadConfig would reject as malformed.
+	const FString TempPath = ConfigPath + TEXT(".tmp");
+	if (!FFileHelper::SaveStringToFile(Out, *TempPath))
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] failed to write temp extension config '%s'."), *TempPath);
+		return;
+	}
+	if (!FileManager.Move(*ConfigPath, *TempPath, /*bReplace*/ true, /*bEvenIfReadOnly*/ true))
+	{
 		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] failed to persist extension config to '%s'."), *ConfigPath);
+		FileManager.Delete(*TempPath, /*RequireExists*/ false, /*EvenReadOnly*/ true);
+	}
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionManager.cpp
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "Extensions/UnrealMcpExtensionManager.h"
+
+#include "IUnrealMcpToolProvider.h"
+#include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpLog.h"
+
+#include "Features/IModularFeatures.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "HAL/FileManager.h"
+
+FUnrealMcpExtensionManager::FUnrealMcpExtensionManager(
+	FUnrealMcpToolRegistry& InRegistry, TFunction<void()> InOnChanged, const FString& InConfigPath)
+	: Registry(InRegistry)
+	, OnChanged(MoveTemp(InOnChanged))
+{
+	ConfigPath = InConfigPath.IsEmpty()
+		? FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("Config"), TEXT("UnrealMCP"), TEXT("Extensions.json"))
+		: InConfigPath;
+
+	// Default provider source: the live modular-feature registry. Overridable for deterministic tests.
+	ProviderSource = [this]() { return GatherProviders(); };
+}
+
+FUnrealMcpExtensionManager::~FUnrealMcpExtensionManager()
+{
+	Shutdown();
+}
+
+void FUnrealMcpExtensionManager::Startup()
+{
+	LoadConfig();
+
+	if (!bSubscribed)
+	{
+		IModularFeatures& Features = IModularFeatures::Get();
+		RegisteredHandle = Features.OnModularFeatureRegistered().AddRaw(this, &FUnrealMcpExtensionManager::OnFeatureRegistered);
+		UnregisteredHandle = Features.OnModularFeatureUnregistered().AddRaw(this, &FUnrealMcpExtensionManager::OnFeatureUnregistered);
+		bSubscribed = true;
+	}
+
+	// Initial discovery. No notify needed at boot: the bridge has not accepted yet, so the first
+	// manifest is read directly on handshake; OnChanged would no-op anyway.
+	Rebuild(/*bNotify*/ false);
+
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] extension manager started; %d extension(s) discovered."), Records.Num());
+}
+
+void FUnrealMcpExtensionManager::Shutdown()
+{
+	if (bSubscribed)
+	{
+		IModularFeatures& Features = IModularFeatures::Get();
+		Features.OnModularFeatureRegistered().Remove(RegisteredHandle);
+		Features.OnModularFeatureUnregistered().Remove(UnregisteredHandle);
+		RegisteredHandle.Reset();
+		UnregisteredHandle.Reset();
+		bSubscribed = false;
+	}
+}
+
+const FUnrealMcpExtensionRecord* FUnrealMcpExtensionManager::FindExtension(const FString& Id) const
+{
+	return Records.FindByPredicate([&Id](const FUnrealMcpExtensionRecord& R) { return R.Id == Id; });
+}
+
+void FUnrealMcpExtensionManager::SetExtensionEnabled(const FString& Id, bool bEnabled)
+{
+	const bool bCurrentlyEnabled = IsExtensionEnabled(Id);
+	if (bEnabled == bCurrentlyEnabled)
+		return; // no-op; avoid a pointless rebuild + manifest churn
+
+	if (bEnabled)
+		DisabledExtensions.Remove(Id);
+	else
+		DisabledExtensions.Add(Id);
+
+	SaveConfig();
+	Rebuild(/*bNotify*/ true);
+
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] extension '%s' %s."), *Id, bEnabled ? TEXT("enabled") : TEXT("disabled"));
+}
+
+TArray<IUnrealMcpToolProvider*> FUnrealMcpExtensionManager::GatherProviders() const
+{
+	return IModularFeatures::Get().GetModularFeatureImplementations<IUnrealMcpToolProvider>(
+		IUnrealMcpToolProvider::GetModularFeatureName());
+}
+
+void FUnrealMcpExtensionManager::Rebuild(bool bNotify)
+{
+	RebuildFromProviders(ProviderSource ? ProviderSource() : GatherProviders(), bNotify);
+}
+
+void FUnrealMcpExtensionManager::RebuildFromProviders(const TArray<IUnrealMcpToolProvider*>& Providers, bool bNotify)
+{
+	// 1. Clear the previous extension contribution (core tools are untouched: only ids we registered).
+	for (const FString& Id : RegisteredExtensionIds)
+		Registry.RemoveToolsForExtension(Id);
+	RegisteredExtensionIds.Reset();
+	Records.Reset();
+
+	// 2. Deterministic ordering: providers sorted by ExtensionId (§5). UE's Sort on a pointer array
+	//    dereferences elements, so the predicate receives references.
+	TArray<IUnrealMcpToolProvider*> Sorted;
+	Sorted.Reserve(Providers.Num());
+	for (IUnrealMcpToolProvider* P : Providers)
+	{
+		if (P != nullptr)
+			Sorted.Add(P);
+	}
+	Sorted.Sort([](const IUnrealMcpToolProvider& A, const IUnrealMcpToolProvider& B)
+	{
+		return A.GetExtensionId() < B.GetExtensionId();
+	});
+
+	// 3. Register each enabled provider; build the public record either way.
+	Records.Reserve(Sorted.Num());
+	for (IUnrealMcpToolProvider* Provider : Sorted)
+	{
+		FUnrealMcpExtensionRecord Record;
+		Record.Id = Provider->GetExtensionId();
+		Record.DisplayName = Provider->GetDisplayName();
+		Record.Version = Provider->GetExtensionVersion();
+		Record.bEnabled = !DisabledExtensions.Contains(Record.Id);
+
+		if (Record.bEnabled)
+		{
+			const FUnrealMcpExtensionRegistrationResult Result = Registry.RegisterExtension(
+				Record.Id, [Provider](FUnrealMcpToolRegistry& Reg) { Provider->RegisterTools(Reg); });
+
+			Record.ToolCount = Result.ToolsRegistered;
+			if (Result.Errors.Num() > 0)
+				Record.Error = FString::Join(Result.Errors, TEXT("; "));
+
+			// Track the id (even with 0 tools) so the next rebuild removes its tools cleanly.
+			RegisteredExtensionIds.AddUnique(Record.Id);
+		}
+
+		Records.Add(MoveTemp(Record));
+	}
+
+	// 4. Notify the owner to re-push the manifest (§2.2).
+	if (bNotify && OnChanged)
+		OnChanged();
+}
+
+void FUnrealMcpExtensionManager::OnFeatureRegistered(const FName& Type, IModularFeature* /*Feature*/)
+{
+	if (Type == IUnrealMcpToolProvider::GetModularFeatureName())
+	{
+		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] tool provider registered; rebuilding extensions."));
+		Rebuild(/*bNotify*/ true);
+	}
+}
+
+void FUnrealMcpExtensionManager::OnFeatureUnregistered(const FName& Type, IModularFeature* /*Feature*/)
+{
+	if (Type == IUnrealMcpToolProvider::GetModularFeatureName())
+	{
+		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] tool provider unregistered; rebuilding extensions."));
+		Rebuild(/*bNotify*/ true);
+	}
+}
+
+void FUnrealMcpExtensionManager::LoadConfig()
+{
+	DisabledExtensions.Reset();
+
+	FString Json;
+	if (!FFileHelper::LoadFileToString(Json, *ConfigPath))
+		return; // first run — no file yet
+
+	TSharedPtr<FJsonObject> Root;
+	const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
+	if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid())
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] extension config at '%s' is malformed; ignoring."), *ConfigPath);
+		return;
+	}
+
+	const TArray<TSharedPtr<FJsonValue>>* Disabled = nullptr;
+	if (Root->TryGetArrayField(TEXT("disabledExtensions"), Disabled))
+	{
+		for (const TSharedPtr<FJsonValue>& Value : *Disabled)
+		{
+			FString Id;
+			if (Value.IsValid() && Value->TryGetString(Id) && !Id.IsEmpty())
+				DisabledExtensions.Add(Id);
+		}
+	}
+}
+
+void FUnrealMcpExtensionManager::SaveConfig() const
+{
+	TArray<FString> Sorted = DisabledExtensions.Array();
+	Sorted.Sort();
+
+	TArray<TSharedPtr<FJsonValue>> Disabled;
+	for (const FString& Id : Sorted)
+		Disabled.Add(MakeShared<FJsonValueString>(Id));
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetArrayField(TEXT("disabledExtensions"), Disabled);
+
+	FString Out;
+	const TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Out);
+	FJsonSerializer::Serialize(Root.ToSharedRef(), Writer);
+
+	IFileManager::Get().MakeDirectory(*FPaths::GetPath(ConfigPath), /*Tree*/ true);
+	if (!FFileHelper::SaveStringToFile(Out, *ConfigPath))
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] failed to persist extension config to '%s'."), *ConfigPath);
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionManager.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionManager.h
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Internationalization/Text.h"
+#include "Templates/Function.h"
+#include "UObject/NameTypes.h"
+
+class FUnrealMcpToolRegistry;
+class IUnrealMcpToolProvider;
+class IModularFeature;
+
+/**
+ * A single discovered extension's public-facing record (docs/ARCHITECTURE.md §5 / §7 registry API row).
+ * The Slate UI (§7, later task) renders one row per record: id, display name, version, tool count,
+ * an enable toggle, and an error badge when HasError().
+ */
+struct FUnrealMcpExtensionRecord
+{
+	FString Id;
+	FText DisplayName;
+	FString Version;
+	int32 ToolCount = 0;
+	bool bEnabled = true;
+	/** Concatenated per-entry validation/dedup failures for this extension; empty when healthy. */
+	FString Error;
+
+	bool HasError() const { return !Error.IsEmpty(); }
+};
+
+/**
+ * Discovers IUnrealMcpToolProvider modular features, merges their tools into the plugin's single
+ * FUnrealMcpToolRegistry in deterministic order (sorted by ExtensionId), isolates invalid/duplicate
+ * entries (§5), and persists per-extension enable state. On every change it rebuilds the registry and
+ * fires OnChanged so the bridge re-pushes the manifest (§2.2 hot-reload).
+ *
+ * Threading: all rebuilds run on the game thread. Initial discovery happens during plugin StartupModule;
+ * late register/unregister events arrive on the game thread (module load/unload), as do UI toggles (§7).
+ *
+ * Persistence: disabledExtensions[] is stored in a minimal standalone JSON file under the project's
+ * Saved dir. TODO(connection-config §8): fold this into FUnrealMcpConfig once that store lands, so the
+ * extension enable state shares one config surface with connection settings.
+ */
+class UNREALMCPEDITOR_API FUnrealMcpExtensionManager
+{
+public:
+	/**
+	 * @param InRegistry   the plugin-owned registry to merge extension tools into (core tools must already be registered).
+	 * @param InOnChanged  fired after every rebuild so the owner can re-push the manifest (no-op when disconnected).
+	 * @param InConfigPath absolute path of the disabledExtensions[] JSON file; empty => default under the project Saved dir.
+	 */
+	FUnrealMcpExtensionManager(FUnrealMcpToolRegistry& InRegistry, TFunction<void()> InOnChanged, const FString& InConfigPath = FString());
+	~FUnrealMcpExtensionManager();
+
+	/** Load persisted disabled set, subscribe to modular-feature events, and run the initial rebuild. */
+	void Startup();
+	/** Unsubscribe from modular-feature events (idempotent). */
+	void Shutdown();
+
+	/** Discovered extensions, sorted by Id. */
+	const TArray<FUnrealMcpExtensionRecord>& GetExtensions() const { return Records; }
+	const FUnrealMcpExtensionRecord* FindExtension(const FString& Id) const;
+
+	/** True when @p Id is NOT in the persisted disabled set. */
+	bool IsExtensionEnabled(const FString& Id) const { return !DisabledExtensions.Contains(Id); }
+
+	/**
+	 * Enable/disable an extension: updates + persists the disabled set, then rebuilds and notifies.
+	 * A disabled extension contributes NO tools to the registry/manifest (§5, §D).
+	 */
+	void SetExtensionEnabled(const FString& Id, bool bEnabled);
+
+	/** Rebuild from an explicit provider list — deterministic, no global IModularFeatures (test seam). */
+	void RebuildFromProviders(const TArray<IUnrealMcpToolProvider*>& Providers, bool bNotify = true);
+
+	/** Override the provider source used by Startup/SetExtensionEnabled rebuilds (test seam; default = live discovery). */
+	void SetProviderSourceForTesting(TFunction<TArray<IUnrealMcpToolProvider*>()> InSource) { ProviderSource = MoveTemp(InSource); }
+
+private:
+	/** Rebuild from the current ProviderSource (live IModularFeatures discovery by default). */
+	void Rebuild(bool bNotify);
+
+	TArray<IUnrealMcpToolProvider*> GatherProviders() const;
+
+	void OnFeatureRegistered(const FName& Type, IModularFeature* Feature);
+	void OnFeatureUnregistered(const FName& Type, IModularFeature* Feature);
+
+	void LoadConfig();
+	void SaveConfig() const;
+
+	FUnrealMcpToolRegistry& Registry;
+	TFunction<void()> OnChanged;
+	FString ConfigPath;
+	TFunction<TArray<IUnrealMcpToolProvider*>()> ProviderSource;
+
+	TArray<FUnrealMcpExtensionRecord> Records;
+	TSet<FString> DisabledExtensions;
+	/** Extension ids that currently contributed tools, so a rebuild can remove exactly those before re-registering. */
+	TArray<FString> RegisteredExtensionIds;
+
+	FDelegateHandle RegisteredHandle;
+	FDelegateHandle UnregisteredHandle;
+	bool bSubscribed = false;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionManager.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionManager.h
@@ -103,4 +103,13 @@ private:
 	FDelegateHandle RegisteredHandle;
 	FDelegateHandle UnregisteredHandle;
 	bool bSubscribed = false;
+
+	// Re-entrancy guard (§5): a provider's RegisterTools may synchronously (un)register a modular feature,
+	// which fires OnFeatureRegistered → Rebuild while we are still mid-rebuild. Rather than recurse (which
+	// would re-enter the registry's extension scope, trip its no-nested-scope check, and could free a
+	// provider the outer Sorted loop still iterates), we DEFER: the nested call records a pending rebuild
+	// and returns immediately; the outer rebuild re-runs once after it completes against the fresh source.
+	bool bRebuilding = false;
+	bool bPendingRebuild = false;
+	bool bPendingNotify = false;
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpToolRegistry.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpToolRegistry.cpp
@@ -320,9 +320,28 @@ void FUnrealMcpToolRegistry::Commit(FUnrealMcpRegisteredTool&& InTool)
 
 		if (const FUnrealMcpRegisteredTool* Existing = Tools.Find(InTool.Name))
 		{
-			const FString Rejection = FString::Printf(
-				TEXT("tool '%s' rejected: name already registered by '%s' (first-wins by ExtensionId sort)"),
-				*InTool.Name, *Existing->ExtensionId);
+			// Tailor the reason to the kind of collision so the recorded error is not misleading:
+			// a core-tool clash, a clash with a different extension (first-wins by ExtensionId sort),
+			// or two tools sharing a name WITHIN this same provider (an authoring error, no sort involved).
+			FString Rejection;
+			if (Existing->ExtensionId == TEXT("core"))
+			{
+				Rejection = FString::Printf(
+					TEXT("tool '%s' rejected: name collides with a built-in core tool (extensions may not shadow core)"),
+					*InTool.Name);
+			}
+			else if (Existing->ExtensionId == ScopeExtensionId)
+			{
+				Rejection = FString::Printf(
+					TEXT("tool '%s' rejected: this extension already declared a tool with that name (duplicate within the extension)"),
+					*InTool.Name);
+			}
+			else
+			{
+				Rejection = FString::Printf(
+					TEXT("tool '%s' rejected: name already registered by extension '%s' (first-wins by ExtensionId sort)"),
+					*InTool.Name, *Existing->ExtensionId);
+			}
 			ScopeErrors.Add(Rejection);
 			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] extension '%s': %s"), *ScopeExtensionId, *Rejection);
 			return;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpToolRegistry.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpToolRegistry.cpp
@@ -223,13 +223,157 @@ FString FUnrealMcpToolRegistry::ComputeSchemaHash(const FUnrealMcpRegisteredTool
 	return FString(TEXT("sha1:")) + BytesToHex(Digest, 20).ToLower();
 }
 
+bool FUnrealMcpToolRegistry::IsValidToolName(const FString& Name)
+{
+	if (Name.IsEmpty())
+		return false;
+
+	bool bPrevHyphen = false;
+	const int32 Len = Name.Len();
+	for (int32 i = 0; i < Len; ++i)
+	{
+		const TCHAR C = Name[i];
+		const bool bLower = (C >= TEXT('a') && C <= TEXT('z'));
+		const bool bDigit = (C >= TEXT('0') && C <= TEXT('9'));
+		const bool bHyphen = (C == TEXT('-'));
+		if (!bLower && !bDigit && !bHyphen)
+			return false;
+		if (bHyphen && (i == 0 || i == Len - 1 || bPrevHyphen))
+			return false; // no leading, trailing, or doubled hyphen
+		bPrevHyphen = bHyphen;
+	}
+	return true;
+}
+
+bool FUnrealMcpToolRegistry::ValidateTool(const FUnrealMcpRegisteredTool& InTool, FString& OutError)
+{
+	if (!IsValidToolName(InTool.Name))
+	{
+		OutError = FString::Printf(
+			TEXT("invalid tool name '%s' (must be non-empty kebab-case: lowercase letters, digits, single internal hyphens)"),
+			*InTool.Name);
+		return false;
+	}
+
+	if (!InTool.Handler)
+	{
+		OutError = FString::Printf(TEXT("tool '%s' has no bound handler"), *InTool.Name);
+		return false;
+	}
+
+	static const TCHAR* const KnownTypes[] = { TEXT("string"), TEXT("integer"), TEXT("number"), TEXT("boolean"), TEXT("object") };
+	TSet<FString> SeenParams;
+	for (const FUnrealMcpParamSpec& Param : InTool.Params)
+	{
+		if (Param.Name.IsEmpty())
+		{
+			OutError = FString::Printf(TEXT("tool '%s' has a parameter with an empty name (malformed schema)"), *InTool.Name);
+			return false;
+		}
+
+		bool bKnown = false;
+		for (const TCHAR* const Known : KnownTypes)
+		{
+			if (Param.JsonType == Known) { bKnown = true; break; }
+		}
+		if (!bKnown)
+		{
+			OutError = FString::Printf(TEXT("tool '%s' parameter '%s' has unknown JSON type '%s' (malformed schema)"),
+				*InTool.Name, *Param.Name, *Param.JsonType);
+			return false;
+		}
+
+		if (Param.JsonType == TEXT("object") && !Param.ObjectSchema.IsValid())
+		{
+			OutError = FString::Printf(TEXT("tool '%s' object parameter '%s' has no schema (malformed schema)"),
+				*InTool.Name, *Param.Name);
+			return false;
+		}
+
+		bool bAlreadyPresent = false;
+		SeenParams.Add(Param.Name, &bAlreadyPresent);
+		if (bAlreadyPresent)
+		{
+			OutError = FString::Printf(TEXT("tool '%s' declares duplicate parameter '%s' (malformed schema)"),
+				*InTool.Name, *Param.Name);
+			return false;
+		}
+	}
+	return true;
+}
+
 void FUnrealMcpToolRegistry::Commit(FUnrealMcpRegisteredTool&& InTool)
 {
+	if (bExtensionScope)
+	{
+		// Extensions are untrusted: stamp the owning id, validate, and dedup (§5). A dropped/rejected
+		// entry never touches the committed set, so other tools and extensions are unaffected.
+		InTool.ExtensionId = ScopeExtensionId;
+
+		FString Error;
+		if (!ValidateTool(InTool, Error))
+		{
+			ScopeErrors.Add(Error);
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] extension '%s': %s — entry dropped."), *ScopeExtensionId, *Error);
+			return;
+		}
+
+		if (const FUnrealMcpRegisteredTool* Existing = Tools.Find(InTool.Name))
+		{
+			const FString Rejection = FString::Printf(
+				TEXT("tool '%s' rejected: name already registered by '%s' (first-wins by ExtensionId sort)"),
+				*InTool.Name, *Existing->ExtensionId);
+			ScopeErrors.Add(Rejection);
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] extension '%s': %s"), *ScopeExtensionId, *Rejection);
+			return;
+		}
+
+		++ScopeToolsRegistered;
+	}
+
 	InTool.SchemaHash = ComputeSchemaHash(InTool);
 	const FString Name = InTool.Name;
 	Tools.Add(Name, MoveTemp(InTool));
 	++Revision;
 	UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] registered tool '%s' (revision %d)."), *Name, Revision);
+}
+
+FUnrealMcpExtensionRegistrationResult FUnrealMcpToolRegistry::RegisterExtension(
+	const FString& ExtensionId, TFunctionRef<void(FUnrealMcpToolRegistry&)> RegisterFn)
+{
+	checkf(!bExtensionScope, TEXT("FUnrealMcpToolRegistry::RegisterExtension does not support nested scopes."));
+
+	bExtensionScope = true;
+	ScopeExtensionId = ExtensionId;
+	ScopeToolsRegistered = 0;
+	ScopeErrors.Reset();
+
+	RegisterFn(*this);
+
+	FUnrealMcpExtensionRegistrationResult Result;
+	Result.ToolsRegistered = ScopeToolsRegistered;
+	Result.Errors = MoveTemp(ScopeErrors);
+
+	bExtensionScope = false;
+	ScopeExtensionId.Empty();
+	ScopeToolsRegistered = 0;
+	ScopeErrors.Reset();
+	return Result;
+}
+
+int32 FUnrealMcpToolRegistry::RemoveToolsForExtension(const FString& ExtensionId)
+{
+	TArray<FString> ToRemove;
+	for (const TPair<FString, FUnrealMcpRegisteredTool>& Pair : Tools)
+	{
+		if (Pair.Value.ExtensionId == ExtensionId)
+			ToRemove.Add(Pair.Key);
+	}
+	for (const FString& Name : ToRemove)
+		Tools.Remove(Name);
+	if (ToRemove.Num() > 0)
+		++Revision;
+	return ToRemove.Num();
 }
 
 TSharedPtr<FJsonObject> FUnrealMcpToolRegistry::BuildManifestJson() const

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -8,11 +8,17 @@
 #include "Dispatch/UnrealMcpGameThreadDispatcher.h"
 #include "Bridge/UnrealMcpBridgeServer.h"
 #include "Sidecar/UnrealMcpSidecarManager.h"
+#include "Extensions/UnrealMcpExtensionManager.h"
 
 #include "Misc/CoreDelegates.h"
 #include "Misc/Paths.h"
 #include "Misc/EngineVersion.h"
 #include "Interfaces/IPluginManager.h"
+
+// Defined here (where every subsystem type is complete) so the TUniquePtr member deleters instantiate
+// correctly regardless of unity-build grouping. See the header comment.
+FUnrealMcpRuntime::FUnrealMcpRuntime() = default;
+FUnrealMcpRuntime::~FUnrealMcpRuntime() = default;
 
 void FUnrealMcpRuntime::Startup()
 {
@@ -25,6 +31,14 @@ void FUnrealMcpRuntime::Startup()
 
 	Dispatcher = MakeUnique<FUnrealMcpGameThreadDispatcher>();
 	BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(*Registry, *Dispatcher);
+
+	// Discover 3rd-party extension tool providers (§5) and merge them into the registry BEFORE the bridge
+	// starts accepting, so the first manifest a sidecar reads on handshake already includes them. Late
+	// register/unregister events rebuild the registry and re-push the manifest via the OnChanged callback.
+	ExtensionManager = MakeUnique<FUnrealMcpExtensionManager>(
+		*Registry,
+		[this]() { if (BridgeServer.IsValid()) BridgeServer->PushManifest(); });
+	ExtensionManager->Startup();
 
 	const FString ProjectPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
 	const FString EngineVersion = FEngineVersion::Current().ToString();
@@ -82,6 +96,13 @@ void FUnrealMcpRuntime::Shutdown()
 		SidecarManager->WaitForExit(FTimespan::FromSeconds(3)); // bounded grace for a clean self-exit
 		SidecarManager->Stop();                                 // backstop: TerminateProc if still alive
 		SidecarManager.Reset();
+	}
+
+	// Unsubscribe from modular-feature events before the registry it mutates is torn down.
+	if (ExtensionManager.IsValid())
+	{
+		ExtensionManager->Shutdown();
+		ExtensionManager.Reset();
 	}
 
 	Dispatcher.Reset();

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.h
@@ -9,6 +9,7 @@ class FUnrealMcpToolRegistry;
 class FUnrealMcpGameThreadDispatcher;
 class FUnrealMcpBridgeServer;
 class FUnrealMcpSidecarManager;
+class FUnrealMcpExtensionManager;
 
 /**
  * Plugin-lifetime coordinator (docs/ARCHITECTURE.md §0). Wires the four subsystems together: the tool
@@ -19,17 +20,26 @@ class FUnrealMcpSidecarManager;
 class FUnrealMcpRuntime
 {
 public:
+	// Declared (not defaulted inline) and defined in the .cpp so the TUniquePtr deleters for the
+	// forward-declared subsystem members are instantiated where those types are complete. Without this,
+	// a non-unity / adaptive build of UnrealMcpEditorModule.cpp (which only sees the forward decls)
+	// fails with C4150 "deletion of pointer to incomplete type".
+	FUnrealMcpRuntime();
+	~FUnrealMcpRuntime();
+
 	void Startup();
 	void Shutdown();
 
 	FUnrealMcpToolRegistry* GetRegistry() const { return Registry.Get(); }
 	FUnrealMcpBridgeServer* GetBridgeServer() const { return BridgeServer.Get(); }
+	FUnrealMcpExtensionManager* GetExtensionManager() const { return ExtensionManager.Get(); }
 
 private:
 	TUniquePtr<FUnrealMcpToolRegistry> Registry;
 	TUniquePtr<FUnrealMcpGameThreadDispatcher> Dispatcher;
 	TUniquePtr<FUnrealMcpBridgeServer> BridgeServer;
 	TUniquePtr<FUnrealMcpSidecarManager> SidecarManager;
+	TUniquePtr<FUnrealMcpExtensionManager> ExtensionManager;
 
 	FDelegateHandle PreExitHandle;
 	bool bStarted = false;

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/IUnrealMcpToolProvider.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/IUnrealMcpToolProvider.h
@@ -9,8 +9,9 @@
 class FUnrealMcpToolRegistry;
 
 /**
- * The Unreal-MCP extension contract (docs/ARCHITECTURE.md §5) — the ONLY header a third-party
- * extension author needs to include.
+ * The Unreal-MCP extension contract (docs/ARCHITECTURE.md §5) — the only Unreal-MCP-specific contract
+ * header. To declare tools you also include UnrealMcpToolRegistry.h, and to register the provider as a
+ * modular feature you include Features/IModularFeatures.h (see Step 2/3 in docs/EXTENSIONS.md).
  *
  * An extension is any UE plugin that implements this interface and registers an instance as a
  * modular feature under GetModularFeatureName():

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/IUnrealMcpToolProvider.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/IUnrealMcpToolProvider.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Features/IModularFeature.h"
+
+class FUnrealMcpToolRegistry;
+
+/**
+ * The Unreal-MCP extension contract (docs/ARCHITECTURE.md §5) — the ONLY header a third-party
+ * extension author needs to include.
+ *
+ * An extension is any UE plugin that implements this interface and registers an instance as a
+ * modular feature under GetModularFeatureName():
+ *
+ *     IModularFeatures::Get().RegisterModularFeature(
+ *         IUnrealMcpToolProvider::GetModularFeatureName(), MyProviderInstance);
+ *
+ * Unreal-MCP discovers every registered provider on boot (and subscribes to register/unregister
+ * events for late-loaded / hot-unloaded plugins), merges their tools into the single tool registry
+ * in deterministic order (sorted by ExtensionId), and surfaces the merged manifest to the sidecar
+ * (§2.2). See docs/EXTENSIONS.md for the full author guide and samples/UnrealAITemplate for a
+ * working example.
+ *
+ * Isolation (§5): UE builds without C++ exceptions, so isolation is descriptor-level, not
+ * body-level. Each tool a provider declares is validated (name pattern, schema well-formedness,
+ * handler bound). Invalid entries are dropped and the failure is recorded on the extension's
+ * registry record; a duplicate tool name across providers rejects the later registration
+ * (first-wins by the ExtensionId sort). Other extensions are never affected. Crash-level faults
+ * inside a tool body are editor crashes regardless of family and are out of isolation scope.
+ */
+class IUnrealMcpToolProvider : public IModularFeature
+{
+public:
+	virtual ~IUnrealMcpToolProvider() = default;
+
+	/** The modular-feature name every provider registers under. Stable across the plugin's lifetime. */
+	static FName GetModularFeatureName()
+	{
+		return FName(TEXT("UnrealMcpToolProvider"));
+	}
+
+	/**
+	 * Stable, unique extension identifier — reverse-DNS recommended (e.g. "com.foo.niagara-ai").
+	 * Used as the deterministic sort key and as the manifest's per-tool extensionId. Two providers
+	 * with the same id is an authoring error (the second's duplicate tools are rejected).
+	 */
+	virtual FString GetExtensionId() const = 0;
+
+	/** Human-readable name shown in the extensions UI row (§7). */
+	virtual FText GetDisplayName() const = 0;
+
+	/** Free-form version string of the extension (independent of the Unreal-MCP plugin version). */
+	virtual FString GetExtensionVersion() const = 0;
+
+	/**
+	 * Declare the extension's tools into @p Registry using the fluent FUnrealMcpToolBuilder
+	 * (Registry.Tool("my-tool").Title(...).Param*(...).Handle(...)). Called on the game thread.
+	 * Tools are automatically stamped with this provider's ExtensionId — do not call .ExtensionId().
+	 * Invalid or duplicate entries are dropped/rejected and recorded; valid entries register normally.
+	 */
+	virtual void RegisterTools(FUnrealMcpToolRegistry& Registry) = 0;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
@@ -6,6 +6,7 @@
 #include "CoreMinimal.h"
 #include "Dom/JsonObject.h"
 #include "HAL/ThreadSafeBool.h"
+#include "Templates/Function.h"
 
 /**
  * Core tool-registration types for the Unreal-MCP plugin (docs/ARCHITECTURE.md §2, §3.3).
@@ -109,6 +110,15 @@ struct UNREALMCPEDITOR_API FUnrealMcpRegisteredTool
 
 class FUnrealMcpToolRegistry;
 
+/** Outcome of registering one extension provider's tools (docs/ARCHITECTURE.md §5). */
+struct UNREALMCPEDITOR_API FUnrealMcpExtensionRegistrationResult
+{
+	/** Number of tools that passed validation + dedup and were committed under the extension's id. */
+	int32 ToolsRegistered = 0;
+	/** One human-readable line per dropped (invalid) or rejected (duplicate) entry; empty when healthy. */
+	TArray<FString> Errors;
+};
+
 /** Fluent declaration builder (docs/ARCHITECTURE.md §3.3). One per tool; commits on destruction-free Handle(). */
 class UNREALMCPEDITOR_API FUnrealMcpToolBuilder
 {
@@ -151,8 +161,31 @@ public:
 	/** Begin declaring a tool (docs/ARCHITECTURE.md §3.3 fluent API). */
 	FUnrealMcpToolBuilder Tool(const FString& Name);
 
-	/** Commit a fully-built tool (called by the builder's Handle()). Replaces any same-named tool. */
+	/**
+	 * Commit a fully-built tool (called by the builder's Handle()).
+	 * - Core path (default): replaces any same-named tool — core families are trusted.
+	 * - Extension scope (inside RegisterExtension): the tool is stamped with the scope's ExtensionId,
+	 *   validated (§5 — name pattern / schema well-formedness / handler bound), and deduped against
+	 *   already-registered tools. An invalid entry is DROPPED and a duplicate is REJECTED (first-wins),
+	 *   each recording a line in the scope's error list; neither affects other tools or extensions.
+	 */
 	void Commit(FUnrealMcpRegisteredTool&& InTool);
+
+	/**
+	 * Register an extension provider's tools (docs/ARCHITECTURE.md §5). Opens an "extension scope":
+	 * every Commit during @p RegisterFn is stamped with @p ExtensionId, validated, and deduped, with
+	 * invalid/duplicate entries dropped/rejected and recorded in the returned result. Scopes never nest.
+	 */
+	FUnrealMcpExtensionRegistrationResult RegisterExtension(const FString& ExtensionId, TFunctionRef<void(FUnrealMcpToolRegistry&)> RegisterFn);
+
+	/** Remove every tool stamped with @p ExtensionId (hot-unload / rebuild, §5). Bumps revision if any removed. Returns count removed. */
+	int32 RemoveToolsForExtension(const FString& ExtensionId);
+
+	/** True iff @p Name is a valid kebab-case tool id (non-empty; lowercase letters/digits with single internal hyphens). */
+	static bool IsValidToolName(const FString& Name);
+
+	/** Validate a tool descriptor for the §5 isolation contract. Returns false + a reason on the first problem. */
+	static bool ValidateTool(const FUnrealMcpRegisteredTool& InTool, FString& OutError);
 
 	bool HasTool(const FString& Name) const { return Tools.Contains(Name); }
 	int32 Num() const { return Tools.Num(); }
@@ -176,4 +209,10 @@ public:
 private:
 	TMap<FString, FUnrealMcpRegisteredTool> Tools;
 	int32 Revision = 0;
+
+	// --- Extension-scope state (active only inside RegisterExtension; scopes never nest) ----------
+	bool bExtensionScope = false;
+	FString ScopeExtensionId;
+	int32 ScopeToolsRegistered = 0;
+	TArray<FString> ScopeErrors;
 };

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpExtensionsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpExtensionsSpec.cpp
@@ -7,6 +7,7 @@
 #include "Misc/AutomationTest.h"
 #include "Misc/Paths.h"
 #include "Misc/Guid.h"
+#include "Misc/FileHelper.h"
 #include "HAL/FileManager.h"
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpExtensionsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpExtensionsSpec.cpp
@@ -207,9 +207,14 @@ void FUnrealMcpExtensionsSpec::Define()
 	{
 		It("rebuilds the registry and bumps the revision on register and unregister", [this]()
 		{
+			// A throwaway config path so Startup() does not read the developer's real
+			// <ProjectSaved>/Config/UnrealMCP/Extensions.json (whose persisted disabled set could
+			// otherwise make this live-discovery spec fail non-locally).
+			const FString ConfigPath = MakeTempConfigPath();
+
 			FUnrealMcpToolRegistry Registry;
 			int32 OnChangedCount = 0;
-			FUnrealMcpExtensionManager Manager(Registry, [&OnChangedCount]() { ++OnChangedCount; });
+			FUnrealMcpExtensionManager Manager(Registry, [&OnChangedCount]() { ++OnChangedCount; }, ConfigPath);
 
 			// Default provider source = live discovery; subscribe to modular-feature events.
 			Manager.Startup();
@@ -238,6 +243,8 @@ void FUnrealMcpExtensionsSpec::Define()
 			TestTrue(TEXT("OnChanged fired on unregister"), OnChangedCount > OnAfterReg);
 
 			Manager.Shutdown();
+
+			IFileManager::Get().Delete(*ConfigPath, /*RequireExists*/ false, /*EvenReadOnly*/ true);
 		});
 	});
 

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpExtensionsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpExtensionsSpec.cpp
@@ -287,6 +287,105 @@ void FUnrealMcpExtensionsSpec::Define()
 
 			IFileManager::Get().Delete(*ConfigPath, /*RequireExists*/ false, /*EvenReadOnly*/ true);
 		});
+
+		It("ignores a corrupt config file and starts every extension enabled", [this]()
+		{
+			const FString ConfigPath = MakeTempConfigPath();
+
+			// Write malformed JSON to the config path before the manager loads it.
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(ConfigPath), /*Tree*/ true);
+			FFileHelper::SaveStringToFile(TEXT("{ this is not valid json"), *ConfigPath);
+
+			FMockToolProvider P(TEXT("p.ext"), [](FUnrealMcpToolRegistry& R) { AddSimpleTool(R, TEXT("p-tool")); });
+			auto Source = [&P]() { return TArray<IUnrealMcpToolProvider*>{ &P }; };
+
+			FUnrealMcpToolRegistry Registry;
+			FUnrealMcpExtensionManager Manager(Registry, nullptr, ConfigPath);
+			Manager.SetProviderSourceForTesting(Source);
+
+			// LoadConfig logs an Error for the malformed file (a deliberately loud signal). Whitelist it
+			// so the Automation framework does not treat the expected log as a failure — and so this test
+			// also asserts that the loud error actually fired.
+			AddExpectedError(TEXT("malformed and was ignored"), EAutomationExpectedErrorFlags::Contains);
+			Manager.Startup(); // must not crash on the malformed file
+
+			// A corrupt file is discarded, so the persisted disabled set is empty => P is enabled.
+			TestTrue(TEXT("extension enabled despite corrupt config"), Manager.IsExtensionEnabled(TEXT("p.ext")));
+			TestTrue(TEXT("p-tool present despite corrupt config"), Registry.HasTool(TEXT("p-tool")));
+
+			IFileManager::Get().Delete(*ConfigPath, /*RequireExists*/ false, /*EvenReadOnly*/ true);
+		});
+	});
+
+	Describe("extension id validation", [this]()
+	{
+		It("skips a provider whose id collides with the reserved 'core' scope and preserves core tools", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			FUnrealMcpExtensionManager Manager(Registry, nullptr);
+
+			// A core tool registered on the default (non-extension) path — ExtensionId defaults to "core".
+			AddSimpleTool(Registry, TEXT("core-tool"));
+			TestTrue(TEXT("core-tool registered"), Registry.HasTool(TEXT("core-tool")));
+
+			// A malicious/buggy provider claiming the reserved "core" id.
+			FMockToolProvider Evil(TEXT("core"), [](FUnrealMcpToolRegistry& R) { AddSimpleTool(R, TEXT("evil-tool")); });
+
+			Manager.RebuildFromProviders({ &Evil }, false);
+
+			TestFalse(TEXT("evil-tool not registered"), Registry.HasTool(TEXT("evil-tool")));
+			TestTrue(TEXT("core-tool survives the rebuild"), Registry.HasTool(TEXT("core-tool")));
+			const FUnrealMcpExtensionRecord* Rec = Manager.FindExtension(TEXT("core"));
+			TestTrue(TEXT("core-id record exists"), Rec != nullptr);
+			TestTrue(TEXT("core-id record has an error"), Rec->HasError());
+			TestEqual(TEXT("core-id record registered nothing"), Rec->ToolCount, 0);
+
+			// Regression guard: a SECOND rebuild must not delete the core tools under the "core" key.
+			Manager.RebuildFromProviders({ &Evil }, false);
+			TestTrue(TEXT("core-tool still present after a second rebuild"), Registry.HasTool(TEXT("core-tool")));
+		});
+
+		It("skips a provider with an empty id and records the failure", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			FUnrealMcpExtensionManager Manager(Registry, nullptr);
+
+			FMockToolProvider Empty(TEXT(""), [](FUnrealMcpToolRegistry& R) { AddSimpleTool(R, TEXT("orphan-tool")); });
+
+			Manager.RebuildFromProviders({ &Empty }, false);
+
+			TestFalse(TEXT("orphan-tool not registered"), Registry.HasTool(TEXT("orphan-tool")));
+			const FUnrealMcpExtensionRecord* Rec = Manager.FindExtension(TEXT(""));
+			TestTrue(TEXT("empty-id record exists"), Rec != nullptr);
+			TestTrue(TEXT("empty-id record has an error"), Rec->HasError());
+			TestEqual(TEXT("empty-id record registered nothing"), Rec->ToolCount, 0);
+		});
+
+		It("keeps the first provider when two share an ExtensionId and records an error on the later", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			FUnrealMcpExtensionManager Manager(Registry, nullptr);
+
+			// Two providers with the SAME id; each declares a distinct tool.
+			FMockToolProvider First(TEXT("dup.ext"), [](FUnrealMcpToolRegistry& R) { AddSimpleTool(R, TEXT("tool-1")); });
+			FMockToolProvider Second(TEXT("dup.ext"), [](FUnrealMcpToolRegistry& R) { AddSimpleTool(R, TEXT("tool-2")); });
+
+			// StableSort tie-breaks on input order, so First (passed first) wins deterministically.
+			Manager.RebuildFromProviders({ &First, &Second }, false);
+
+			TestTrue(TEXT("first provider's tool registered"), Registry.HasTool(TEXT("tool-1")));
+			TestFalse(TEXT("second provider's tool skipped"), Registry.HasTool(TEXT("tool-2")));
+			TestEqual(TEXT("both providers produced a record"), Manager.GetExtensions().Num(), 2);
+
+			int32 HealthyCount = 0;
+			int32 ErroredCount = 0;
+			for (const FUnrealMcpExtensionRecord& Rec : Manager.GetExtensions())
+			{
+				if (Rec.HasError()) ++ErroredCount; else ++HealthyCount;
+			}
+			TestEqual(TEXT("exactly one healthy record"), HealthyCount, 1);
+			TestEqual(TEXT("exactly one errored record"), ErroredCount, 1);
+		});
 	});
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpExtensionsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpExtensionsSpec.cpp
@@ -1,0 +1,293 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/Paths.h"
+#include "Misc/Guid.h"
+#include "HAL/FileManager.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Features/IModularFeatures.h"
+
+#include "IUnrealMcpToolProvider.h"
+#include "UnrealMcpToolRegistry.h"
+#include "Extensions/UnrealMcpExtensionManager.h"
+
+/**
+ * Extensions mechanism specs (docs/ARCHITECTURE.md §5): discovery + deterministic ordering, duplicate
+ * tool-name rejection, invalid-descriptor isolation, late-registration rebuild + revision bump through
+ * IModularFeatures, and disabled-extension exclusion with a persistence round-trip.
+ */
+
+namespace
+{
+	/** A test-only tool provider whose RegisterTools delegates to a supplied lambda. */
+	class FMockToolProvider : public IUnrealMcpToolProvider
+	{
+	public:
+		FMockToolProvider(const FString& InId, TFunction<void(FUnrealMcpToolRegistry&)> InRegisterFn)
+			: Id(InId), Display(FText::FromString(InId)), Version(TEXT("1.0.0")), RegisterFn(MoveTemp(InRegisterFn)) {}
+
+		virtual FString GetExtensionId() const override { return Id; }
+		virtual FText GetDisplayName() const override { return Display; }
+		virtual FString GetExtensionVersion() const override { return Version; }
+		virtual void RegisterTools(FUnrealMcpToolRegistry& Registry) override { if (RegisterFn) RegisterFn(Registry); }
+
+		FString Id;
+		FText Display;
+		FString Version;
+		TFunction<void(FUnrealMcpToolRegistry&)> RegisterFn;
+	};
+
+	/** Register a minimal valid tool. */
+	void AddSimpleTool(FUnrealMcpToolRegistry& Registry, const FString& Name)
+	{
+		Registry.Tool(Name)
+			.Title(Name)
+			.Description(TEXT("test tool"))
+			.ParamString(TEXT("arg"), TEXT("an argument"))
+			.Handle([](const FUnrealMcpToolCall&) { return FUnrealMcpToolResult::Success(TEXT("ok")); });
+	}
+
+	/** Whether the manifest's tools[] array contains a tool with the given name. */
+	bool ManifestHasTool(const FUnrealMcpToolRegistry& Registry, const FString& Name)
+	{
+		const TSharedPtr<FJsonObject> Manifest = Registry.BuildManifestJson();
+		const TArray<TSharedPtr<FJsonValue>>* Tools = nullptr;
+		if (!Manifest->TryGetArrayField(TEXT("tools"), Tools))
+			return false;
+		for (const TSharedPtr<FJsonValue>& Value : *Tools)
+		{
+			const TSharedPtr<FJsonObject> Obj = Value->AsObject();
+			if (Obj.IsValid() && Obj->GetStringField(TEXT("name")) == Name)
+				return true;
+		}
+		return false;
+	}
+
+	FString MakeTempConfigPath()
+	{
+		return FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("UnrealMcpTests"),
+			FString::Printf(TEXT("ext-%s.json"), *FGuid::NewGuid().ToString(EGuidFormats::Digits)));
+	}
+}
+
+BEGIN_DEFINE_SPEC(FUnrealMcpExtensionsSpec, "UnrealMcp.Extensions",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FUnrealMcpExtensionsSpec)
+
+void FUnrealMcpExtensionsSpec::Define()
+{
+	Describe("discovery and ordering", [this]()
+	{
+		It("merges tools from multiple providers, recording them in ExtensionId order", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			FUnrealMcpExtensionManager Manager(Registry, nullptr);
+
+			FMockToolProvider A(TEXT("a.ext"), [](FUnrealMcpToolRegistry& R) { AddSimpleTool(R, TEXT("tool-a")); });
+			FMockToolProvider B(TEXT("b.ext"), [](FUnrealMcpToolRegistry& R) { AddSimpleTool(R, TEXT("tool-b")); });
+
+			// Pass out of order to prove the manager sorts deterministically.
+			Manager.RebuildFromProviders({ &B, &A }, /*bNotify*/ false);
+
+			TestTrue(TEXT("tool-a registered"), Registry.HasTool(TEXT("tool-a")));
+			TestTrue(TEXT("tool-b registered"), Registry.HasTool(TEXT("tool-b")));
+			TestEqual(TEXT("two extension records"), Manager.GetExtensions().Num(), 2);
+			TestEqual(TEXT("record[0] is a.ext"), Manager.GetExtensions()[0].Id, FString(TEXT("a.ext")));
+			TestEqual(TEXT("record[1] is b.ext"), Manager.GetExtensions()[1].Id, FString(TEXT("b.ext")));
+			TestEqual(TEXT("a.ext tool count"), Manager.GetExtensions()[0].ToolCount, 1);
+
+			// Extension tools carry their owner's ExtensionId on the descriptor.
+			TestEqual(TEXT("tool-a owned by a.ext"), Registry.Find(TEXT("tool-a"))->ExtensionId, FString(TEXT("a.ext")));
+		});
+
+		It("removes an extension's tools when it disappears from a later rebuild", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			FUnrealMcpExtensionManager Manager(Registry, nullptr);
+
+			FMockToolProvider A(TEXT("a.ext"), [](FUnrealMcpToolRegistry& R) { AddSimpleTool(R, TEXT("tool-a")); });
+			FMockToolProvider B(TEXT("b.ext"), [](FUnrealMcpToolRegistry& R) { AddSimpleTool(R, TEXT("tool-b")); });
+
+			Manager.RebuildFromProviders({ &A, &B }, false);
+			TestTrue(TEXT("both present"), Registry.HasTool(TEXT("tool-a")) && Registry.HasTool(TEXT("tool-b")));
+
+			// B unloaded -> rebuild with only A.
+			Manager.RebuildFromProviders({ &A }, false);
+			TestTrue(TEXT("tool-a still present"), Registry.HasTool(TEXT("tool-a")));
+			TestFalse(TEXT("tool-b removed"), Registry.HasTool(TEXT("tool-b")));
+			TestEqual(TEXT("one extension record"), Manager.GetExtensions().Num(), 1);
+		});
+	});
+
+	Describe("duplicate tool-name rejection", [this]()
+	{
+		It("keeps the first-sorted extension's tool and records an error on the later one", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			FUnrealMcpExtensionManager Manager(Registry, nullptr);
+
+			FMockToolProvider A(TEXT("a.ext"), [](FUnrealMcpToolRegistry& R) { AddSimpleTool(R, TEXT("dup")); });
+			FMockToolProvider B(TEXT("b.ext"), [](FUnrealMcpToolRegistry& R) { AddSimpleTool(R, TEXT("dup")); });
+
+			Manager.RebuildFromProviders({ &B, &A }, false);
+
+			TestTrue(TEXT("dup present"), Registry.HasTool(TEXT("dup")));
+			TestEqual(TEXT("dup owned by first-sorted a.ext"), Registry.Find(TEXT("dup"))->ExtensionId, FString(TEXT("a.ext")));
+
+			const FUnrealMcpExtensionRecord* RecA = Manager.FindExtension(TEXT("a.ext"));
+			const FUnrealMcpExtensionRecord* RecB = Manager.FindExtension(TEXT("b.ext"));
+			TestTrue(TEXT("a.ext record exists"), RecA != nullptr);
+			TestTrue(TEXT("b.ext record exists"), RecB != nullptr);
+			TestEqual(TEXT("a.ext registered its tool"), RecA->ToolCount, 1);
+			TestFalse(TEXT("a.ext healthy"), RecA->HasError());
+			TestEqual(TEXT("b.ext registered nothing"), RecB->ToolCount, 0);
+			TestTrue(TEXT("b.ext has a rejection error"), RecB->HasError());
+		});
+	});
+
+	Describe("invalid-descriptor isolation", [this]()
+	{
+		It("drops only the invalid entry and leaves other tools and extensions intact", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			FUnrealMcpExtensionManager Manager(Registry, nullptr);
+
+			// A: one valid tool + one invalid (empty-named parameter => malformed schema).
+			FMockToolProvider A(TEXT("a.ext"), [](FUnrealMcpToolRegistry& R)
+			{
+				AddSimpleTool(R, TEXT("good-tool"));
+				R.Tool(TEXT("bad-tool"))
+					.Title(TEXT("Bad"))
+					.Description(TEXT("invalid"))
+					.ParamString(TEXT(""), TEXT("empty-named param"))
+					.Handle([](const FUnrealMcpToolCall&) { return FUnrealMcpToolResult::Success(TEXT("x")); });
+			});
+			// B: a healthy neighbour that must be unaffected.
+			FMockToolProvider B(TEXT("b.ext"), [](FUnrealMcpToolRegistry& R) { AddSimpleTool(R, TEXT("other-tool")); });
+
+			Manager.RebuildFromProviders({ &A, &B }, false);
+
+			TestTrue(TEXT("good-tool registered"), Registry.HasTool(TEXT("good-tool")));
+			TestFalse(TEXT("bad-tool dropped"), Registry.HasTool(TEXT("bad-tool")));
+			TestTrue(TEXT("other-tool registered"), Registry.HasTool(TEXT("other-tool")));
+
+			const FUnrealMcpExtensionRecord* RecA = Manager.FindExtension(TEXT("a.ext"));
+			const FUnrealMcpExtensionRecord* RecB = Manager.FindExtension(TEXT("b.ext"));
+			TestEqual(TEXT("a.ext kept 1 tool"), RecA->ToolCount, 1);
+			TestTrue(TEXT("a.ext records the drop"), RecA->HasError());
+			TestEqual(TEXT("b.ext kept 1 tool"), RecB->ToolCount, 1);
+			TestFalse(TEXT("b.ext healthy"), RecB->HasError());
+		});
+
+		It("rejects an invalid tool name", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			FUnrealMcpExtensionManager Manager(Registry, nullptr);
+
+			FMockToolProvider A(TEXT("a.ext"), [](FUnrealMcpToolRegistry& R)
+			{
+				// Uppercase + underscore is not kebab-case.
+				R.Tool(TEXT("Bad_Name"))
+					.Description(TEXT("x"))
+					.Handle([](const FUnrealMcpToolCall&) { return FUnrealMcpToolResult::Success(TEXT("x")); });
+			});
+
+			Manager.RebuildFromProviders({ &A }, false);
+			TestFalse(TEXT("invalid-named tool dropped"), Registry.HasTool(TEXT("Bad_Name")));
+			TestTrue(TEXT("a.ext records the drop"), Manager.FindExtension(TEXT("a.ext"))->HasError());
+		});
+	});
+
+	Describe("late registration via IModularFeatures", [this]()
+	{
+		It("rebuilds the registry and bumps the revision on register and unregister", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			int32 OnChangedCount = 0;
+			FUnrealMcpExtensionManager Manager(Registry, [&OnChangedCount]() { ++OnChangedCount; });
+
+			// Default provider source = live discovery; subscribe to modular-feature events.
+			Manager.Startup();
+
+			// A uniquely-named provider so the assertions are robust against any ambient providers.
+			FMockToolProvider Late(TEXT("test.late.reg"),
+				[](FUnrealMcpToolRegistry& R) { AddSimpleTool(R, TEXT("late-reg-probe-tool")); });
+
+			TestFalse(TEXT("probe tool absent before register"), Registry.HasTool(TEXT("late-reg-probe-tool")));
+			const int32 RevBefore = Registry.GetRevision();
+			const int32 OnBefore = OnChangedCount;
+
+			IModularFeatures::Get().RegisterModularFeature(IUnrealMcpToolProvider::GetModularFeatureName(), &Late);
+
+			TestTrue(TEXT("probe tool present after register"), Registry.HasTool(TEXT("late-reg-probe-tool")));
+			TestTrue(TEXT("revision bumped on register"), Registry.GetRevision() > RevBefore);
+			TestTrue(TEXT("OnChanged fired on register"), OnChangedCount > OnBefore);
+
+			const int32 RevAfterReg = Registry.GetRevision();
+			const int32 OnAfterReg = OnChangedCount;
+
+			IModularFeatures::Get().UnregisterModularFeature(IUnrealMcpToolProvider::GetModularFeatureName(), &Late);
+
+			TestFalse(TEXT("probe tool absent after unregister"), Registry.HasTool(TEXT("late-reg-probe-tool")));
+			TestTrue(TEXT("revision bumped on unregister"), Registry.GetRevision() > RevAfterReg);
+			TestTrue(TEXT("OnChanged fired on unregister"), OnChangedCount > OnAfterReg);
+
+			Manager.Shutdown();
+		});
+	});
+
+	Describe("disabled-extension exclusion and persistence", [this]()
+	{
+		It("excludes a disabled extension's tools and round-trips the disabled set to disk", [this]()
+		{
+			const FString ConfigPath = MakeTempConfigPath();
+
+			FMockToolProvider P(TEXT("p.ext"), [](FUnrealMcpToolRegistry& R) { AddSimpleTool(R, TEXT("p-tool")); });
+			auto Source = [&P]() { return TArray<IUnrealMcpToolProvider*>{ &P }; };
+
+			// Manager 1: discover P (enabled), then disable it.
+			{
+				FUnrealMcpToolRegistry Registry;
+				FUnrealMcpExtensionManager Manager(Registry, nullptr, ConfigPath);
+				Manager.SetProviderSourceForTesting(Source);
+				Manager.Startup();
+
+				TestTrue(TEXT("p-tool present while enabled"), Registry.HasTool(TEXT("p-tool")));
+				TestTrue(TEXT("manifest includes p-tool while enabled"), ManifestHasTool(Registry, TEXT("p-tool")));
+
+				Manager.SetExtensionEnabled(TEXT("p.ext"), false);
+
+				TestFalse(TEXT("p-tool absent when disabled"), Registry.HasTool(TEXT("p-tool")));
+				TestFalse(TEXT("manifest excludes p-tool when disabled"), ManifestHasTool(Registry, TEXT("p-tool")));
+				const FUnrealMcpExtensionRecord* Rec = Manager.FindExtension(TEXT("p.ext"));
+				TestTrue(TEXT("record exists when disabled"), Rec != nullptr);
+				TestFalse(TEXT("record marked disabled"), Rec->bEnabled);
+				TestEqual(TEXT("disabled tool count is 0"), Rec->ToolCount, 0);
+			}
+
+			// Manager 2: a fresh manager + registry reading the SAME config file starts P disabled.
+			{
+				FUnrealMcpToolRegistry Registry;
+				FUnrealMcpExtensionManager Manager(Registry, nullptr, ConfigPath);
+				Manager.SetProviderSourceForTesting(Source);
+				Manager.Startup();
+
+				TestFalse(TEXT("disabled state persisted across managers"), Registry.HasTool(TEXT("p-tool")));
+				TestFalse(TEXT("p.ext starts disabled"), Manager.IsExtensionEnabled(TEXT("p.ext")));
+
+				// Re-enabling restores the tool.
+				Manager.SetExtensionEnabled(TEXT("p.ext"), true);
+				TestTrue(TEXT("p-tool restored when re-enabled"), Registry.HasTool(TEXT("p-tool")));
+			}
+
+			IFileManager::Get().Delete(*ConfigPath, /*RequireExists*/ false, /*EvenReadOnly*/ true);
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -1,0 +1,188 @@
+# Writing an Unreal-MCP Extension
+
+Unreal-MCP exposes the Unreal Editor to MCP-aware AI assistants as a set of **tools**. Any third-party
+UE plugin can contribute its own tools through a small, public, modular-feature-based contract — no
+fork, no link-time coupling, no load-order assumptions. This guide is the authoritative author
+reference. The design rationale lives in [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) §5.
+
+A complete, buildable example accompanies this guide:
+[`samples/UnrealAITemplate/`](../samples/UnrealAITemplate).
+
+---
+
+## The contract
+
+Implement a single interface —
+[`IUnrealMcpToolProvider`](../UnrealMCP/Source/UnrealMcpEditor/Public/IUnrealMcpToolProvider.h), the
+**only** Unreal-MCP header you need to include:
+
+```cpp
+class IUnrealMcpToolProvider : public IModularFeature
+{
+public:
+    static FName GetModularFeatureName();          // FName("UnrealMcpToolProvider")
+    virtual FString GetExtensionId() const = 0;    // stable, unique, reverse-DNS — e.g. "com.foo.niagara-ai"
+    virtual FText   GetDisplayName() const = 0;    // shown in the extensions UI
+    virtual FString GetExtensionVersion() const = 0;
+    virtual void    RegisterTools(FUnrealMcpToolRegistry& Registry) = 0;
+};
+```
+
+| Member | Purpose |
+| --- | --- |
+| `GetExtensionId()` | Stable, **unique** identifier. Used as the deterministic sort key and stamped onto every tool the extension contributes (the manifest's `extensionId`). Reverse-DNS is recommended. |
+| `GetDisplayName()` | Human-readable name for the extensions UI row. |
+| `GetExtensionVersion()` | Free-form version string, independent of the Unreal-MCP plugin version. |
+| `RegisterTools(Registry)` | Declare your tools into the registry (see below). Called on the game thread. |
+
+---
+
+## Step 1 — depend on the UnrealMCP plugin
+
+In your module's `*.Build.cs`:
+
+```csharp
+PrivateDependencyModuleNames.AddRange(new string[]
+{
+    "CoreUObject", "Engine", "Projects",
+    "Json",            // the registry header includes Dom/JsonObject.h
+    "UnrealMcpEditor", // the extension contract + tool registry
+});
+```
+
+In your `*.uplugin`, declare the dependency so load order resolves:
+
+```json
+"Plugins": [ { "Name": "UnrealMCP", "Enabled": true } ]
+```
+
+## Step 2 — implement the provider
+
+```cpp
+#include "IUnrealMcpToolProvider.h"
+#include "UnrealMcpToolRegistry.h"
+
+class FMyExtensionProvider : public IUnrealMcpToolProvider
+{
+public:
+    virtual FString GetExtensionId() const override      { return TEXT("com.foo.my-extension"); }
+    virtual FText   GetDisplayName() const override      { return NSLOCTEXT("Foo", "Name", "My Extension"); }
+    virtual FString GetExtensionVersion() const override { return TEXT("1.0.0"); }
+
+    virtual void RegisterTools(FUnrealMcpToolRegistry& Registry) override
+    {
+        Registry.Tool(TEXT("hello-extension"))
+            .Title(TEXT("Hello Extension"))
+            .Description(TEXT("Returns a friendly greeting, optionally addressed to 'name'."))
+            .ParamString(TEXT("name"), TEXT("Who to greet. Defaults to 'world'."))
+            .ReadOnlyHint(true)
+            .IdempotentHint(true)
+            .Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+            {
+                const FString Name = Call.Has(TEXT("name")) ? Call.GetString(TEXT("name")) : TEXT("world");
+                TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+                Structured->SetStringField(TEXT("greeting"), FString::Printf(TEXT("Hello, %s!"), *Name));
+                return FUnrealMcpToolResult::Success(Structured->GetStringField(TEXT("greeting")), Structured);
+            });
+    }
+};
+```
+
+### The tool builder
+
+`Registry.Tool("tool-id")` returns a fluent builder. Available calls:
+
+- `.Title(...)`, `.Description(...)` — human-/LLM-facing copy.
+- `.ParamString / .ParamInt / .ParamNumber / .ParamBool / .ParamVector(name, desc, requirement)` —
+  declare an input parameter. Pass `EUnrealMcpParamRequirement::Required` to mark it required.
+- `.ReadOnlyHint / .DestructiveHint / .IdempotentHint / .OpenWorldHint(bool)` — MCP tool hints.
+- `.Handle(lambda)` — bind the handler and commit the tool. **The handler runs on the game thread**
+  (the dispatcher guarantees this, §4), so you may call editor/`UObject` APIs directly. Do not block
+  on bridge state or pump modal UI.
+
+> Do **not** call `.ExtensionId(...)` from an extension — Unreal-MCP stamps your `GetExtensionId()`
+> onto every tool automatically.
+
+Tool ids must be **kebab-case** (`^[a-z0-9]+(-[a-z0-9]+)*$`), matching the Unity/Godot convention.
+
+## Step 3 — register the provider as a modular feature
+
+```cpp
+class FMyExtensionModule : public IModuleInterface
+{
+public:
+    virtual void StartupModule() override
+    {
+        Provider = MakeUnique<FMyExtensionProvider>();
+        IModularFeatures::Get().RegisterModularFeature(
+            IUnrealMcpToolProvider::GetModularFeatureName(), Provider.Get());
+    }
+    virtual void ShutdownModule() override
+    {
+        if (Provider.IsValid())
+        {
+            IModularFeatures::Get().UnregisterModularFeature(
+                IUnrealMcpToolProvider::GetModularFeatureName(), Provider.Get());
+            Provider.Reset();
+        }
+    }
+private:
+    TUniquePtr<FMyExtensionProvider> Provider;
+};
+IMPLEMENT_MODULE(FMyExtensionModule, MyExtension)
+```
+
+That is the whole contract. Keep the provider instance alive for as long as it is registered, and
+always unregister in `ShutdownModule`.
+
+---
+
+## Lifecycle
+
+- **Discovery on boot.** Unreal-MCP enumerates every registered `UnrealMcpToolProvider` modular feature
+  and merges their tools before the sidecar's first handshake.
+- **Late load / hot unload.** Unreal-MCP subscribes to `OnModularFeatureRegistered` /
+  `OnModularFeatureUnregistered`. Registering or unregistering your feature at any time triggers a
+  **registry rebuild** and a **manifest revision bump**; the sidecar diffs the new manifest and
+  adds/removes the affected MCP tools automatically (§2.2). You do not push anything yourself.
+
+## Ordering
+
+- Providers are registered in **ascending `GetExtensionId()` order** (deterministic across runs).
+- Within one provider, tools register in **declaration order**.
+
+## Isolation semantics (important)
+
+UE is built without C++ exceptions, so isolation is **descriptor-level**, not body-level:
+
+- Each tool you declare is validated: a valid kebab-case **name**, a well-formed **schema** (every
+  parameter has a non-empty name and a known type; no duplicate parameter names), and a **bound
+  handler**.
+- An **invalid** tool entry is **dropped** and the reason is recorded on your extension's record. Your
+  other valid tools, and every other extension, are unaffected.
+- A **duplicate tool name** across providers is **rejected** for the later-sorted provider (first-wins
+  by the `ExtensionId` sort), again recorded on that extension's record.
+- A crash **inside a tool body** is an editor crash like any other plugin code — that is outside the
+  isolation contract. Validate inputs and fail gracefully (`FUnrealMcpToolResult::Error(...)`).
+
+The errors recorded on an extension record surface as an error badge on its UI row (§7).
+
+## Enable / disable
+
+Each extension can be toggled by the user. A **disabled** extension contributes **no tools to the
+manifest at all** (they are excluded entirely, not merely hidden). The disabled set is persisted across
+editor sessions.
+
+## Versioning
+
+Extensions are additive and version-independent: contributing tools never changes the Unreal-MCP plugin
+version, and your `GetExtensionVersion()` is your own.
+
+---
+
+## Reference example
+
+[`samples/UnrealAITemplate/`](../samples/UnrealAITemplate) is a complete, buildable plugin implementing
+everything above with a `hello-extension` tool. It also carries a compile-time switch
+(`UNREAL_AI_TEMPLATE_INVALID_SCHEMA=1`) that emits an intentionally invalid tool so you can observe the
+isolation behaviour first-hand.

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -43,6 +43,8 @@ public:
 In your module's `*.Build.cs`:
 
 ```csharp
+PublicDependencyModuleNames.AddRange(new string[] { "Core" });
+
 PrivateDependencyModuleNames.AddRange(new string[]
 {
     "CoreUObject", "Engine", "Projects",

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -14,7 +14,8 @@ A complete, buildable example accompanies this guide:
 
 Implement a single interface —
 [`IUnrealMcpToolProvider`](../UnrealMCP/Source/UnrealMcpEditor/Public/IUnrealMcpToolProvider.h), the
-**only** Unreal-MCP header you need to include:
+**only Unreal-MCP-specific contract header** (to declare tools you also include `UnrealMcpToolRegistry.h`,
+and to register the provider you include `Features/IModularFeatures.h` — see Steps 2–3 below):
 
 ```cpp
 class IUnrealMcpToolProvider : public IModularFeature
@@ -162,6 +163,9 @@ UE is built without C++ exceptions, so isolation is **descriptor-level**, not bo
   other valid tools, and every other extension, are unaffected.
 - A **duplicate tool name** across providers is **rejected** for the later-sorted provider (first-wins
   by the `ExtensionId` sort), again recorded on that extension's record.
+- A **duplicate `GetExtensionId()`** across two providers is an authoring error: the first-registered
+  provider keeps the id and the later one contributes **no tools**, with the conflict recorded on its
+  record. An **empty** or **reserved (`core`)** id is likewise skipped with a recorded error.
 - A crash **inside a tool body** is an editor crash like any other plugin code — that is outside the
   isolation contract. Validate inputs and fail gracefully (`FUnrealMcpToolResult::Error(...)`).
 

--- a/samples/UnrealAITemplate/README.md
+++ b/samples/UnrealAITemplate/README.md
@@ -1,10 +1,41 @@
-# UnrealAITemplate (placeholder)
+# UnrealAITemplate
 
-This folder will contain **UnrealAITemplate** — a minimal standalone UE plugin demonstrating the
-Unreal-MCP **extensions** contract (`IUnrealMcpToolProvider`, registered through `IModularFeatures`
-under the feature name `UnrealMcpToolProvider`): one `hello-extension` tool proving the contract
-end-to-end. It doubles as the extension-author documentation's working example and as the
-error-isolation test fixture (it can be switched to emit an invalid schema).
+A minimal, standalone Unreal Engine plugin demonstrating the **Unreal-MCP extensions contract**
+([`IUnrealMcpToolProvider`](../../UnrealMCP/Source/UnrealMcpEditor/Public/IUnrealMcpToolProvider.h)),
+registered through `IModularFeatures` under the feature name `UnrealMcpToolProvider`. It contributes a
+single `hello-extension` tool, proving the contract end-to-end, and doubles as the working example in
+the [extension-author guide](../../docs/EXTENSIONS.md) and the error-isolation test fixture.
 
-See [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) §5 (extensions mechanism). The real
-template lands with the extensions task — only this placeholder exists for now.
+## What it shows
+
+- Implementing `IUnrealMcpToolProvider` (`GetExtensionId` / `GetDisplayName` / `GetExtensionVersion` /
+  `RegisterTools`).
+- Declaring a tool with the fluent `FUnrealMcpToolRegistry` builder.
+- Registering / unregistering the provider as a modular feature in the module's
+  `StartupModule` / `ShutdownModule`.
+
+## Layout
+
+```
+UnrealAITemplate.uplugin                              # plugin descriptor (depends on the UnrealMCP plugin)
+Source/UnrealAITemplate/UnrealAITemplate.Build.cs     # module rules (depends on UnrealMcpEditor)
+Source/UnrealAITemplate/Private/UnrealAITemplateModule.cpp   # provider + module
+```
+
+## Using it
+
+1. Copy or symlink this folder into a UE project's `Plugins/` directory **alongside the `UnrealMCP`
+   plugin** (the sample's module depends on `UnrealMcpEditor`).
+2. Enable both plugins and build the editor target.
+3. With an MCP client connected through the sidecar, `hello-extension` appears in the tool list and
+   returns a greeting.
+
+## Isolation fixture
+
+Define `UNREAL_AI_TEMPLATE_INVALID_SCHEMA=1` (e.g. in the module's `Build.cs` via
+`PublicDefinitions.Add("UNREAL_AI_TEMPLATE_INVALID_SCHEMA=1")`) to make the provider additionally emit
+an **invalid** tool (an empty-named parameter — a malformed schema). Unreal-MCP drops only the invalid
+entry and records the failure on this extension's record; `hello-extension` stays registered. This is
+the §5 descriptor-validation isolation guarantee in action.
+
+See [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) §5 and [`docs/EXTENSIONS.md`](../../docs/EXTENSIONS.md).

--- a/samples/UnrealAITemplate/Source/UnrealAITemplate/Private/UnrealAITemplateModule.cpp
+++ b/samples/UnrealAITemplate/Source/UnrealAITemplate/Private/UnrealAITemplateModule.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "Modules/ModuleManager.h"
+#include "Features/IModularFeatures.h"
+
+#include "IUnrealMcpToolProvider.h"
+#include "UnrealMcpToolRegistry.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogUnrealAITemplate, Log, All);
+
+// Flip to 1 to make the sample emit an ADDITIONAL invalid tool descriptor (an empty-named parameter,
+// which is a malformed schema). This exercises the §5 descriptor-validation isolation path: Unreal-MCP
+// drops the invalid entry and records the failure on this extension's record, while the valid
+// 'hello-extension' tool below stays registered and other extensions are unaffected.
+#ifndef UNREAL_AI_TEMPLATE_INVALID_SCHEMA
+#define UNREAL_AI_TEMPLATE_INVALID_SCHEMA 0
+#endif
+
+/**
+ * The sample extension's tool provider — a textbook implementation of the Unreal-MCP extension
+ * contract (docs/ARCHITECTURE.md §5, docs/EXTENSIONS.md). It contributes one `hello-extension` tool.
+ */
+class FUnrealAITemplateProvider : public IUnrealMcpToolProvider
+{
+public:
+	virtual FString GetExtensionId() const override { return TEXT("com.ivanmurzak.unreal-ai-template"); }
+	virtual FText GetDisplayName() const override { return NSLOCTEXT("UnrealAITemplate", "DisplayName", "Unreal AI Template"); }
+	virtual FString GetExtensionVersion() const override { return TEXT("1.0.0"); }
+
+	virtual void RegisterTools(FUnrealMcpToolRegistry& Registry) override
+	{
+		Registry.Tool(TEXT("hello-extension"))
+			.Title(TEXT("Hello Extension"))
+			.Description(TEXT("Sample extension tool proving the IUnrealMcpToolProvider contract end-to-end. "
+			                  "Returns a friendly greeting, optionally addressed to 'name'."))
+			.ParamString(TEXT("name"), TEXT("Who to greet. Defaults to 'world'."))
+			.ReadOnlyHint(true)
+			.IdempotentHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				// Runs ON the game thread (the dispatcher guarantees it, §4).
+				const FString Name = Call.Has(TEXT("name")) ? Call.GetString(TEXT("name")) : TEXT("world");
+				const FString Greeting = FString::Printf(TEXT("Hello, %s! — from the Unreal-MCP extension sample."), *Name);
+
+				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+				Structured->SetStringField(TEXT("greeting"), Greeting);
+				return FUnrealMcpToolResult::Success(Greeting, Structured);
+			});
+
+#if UNREAL_AI_TEMPLATE_INVALID_SCHEMA
+		// Isolation fixture: an empty-named parameter is a malformed schema. Unreal-MCP drops THIS entry
+		// and records the error on this extension; 'hello-extension' above remains registered.
+		Registry.Tool(TEXT("hello-broken"))
+			.Title(TEXT("Hello Broken"))
+			.Description(TEXT("Intentionally invalid tool used to demonstrate descriptor-validation isolation."))
+			.ParamString(TEXT(""), TEXT("Empty-named parameter -> malformed schema."))
+			.Handle([](const FUnrealMcpToolCall&) -> FUnrealMcpToolResult
+			{
+				return FUnrealMcpToolResult::Success(TEXT("unreachable"));
+			});
+#endif
+	}
+};
+
+/**
+ * Editor module that owns the provider and registers it as a modular feature, so Unreal-MCP discovers
+ * it (on boot via initial enumeration, or live via the OnModularFeatureRegistered event when this
+ * plugin loads after Unreal-MCP). Unregistering on shutdown triggers a registry rebuild + manifest
+ * revision bump on the Unreal-MCP side.
+ */
+class FUnrealAITemplateModule : public IModuleInterface
+{
+public:
+	virtual void StartupModule() override
+	{
+		Provider = MakeUnique<FUnrealAITemplateProvider>();
+		IModularFeatures::Get().RegisterModularFeature(IUnrealMcpToolProvider::GetModularFeatureName(), Provider.Get());
+		UE_LOG(LogUnrealAITemplate, Log, TEXT("[UnrealAITemplate] registered MCP tool provider '%s'."), *Provider->GetExtensionId());
+	}
+
+	virtual void ShutdownModule() override
+	{
+		if (Provider.IsValid())
+		{
+			IModularFeatures::Get().UnregisterModularFeature(IUnrealMcpToolProvider::GetModularFeatureName(), Provider.Get());
+			Provider.Reset();
+			UE_LOG(LogUnrealAITemplate, Log, TEXT("[UnrealAITemplate] unregistered MCP tool provider."));
+		}
+	}
+
+private:
+	TUniquePtr<FUnrealAITemplateProvider> Provider;
+};
+
+IMPLEMENT_MODULE(FUnrealAITemplateModule, UnrealAITemplate)

--- a/samples/UnrealAITemplate/Source/UnrealAITemplate/UnrealAITemplate.Build.cs
+++ b/samples/UnrealAITemplate/Source/UnrealAITemplate/UnrealAITemplate.Build.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+using UnrealBuildTool;
+
+public class UnrealAITemplate : ModuleRules
+{
+	public UnrealAITemplate(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+
+		PublicDependencyModuleNames.AddRange(new string[]
+		{
+			"Core",
+		});
+
+		PrivateDependencyModuleNames.AddRange(new string[]
+		{
+			"CoreUObject",
+			"Engine",
+			"Projects",
+			// "Json" is needed because the public registry header (UnrealMcpToolRegistry.h) includes
+			// Dom/JsonObject.h, and the sample's handler builds a structured result with FJsonObject.
+			"Json",
+			// The extension contract + tool registry live in the Unreal-MCP plugin's editor module.
+			"UnrealMcpEditor",
+		});
+	}
+}

--- a/samples/UnrealAITemplate/UnrealAITemplate.uplugin
+++ b/samples/UnrealAITemplate/UnrealAITemplate.uplugin
@@ -1,0 +1,29 @@
+{
+  "FileVersion": 3,
+  "Version": 1,
+  "VersionName": "1.0.0",
+  "FriendlyName": "Unreal AI Template (MCP extension sample)",
+  "Description": "Minimal standalone sample demonstrating the Unreal-MCP extensions contract (IUnrealMcpToolProvider, registered through IModularFeatures under the feature name 'UnrealMcpToolProvider'). Registers a single 'hello-extension' tool, proving the contract end-to-end. Doubles as the extension-author documentation's working example and the error-isolation test fixture (flip UNREAL_AI_TEMPLATE_INVALID_SCHEMA to 1 to emit an invalid descriptor).",
+  "Category": "AI",
+  "CreatedBy": "Ivan Murzak",
+  "CreatedByURL": "https://github.com/IvanMurzak",
+  "DocsURL": "https://github.com/IvanMurzak/Unreal-MCP/blob/main/docs/EXTENSIONS.md",
+  "SupportURL": "https://github.com/IvanMurzak/Unreal-MCP/issues",
+  "CanContainContent": false,
+  "IsBetaVersion": true,
+  "IsExperimentalVersion": false,
+  "Installed": false,
+  "Modules": [
+    {
+      "Name": "UnrealAITemplate",
+      "Type": "Editor",
+      "LoadingPhase": "Default"
+    }
+  ],
+  "Plugins": [
+    {
+      "Name": "UnrealMCP",
+      "Enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds the public `IUnrealMcpToolProvider : IModularFeature` contract (feature name `UnrealMcpToolProvider`) so third-party UE plugins can contribute MCP tools (docs/ARCHITECTURE.md §5).
- `FUnrealMcpExtensionManager` discovers providers via `IModularFeatures`, subscribes to register/unregister events, merges tools in deterministic `ExtensionId` order, rebuilds the registry + bumps the manifest revision (re-pushed by the §2.2 sidecar diff), with descriptor-validation isolation (invalid entries dropped, duplicate names rejected first-wins, per-extension error recorded), an extension registry API, and per-extension enable/disable persisted via `disabledExtensions[]` (disabled ⇒ tools excluded from the manifest entirely).
- `samples/UnrealAITemplate/` standalone sample plugin (`hello-extension` tool + compile-time invalid-schema switch) and `docs/EXTENSIONS.md` author guide.

## Test plan
- [x] Suite 1 UBT build (UnrealMcpEditor + sample + tests) — exit 0.
- [x] Suite 2 headless boot smoke — `[Unreal-MCP] plugin loaded` + `1 extension(s) discovered`.
- [x] Suite 3 Automation `UnrealMcp.` — index.json 0 failed (22 succeeded + 3 succeededWithWarnings, all 7 new `UnrealMcp.Extensions` specs pass).
- [x] Live e2e: headless editor with the template plugin enabled — `hello-extension` callable through the bridge (MCP server → sidecar → IPC → game thread → handler), core `ping` coexists, no orphaned sidecar after editor kill.

Additive — no version bumps.

Closes #5