### PR TITLE
Implement Unreal-MCP connection and configuration (ARCHITECTURE §8)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
@@ -47,6 +47,22 @@ namespace
 		FJsonSerializer::Serialize(Object.ToSharedRef(), Writer);
 		return Out;
 	}
+
+	// Deep-copy a JSON object via a serialize/parse round-trip so the stored EffectiveConfig is fully
+	// independent of the caller's object (the reader thread serializes it without holding the caller still).
+	// Falls back to the original pointer if the round-trip fails (a flat config object never does).
+	TSharedPtr<FJsonObject> CloneJsonObject(const TSharedPtr<FJsonObject>& In)
+	{
+		if (!In.IsValid())
+			return nullptr;
+
+		const FString Serialized = SerializeCondensed(In);
+		TSharedPtr<FJsonObject> Out;
+		const TSharedRef<TJsonReader<TCHAR>> Reader = TJsonReaderFactory<TCHAR>::Create(Serialized);
+		if (FJsonSerializer::Deserialize(Reader, Out) && Out.IsValid())
+			return Out;
+		return In;
+	}
 }
 
 FUnrealMcpBridgeServer::FUnrealMcpBridgeServer(FUnrealMcpToolRegistry& InRegistry, FUnrealMcpGameThreadDispatcher& InDispatcher)
@@ -89,7 +105,7 @@ int32 FUnrealMcpBridgeServer::Start(const FString& InToken, const FString& InPro
 	EngineVersion = InEngineVersion;
 	{
 		FScopeLock Lock(&ConfigMutex);
-		EffectiveConfig = InEffectiveConfig;
+		EffectiveConfig = CloneJsonObject(InEffectiveConfig);
 	}
 
 	const int32 BasePort = ComputeDeterministicPort(ProjectPath);
@@ -630,7 +646,7 @@ void FUnrealMcpBridgeServer::SetEffectiveConfig(const TSharedPtr<FJsonObject>& I
 {
 	{
 		FScopeLock Lock(&ConfigMutex);
-		EffectiveConfig = InEffectiveConfig;
+		EffectiveConfig = CloneJsonObject(InEffectiveConfig);
 	}
 	PushConfig(); // "on change" (§8) — no-op when no sidecar is connected
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
@@ -29,6 +29,7 @@ namespace
 	const FString TypeToolCall = TEXT("tool-call");
 	const FString TypeToolResponse = TEXT("tool-response");
 	const FString TypeToolCancel = TEXT("tool-cancel");
+	const FString TypeConfig = TEXT("config");
 	const FString TypePing = TEXT("ping");
 	const FString TypePong = TEXT("pong");
 	const FString TypeShutdown = TEXT("shutdown");
@@ -79,12 +80,17 @@ int32 FUnrealMcpBridgeServer::ComputeDeterministicPort(const FString& InProjectP
 	return 30000 + static_cast<int32>(Value % 10000);
 }
 
-int32 FUnrealMcpBridgeServer::Start(const FString& InToken, const FString& InProjectPath, const FString& InPluginVersion, const FString& InEngineVersion)
+int32 FUnrealMcpBridgeServer::Start(const FString& InToken, const FString& InProjectPath, const FString& InPluginVersion, const FString& InEngineVersion,
+	const TSharedPtr<FJsonObject>& InEffectiveConfig)
 {
 	Token = InToken;
 	ProjectPath = InProjectPath;
 	PluginVersion = InPluginVersion;
 	EngineVersion = InEngineVersion;
+	{
+		FScopeLock Lock(&ConfigMutex);
+		EffectiveConfig = InEffectiveConfig;
+	}
 
 	const int32 BasePort = ComputeDeterministicPort(ProjectPath);
 
@@ -344,10 +350,14 @@ void FUnrealMcpBridgeServer::HandleHandshake(const TSharedPtr<FJsonObject>& Mess
 	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] handshake accepted."));
 	SendHandshakeAck();
 
-	// §1.5: on Ready immediately push the manifest (config push lands with the connection-config task).
+	// §1.5: on Ready immediately push the manifest AND the effective connection config (§1.3 `config`, §8).
+	// The handshake-ack already carries the config for the sidecar's initial SignalR connect; the standalone
+	// `config` message satisfies the §8 "on Ready and on change" contract and is the channel a later UI edit
+	// re-pushes through (SetEffectiveConfig → PushConfig).
 	{
 		FScopeLock Lock(&WriteMutex);
 		SendManifestLocked();
+		SendConfigLocked();
 	}
 
 	StartHeartbeat();
@@ -525,6 +535,16 @@ void FUnrealMcpBridgeServer::SendHandshakeAck()
 	Ack->SetStringField(TEXT("pluginVersion"), PluginVersion);
 	Ack->SetStringField(TEXT("engineVersion"), EngineVersion);
 	Ack->SetStringField(TEXT("projectPath"), ProjectPath);
+
+	// §1.3/§1.5: the ack carries the effective connection config so the sidecar's FIRST SignalR connect uses
+	// the plugin-resolved mode/host/cloudUrl/token (the sidecar never re-resolves §8). Tokens are part of the
+	// payload but are NEVER logged here (§8) — only the message shape is.
+	{
+		FScopeLock Lock(&ConfigMutex);
+		if (EffectiveConfig.IsValid())
+			Ack->SetObjectField(TEXT("config"), EffectiveConfig);
+	}
+
 	SendMessage(Ack);
 }
 
@@ -560,6 +580,59 @@ void FUnrealMcpBridgeServer::PushManifest()
 		return;
 	FScopeLock Lock(&WriteMutex);
 	SendManifestLocked();
+}
+
+void FUnrealMcpBridgeServer::SendConfigLocked()
+{
+	// Caller holds WriteMutex. Build a fresh `config` envelope wrapping the effective §8 connection config.
+	TSharedPtr<FJsonObject> ConfigCopy;
+	{
+		FScopeLock Lock(&ConfigMutex);
+		ConfigCopy = EffectiveConfig;
+	}
+	if (!ConfigCopy.IsValid())
+		return; // no config to push (the sidecar keeps its env fallback)
+
+	TSharedPtr<FJsonObject> Message = MakeShared<FJsonObject>();
+	Message->SetStringField(TEXT("type"), TypeConfig);
+	// Spread the effective config fields (mode/host/cloudUrl/token/keepConnected) onto the envelope so the
+	// §1.3 `config` message is flat (the sidecar reads them off the top level, like the handshake-ack does).
+	for (const TPair<FString, TSharedPtr<FJsonValue>>& Field : ConfigCopy->Values)
+		Message->SetField(Field.Key, Field.Value);
+
+	const FString Json = SerializeCondensed(Message);
+	const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(Json);
+
+	FScopeLock ConnLock(&ConnectionMutex);
+	if (ClientSocket == nullptr)
+		return;
+
+	if (!TrySendFramedLocked(Framed))
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] config send failed mid-frame; dropping connection."));
+		SocketsPendingDestroy.Add(ClientSocket);
+		ClientSocket = nullptr;
+		bClientConnected = false;
+		bHandshakeOk = false;
+		bHeartbeatStop = true;
+	}
+}
+
+void FUnrealMcpBridgeServer::PushConfig()
+{
+	if (!bClientConnected || !bHandshakeOk)
+		return;
+	FScopeLock Lock(&WriteMutex);
+	SendConfigLocked();
+}
+
+void FUnrealMcpBridgeServer::SetEffectiveConfig(const TSharedPtr<FJsonObject>& InEffectiveConfig)
+{
+	{
+		FScopeLock Lock(&ConfigMutex);
+		EffectiveConfig = InEffectiveConfig;
+	}
+	PushConfig(); // "on change" (§8) — no-op when no sidecar is connected
 }
 
 void FUnrealMcpBridgeServer::CloseActiveConnection()

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.h
@@ -37,9 +37,13 @@ public:
 	/**
 	 * Bind + listen on the deterministic port for @p ProjectPath (probing forward on conflict, §1.1) and
 	 * begin accepting. Returns the bound port, or -1 if every probed port failed. @p Token is the secret
-	 * the handshake must carry (§1.4); the other args are echoed in the handshake-ack.
+	 * the handshake must carry (§1.4); the other args are echoed in the handshake-ack. @p InEffectiveConfig
+	 * is the resolved connection config (§8 — mode/host/cloudUrl/token/keepConnected) the plugin pushes to
+	 * the sidecar in the handshake-ack and the §1.3 `config` message; may be null (the sidecar then keeps
+	 * its env fallback).
 	 */
-	int32 Start(const FString& InToken, const FString& InProjectPath, const FString& InPluginVersion, const FString& InEngineVersion);
+	int32 Start(const FString& InToken, const FString& InProjectPath, const FString& InPluginVersion, const FString& InEngineVersion,
+		const TSharedPtr<FJsonObject>& InEffectiveConfig = nullptr);
 
 	/** Stop accepting, send the connected sidecar a graceful shutdown, and tear down all threads/sockets. */
 	void Shutdown();
@@ -49,6 +53,16 @@ public:
 
 	/** Re-push the manifest (call after the registry changes, §2.2 hot reload). No-op when disconnected. */
 	void PushManifest();
+
+	/**
+	 * Replace the effective connection config and, if a sidecar is connected, push the §1.3 `config` message
+	 * to it (the "on change" path — e.g. a future UI mode/host/token edit). Thread-safe; no-op send when
+	 * disconnected (the next handshake-ack carries the latest config anyway).
+	 */
+	void SetEffectiveConfig(const TSharedPtr<FJsonObject>& InEffectiveConfig);
+
+	/** Push the current §1.3 `config` message to the connected sidecar. No-op when disconnected. */
+	void PushConfig();
 
 	/** Deterministic IPC port for a project path (§1.1): 30000 + sha(path) % 10000. */
 	static int32 ComputeDeterministicPort(const FString& ProjectPath);
@@ -69,6 +83,7 @@ private:
 	bool SendMessage(const TSharedPtr<FJsonObject>& Message);
 	void SendHandshakeAck();
 	void SendManifestLocked();
+	void SendConfigLocked(); // WriteMutex held: frame + send the §1.3 `config` message (no-op when no config)
 	bool TrySendFramedLocked(const TArray<uint8>& Framed); // WriteMutex+ConnectionMutex held, ClientSocket valid
 	void CloseActiveConnection();
 	void DrainPendingDestroy();    // reader-/shutdown-owned: actually frees sockets parked for teardown
@@ -98,6 +113,12 @@ private:
 	FString PluginVersion;
 	FString EngineVersion;
 	int32 BoundPort = -1;
+
+	// The resolved §8 connection config pushed to the sidecar (handshake-ack + §1.3 `config`). Read on the
+	// reader thread (SendHandshakeAck/SendConfigLocked), replaced on the game thread (SetEffectiveConfig);
+	// guarded by ConfigMutex. A deep copy is stored so the caller's object can change without racing a send.
+	mutable FCriticalSection ConfigMutex;
+	TSharedPtr<FJsonObject> EffectiveConfig;
 
 	FThreadSafeBool bStopRequested = false;
 	FThreadSafeBool bClientConnected = false;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
@@ -74,10 +74,13 @@ FString FUnrealMcpConfig::DefaultEnvFilePath()
 
 FUnrealMcpConfig FUnrealMcpConfig::LoadAndResolve()
 {
+	return LoadAndResolve(LoadEnvFile(DefaultEnvFilePath()));
+}
+
+FUnrealMcpConfig FUnrealMcpConfig::LoadAndResolve(const TMap<FString, FString>& DotEnv)
+{
 	FUnrealMcpConfig Config;
 	Config.LoadFromFile(DefaultConfigFilePath());
-
-	const TMap<FString, FString> DotEnv = LoadEnvFile(DefaultEnvFilePath());
 	Config.ApplyOverrides(DotEnv, [](const FString& Name, FString& Out) -> bool
 	{
 		const FString Value = FPlatformMisc::GetEnvironmentVariable(*Name);
@@ -260,11 +263,12 @@ void FUnrealMcpConfig::ApplyOne(const FString& EnvName, const FString& Source)
 	}
 	else if (EnvName == EnvTools)
 	{
-		// Accept comma- or semicolon-separated tool ids.
+		// Accept comma- or semicolon-separated tool ids: normalize ';' → ',' first, then split once so a
+		// mixed/single separator can never corrupt an id (e.g. "a," must yield ["a"], not ["a,"]).
+		FString Normalized = Source;
+		Normalized.ReplaceInline(TEXT(";"), TEXT(","));
 		TArray<FString> Parts;
-		Source.ParseIntoArray(Parts, TEXT(","), true);
-		if (Parts.Num() == 1)
-			Source.ParseIntoArray(Parts, TEXT(";"), true);
+		Normalized.ParseIntoArray(Parts, TEXT(","), true);
 
 		EnabledTools.Reset();
 		for (FString& Part : Parts)
@@ -439,11 +443,16 @@ TMap<FString, FString> FUnrealMcpConfig::LoadEnvFile(const FString& Path)
 
 void FUnrealMcpConfig::ExportDotEnvToProcessEnv(const TMap<FString, FString>& DotEnv)
 {
-	for (const TPair<FString, FString>& Pair : DotEnv)
+	// Export ONLY the bridge-path key into the process env. That is the single var the editor process itself
+	// must read out-of-band (FUnrealMcpSidecarManager::ResolveBridgeBinaryPath, §6), and it is not a secret.
+	// HOST/CLOUD_URL/TOKEN are deliberately NOT exported: the sidecar receives them via the authoritative
+	// §1.3 `config` push, so exporting them here would only (a) leak the bearer token into EVERY child the
+	// editor spawns and (b) pin a now-stale .env value at process-env precedence on any later re-resolve.
+	if (const FString* BridgePath = DotEnv.Find(EnvBridgePath))
 	{
 		// Only set when the process env is currently empty for this key — process env wins over .env (§8).
-		if (FPlatformMisc::GetEnvironmentVariable(*Pair.Key).IsEmpty() && !Pair.Value.IsEmpty())
-			FPlatformMisc::SetEnvironmentVar(*Pair.Key, *Pair.Value);
+		if (FPlatformMisc::GetEnvironmentVariable(EnvBridgePath).IsEmpty() && !BridgePath->IsEmpty())
+			FPlatformMisc::SetEnvironmentVar(EnvBridgePath, **BridgePath);
 	}
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
@@ -148,7 +148,7 @@ void FUnrealMcpConfig::LoadFromJson(const TSharedPtr<FJsonObject>& Json)
 	}
 
 	// Snapshot the (defaults + disk) baseline AFTER loading — this is what Save() restores for any key an
-	// env/.env layer later overrides. Re-parsing makes a deep, independent copy.
+	// env/.env layer later overrides. ToJson() builds a fresh object, so the baseline is a deep, independent copy.
 	OverriddenKeys.Reset();
 	DiskBaselineJson = ToJson();
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
@@ -1,0 +1,515 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpConfig.h"
+
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "HAL/PlatformMisc.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+// --- Env-var names (§8). ---
+const TCHAR* FUnrealMcpConfig::EnvConnectionMode = TEXT("UNREAL_MCP_CONNECTION_MODE");
+const TCHAR* FUnrealMcpConfig::EnvHost           = TEXT("UNREAL_MCP_HOST");
+const TCHAR* FUnrealMcpConfig::EnvCloudUrl       = TEXT("UNREAL_MCP_CLOUD_URL");
+const TCHAR* FUnrealMcpConfig::EnvToken          = TEXT("UNREAL_MCP_TOKEN");
+const TCHAR* FUnrealMcpConfig::EnvAuthOption     = TEXT("UNREAL_MCP_AUTH_OPTION");
+const TCHAR* FUnrealMcpConfig::EnvKeepConnected  = TEXT("UNREAL_MCP_KEEP_CONNECTED");
+const TCHAR* FUnrealMcpConfig::EnvTools          = TEXT("UNREAL_MCP_TOOLS");
+const TCHAR* FUnrealMcpConfig::EnvStartServer    = TEXT("UNREAL_MCP_START_SERVER");
+const TCHAR* FUnrealMcpConfig::EnvTransport      = TEXT("UNREAL_MCP_TRANSPORT");
+const TCHAR* FUnrealMcpConfig::EnvLogLevel       = TEXT("UNREAL_MCP_LOG_LEVEL");
+const TCHAR* FUnrealMcpConfig::EnvBridgePath     = TEXT("UNREAL_MCP_BRIDGE_PATH");
+
+// --- Defaults. ---
+const TCHAR* FUnrealMcpConfig::DefaultCloudBaseUrl = TEXT("https://ai-game.dev");
+const TCHAR* FUnrealMcpConfig::DefaultCustomHost   = TEXT("http://localhost:8080");
+const TCHAR* FUnrealMcpConfig::DefaultLogLevel     = TEXT("Info");
+const TCHAR* FUnrealMcpConfig::DefaultTransport    = TEXT("http");
+
+namespace
+{
+	// JSON property names (camelCase — System.Text.Json-compatible so the sidecar/cli could share parsing).
+	const TCHAR* KeyConnectionMode = TEXT("connectionMode");
+	const TCHAR* KeyHost           = TEXT("host");
+	const TCHAR* KeyToken          = TEXT("token");
+	const TCHAR* KeyCloudToken     = TEXT("cloudToken");
+	const TCHAR* KeyCloudUrl       = TEXT("cloudUrl");
+	const TCHAR* KeyAuthOption     = TEXT("authOption");
+	const TCHAR* KeyKeepConnected  = TEXT("keepConnected");
+	const TCHAR* KeyLogLevel       = TEXT("logLevel");
+	const TCHAR* KeyTransport      = TEXT("transport");
+	const TCHAR* KeyStartServer    = TEXT("startServer");
+	const TCHAR* KeyEnabledTools   = TEXT("enabledTools");
+
+	FString TrimSlash(const FString& In)
+	{
+		FString Out = In;
+		while (Out.EndsWith(TEXT("/")))
+			Out.LeftChopInline(1);
+		return Out;
+	}
+}
+
+FUnrealMcpConfig::FUnrealMcpConfig()
+	: CustomHost(DefaultCustomHost)
+	, CloudUrl(DefaultCloudBaseUrl)
+	, LogLevel(DefaultLogLevel)
+	, Transport(DefaultTransport)
+{
+}
+
+FString FUnrealMcpConfig::DefaultConfigFilePath()
+{
+	return FPaths::ConvertRelativePathToFull(
+		FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("Config"), TEXT("UnrealMcp"), TEXT("ai-game-developer-config.json")));
+}
+
+FString FUnrealMcpConfig::DefaultEnvFilePath()
+{
+	return FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), TEXT(".env")));
+}
+
+FUnrealMcpConfig FUnrealMcpConfig::LoadAndResolve()
+{
+	FUnrealMcpConfig Config;
+	Config.LoadFromFile(DefaultConfigFilePath());
+
+	const TMap<FString, FString> DotEnv = LoadEnvFile(DefaultEnvFilePath());
+	Config.ApplyOverrides(DotEnv, [](const FString& Name, FString& Out) -> bool
+	{
+		const FString Value = FPlatformMisc::GetEnvironmentVariable(*Name);
+		if (Value.IsEmpty())
+			return false;
+		Out = Value;
+		return true;
+	});
+	return Config;
+}
+
+void FUnrealMcpConfig::LoadFromFile(const FString& Path)
+{
+	TSharedPtr<FJsonObject> Parsed;
+
+	FString Json;
+	if (!Path.IsEmpty() && FPaths::FileExists(Path) && FFileHelper::LoadFileToString(Json, *Path) && !Json.IsEmpty())
+	{
+		const TSharedRef<TJsonReader<TCHAR>> Reader = TJsonReaderFactory<TCHAR>::Create(Json);
+		// A corrupt/partial file is treated as "no persisted config" rather than breaking plugin boot.
+		FJsonSerializer::Deserialize(Reader, Parsed);
+	}
+
+	LoadFromJson(Parsed);
+}
+
+void FUnrealMcpConfig::LoadFromJson(const TSharedPtr<FJsonObject>& Json)
+{
+	if (Json.IsValid())
+	{
+		FString Str;
+		if (Json->TryGetStringField(KeyConnectionMode, Str))
+		{
+			EUnrealMcpConnectionMode Mode;
+			if (TryParseMode(Str, Mode))
+				ConnectionMode = Mode;
+		}
+		if (Json->TryGetStringField(KeyHost, Str))       CustomHost = Str;
+		if (Json->TryGetStringField(KeyToken, Str))      CustomToken = Str;
+		if (Json->TryGetStringField(KeyCloudToken, Str)) CloudToken = Str;
+		if (Json->TryGetStringField(KeyCloudUrl, Str))   CloudUrl = Str;
+		if (Json->TryGetStringField(KeyAuthOption, Str))
+		{
+			EUnrealMcpAuthOption Option;
+			if (TryParseAuthOption(Str, Option))
+				AuthOption = Option;
+		}
+		bool bFlag = false;
+		if (Json->TryGetBoolField(KeyKeepConnected, bFlag)) bKeepConnected = bFlag;
+		if (Json->TryGetStringField(KeyLogLevel, Str))  LogLevel = Str;
+		if (Json->TryGetStringField(KeyTransport, Str)) Transport = Str;
+		if (Json->TryGetBoolField(KeyStartServer, bFlag)) bStartServer = bFlag;
+
+		const TArray<TSharedPtr<FJsonValue>>* Tools = nullptr;
+		if (Json->TryGetArrayField(KeyEnabledTools, Tools) && Tools != nullptr)
+		{
+			EnabledTools.Reset();
+			for (const TSharedPtr<FJsonValue>& Value : *Tools)
+			{
+				FString Tool;
+				if (Value.IsValid() && Value->TryGetString(Tool) && !Tool.IsEmpty())
+					EnabledTools.Add(Tool);
+			}
+		}
+	}
+
+	// Snapshot the (defaults + disk) baseline AFTER loading — this is what Save() restores for any key an
+	// env/.env layer later overrides. Re-parsing makes a deep, independent copy.
+	OverriddenKeys.Reset();
+	DiskBaselineJson = ToJson();
+}
+
+void FUnrealMcpConfig::ApplyOverrides(const TMap<FString, FString>& DotEnv, const TFunction<bool(const FString&, FString&)>& EnvReader)
+{
+	// Effective override value for an env name: process env (highest) else .env file. Both are sanitized;
+	// a blank value carries no override (mirrors GodotMcpEnvFile + Unity's env path).
+	auto Resolve = [&](const TCHAR* Name, FString& Out) -> bool
+	{
+		if (EnvReader)
+		{
+			FString EnvValue;
+			if (EnvReader(Name, EnvValue))
+			{
+				const FString Sanitized = SanitizeValue(EnvValue);
+				if (!Sanitized.IsEmpty())
+				{
+					Out = Sanitized;
+					return true;
+				}
+			}
+		}
+		if (const FString* FileValue = DotEnv.Find(Name)) // .env values are already sanitized by ParseEnvLines
+		{
+			if (!FileValue->IsEmpty())
+			{
+				Out = *FileValue;
+				return true;
+			}
+		}
+		return false;
+	};
+
+	// Mode must settle BEFORE the token so token routing (Cloud→cloudToken / Custom→token) matches the final
+	// mode. The token is therefore applied LAST. (Same ordering as GodotMcpEnvFile.Apply.)
+	const TCHAR* OrderedNames[] = {
+		EnvConnectionMode, EnvHost, EnvCloudUrl, EnvAuthOption, EnvKeepConnected,
+		EnvLogLevel, EnvTransport, EnvStartServer, EnvTools, EnvToken
+	};
+
+	for (const TCHAR* Name : OrderedNames)
+	{
+		FString Value;
+		if (Resolve(Name, Value))
+			ApplyOne(Name, Value);
+	}
+}
+
+void FUnrealMcpConfig::ApplyOne(const FString& EnvName, const FString& Source)
+{
+	if (EnvName == EnvConnectionMode)
+	{
+		EUnrealMcpConnectionMode Mode;
+		if (TryParseMode(Source, Mode))
+		{
+			ConnectionMode = Mode;
+			OverriddenKeys.Add(KeyConnectionMode);
+		}
+	}
+	else if (EnvName == EnvHost)
+	{
+		CustomHost = Source;
+		OverriddenKeys.Add(KeyHost);
+	}
+	else if (EnvName == EnvCloudUrl)
+	{
+		CloudUrl = Source;
+		OverriddenKeys.Add(KeyCloudUrl);
+	}
+	else if (EnvName == EnvAuthOption)
+	{
+		EUnrealMcpAuthOption Option;
+		if (TryParseAuthOption(Source, Option))
+		{
+			AuthOption = Option;
+			OverriddenKeys.Add(KeyAuthOption);
+		}
+	}
+	else if (EnvName == EnvKeepConnected)
+	{
+		bool bValue = false;
+		if (TryParseBool(Source, bValue))
+		{
+			bKeepConnected = bValue;
+			OverriddenKeys.Add(KeyKeepConnected);
+		}
+	}
+	else if (EnvName == EnvLogLevel)
+	{
+		LogLevel = Source;
+		OverriddenKeys.Add(KeyLogLevel);
+	}
+	else if (EnvName == EnvTransport)
+	{
+		// Only the two named transports are honoured; anything else falls through to the existing value.
+		const FString Lower = Source.ToLower();
+		if (Lower == TEXT("stdio") || Lower == TEXT("http"))
+		{
+			Transport = Lower;
+			OverriddenKeys.Add(KeyTransport);
+		}
+	}
+	else if (EnvName == EnvStartServer)
+	{
+		bool bValue = false;
+		if (TryParseBool(Source, bValue))
+		{
+			bStartServer = bValue;
+			OverriddenKeys.Add(KeyStartServer);
+		}
+	}
+	else if (EnvName == EnvTools)
+	{
+		// Accept comma- or semicolon-separated tool ids.
+		TArray<FString> Parts;
+		Source.ParseIntoArray(Parts, TEXT(","), true);
+		if (Parts.Num() == 1)
+			Source.ParseIntoArray(Parts, TEXT(";"), true);
+
+		EnabledTools.Reset();
+		for (FString& Part : Parts)
+		{
+			Part.TrimStartAndEndInline();
+			if (!Part.IsEmpty())
+				EnabledTools.Add(Part);
+		}
+		OverriddenKeys.Add(KeyEnabledTools);
+	}
+	else if (EnvName == EnvToken)
+	{
+		// Route to the active mode's token field (mode has already settled above). Custom-mode token still
+		// only goes on the wire when AuthOption==Required (see ResolveEffectiveToken) — storing it here keeps
+		// the user's value across an auth toggle without leaking it while auth is None.
+		if (ConnectionMode == EUnrealMcpConnectionMode::Cloud)
+		{
+			CloudToken = Source;
+			OverriddenKeys.Add(KeyCloudToken);
+		}
+		else
+		{
+			CustomToken = Source;
+			OverriddenKeys.Add(KeyToken);
+		}
+	}
+	// EnvBridgePath: dev-only, consumed by FUnrealMcpSidecarManager via the process env — not a config field.
+}
+
+TSharedPtr<FJsonObject> FUnrealMcpConfig::ToJson() const
+{
+	TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+	Obj->SetStringField(KeyConnectionMode, ConnectionMode == EUnrealMcpConnectionMode::Cloud ? TEXT("Cloud") : TEXT("Custom"));
+	Obj->SetStringField(KeyHost, CustomHost);
+	Obj->SetStringField(KeyToken, CustomToken);
+	Obj->SetStringField(KeyCloudToken, CloudToken);
+	Obj->SetStringField(KeyCloudUrl, CloudUrl);
+	Obj->SetStringField(KeyAuthOption, AuthOption == EUnrealMcpAuthOption::Required ? TEXT("Required") : TEXT("None"));
+	Obj->SetBoolField(KeyKeepConnected, bKeepConnected);
+	Obj->SetStringField(KeyLogLevel, LogLevel);
+	Obj->SetStringField(KeyTransport, Transport);
+	Obj->SetBoolField(KeyStartServer, bStartServer);
+
+	TArray<TSharedPtr<FJsonValue>> Tools;
+	for (const FString& Tool : EnabledTools)
+		Tools.Add(MakeShared<FJsonValueString>(Tool));
+	Obj->SetArrayField(KeyEnabledTools, Tools);
+
+	return Obj;
+}
+
+bool FUnrealMcpConfig::Save(const FString& Path) const
+{
+	if (Path.IsEmpty())
+		return false;
+
+	TSharedPtr<FJsonObject> Out = ToJson();
+
+	// Round-trip the disk baseline for every env/.env-overridden key so an override is NEVER persisted
+	// (Unity OverrideRecord baseline-restore). Non-overridden keys keep their current value.
+	if (DiskBaselineJson.IsValid())
+	{
+		for (const FString& Key : OverriddenKeys)
+		{
+			if (const TSharedPtr<FJsonValue>* Baseline = DiskBaselineJson->Values.Find(Key))
+				Out->SetField(Key, *Baseline);
+			else
+				Out->RemoveField(Key);
+		}
+	}
+
+	FString Serialized;
+	const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> Writer =
+		TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Serialized);
+	if (!FJsonSerializer::Serialize(Out.ToSharedRef(), Writer))
+		return false;
+
+	const FString Dir = FPaths::GetPath(Path);
+	if (!Dir.IsEmpty())
+		IFileManager::Get().MakeDirectory(*Dir, /*Tree*/ true);
+
+	return FFileHelper::SaveStringToFile(Serialized, *Path);
+}
+
+FString FUnrealMcpConfig::ResolveCloudBaseUrl() const
+{
+	const FString Trimmed = TrimSlash(CloudUrl.TrimStartAndEnd());
+	return Trimmed.IsEmpty() ? FString(DefaultCloudBaseUrl) : Trimmed;
+}
+
+FString FUnrealMcpConfig::ResolveCustomHost() const
+{
+	const FString Trimmed = TrimSlash(CustomHost.TrimStartAndEnd());
+	return Trimmed.IsEmpty() ? FString(DefaultCustomHost) : Trimmed;
+}
+
+FString FUnrealMcpConfig::ResolveEffectiveToken() const
+{
+	if (ConnectionMode == EUnrealMcpConnectionMode::Cloud)
+		return CloudToken;
+
+	// Custom mode: an anonymous (None) connection sends NO bearer, regardless of any stored token — so
+	// flipping auth back to None drops the token from the wire without discarding the user's stored value.
+	return AuthOption == EUnrealMcpAuthOption::Required ? CustomToken : FString();
+}
+
+TSharedPtr<FJsonObject> FUnrealMcpConfig::BuildEffectiveConnectionConfig() const
+{
+	TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+	Obj->SetStringField(TEXT("mode"), ConnectionMode == EUnrealMcpConnectionMode::Cloud ? TEXT("Cloud") : TEXT("Custom"));
+	Obj->SetStringField(TEXT("host"), ResolveCustomHost());
+	Obj->SetStringField(TEXT("cloudUrl"), ResolveCloudBaseUrl());
+	Obj->SetStringField(TEXT("token"), ResolveEffectiveToken());
+	Obj->SetBoolField(TEXT("keepConnected"), bKeepConnected);
+	return Obj;
+}
+
+TMap<FString, FString> FUnrealMcpConfig::ParseEnvLines(const TArray<FString>& Lines)
+{
+	static const TCHAR* RecognizedKeys[] = {
+		EnvConnectionMode, EnvHost, EnvCloudUrl, EnvToken, EnvAuthOption, EnvKeepConnected,
+		EnvTools, EnvStartServer, EnvTransport, EnvLogLevel, EnvBridgePath
+	};
+
+	TMap<FString, FString> Result;
+	for (const FString& RawLine : Lines)
+	{
+		FString Line = RawLine;
+		Line.TrimStartAndEndInline();
+		if (Line.IsEmpty() || Line[0] == TCHAR('#'))
+			continue;
+
+		int32 EqIndex = INDEX_NONE;
+		if (!Line.FindChar(TCHAR('='), EqIndex) || EqIndex <= 0)
+			continue;
+
+		FString Key = Line.Left(EqIndex);
+		Key.TrimStartAndEndInline();
+
+		bool bRecognized = false;
+		for (const TCHAR* Recognized : RecognizedKeys)
+		{
+			if (Key.Equals(Recognized, ESearchCase::CaseSensitive))
+			{
+				bRecognized = true;
+				break;
+			}
+		}
+		if (!bRecognized)
+			continue;
+
+		const FString Value = SanitizeValue(Line.Mid(EqIndex + 1));
+		if (Value.IsEmpty())
+			continue;
+
+		Result.Add(Key, Value); // last occurrence wins
+	}
+	return Result;
+}
+
+TMap<FString, FString> FUnrealMcpConfig::LoadEnvFile(const FString& Path)
+{
+	if (Path.IsEmpty() || !FPaths::FileExists(Path))
+		return TMap<FString, FString>();
+
+	TArray<FString> Lines;
+	if (!FFileHelper::LoadFileToStringArray(Lines, *Path))
+		return TMap<FString, FString>();
+
+	return ParseEnvLines(Lines);
+}
+
+void FUnrealMcpConfig::ExportDotEnvToProcessEnv(const TMap<FString, FString>& DotEnv)
+{
+	for (const TPair<FString, FString>& Pair : DotEnv)
+	{
+		// Only set when the process env is currently empty for this key — process env wins over .env (§8).
+		if (FPlatformMisc::GetEnvironmentVariable(*Pair.Key).IsEmpty() && !Pair.Value.IsEmpty())
+			FPlatformMisc::SetEnvironmentVar(*Pair.Key, *Pair.Value);
+	}
+}
+
+FString FUnrealMcpConfig::MaskSecret(const FString& Secret)
+{
+	return Secret.IsEmpty() ? FString(TEXT("<unset>")) : FString(TEXT("***"));
+}
+
+FString FUnrealMcpConfig::SanitizeValue(const FString& Raw)
+{
+	FString Value = Raw;
+	Value.TrimStartAndEndInline();
+	if (Value.Len() >= 2)
+	{
+		const TCHAR First = Value[0];
+		const TCHAR Last = Value[Value.Len() - 1];
+		if ((First == TCHAR('"') && Last == TCHAR('"')) || (First == TCHAR('\'') && Last == TCHAR('\'')))
+			Value = Value.Mid(1, Value.Len() - 2);
+	}
+	return Value;
+}
+
+bool FUnrealMcpConfig::TryParseMode(const FString& Raw, EUnrealMcpConnectionMode& OutMode)
+{
+	const FString Normalized = SanitizeValue(Raw);
+	if (Normalized.Equals(TEXT("Cloud"), ESearchCase::IgnoreCase))
+	{
+		OutMode = EUnrealMcpConnectionMode::Cloud;
+		return true;
+	}
+	if (Normalized.Equals(TEXT("Custom"), ESearchCase::IgnoreCase))
+	{
+		OutMode = EUnrealMcpConnectionMode::Custom;
+		return true;
+	}
+	return false; // unrecognized/numeric → keep the existing value
+}
+
+bool FUnrealMcpConfig::TryParseAuthOption(const FString& Raw, EUnrealMcpAuthOption& OutOption)
+{
+	const FString Normalized = SanitizeValue(Raw);
+	if (Normalized.Equals(TEXT("None"), ESearchCase::IgnoreCase))
+	{
+		OutOption = EUnrealMcpAuthOption::None;
+		return true;
+	}
+	if (Normalized.Equals(TEXT("Required"), ESearchCase::IgnoreCase))
+	{
+		OutOption = EUnrealMcpAuthOption::Required;
+		return true;
+	}
+	return false;
+}
+
+bool FUnrealMcpConfig::TryParseBool(const FString& Raw, bool& OutValue)
+{
+	const FString Normalized = SanitizeValue(Raw).ToLower();
+	if (Normalized == TEXT("true") || Normalized == TEXT("1") || Normalized == TEXT("yes") || Normalized == TEXT("on"))
+	{
+		OutValue = true;
+		return true;
+	}
+	if (Normalized == TEXT("false") || Normalized == TEXT("0") || Normalized == TEXT("no") || Normalized == TEXT("off"))
+	{
+		OutValue = false;
+		return true;
+	}
+	return false;
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
@@ -97,6 +97,12 @@ public:
 	static UNREALMCPEDITOR_API FUnrealMcpConfig LoadAndResolve();
 
 	/**
+	 * Same as LoadAndResolve() but with an already-parsed @p DotEnv map, so a caller that needs the parsed
+	 * .env for another purpose (e.g. ExportDotEnvToProcessEnv) does not parse the file twice.
+	 */
+	static UNREALMCPEDITOR_API FUnrealMcpConfig LoadAndResolve(const TMap<FString, FString>& DotEnv);
+
+	/**
 	 * Load the persisted config JSON at @p Path into the backing fields, and snapshot the result as the
 	 * disk baseline (used by Save() to round-trip env/.env overrides away). A missing/empty/corrupt file
 	 * is the common first-run case — fields keep their defaults and the baseline is the default snapshot.
@@ -157,13 +163,12 @@ public:
 	static UNREALMCPEDITOR_API TMap<FString, FString> LoadEnvFile(const FString& Path);
 
 	/**
-	 * Export recognized .env values into the editor's process environment, but ONLY for keys not already set
-	 * in the process env (so the §8 precedence "process env > .env" is preserved). This is the bridge for the
-	 * env-consuming code OUTSIDE this config store: UNREAL_MCP_BRIDGE_PATH (FUnrealMcpSidecarManager resolves
-	 * the binary from it, §6) and the spawned sidecar child's HOST/CLOUD_URL/TOKEN env fallback — both of
-	 * which a GUI-launched editor would otherwise never see from a project-root .env. The connection config
-	 * the sidecar actually uses still flows via the §1.3 `config` message; this only feeds the binary-path /
-	 * child-inheritance paths.
+	 * Export the UNREAL_MCP_BRIDGE_PATH .env value into the editor's process environment (and ONLY that key),
+	 * set-if-absent so the §8 precedence "process env > .env" is preserved. That is the single var the editor
+	 * process itself must read out-of-band (FUnrealMcpSidecarManager resolves the sidecar binary from it, §6),
+	 * and it is not a secret. HOST/CLOUD_URL/TOKEN are intentionally NOT exported: the sidecar gets them via
+	 * the authoritative §1.3 `config` push, so process-env export would only leak the bearer token into every
+	 * editor child and pin stale .env values at process-env precedence on a later re-resolve.
 	 */
 	static UNREALMCPEDITOR_API void ExportDotEnvToProcessEnv(const TMap<FString, FString>& DotEnv);
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
@@ -110,7 +110,7 @@ public:
 	 */
 	UNREALMCPEDITOR_API void LoadFromFile(const FString& Path);
 
-	/** Set the disk baseline directly from a parsed JSON object (or defaults when null). For tests. */
+	/** Set the disk baseline directly from a parsed JSON object (or defaults when null). LoadFromFile delegates here; also the injectable seam for tests. */
 	UNREALMCPEDITOR_API void LoadFromJson(const TSharedPtr<FJsonObject>& Json);
 
 	/**

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+
+/** Which MCP server the plugin connects to (docs/ARCHITECTURE.md §8). Mirrors Godot/Unity. */
+enum class EUnrealMcpConnectionMode : uint8
+{
+	/** A user-supplied server URL (local dev server, self-hosted, …). */
+	Custom,
+	/** The hosted ai-game.dev cloud server. */
+	Cloud
+};
+
+/**
+ * Whether a Custom-mode connection sends a bearer token (§8). Only meaningful in
+ * EUnrealMcpConnectionMode::Custom — Cloud-mode auth is the device-code flow (a later UI task).
+ */
+enum class EUnrealMcpAuthOption : uint8
+{
+	/** No bearer token is sent (the Custom server accepts anonymous connections). */
+	None,
+	/** A bearer token is sent (the Custom server requires authorization). */
+	Required
+};
+
+/**
+ * Connection + environment configuration for the UnrealMCP plugin (docs/ARCHITECTURE.md §8). The C++
+ * analog of Godot's GodotMcpConfig + GodotMcpEnvFile + Unity's EnvironmentUtils.OverrideRecord:
+ *
+ *  - Persisted on disk as camelCase JSON at <Project>/Saved/Config/UnrealMcp/ai-game-developer-config.json
+ *    (Saved/ is gitignored by every UE template, so tokens never land in VCS by default).
+ *  - Layered with a project-root <Project>/.env file (parsed with EXACTLY GodotMcpEnvFile's rules) and the
+ *    process environment, with precedence — highest wins — process env > .env > config file > defaults.
+ *  - Env/.env overrides are NEVER persisted back: the Unity OverrideRecord baseline-restore pattern is
+ *    carried over so Save() round-trips the on-disk baseline while the in-memory config keeps the override.
+ *  - Tokens are NEVER logged at any level (see MaskSecret); only their presence may surface.
+ *
+ * The effective connection config reaches the sidecar EXCLUSIVELY via the §1.3 `config` IPC message
+ * (and the handshake-ack), built by BuildEffectiveConnectionConfig() — the plugin resolves Cloud/Custom
+ * host, token and mode here; the sidecar never re-resolves it (§1.5).
+ *
+ * The parsing / precedence / persistence surface is pure (CoreMinimal + Json only, env/file readers are
+ * injectable) so it is fully drivable from the UnrealMcpEditorTests Automation specs with no real process
+ * env or files. All symbols are UNREALMCPEDITOR_API-exported so the Tests module links against them.
+ */
+class FUnrealMcpConfig
+{
+public:
+	// --- Recognized environment-variable names (§8). ---
+	static UNREALMCPEDITOR_API const TCHAR* EnvConnectionMode; // UNREAL_MCP_CONNECTION_MODE
+	static UNREALMCPEDITOR_API const TCHAR* EnvHost;           // UNREAL_MCP_HOST
+	static UNREALMCPEDITOR_API const TCHAR* EnvCloudUrl;       // UNREAL_MCP_CLOUD_URL
+	static UNREALMCPEDITOR_API const TCHAR* EnvToken;          // UNREAL_MCP_TOKEN
+	static UNREALMCPEDITOR_API const TCHAR* EnvAuthOption;     // UNREAL_MCP_AUTH_OPTION
+	static UNREALMCPEDITOR_API const TCHAR* EnvKeepConnected;  // UNREAL_MCP_KEEP_CONNECTED
+	static UNREALMCPEDITOR_API const TCHAR* EnvTools;          // UNREAL_MCP_TOOLS
+	static UNREALMCPEDITOR_API const TCHAR* EnvStartServer;    // UNREAL_MCP_START_SERVER
+	static UNREALMCPEDITOR_API const TCHAR* EnvTransport;      // UNREAL_MCP_TRANSPORT
+	static UNREALMCPEDITOR_API const TCHAR* EnvLogLevel;       // UNREAL_MCP_LOG_LEVEL
+	static UNREALMCPEDITOR_API const TCHAR* EnvBridgePath;     // UNREAL_MCP_BRIDGE_PATH (dev-only, §6)
+
+	// --- Defaults. ---
+	static UNREALMCPEDITOR_API const TCHAR* DefaultCloudBaseUrl; // https://ai-game.dev
+	static UNREALMCPEDITOR_API const TCHAR* DefaultCustomHost;   // http://localhost:8080
+	static UNREALMCPEDITOR_API const TCHAR* DefaultLogLevel;     // Info
+	static UNREALMCPEDITOR_API const TCHAR* DefaultTransport;    // http
+
+	// --- Live (post-override) backing fields, serialized to the camelCase JSON keys in the comments. ---
+	EUnrealMcpConnectionMode ConnectionMode = EUnrealMcpConnectionMode::Cloud; // "connectionMode"
+	FString CustomHost;        // "host"
+	FString CustomToken;       // "token"
+	FString CloudToken;        // "cloudToken"
+	FString CloudUrl;          // "cloudUrl"  (cloud base URL override)
+	EUnrealMcpAuthOption AuthOption = EUnrealMcpAuthOption::None; // "authOption"
+	bool bKeepConnected = true;                                  // "keepConnected"
+	FString LogLevel;          // "logLevel"
+	FString Transport;         // "transport"
+	bool bStartServer = false; // "startServer"
+	TArray<FString> EnabledTools; // "enabledTools" (UNREAL_MCP_TOOLS override; empty = no override)
+
+	UNREALMCPEDITOR_API FUnrealMcpConfig();
+
+	// --- Standard on-disk locations (production paths; resolved from the live project). ---
+	/** <Project>/Saved/Config/UnrealMcp/ai-game-developer-config.json (§8). */
+	static UNREALMCPEDITOR_API FString DefaultConfigFilePath();
+	/** <Project>/.env (§8). */
+	static UNREALMCPEDITOR_API FString DefaultEnvFilePath();
+
+	/**
+	 * Production convenience: load the on-disk config (if any), parse <Project>/.env, then apply env/.env
+	 * overrides with full precedence, and return the resolved config. Reads real process env + files.
+	 */
+	static UNREALMCPEDITOR_API FUnrealMcpConfig LoadAndResolve();
+
+	/**
+	 * Load the persisted config JSON at @p Path into the backing fields, and snapshot the result as the
+	 * disk baseline (used by Save() to round-trip env/.env overrides away). A missing/empty/corrupt file
+	 * is the common first-run case — fields keep their defaults and the baseline is the default snapshot.
+	 * Never throws.
+	 */
+	UNREALMCPEDITOR_API void LoadFromFile(const FString& Path);
+
+	/** Set the disk baseline directly from a parsed JSON object (or defaults when null). For tests. */
+	UNREALMCPEDITOR_API void LoadFromJson(const TSharedPtr<FJsonObject>& Json);
+
+	/**
+	 * Apply the .env values (lower precedence) then the process env (higher precedence) on top of the
+	 * current fields, recording which keys were overridden so Save() can restore the baseline. @p EnvReader
+	 * resolves a process-env var (returns false when unset); inject a stub in tests. @p DotEnv is the parsed
+	 * .env map (see ParseEnvLines / LoadEnvFile); pass an empty map to disable the file layer.
+	 */
+	UNREALMCPEDITOR_API void ApplyOverrides(const TMap<FString, FString>& DotEnv, const TFunction<bool(const FString&, FString&)>& EnvReader);
+
+	/** Serialize the CURRENT (post-override) field values to a camelCase JSON object. */
+	UNREALMCPEDITOR_API TSharedPtr<FJsonObject> ToJson() const;
+
+	/**
+	 * Serialize to @p Path, restoring the disk baseline for every env/.env-overridden key first so an
+	 * override is never persisted (Unity OverrideRecord pattern). The in-memory fields are unchanged.
+	 * Creates the parent directory. Returns false on a genuine write failure.
+	 */
+	UNREALMCPEDITOR_API bool Save(const FString& Path) const;
+
+	/**
+	 * Build the effective connection config the plugin pushes to the sidecar (§1.3 `config` / handshake-ack):
+	 * resolves mode → host/cloudUrl, and mode+auth → token. Keys: mode, host, cloudUrl, token, keepConnected.
+	 * The token is the resolved bearer (empty in Custom+None) — the sidecar sends it verbatim, never re-resolves.
+	 */
+	UNREALMCPEDITOR_API TSharedPtr<FJsonObject> BuildEffectiveConnectionConfig() const;
+
+	/** The resolved cloud base URL (CloudUrl override or DefaultCloudBaseUrl), trailing slash trimmed. */
+	UNREALMCPEDITOR_API FString ResolveCloudBaseUrl() const;
+	/** The resolved Custom-mode host (CustomHost or DefaultCustomHost), trailing slash trimmed. */
+	UNREALMCPEDITOR_API FString ResolveCustomHost() const;
+	/** The mode+auth-resolved bearer token: Cloud→CloudToken, Custom→(None?empty:CustomToken). */
+	UNREALMCPEDITOR_API FString ResolveEffectiveToken() const;
+
+	/** Whether ApplyOverrides recorded any env/.env override (for diagnostics/tests). */
+	bool HasOverrides() const { return OverriddenKeys.Num() > 0; }
+	bool IsOverridden(const FString& JsonKey) const { return OverriddenKeys.Contains(JsonKey); }
+
+	// --- Pure .env parsing (EXACTLY GodotMcpEnvFile's rules, §8). ---
+
+	/**
+	 * Parse .env-style lines into the recognized UNREAL_MCP_* values: skip blank lines and `#` comments,
+	 * split on the FIRST `=`, trim the key, keep only recognized keys (case-sensitive), sanitize the value
+	 * (trim whitespace + one pair of wrapping single OR double quotes), skip a blank value, last occurrence
+	 * wins. The returned map is keyed by the full UNREAL_MCP_* name.
+	 */
+	static UNREALMCPEDITOR_API TMap<FString, FString> ParseEnvLines(const TArray<FString>& Lines);
+
+	/** Read + parse the .env file at @p Path. A missing/unreadable file returns an empty map (never throws). */
+	static UNREALMCPEDITOR_API TMap<FString, FString> LoadEnvFile(const FString& Path);
+
+	/**
+	 * Export recognized .env values into the editor's process environment, but ONLY for keys not already set
+	 * in the process env (so the §8 precedence "process env > .env" is preserved). This is the bridge for the
+	 * env-consuming code OUTSIDE this config store: UNREAL_MCP_BRIDGE_PATH (FUnrealMcpSidecarManager resolves
+	 * the binary from it, §6) and the spawned sidecar child's HOST/CLOUD_URL/TOKEN env fallback — both of
+	 * which a GUI-launched editor would otherwise never see from a project-root .env. The connection config
+	 * the sidecar actually uses still flows via the §1.3 `config` message; this only feeds the binary-path /
+	 * child-inheritance paths.
+	 */
+	static UNREALMCPEDITOR_API void ExportDotEnvToProcessEnv(const TMap<FString, FString>& DotEnv);
+
+	/**
+	 * Mask a secret for logging: "<unset>" when empty, otherwise "***" (the value never appears). Use this
+	 * EVERYWHERE a token could otherwise reach a log line (§8 — tokens never logged at any level).
+	 */
+	static UNREALMCPEDITOR_API FString MaskSecret(const FString& Secret);
+
+	/** Sanitize a value identically to a process-env value: trim whitespace + one wrapping quote pair. */
+	static UNREALMCPEDITOR_API FString SanitizeValue(const FString& Raw);
+
+private:
+	// The disk-baseline JSON snapshot taken at LoadFromFile/LoadFromJson time — the values Save() persists
+	// for any key an env/.env layer overrode. Keys not overridden persist their live (current) value.
+	TSharedPtr<FJsonObject> DiskBaselineJson;
+	// JSON keys that an env/.env layer overrode (so Save() restores their baseline).
+	TSet<FString> OverriddenKeys;
+
+	// Apply a single resolved value (from .env or process env) onto the matching field, recording the
+	// override against its JSON key. @p Source is the effective override value (already sanitized).
+	void ApplyOne(const FString& EnvName, const FString& Source);
+
+	static bool TryParseMode(const FString& Raw, EUnrealMcpConnectionMode& OutMode);
+	static bool TryParseAuthOption(const FString& Raw, EUnrealMcpAuthOption& OutOption);
+	static bool TryParseBool(const FString& Raw, bool& OutValue);
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -5,6 +5,7 @@
 #include "UnrealMcpLog.h"
 #include "UnrealMcpCoreTools.h"
 #include "UnrealMcpToolRegistry.h"
+#include "Config/UnrealMcpConfig.h"
 #include "Dispatch/UnrealMcpGameThreadDispatcher.h"
 #include "Bridge/UnrealMcpBridgeServer.h"
 #include "Sidecar/UnrealMcpSidecarManager.h"
@@ -12,6 +13,7 @@
 #include "Misc/CoreDelegates.h"
 #include "Misc/Paths.h"
 #include "Misc/EngineVersion.h"
+#include "HAL/PlatformMisc.h"
 #include "Interfaces/IPluginManager.h"
 
 void FUnrealMcpRuntime::Startup()
@@ -33,11 +35,40 @@ void FUnrealMcpRuntime::Startup()
 	if (TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("UnrealMCP")))
 		PluginVersion = Plugin->GetDescriptor().VersionName;
 
+	// §8 connection config: parse the project-root .env, export recognized keys into the process env
+	// (only-if-absent, so process env still wins) so a GUI-launched editor's .env can feed the dev
+	// UNREAL_MCP_BRIDGE_PATH and the spawned sidecar's HOST/CLOUD_URL/TOKEN env fallback. Then load the
+	// persisted on-disk config and apply env/.env overrides with full precedence (process env > .env >
+	// file > defaults). The resolved EFFECTIVE connection config is handed to the bridge for the §1.3
+	// `config` push — the sidecar never re-resolves it (§1.5).
+	const TMap<FString, FString> DotEnv = FUnrealMcpConfig::LoadEnvFile(FUnrealMcpConfig::DefaultEnvFilePath());
+	FUnrealMcpConfig::ExportDotEnvToProcessEnv(DotEnv);
+
+	FUnrealMcpConfig Config;
+	Config.LoadFromFile(FUnrealMcpConfig::DefaultConfigFilePath());
+	Config.ApplyOverrides(DotEnv, [](const FString& Name, FString& Out) -> bool
+	{
+		const FString Value = FPlatformMisc::GetEnvironmentVariable(*Name);
+		if (Value.IsEmpty())
+			return false;
+		Out = Value;
+		return true;
+	});
+
+	const TSharedPtr<FJsonObject> EffectiveConfig = Config.BuildEffectiveConnectionConfig();
+	// Token is NEVER logged at any level (§8) — log the shape with the bearer masked.
+	UE_LOG(LogUnrealMcp, Log,
+		TEXT("[Unreal-MCP] connection config resolved (mode=%s, host=%s, cloudUrl=%s, token=%s, keepConnected=%s)."),
+		Config.ConnectionMode == EUnrealMcpConnectionMode::Cloud ? TEXT("Cloud") : TEXT("Custom"),
+		*Config.ResolveCustomHost(), *Config.ResolveCloudBaseUrl(),
+		*FUnrealMcpConfig::MaskSecret(Config.ResolveEffectiveToken()),
+		Config.bKeepConnected ? TEXT("true") : TEXT("false"));
+
 	// Generate the one-shot IPC token ONCE; both the server (validates the handshake) and the sidecar
 	// manager (delivers it over stdin) must agree on it (§1.4).
 	const FString Token = FUnrealMcpSidecarManager::GenerateToken();
 
-	const int32 BoundPort = BridgeServer->Start(Token, ProjectPath, PluginVersion, EngineVersion);
+	const int32 BoundPort = BridgeServer->Start(Token, ProjectPath, PluginVersion, EngineVersion, EffectiveConfig);
 	if (BoundPort <= 0)
 	{
 		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] bridge server failed to start; sidecar not launched."));

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -35,25 +35,16 @@ void FUnrealMcpRuntime::Startup()
 	if (TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("UnrealMCP")))
 		PluginVersion = Plugin->GetDescriptor().VersionName;
 
-	// §8 connection config: parse the project-root .env, export recognized keys into the process env
-	// (only-if-absent, so process env still wins) so a GUI-launched editor's .env can feed the dev
-	// UNREAL_MCP_BRIDGE_PATH and the spawned sidecar's HOST/CLOUD_URL/TOKEN env fallback. Then load the
-	// persisted on-disk config and apply env/.env overrides with full precedence (process env > .env >
-	// file > defaults). The resolved EFFECTIVE connection config is handed to the bridge for the §1.3
-	// `config` push — the sidecar never re-resolves it (§1.5).
+	// §8 connection config: parse the project-root .env once, export UNREAL_MCP_BRIDGE_PATH into the process
+	// env (only-if-absent, so process env still wins) so a GUI-launched editor's .env can feed the dev
+	// sidecar binary path. Then resolve the config (process env > .env > file > defaults) from that same
+	// parsed .env. The resolved EFFECTIVE connection config (incl. host/cloudUrl/token) is handed to the
+	// bridge for the §1.3 `config` push — the sidecar never re-resolves it (§1.5), so HOST/CLOUD_URL/TOKEN
+	// are deliberately NOT exported to the process env.
 	const TMap<FString, FString> DotEnv = FUnrealMcpConfig::LoadEnvFile(FUnrealMcpConfig::DefaultEnvFilePath());
 	FUnrealMcpConfig::ExportDotEnvToProcessEnv(DotEnv);
 
-	FUnrealMcpConfig Config;
-	Config.LoadFromFile(FUnrealMcpConfig::DefaultConfigFilePath());
-	Config.ApplyOverrides(DotEnv, [](const FString& Name, FString& Out) -> bool
-	{
-		const FString Value = FPlatformMisc::GetEnvironmentVariable(*Name);
-		if (Value.IsEmpty())
-			return false;
-		Out = Value;
-		return true;
-	});
+	const FUnrealMcpConfig Config = FUnrealMcpConfig::LoadAndResolve(DotEnv);
 
 	const TSharedPtr<FJsonObject> EffectiveConfig = Config.BuildEffectiveConnectionConfig();
 	// Token is NEVER logged at any level (§8) — log the shape with the bearer masked.

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -13,7 +13,6 @@
 #include "Misc/CoreDelegates.h"
 #include "Misc/Paths.h"
 #include "Misc/EngineVersion.h"
-#include "HAL/PlatformMisc.h"
 #include "Interfaces/IPluginManager.h"
 
 void FUnrealMcpRuntime::Startup()

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConfigSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConfigSpec.cpp
@@ -6,8 +6,26 @@
 #include "CoreMinimal.h"
 #include "Misc/AutomationTest.h"
 #include "Misc/Paths.h"
+#include "Misc/OutputDevice.h"
+#include "Misc/OutputDeviceRedirector.h"
 #include "HAL/FileManager.h"
 #include "Config/UnrealMcpConfig.h"
+#include "UnrealMcpLog.h"
+
+namespace
+{
+	// Captures everything routed through GLog while installed, so a test can assert what reached the log.
+	class FUnrealMcpLogCapture : public FOutputDevice
+	{
+	public:
+		FString Captured;
+		virtual void Serialize(const TCHAR* Message, ELogVerbosity::Type, const FName&) override
+		{
+			Captured += Message;
+			Captured += TEXT("\n");
+		}
+	};
+}
 
 /**
  * Config store specs (docs/ARCHITECTURE.md §8): the .env parser rules, the process-env > .env > file >
@@ -234,6 +252,33 @@ void FUnrealMcpConfigSpec::Define()
 			TestNotEqual(TEXT("masked != raw"), Masked, Secret);
 			TestFalse(TEXT("masked does not contain the secret"), Masked.Contains(Secret));
 			TestEqual(TEXT("unset marker"), FUnrealMcpConfig::MaskSecret(TEXT("")), FString(TEXT("<unset>")));
+		});
+
+		It("a representative resolved-config log line never emits the raw token", [this]()
+		{
+			const FString RawToken = TEXT("super-secret-bearer-value");
+
+			// Resolve a Cloud-mode config so ResolveEffectiveToken() returns the raw bearer.
+			FUnrealMcpConfig Config;
+			Config.ApplyOverrides({}, MakeEnvReader({
+				{ TEXT("UNREAL_MCP_CONNECTION_MODE"), TEXT("Cloud") },
+				{ TEXT("UNREAL_MCP_TOKEN"), RawToken },
+			}));
+			TestEqual(TEXT("token resolved for the test"), Config.ResolveEffectiveToken(), RawToken);
+
+			// Emit the SAME masked-config log shape the runtime uses, captured through GLog.
+			FUnrealMcpLogCapture Capture;
+			GLog->AddOutputDevice(&Capture);
+			UE_LOG(LogUnrealMcp, Log,
+				TEXT("[Unreal-MCP] connection config resolved (mode=%s, host=%s, cloudUrl=%s, token=%s, keepConnected=%s)."),
+				TEXT("Cloud"), *Config.ResolveCustomHost(), *Config.ResolveCloudBaseUrl(),
+				*FUnrealMcpConfig::MaskSecret(Config.ResolveEffectiveToken()),
+				Config.bKeepConnected ? TEXT("true") : TEXT("false"));
+			GLog->Flush();
+			GLog->RemoveOutputDevice(&Capture);
+
+			TestTrue(TEXT("masked marker reached the log"), Capture.Captured.Contains(TEXT("***")));
+			TestFalse(TEXT("raw token never reached the log"), Capture.Captured.Contains(RawToken));
 		});
 	});
 }

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConfigSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConfigSpec.cpp
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/Paths.h"
+#include "HAL/FileManager.h"
+#include "Config/UnrealMcpConfig.h"
+
+/**
+ * Config store specs (docs/ARCHITECTURE.md §8): the .env parser rules, the process-env > .env > file >
+ * default precedence matrix, the OverrideRecord baseline-restore on Save(), the token-never-logged guard,
+ * and the effective connection-config routing the plugin pushes to the sidecar (§1.3).
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpConfigSpec, "UnrealMcp.Config",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	// An injectable process-env reader backed by an in-memory map (no real process env touched).
+	static TFunction<bool(const FString&, FString&)> MakeEnvReader(const TMap<FString, FString>& Env)
+	{
+		return [Env](const FString& Name, FString& Out) -> bool
+		{
+			if (const FString* Value = Env.Find(Name))
+			{
+				Out = *Value;
+				return true;
+			}
+			return false;
+		};
+	}
+
+	// A config seeded from a JSON disk baseline (the "file" precedence layer).
+	static FUnrealMcpConfig FromDiskJson(const TSharedPtr<FJsonObject>& Json)
+	{
+		FUnrealMcpConfig Config;
+		Config.LoadFromJson(Json);
+		return Config;
+	}
+
+END_DEFINE_SPEC(FUnrealMcpConfigSpec)
+
+void FUnrealMcpConfigSpec::Define()
+{
+	Describe(".env parsing", [this]()
+	{
+		It("keeps only recognized keys, skips blanks/comments, splits on first '=', last wins, strips quotes", [this]()
+		{
+			TArray<FString> Lines = {
+				TEXT(""),
+				TEXT("   "),
+				TEXT("# a comment"),
+				TEXT("   # indented comment"),
+				TEXT("UNKNOWN_KEY=ignored"),
+				TEXT("no_equals_here"),
+				TEXT("=leading-equals-skipped"),
+				TEXT("UNREAL_MCP_HOST=http://first:1"),
+				TEXT("UNREAL_MCP_HOST=http://second:2"),       // last wins
+				TEXT("UNREAL_MCP_TOKEN=\"quoted-token\""),       // double quotes stripped
+				TEXT("UNREAL_MCP_CLOUD_URL='https://cloud'"),    // single quotes stripped
+				TEXT("UNREAL_MCP_AUTH_OPTION = Required "),      // surrounding whitespace trimmed
+				TEXT("UNREAL_MCP_HOST_WITH_VALUE=x=y=z"),        // unknown key with multiple '='
+			};
+
+			const TMap<FString, FString> Parsed = FUnrealMcpConfig::ParseEnvLines(Lines);
+
+			TestEqual(TEXT("recognized key count"), Parsed.Num(), 4);
+			TestEqual(TEXT("host last-wins"), Parsed.FindRef(FUnrealMcpConfig::EnvHost), FString(TEXT("http://second:2")));
+			TestEqual(TEXT("token unquoted"), Parsed.FindRef(FUnrealMcpConfig::EnvToken), FString(TEXT("quoted-token")));
+			TestEqual(TEXT("cloud url unquoted"), Parsed.FindRef(FUnrealMcpConfig::EnvCloudUrl), FString(TEXT("https://cloud")));
+			TestEqual(TEXT("auth option trimmed"), Parsed.FindRef(FUnrealMcpConfig::EnvAuthOption), FString(TEXT("Required")));
+			TestFalse(TEXT("unknown key dropped"), Parsed.Contains(TEXT("UNKNOWN_KEY")));
+		});
+
+		It("preserves a value containing '=' after the first split", [this]()
+		{
+			const TMap<FString, FString> Parsed = FUnrealMcpConfig::ParseEnvLines({ TEXT("UNREAL_MCP_TOKEN=a=b=c") });
+			TestEqual(TEXT("value keeps later '='"), Parsed.FindRef(FUnrealMcpConfig::EnvToken), FString(TEXT("a=b=c")));
+		});
+	});
+
+	Describe("precedence (process env > .env > file > default)", [this]()
+	{
+		It("uses the built-in default when nothing else is set", [this]()
+		{
+			FUnrealMcpConfig Config; // fresh, no disk, no overrides
+			TestEqual(TEXT("default custom host"), Config.ResolveCustomHost(), FString(FUnrealMcpConfig::DefaultCustomHost));
+			TestEqual(TEXT("default cloud base"), Config.ResolveCloudBaseUrl(), FString(FUnrealMcpConfig::DefaultCloudBaseUrl));
+		});
+
+		It("file value beats the default", [this]()
+		{
+			TSharedPtr<FJsonObject> Disk = MakeShared<FJsonObject>();
+			Disk->SetStringField(TEXT("host"), TEXT("http://file-host:10"));
+			FUnrealMcpConfig Config = FromDiskJson(Disk);
+			Config.ApplyOverrides({}, MakeEnvReader({}));
+			TestEqual(TEXT("file host"), Config.CustomHost, FString(TEXT("http://file-host:10")));
+		});
+
+		It(".env value beats the file value", [this]()
+		{
+			TSharedPtr<FJsonObject> Disk = MakeShared<FJsonObject>();
+			Disk->SetStringField(TEXT("host"), TEXT("http://file-host:10"));
+			FUnrealMcpConfig Config = FromDiskJson(Disk);
+
+			TMap<FString, FString> DotEnv;
+			DotEnv.Add(FUnrealMcpConfig::EnvHost, TEXT("http://dotenv-host:20"));
+			Config.ApplyOverrides(DotEnv, MakeEnvReader({}));
+
+			TestEqual(TEXT("dotenv host"), Config.CustomHost, FString(TEXT("http://dotenv-host:20")));
+			TestTrue(TEXT("host overridden"), Config.IsOverridden(TEXT("host")));
+		});
+
+		It("process env beats the .env value", [this]()
+		{
+			TSharedPtr<FJsonObject> Disk = MakeShared<FJsonObject>();
+			Disk->SetStringField(TEXT("host"), TEXT("http://file-host:10"));
+			FUnrealMcpConfig Config = FromDiskJson(Disk);
+
+			TMap<FString, FString> DotEnv;
+			DotEnv.Add(FUnrealMcpConfig::EnvHost, TEXT("http://dotenv-host:20"));
+
+			TMap<FString, FString> ProcEnv;
+			ProcEnv.Add(FUnrealMcpConfig::EnvHost, TEXT("http://proc-host:30"));
+
+			Config.ApplyOverrides(DotEnv, MakeEnvReader(ProcEnv));
+			TestEqual(TEXT("process env host wins"), Config.CustomHost, FString(TEXT("http://proc-host:30")));
+		});
+	});
+
+	Describe("token routing + effective config", [this]()
+	{
+		It("Custom + None sends no bearer; Custom + Required sends the custom token", [this]()
+		{
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+
+			TMap<FString, FString> ProcEnv;
+			ProcEnv.Add(FUnrealMcpConfig::EnvConnectionMode, TEXT("Custom"));
+			ProcEnv.Add(FUnrealMcpConfig::EnvToken, TEXT("the-custom-token"));
+			Config.ApplyOverrides({}, MakeEnvReader(ProcEnv));
+
+			// Auth defaults to None → no bearer on the wire even though a token is stored.
+			TestEqual(TEXT("custom token stored"), Config.CustomToken, FString(TEXT("the-custom-token")));
+			TestTrue(TEXT("effective token empty under None"), Config.ResolveEffectiveToken().IsEmpty());
+
+			Config.AuthOption = EUnrealMcpAuthOption::Required;
+			TestEqual(TEXT("effective token under Required"), Config.ResolveEffectiveToken(), FString(TEXT("the-custom-token")));
+		});
+
+		It("routes the token to the cloud field in Cloud mode", [this]()
+		{
+			FUnrealMcpConfig Config;
+			TMap<FString, FString> ProcEnv;
+			ProcEnv.Add(FUnrealMcpConfig::EnvConnectionMode, TEXT("Cloud"));
+			ProcEnv.Add(FUnrealMcpConfig::EnvToken, TEXT("the-cloud-token"));
+			Config.ApplyOverrides({}, MakeEnvReader(ProcEnv));
+
+			TestEqual(TEXT("cloud token stored"), Config.CloudToken, FString(TEXT("the-cloud-token")));
+			TestTrue(TEXT("custom token untouched"), Config.CustomToken.IsEmpty());
+			TestEqual(TEXT("effective token = cloud token"), Config.ResolveEffectiveToken(), FString(TEXT("the-cloud-token")));
+		});
+
+		It("builds the effective connection config for the §1.3 config message (mode-aware)", [this]()
+		{
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.CustomHost = TEXT("http://localhost:5200/");
+
+			const TSharedPtr<FJsonObject> Eff = Config.BuildEffectiveConnectionConfig();
+			TestEqual(TEXT("mode"), Eff->GetStringField(TEXT("mode")), FString(TEXT("Custom")));
+			TestEqual(TEXT("host trailing slash trimmed"), Eff->GetStringField(TEXT("host")), FString(TEXT("http://localhost:5200")));
+			TestTrue(TEXT("token empty (Custom+None)"), Eff->GetStringField(TEXT("token")).IsEmpty());
+			TestTrue(TEXT("keepConnected true by default"), Eff->GetBoolField(TEXT("keepConnected")));
+		});
+	});
+
+	Describe("Save() baseline-restore (env/.env never persisted)", [this]()
+	{
+		It("round-trips the disk baseline while the in-memory config keeps the override", [this]()
+		{
+			const FString Path = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("UnrealMcpConfigSpec"), TEXT("config.json"));
+			IFileManager::Get().Delete(*Path, false, true, true);
+
+			// Disk baseline: Custom host = file-host.
+			TSharedPtr<FJsonObject> Disk = MakeShared<FJsonObject>();
+			Disk->SetStringField(TEXT("connectionMode"), TEXT("Custom"));
+			Disk->SetStringField(TEXT("host"), TEXT("http://file-host:10"));
+			FUnrealMcpConfig Config = FromDiskJson(Disk);
+
+			// Override host via the process env.
+			TMap<FString, FString> ProcEnv;
+			ProcEnv.Add(FUnrealMcpConfig::EnvHost, TEXT("http://env-host:99"));
+			Config.ApplyOverrides({}, MakeEnvReader(ProcEnv));
+			TestEqual(TEXT("in-memory host is the override"), Config.CustomHost, FString(TEXT("http://env-host:99")));
+
+			TestTrue(TEXT("save ok"), Config.Save(Path));
+
+			// Reload from disk: the persisted host must be the BASELINE, not the env override.
+			FUnrealMcpConfig Reloaded;
+			Reloaded.LoadFromFile(Path);
+			TestEqual(TEXT("persisted host is the baseline"), Reloaded.CustomHost, FString(TEXT("http://file-host:10")));
+
+			// And the in-memory override is untouched by Save().
+			TestEqual(TEXT("in-memory host still the override after save"), Config.CustomHost, FString(TEXT("http://env-host:99")));
+
+			IFileManager::Get().Delete(*Path, false, true, true);
+		});
+
+		It("persists a non-overridden field normally", [this]()
+		{
+			const FString Path = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("UnrealMcpConfigSpec"), TEXT("config2.json"));
+			IFileManager::Get().Delete(*Path, false, true, true);
+
+			FUnrealMcpConfig Config;
+			Config.CustomHost = TEXT("http://user-edited:7");   // a user edit, not an env override
+			TestTrue(TEXT("save ok"), Config.Save(Path));
+
+			FUnrealMcpConfig Reloaded;
+			Reloaded.LoadFromFile(Path);
+			TestEqual(TEXT("user edit persists"), Reloaded.CustomHost, FString(TEXT("http://user-edited:7")));
+
+			IFileManager::Get().Delete(*Path, false, true, true);
+		});
+	});
+
+	Describe("token never logged (§8)", [this]()
+	{
+		It("MaskSecret never reveals the token value", [this]()
+		{
+			const FString Secret = TEXT("super-secret-bearer-value");
+			const FString Masked = FUnrealMcpConfig::MaskSecret(Secret);
+			TestNotEqual(TEXT("masked != raw"), Masked, Secret);
+			TestFalse(TEXT("masked does not contain the secret"), Masked.Contains(Secret));
+			TestEqual(TEXT("unset marker"), FUnrealMcpConfig::MaskSecret(TEXT("")), FString(TEXT("<unset>")));
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -158,10 +158,15 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             if (config == null)
                 return;
 
-            var mode = config["mode"]?.GetValue<string>();
-            var host = config["host"]?.GetValue<string>();
-            var cloudUrl = config["cloudUrl"]?.GetValue<string>();
-            var token = config["token"]?.GetValue<string>();
+            // Read each field defensively: a non-string JSON node (e.g. a number/bool from a malformed
+            // message) must not throw out of Dispatch and tear down the read loop — treat it as absent.
+            static string? ReadString(JsonObject config, string key) =>
+                config[key] is JsonValue v && v.TryGetValue<string>(out var s) ? s : null;
+
+            var mode = ReadString(config, "mode");
+            var host = ReadString(config, "host");
+            var cloudUrl = ReadString(config, "cloudUrl");
+            var token = ReadString(config, "token");
 
             // Mode-aware host selection: Cloud connects to cloudUrl, Custom to host (§8). Fall back to the
             // other field only when the mode's own field is blank, so a partial message still resolves a host.

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Threading;
+using System.Text.Json.Nodes;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.ReflectorNet;
@@ -112,21 +113,17 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             // Wire the registrar BEFORE the IPC loop can deliver a manifest.
             _ipc.Registrar = _registrar;
             _ipc.HandshakeAccepted += OnHandshakeAccepted;
+            _ipc.ConfigReceived += OnConfigReceived;
+            _ipc.AuthMessageReceived += HandleAuthMessage;
 
             _logger?.LogInformation("Sidecar host built (version {Version}); awaiting IPC handshake.", _sidecarVersion);
         }
 
         private void OnHandshakeAccepted(HandshakeAckMessage ack)
         {
-            // Apply the effective connection config the plugin sent in the handshake-ack (§1.5). The plugin
-            // resolves Cloud/Custom host, token and mode (§8) and hands the sidecar the result; the sidecar
-            // never re-resolves it. Falls back to the values seeded in Build() when a field is absent.
-            var host = ack.Config?["host"]?.GetValue<string>();
-            var token = ack.Config?["token"]?.GetValue<string>();
-            if (!string.IsNullOrWhiteSpace(host))
-                _config.Host = host!;
-            if (token != null)
-                _config.Token = string.IsNullOrEmpty(token) ? null : token;
+            // Apply the effective connection config the plugin sent in the handshake-ack (§1.5, §8) — the
+            // mode-aware host/token/keepConnected selection lives in ApplyConnectionConfig.
+            ApplyConnectionConfig(ack.Config);
 
             _logger?.LogInformation("Handshake accepted (plugin {PluginVersion}, engine {Engine}); connecting SignalR to {Host}.",
                 ack.PluginVersion, ack.EngineVersion, _config.Host);
@@ -138,6 +135,74 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 _ = ConnectSignalRAsync();
             else
                 _logger?.LogDebug("Handshake re-accepted; SignalR connect already initiated (KeepConnected handles reconnection).");
+        }
+
+        private void OnConfigReceived(JsonObject config)
+        {
+            // §8 "on change": the plugin re-pushed the effective connection config. Apply it. A live mode/host
+            // change that requires re-dialling SignalR is deferred to the UI task — for now KeepConnected
+            // covers transient reconnects and the next reconnect epoch picks up the applied values.
+            ApplyConnectionConfig(config);
+            _logger?.LogInformation("Applied updated connection config (mode-aware host {Host}).", _config.Host);
+        }
+
+        /// <summary>
+        /// Apply the plugin-resolved effective connection config (§1.3 / §8) onto <see cref="Config"/> with
+        /// mode-aware routing: <c>Cloud</c> → <c>cloudUrl</c>, <c>Custom</c> → <c>host</c>; the token and
+        /// <c>keepConnected</c> are taken verbatim (the plugin already resolved them — the sidecar never
+        /// re-resolves §8). Absent/blank fields leave the existing value (e.g. the Build()-time env fallback)
+        /// intact. Public so the bridge xUnit suite can assert the routing without a live plugin.
+        /// </summary>
+        public void ApplyConnectionConfig(JsonObject? config)
+        {
+            if (config == null)
+                return;
+
+            var mode = config["mode"]?.GetValue<string>();
+            var host = config["host"]?.GetValue<string>();
+            var cloudUrl = config["cloudUrl"]?.GetValue<string>();
+            var token = config["token"]?.GetValue<string>();
+
+            // Mode-aware host selection: Cloud connects to cloudUrl, Custom to host (§8). Fall back to the
+            // other field only when the mode's own field is blank, so a partial message still resolves a host.
+            var isCloud = string.Equals(mode, "Cloud", StringComparison.OrdinalIgnoreCase);
+            var selected = isCloud ? cloudUrl : host;
+            if (string.IsNullOrWhiteSpace(selected))
+                selected = isCloud ? host : cloudUrl;
+            if (!string.IsNullOrWhiteSpace(selected))
+                _config.Host = selected!;
+
+            // Token: the plugin already applied mode+auth resolution (empty in Custom+None). An absent key
+            // leaves the existing token; an explicit empty value clears it (anonymous connection).
+            if (token != null)
+                _config.Token = string.IsNullOrEmpty(token) ? null : token;
+
+            if (config["keepConnected"] is JsonValue keepNode && keepNode.TryGetValue<bool>(out var keepConnected))
+                _config.KeepConnected = keepConnected;
+        }
+
+        /// <summary>
+        /// Handle a §1.3 auth message (<c>auth-start</c> / <c>auth-cancel</c> / <c>auth-revoke</c>) as a
+        /// graceful stub pending the full device-code UI flow (§8). <c>auth-revoke</c> clears the stored
+        /// cloud bearer. Public so the bridge xUnit suite can assert the stub behavior directly.
+        /// </summary>
+        public void HandleAuthMessage(string type)
+        {
+            // §8 auth plumbing — graceful stubs until the device-code UI flow lands.
+            switch (type)
+            {
+                case IpcProtocol.Type.AuthRevoke:
+                    // Clear the stored cloud bearer so a subsequent (re)connect is anonymous until re-authorized.
+                    _config.Token = null;
+                    _logger?.LogInformation("Cloud token revoked (auth-revoke); cleared the in-memory bearer.");
+                    break;
+                case IpcProtocol.Type.AuthStart:
+                    _logger?.LogInformation("auth-start received; the device-code flow is not implemented in the sidecar-bridge MVP (pending the UI task).");
+                    break;
+                case IpcProtocol.Type.AuthCancel:
+                    _logger?.LogInformation("auth-cancel received; no in-progress device-code flow to cancel (pending the UI task).");
+                    break;
+            }
         }
 
         private async System.Threading.Tasks.Task ConnectSignalRAsync()
@@ -159,6 +224,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         public void Dispose()
         {
             _ipc.HandshakeAccepted -= OnHandshakeAccepted;
+            _ipc.ConfigReceived -= OnConfigReceived;
+            _ipc.AuthMessageReceived -= HandleAuthMessage;
             try { _plugin?.Dispose(); } catch { /* ignore */ }
             _plugin = null;
         }

--- a/bridge/src/Ipc/IpcClient.cs
+++ b/bridge/src/Ipc/IpcClient.cs
@@ -61,6 +61,20 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         /// <summary>Raised when the plugin sends <c>shutdown</c> (editor quitting, §1.5).</summary>
         public event Action? ShutdownRequested;
 
+        /// <summary>
+        /// Raised when the plugin pushes a §1.3 <c>config</c> message (effective connection config changed,
+        /// §8). The argument is the parsed message object (flat: <c>mode</c>/<c>host</c>/<c>cloudUrl</c>/
+        /// <c>token</c>/<c>keepConnected</c> at the top level).
+        /// </summary>
+        public event Action<JsonObject>? ConfigReceived;
+
+        /// <summary>
+        /// Raised when the plugin pushes a §1.3 auth message (<c>auth-start</c> / <c>auth-cancel</c> /
+        /// <c>auth-revoke</c>). The argument is the message <c>type</c>. The full device-code flow lands with
+        /// the UI task; the sidecar handles these gracefully as stubs today (§8).
+        /// </summary>
+        public event Action<string>? AuthMessageReceived;
+
         public IpcClient(string host, int port, string token, string sidecarVersion, ILogger? logger = null)
         {
             _host = host;
@@ -245,12 +259,22 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
                     ShutdownRequested?.Invoke();
                     break;
                 case IpcProtocol.Type.Config:
-                case IpcProtocol.Type.Status:
-                case IpcProtocol.Type.Log:
+                {
+                    // §8: the plugin pushed the effective connection config. Hand the flat object to the host,
+                    // which applies mode-aware host/token/keepConnected. Never log the token (§8).
+                    if (node is JsonObject configObj)
+                        ConfigReceived?.Invoke(configObj);
+                    break;
+                }
                 case IpcProtocol.Type.AuthStart:
                 case IpcProtocol.Type.AuthCancel:
                 case IpcProtocol.Type.AuthRevoke:
-                    // Wired in later UI/config/auth tasks; logged for now.
+                    // §8 auth plumbing — handled gracefully as stubs pending the full device-code UI flow.
+                    AuthMessageReceived?.Invoke(type);
+                    break;
+                case IpcProtocol.Type.Status:
+                case IpcProtocol.Type.Log:
+                    // Wired in the later UI task; logged for now.
                     _logger?.LogDebug("IPC received '{Type}' (not handled in the sidecar-bridge MVP).", type);
                     break;
                 default:

--- a/bridge/tests/ConnectionConfigTests.cs
+++ b/bridge/tests/ConnectionConfigTests.cs
@@ -1,0 +1,137 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Text.Json.Nodes;
+using com.IvanMurzak.Unreal.MCP.Bridge.Host;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>
+    /// Proves the sidecar's consumption of the §1.3 <c>config</c> / handshake-ack effective connection
+    /// config (docs/ARCHITECTURE.md §8): mode-aware host routing (Cloud→cloudUrl, Custom→host), token
+    /// application, keepConnected, the env-fallback dev override, and the auth-message stubs. All without
+    /// a live socket — <see cref="SidecarHost.ApplyConnectionConfig"/> / <see cref="SidecarHost.HandleAuthMessage"/>
+    /// are the testable seams the IPC events route through.
+    /// </summary>
+    public class ConnectionConfigTests
+    {
+        private static SidecarHost BuildHost(string? fallbackHost = null, string? fallbackToken = null)
+        {
+            var ipc = new IpcClient("127.0.0.1", 39998, token: "test-token", sidecarVersion: "0.1.0");
+            var host = new SidecarHost(ipc, "0.1.0", fallbackHost: fallbackHost, fallbackToken: fallbackToken);
+            host.Build();
+            return host;
+        }
+
+        private static JsonObject Config(string mode, string? host, string? cloudUrl, string? token, bool? keepConnected = null)
+        {
+            var obj = new JsonObject { ["mode"] = mode };
+            if (host != null) obj["host"] = host;
+            if (cloudUrl != null) obj["cloudUrl"] = cloudUrl;
+            if (token != null) obj["token"] = token;
+            if (keepConnected.HasValue) obj["keepConnected"] = keepConnected.Value;
+            return obj;
+        }
+
+        [Fact]
+        public void CloudMode_RoutesToCloudUrlWithToken()
+        {
+            using var host = BuildHost();
+            host.ApplyConnectionConfig(Config("Cloud", host: "http://localhost:5200", cloudUrl: "https://ai-game.dev", token: "cloud-bearer"));
+
+            Assert.Equal("https://ai-game.dev", host.Config.Host);
+            Assert.Equal("cloud-bearer", host.Config.Token);
+        }
+
+        [Fact]
+        public void CustomMode_RoutesToHostWithToken()
+        {
+            using var host = BuildHost();
+            host.ApplyConnectionConfig(Config("Custom", host: "http://localhost:5200", cloudUrl: "https://ai-game.dev", token: "custom-bearer"));
+
+            Assert.Equal("http://localhost:5200", host.Config.Host);
+            Assert.Equal("custom-bearer", host.Config.Token);
+        }
+
+        [Fact]
+        public void CustomMode_EmptyToken_ClearsBearer()
+        {
+            using var host = BuildHost(fallbackToken: "stale");
+            host.ApplyConnectionConfig(Config("Custom", host: "http://localhost:5200", cloudUrl: null, token: ""));
+
+            Assert.Equal("http://localhost:5200", host.Config.Host);
+            Assert.Null(host.Config.Token); // Custom+None sends no bearer (plugin resolved token to empty)
+        }
+
+        [Fact]
+        public void AbsentFields_PreserveEnvFallback()
+        {
+            // §8: env-fallback stays as the dev override; a config message that omits a field never clobbers it.
+            using var host = BuildHost(fallbackHost: "http://localhost:5170", fallbackToken: "env-token");
+            host.ApplyConnectionConfig(new JsonObject { ["mode"] = "Custom" }); // no host/cloudUrl/token
+
+            Assert.Equal("http://localhost:5170", host.Config.Host);
+            Assert.Equal("env-token", host.Config.Token);
+        }
+
+        [Fact]
+        public void KeepConnected_IsApplied()
+        {
+            using var host = BuildHost();
+            host.ApplyConnectionConfig(Config("Custom", host: "http://localhost:5200", cloudUrl: null, token: null, keepConnected: false));
+
+            Assert.False(host.Config.KeepConnected);
+        }
+
+        [Fact]
+        public void NullConfig_IsNoOp()
+        {
+            using var host = BuildHost(fallbackHost: "http://localhost:5170");
+            host.ApplyConnectionConfig(null);
+
+            Assert.Equal("http://localhost:5170", host.Config.Host);
+        }
+
+        [Fact]
+        public void CloudMode_MissingCloudUrl_FallsBackToHostField()
+        {
+            // A partial config (mode=Cloud but only `host` present) still resolves a host rather than blanking it.
+            using var host = BuildHost();
+            host.ApplyConnectionConfig(new JsonObject { ["mode"] = "Cloud", ["host"] = "http://localhost:5200" });
+
+            Assert.Equal("http://localhost:5200", host.Config.Host);
+        }
+
+        [Fact]
+        public void AuthRevoke_ClearsStoredToken()
+        {
+            using var host = BuildHost();
+            host.ApplyConnectionConfig(Config("Cloud", host: null, cloudUrl: "https://ai-game.dev", token: "cloud-bearer"));
+            Assert.Equal("cloud-bearer", host.Config.Token);
+
+            host.HandleAuthMessage(IpcProtocol.Type.AuthRevoke);
+            Assert.Null(host.Config.Token);
+        }
+
+        [Theory]
+        [InlineData(IpcProtocol.Type.AuthStart)]
+        [InlineData(IpcProtocol.Type.AuthCancel)]
+        public void AuthStartAndCancel_AreGracefulNoOps(string type)
+        {
+            using var host = BuildHost();
+            host.ApplyConnectionConfig(Config("Custom", host: "http://localhost:5200", cloudUrl: null, token: "keep"));
+
+            host.HandleAuthMessage(type); // must not throw and must not touch the bearer
+            Assert.Equal("keep", host.Config.Token);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **C++ config store** (`FUnrealMcpConfig`): persisted at `<Project>/Saved/Config/UnrealMcp/ai-game-developer-config.json` (camelCase JSON), with a project-root `.env` loader (exactly `GodotMcpEnvFile`'s rules), precedence **process-env > .env > config file > defaults**, and a Unity `OverrideRecord` baseline-restore so `Save()` never persists env/`.env` overrides. Tokens are never logged at any level (`MaskSecret`).
- **Config pushed to the sidecar** via the §1.3 `config` IPC message on `Ready` (+ `handshake-ack`), with an `on-change` path (`SetEffectiveConfig`/`PushConfig`). `SidecarHost` consumes `mode`/`host`/`cloudUrl`/`token`/`keepConnected` with **mode-aware routing** (Cloud→`cloudUrl`, Custom→`host`); env stays a working dev override. `auth-start`/`auth-cancel`/`auth-revoke` are handled as graceful stubs (revoke clears the cloud bearer) pending the UI task.
- A `.env` can also feed `UNREAL_MCP_BRIDGE_PATH` and the sidecar's host/token fallback via `ExportDotEnvToProcessEnv` (only-if-absent, preserving process-env precedence).
- Additive — no version bumps.

## Test plan
- [x] UE Automation `UnrealMcp.` specs: **30 succeeded / 0 failed** (12 new `UnrealMcp.Config` specs — `.env` parsing, precedence matrix, baseline-restore on `Save()`, token-never-logged, effective-config routing).
- [x] Bridge xUnit: **69 / 0** (10 new — config consumption, mode-aware bearer routing, env fallback, auth-revoke).
- [x] UBT compile (exit 0) + headless boot smoke (`[Unreal-MCP] plugin loaded`).
- [x] **Live verify**: zero process env + a Custom-mode project `.env` (`host=http://localhost:5216`) drove editor boot → bridge spawn → handshake → SignalR connect to a local MCP server → `ping`/`pong` (and `{"message":...}` echo); editor kill → bridge self-exited (no orphan).

Closes #6