### PR TITLE
feat(tools): implement actor & component tool family (native C++)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpActorTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpActorTools.cpp
@@ -75,8 +75,13 @@ namespace
 
 	// --- Small argument helpers ---
 
-	/** Read a string array argument (the scoped-read `paths` filter); empty when absent or not an array. */
-	TArray<FString> GetStringArray(const FUnrealMcpToolCall& Call, const FString& Key)
+	/**
+	 * Read a string array argument (the scoped-read `paths` filter); empty when absent or not an array.
+	 * A non-string entry is reported via OutError (and the array is left empty) rather than silently
+	 * dropped — a dropped entry would otherwise flip the scoped read to "identity only" / "full object"
+	 * (the opposite extremes of the requested scope) with no signal to the caller.
+	 */
+	TArray<FString> GetStringArray(const FUnrealMcpToolCall& Call, const FString& Key, FString& OutError)
 	{
 		TArray<FString> Out;
 		const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
@@ -86,7 +91,15 @@ namespace
 			{
 				FString S;
 				if (V.IsValid() && V->TryGetString(S))
+				{
 					Out.Add(S);
+				}
+				else
+				{
+					OutError = FString::Printf(TEXT("'%s' must be an array of strings; a non-string entry was provided."), *Key);
+					Out.Reset();
+					return Out;
+				}
 			}
 		}
 		return Out;
@@ -207,11 +220,23 @@ namespace UnrealMcpActorTools
 						FActorLabelUtilities::SetActorLabelUnique(Actor, Label);
 				}
 
+				FString AttachNote;
 				if (Parent)
+				{
 					Actor->AttachToActor(Parent, FAttachmentTransformRules::KeepWorldTransform);
+					// AttachToActor returns void and silently no-ops when the freshly spawned actor has no root
+					// component (e.g. a rootless class), so the parentActor request would otherwise be dropped
+					// while we report plain success. Verify it took (the same GetAttachParentActor() check
+					// actor-set-parent uses); since the spawn itself succeeded, surface a warning in the message
+					// rather than failing the whole call and leaking the spawned actor.
+					if (Actor->GetAttachParentActor() != Parent)
+						AttachNote = FString::Printf(
+							TEXT(" (warning: could not attach to parent '%s' — the spawned actor has no root component)"),
+							*Parent->GetActorLabel());
+				}
 
 				return FUnrealMcpToolResult::Success(
-					FString::Printf(TEXT("Spawned %s '%s'."), *Class->GetName(), *Actor->GetActorLabel()),
+					FString::Printf(TEXT("Spawned %s '%s'.%s"), *Class->GetName(), *Actor->GetActorLabel(), *AttachNote),
 					FUnrealMcpObjectRef::ActorIdentity(Actor));
 			});
 
@@ -234,10 +259,13 @@ namespace UnrealMcpActorTools
 				if (!World)
 					return FUnrealMcpToolResult::Error(TEXT("Actor has no world."));
 
-				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorDestroy", "MCP: Destroy Actor"));
+				FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorDestroy", "MCP: Destroy Actor"));
 				const FString Label = Actor->GetActorLabel();
 				if (!World->EditorDestroyActor(Actor, /*bShouldModifyLevel*/ true))
+				{
+					Transaction.Cancel(); // do not leave a dangling no-op entry on the undo stack
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to destroy actor '%s'."), *Label));
+				}
 				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Destroyed actor '%s'."), *Label));
 			});
 
@@ -307,7 +335,10 @@ namespace UnrealMcpActorTools
 				const FString LabelFilter = Call.GetString(TEXT("labelFilter"));
 				const FString PathFilter = Call.GetString(TEXT("pathFilter"));
 				const FString ClassFilter = Call.GetString(TEXT("classFilter"));
-				const TArray<FString> Paths = GetStringArray(Call, TEXT("paths"));
+				FString PathsError;
+				const TArray<FString> Paths = GetStringArray(Call, TEXT("paths"), PathsError);
+				if (!PathsError.IsEmpty())
+					return FUnrealMcpToolResult::Error(PathsError);
 				const int32 Limit = static_cast<int32>(Call.GetInt(TEXT("limit"), 100));
 
 				UClass* FilterClass = ClassFilter.IsEmpty() ? nullptr : FUnrealMcpObjectRef::ResolveClass(ClassFilter);
@@ -391,12 +422,12 @@ namespace UnrealMcpActorTools
 				AActor* Child = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
 				if (bFailed) return Err;
 
-				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorSetParent", "MCP: Set Actor Parent"));
 				const bool bKeepWorld = Call.GetBool(TEXT("keepWorldTransform"), true);
 				const FString ParentRef = Call.GetString(TEXT("parent"));
 
 				if (ParentRef.IsEmpty())
 				{
+					const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorDetach", "MCP: Detach Actor"));
 					Child->DetachFromActor(bKeepWorld
 						? FDetachmentTransformRules::KeepWorldTransform
 						: FDetachmentTransformRules::KeepRelativeTransform);
@@ -414,17 +445,24 @@ namespace UnrealMcpActorTools
 						TEXT("Cannot attach '%s' to '%s': '%s' is already a descendant (would create a cycle)."),
 						*Child->GetActorLabel(), *Parent->GetActorLabel(), *Parent->GetActorLabel()));
 
+				// Open the transaction only AFTER validation: the resolve/self/cycle error paths above would
+				// otherwise leave an empty "MCP: Set Actor Parent" entry on the editor undo stack.
+				FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorSetParent", "MCP: Set Actor Parent"));
 				const FAttachmentTransformRules Rules = bKeepWorld
 					? FAttachmentTransformRules::KeepWorldTransform
 					: FAttachmentTransformRules::KeepRelativeTransform;
 				const FName Socket(*Call.GetString(TEXT("socket")));
 				Child->AttachToActor(Parent, Rules, Socket);
 				// AttachToActor returns void and silently no-ops on rejection (e.g. missing root component);
-				// verify the attachment actually took rather than reporting a false success.
+				// verify the attachment actually took rather than reporting a false success. Cancel the
+				// transaction so the rejected attach does not commit a dangling/partial entry to the undo buffer.
 				if (Child->GetAttachParentActor() != Parent)
+				{
+					Transaction.Cancel();
 					return FUnrealMcpToolResult::Error(FString::Printf(
 						TEXT("Engine rejected attaching '%s' to '%s' (missing root component or invalid attachment)."),
 						*Child->GetActorLabel(), *Parent->GetActorLabel()));
+				}
 				return FUnrealMcpToolResult::Success(
 					FString::Printf(TEXT("Attached '%s' to '%s'."), *Child->GetActorLabel(), *Parent->GetActorLabel()));
 			});
@@ -471,11 +509,14 @@ namespace UnrealMcpActorTools
 							*NameArg, *Actor->GetActorLabel()));
 				}
 
-				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ComponentAdd", "MCP: Add Component"));
+				FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ComponentAdd", "MCP: Add Component"));
 				Actor->Modify();
 				UActorComponent* NewComp = NewObject<UActorComponent>(Actor, CompClass, CompName, RF_Transactional);
 				if (!NewComp)
+				{
+					Transaction.Cancel(); // roll back the Actor->Modify() snapshot rather than leave a no-op entry
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to construct component '%s'."), *ClassRef));
+				}
 
 				Actor->AddInstanceComponent(NewComp);
 				if (USceneComponent* SceneComp = Cast<USceneComponent>(NewComp))
@@ -552,7 +593,10 @@ namespace UnrealMcpActorTools
 				if (!Comp)
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No component matched '%s' on '%s'."), *CompRef, *Actor->GetActorLabel()));
 
-				const TArray<FString> Paths = GetStringArray(Call, TEXT("paths"));
+				FString PathsError;
+				const TArray<FString> Paths = GetStringArray(Call, TEXT("paths"), PathsError);
+				if (!PathsError.IsEmpty())
+					return FUnrealMcpToolResult::Error(PathsError);
 				TSharedPtr<FJsonObject> Data = FUnrealMcpObjectRef::ComponentIdentity(Comp);
 				Data->SetObjectField(TEXT("data"), FUnrealMcpPropertyJson::SerializeObject(Comp, Paths));
 				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Read component '%s'."), *Comp->GetName()), Data);
@@ -662,7 +706,10 @@ namespace UnrealMcpActorTools
 				if (!Object)
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No object matched '%s'."), *Ref));
 
-				const TArray<FString> Paths = GetStringArray(Call, TEXT("paths"));
+				FString PathsError;
+				const TArray<FString> Paths = GetStringArray(Call, TEXT("paths"), PathsError);
+				if (!PathsError.IsEmpty())
+					return FUnrealMcpToolResult::Error(PathsError);
 				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
 				Structured->SetStringField(TEXT("name"), Object->GetName());
 				Structured->SetStringField(TEXT("class"), Object->GetClass() ? Object->GetClass()->GetPathName() : FString());

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpActorTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpActorTools.cpp
@@ -1,0 +1,655 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpCoreTools.h"
+#include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpObjectRef.h"
+#include "UnrealMcpPropertyJson.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Editor.h"
+#include "EngineUtils.h"            // TActorIterator
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "Components/ActorComponent.h"
+#include "Components/SceneComponent.h"
+#include "UObject/UObjectIterator.h"
+
+/**
+ * The actor & component tool family (docs/ARCHITECTURE.md §10 "actor family", declared via §3.3).
+ *
+ * ~13 native C++ tools over UClass/FProperty reflection. Object references are resolved through
+ * FUnrealMcpObjectRef (§3.2: label → FindObject → soft-path load); scoped reads + FProperty/transform
+ * writes go through FUnrealMcpPropertyJson. Every Handle() body runs ON the game thread — the bridge
+ * dispatches Registry.Execute through FUnrealMcpGameThreadDispatcher (§4), so the bodies below touch
+ * the editor world / UObject graph directly without any extra marshalling.
+ */
+namespace
+{
+	// --- Local schema builders (the typed builder helpers don't cover rotators / property bags / lists) ---
+
+	/** `{pitch,yaw,roll: number}` — the §3.2 FRotator mapping (degrees). Read back via FUnrealMcpToolCall::GetRotator. */
+	TSharedPtr<FJsonObject> MakeRotatorSchema(const FString& Desc)
+	{
+		auto Num = []() { TSharedPtr<FJsonObject> N = MakeShared<FJsonObject>(); N->SetStringField(TEXT("type"), TEXT("number")); return N; };
+		TSharedPtr<FJsonObject> Props = MakeShared<FJsonObject>();
+		Props->SetObjectField(TEXT("pitch"), Num());
+		Props->SetObjectField(TEXT("yaw"), Num());
+		Props->SetObjectField(TEXT("roll"), Num());
+
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), TEXT("object"));
+		if (!Desc.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Desc);
+		Schema->SetObjectField(TEXT("properties"), Props);
+		return Schema;
+	}
+
+	/** A free-form `{ key: value }` property bag — arbitrary FProperty writes (§3.2), additionalProperties allowed. */
+	TSharedPtr<FJsonObject> MakePropertyBagSchema(const FString& Desc)
+	{
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), TEXT("object"));
+		if (!Desc.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Desc);
+		Schema->SetBoolField(TEXT("additionalProperties"), true);
+		return Schema;
+	}
+
+	/** An `array` of strings — used for the §3.2 scoped-read `paths` filter. */
+	TSharedPtr<FJsonObject> MakeStringArraySchema(const FString& Desc)
+	{
+		TSharedPtr<FJsonObject> Items = MakeShared<FJsonObject>();
+		Items->SetStringField(TEXT("type"), TEXT("string"));
+
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), TEXT("array"));
+		if (!Desc.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Desc);
+		Schema->SetObjectField(TEXT("items"), Items);
+		return Schema;
+	}
+
+	// --- Small argument helpers ---
+
+	/** Read a string array argument (the scoped-read `paths` filter); empty when absent or not an array. */
+	TArray<FString> GetStringArray(const FUnrealMcpToolCall& Call, const FString& Key)
+	{
+		TArray<FString> Out;
+		const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
+		if (Call.Arguments->TryGetArrayField(Key, Arr) && Arr)
+		{
+			for (const TSharedPtr<FJsonValue>& V : *Arr)
+			{
+				FString S;
+				if (V.IsValid() && V->TryGetString(S))
+					Out.Add(S);
+			}
+		}
+		return Out;
+	}
+
+	/** The 'properties' object argument (the write property bag); null when absent. */
+	TSharedPtr<FJsonObject> GetPropertiesArg(const FUnrealMcpToolCall& Call)
+	{
+		const TSharedPtr<FJsonObject>* Obj = nullptr;
+		if (Call.Arguments->TryGetObjectField(TEXT("properties"), Obj) && Obj && Obj->IsValid())
+			return *Obj;
+		return nullptr;
+	}
+
+	/** Resolve an actor by ref or produce a uniform error result. Returns null + fills OutError on miss. */
+	AActor* ResolveActorOrError(const FString& Ref, FUnrealMcpToolResult& OutError, bool& bFailed)
+	{
+		bFailed = false;
+		if (Ref.IsEmpty())
+		{
+			OutError = FUnrealMcpToolResult::Error(TEXT("Missing required 'actor' reference."));
+			bFailed = true;
+			return nullptr;
+		}
+		AActor* Actor = FUnrealMcpObjectRef::ResolveActor(Ref);
+		if (!Actor)
+		{
+			OutError = FUnrealMcpToolResult::Error(FString::Printf(TEXT("No actor matched '%s' (by label/name/path)."), *Ref));
+			bFailed = true;
+		}
+		return Actor;
+	}
+
+	/** Build a `{ applied, errors:[...] }` structured result for the *-modify tools. */
+	FUnrealMcpToolResult MakeModifyResult(const FString& Subject, int32 Applied, const TArray<FString>& Errors)
+	{
+		TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+		Structured->SetNumberField(TEXT("applied"), Applied);
+		TArray<TSharedPtr<FJsonValue>> ErrArray;
+		for (const FString& E : Errors)
+			ErrArray.Add(MakeShared<FJsonValueString>(E));
+		Structured->SetArrayField(TEXT("errors"), ErrArray);
+
+		// Partial success is still success: report the count and surface per-field reasons in the payload.
+		const FString Message = Errors.Num() == 0
+			? FString::Printf(TEXT("Applied %d propert%s to %s."), Applied, Applied == 1 ? TEXT("y") : TEXT("ies"), *Subject)
+			: FString::Printf(TEXT("Applied %d propert%s to %s; %d field(s) failed."),
+				Applied, Applied == 1 ? TEXT("y") : TEXT("ies"), *Subject, Errors.Num());
+		return FUnrealMcpToolResult::Success(Message, Structured);
+	}
+}
+
+namespace UnrealMcpActorTools
+{
+	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry)
+	{
+		// ----------------------------------------------------------------------------------------
+		// actor-create — spawn from a class path / Blueprint asset path.
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("actor-create"))
+			.Title(TEXT("Create Actor"))
+			.Description(TEXT("Spawn a new actor in the current editor level from a native class path "
+			                  "(e.g. '/Script/Engine.StaticMeshActor', 'PointLight') or a Blueprint asset "
+			                  "path. Optionally set label, location, rotation, and a parent actor to attach to."))
+			.ParamString(TEXT("classPath"), TEXT("Native class or Blueprint asset path/name."), EUnrealMcpParamRequirement::Required)
+			.ParamString(TEXT("name"), TEXT("Actor label. Auto-generated when omitted."))
+			.ParamVector(TEXT("location"), TEXT("World location {x,y,z}. Defaults to origin."))
+			.Param(TEXT("rotation"), TEXT("object"), TEXT("World rotation {pitch,yaw,roll} in degrees."), EUnrealMcpParamRequirement::Optional, MakeRotatorSchema(TEXT("World rotation {pitch,yaw,roll} in degrees.")))
+			.ParamString(TEXT("parentActor"), TEXT("Label/path of an actor to attach the new actor to."))
+			.DestructiveHint(false)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				UWorld* World = FUnrealMcpObjectRef::GetEditorWorld();
+				if (!World)
+					return FUnrealMcpToolResult::Error(TEXT("No editor world available (not running in the editor)."));
+
+				const FString ClassPath = Call.GetString(TEXT("classPath"));
+				UClass* Class = FUnrealMcpObjectRef::ResolveClass(ClassPath);
+				if (!Class || !Class->IsChildOf(AActor::StaticClass()))
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("'%s' is not a spawnable Actor class."), *ClassPath));
+				if (Class->HasAnyClassFlags(CLASS_Abstract))
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("'%s' is abstract and cannot be spawned."), *ClassPath));
+
+				const FVector Location = Call.GetVector(TEXT("location"), FVector::ZeroVector);
+				const FRotator Rotation = Call.GetRotator(TEXT("rotation"), FRotator::ZeroRotator);
+
+				// Spawn through the engine UWorld path (not UEditorActorSubsystem): the actor still lands in
+				// the editor world (outliner-visible), and this avoids the editor viewport-snapping code that
+				// is unsafe under headless -nullrhi automation. SpawnParameters get a transactional, dirtyable actor.
+				FActorSpawnParameters SpawnParams;
+				SpawnParams.ObjectFlags |= RF_Transactional;
+				AActor* Actor = World->SpawnActor<AActor>(Class, Location, Rotation, SpawnParams);
+				if (!Actor)
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to spawn '%s'."), *ClassPath));
+
+				if (Call.Has(TEXT("name")))
+				{
+					const FString Label = Call.GetString(TEXT("name"));
+					if (!Label.IsEmpty())
+						Actor->SetActorLabel(Label);
+				}
+
+				if (Call.Has(TEXT("parentActor")))
+				{
+					const FString ParentRef = Call.GetString(TEXT("parentActor"));
+					if (!ParentRef.IsEmpty())
+					{
+						if (AActor* Parent = FUnrealMcpObjectRef::ResolveActor(ParentRef))
+							Actor->AttachToActor(Parent, FAttachmentTransformRules::KeepWorldTransform);
+						else
+							return FUnrealMcpToolResult::Error(FString::Printf(
+								TEXT("Actor spawned but parent '%s' was not found for attachment."), *ParentRef));
+					}
+				}
+
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Spawned %s '%s'."), *Class->GetName(), *Actor->GetActorLabel()),
+					FUnrealMcpObjectRef::ActorIdentity(Actor));
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// actor-destroy
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("actor-destroy"))
+			.Title(TEXT("Destroy Actor"))
+			.Description(TEXT("Remove an actor from the current editor level. Identify it by label, object "
+			                  "name, or full path."))
+			.ParamString(TEXT("actor"), TEXT("Actor label / name / path to destroy."), EUnrealMcpParamRequirement::Required)
+			.DestructiveHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				FUnrealMcpToolResult Err; bool bFailed = false;
+				AActor* Actor = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				if (bFailed) return Err;
+
+				UWorld* World = Actor->GetWorld();
+				if (!World)
+					return FUnrealMcpToolResult::Error(TEXT("Actor has no world."));
+
+				const FString Label = Actor->GetActorLabel();
+				if (!World->EditorDestroyActor(Actor, /*bShouldModifyLevel*/ true))
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to destroy actor '%s'."), *Label));
+				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Destroyed actor '%s'."), *Label));
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// actor-duplicate
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("actor-duplicate"))
+			.Title(TEXT("Duplicate Actor"))
+			.Description(TEXT("Duplicate an existing actor in the current level, optionally offsetting its "
+			                  "location and assigning a new label."))
+			.ParamString(TEXT("actor"), TEXT("Actor label / name / path to duplicate."), EUnrealMcpParamRequirement::Required)
+			.ParamString(TEXT("name"), TEXT("Label for the duplicate. Auto-generated when omitted."))
+			.ParamVector(TEXT("offset"), TEXT("World-space location offset {x,y,z} applied to the duplicate. Defaults to none."))
+			.DestructiveHint(false)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				FUnrealMcpToolResult Err; bool bFailed = false;
+				AActor* Source = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				if (bFailed) return Err;
+
+				UWorld* World = Source->GetWorld();
+				if (!World)
+					return FUnrealMcpToolResult::Error(TEXT("Source actor has no world."));
+
+				// Duplicate by spawning the same class with the source as a property template (engine path,
+				// headless-safe), then apply the requested location offset.
+				const FVector Offset = Call.GetVector(TEXT("offset"), FVector::ZeroVector);
+				FActorSpawnParameters SpawnParams;
+				SpawnParams.Template = Source;
+				SpawnParams.ObjectFlags |= RF_Transactional;
+				const FTransform DupXform(Source->GetActorRotation(), Source->GetActorLocation() + Offset, Source->GetActorScale3D());
+				AActor* Dup = World->SpawnActor<AActor>(Source->GetClass(), DupXform, SpawnParams);
+				if (!Dup)
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to duplicate actor '%s'."), *Source->GetActorLabel()));
+
+				if (Call.Has(TEXT("name")))
+				{
+					const FString Label = Call.GetString(TEXT("name"));
+					if (!Label.IsEmpty())
+						Dup->SetActorLabel(Label);
+				}
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Duplicated '%s' as '%s'."), *Source->GetActorLabel(), *Dup->GetActorLabel()),
+					FUnrealMcpObjectRef::ActorIdentity(Dup));
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// actor-find — filter by label/path/class; scoped data reads via `paths` (§3.2).
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("actor-find"))
+			.Title(TEXT("Find Actors"))
+			.Description(TEXT("List actors in the current level filtered by label substring, path substring, "
+			                  "and/or class. Optionally include each actor's reflected data, scoped to the "
+			                  "dotted 'paths' filter to save tokens."))
+			.ParamString(TEXT("labelFilter"), TEXT("Case-insensitive substring matched against actor labels."))
+			.ParamString(TEXT("pathFilter"), TEXT("Case-insensitive substring matched against full actor paths."))
+			.ParamString(TEXT("classFilter"), TEXT("Class path/name; matches actors of this class or a subclass."))
+			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include per actor (scoped read). Identity only when omitted."), EUnrealMcpParamRequirement::Optional, MakeStringArraySchema(TEXT("Dotted property paths to include per actor (scoped read).")))
+			.ParamInt(TEXT("limit"), TEXT("Maximum number of actors to return. Defaults to 100."))
+			.ReadOnlyHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				UWorld* World = FUnrealMcpObjectRef::GetEditorWorld();
+				if (!World)
+					return FUnrealMcpToolResult::Error(TEXT("No editor world available."));
+
+				const FString LabelFilter = Call.GetString(TEXT("labelFilter"));
+				const FString PathFilter = Call.GetString(TEXT("pathFilter"));
+				const FString ClassFilter = Call.GetString(TEXT("classFilter"));
+				const TArray<FString> Paths = GetStringArray(Call, TEXT("paths"));
+				const int32 Limit = static_cast<int32>(Call.GetInt(TEXT("limit"), 100));
+
+				UClass* FilterClass = ClassFilter.IsEmpty() ? nullptr : FUnrealMcpObjectRef::ResolveClass(ClassFilter);
+				if (!ClassFilter.IsEmpty() && !FilterClass)
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("classFilter '%s' did not resolve to a class."), *ClassFilter));
+
+				TArray<TSharedPtr<FJsonValue>> Results;
+				int32 Matched = 0;
+				for (TActorIterator<AActor> It(World); It; ++It)
+				{
+					AActor* Actor = *It;
+					if (!Actor)
+						continue;
+					if (FilterClass && !Actor->IsA(FilterClass))
+						continue;
+					if (!LabelFilter.IsEmpty() && !Actor->GetActorLabel().Contains(LabelFilter, ESearchCase::IgnoreCase))
+						continue;
+					if (!PathFilter.IsEmpty() && !Actor->GetPathName().Contains(PathFilter, ESearchCase::IgnoreCase))
+						continue;
+
+					++Matched;
+					if (Results.Num() >= Limit && Limit > 0)
+						continue; // keep counting total matches, but stop materializing entries
+
+					TSharedPtr<FJsonObject> Entry = FUnrealMcpObjectRef::ActorIdentity(Actor);
+					if (Paths.Num() > 0)
+						Entry->SetObjectField(TEXT("data"), FUnrealMcpPropertyJson::SerializeObject(Actor, Paths));
+					Results.Add(MakeShared<FJsonValueObject>(Entry));
+				}
+
+				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+				Structured->SetNumberField(TEXT("count"), Results.Num());
+				Structured->SetNumberField(TEXT("total"), Matched);
+				Structured->SetArrayField(TEXT("actors"), Results);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Found %d actor(s) (returned %d)."), Matched, Results.Num()), Structured);
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// actor-modify — FProperty writes including transform (§3.2 mapping).
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("actor-modify"))
+			.Title(TEXT("Modify Actor"))
+			.Description(TEXT("Write reflected properties on an actor. Transform keys 'location' {x,y,z}, "
+			                  "'rotation' {pitch,yaw,roll}, and 'scale' {x,y,z} are routed to the transform "
+			                  "APIs; all other keys are set by name through FProperty reflection."))
+			.ParamString(TEXT("actor"), TEXT("Actor label / name / path to modify."), EUnrealMcpParamRequirement::Required)
+			.Param(TEXT("properties"), TEXT("object"), TEXT("Property bag of name -> value to write (incl. transform keys)."), EUnrealMcpParamRequirement::Required, MakePropertyBagSchema(TEXT("Property bag of name -> value to write.")))
+			.DestructiveHint(false)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				FUnrealMcpToolResult Err; bool bFailed = false;
+				AActor* Actor = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				if (bFailed) return Err;
+
+				TSharedPtr<FJsonObject> Props = GetPropertiesArg(Call);
+				if (!Props.IsValid())
+					return FUnrealMcpToolResult::Error(TEXT("Missing required 'properties' object."));
+
+				TArray<FString> Errors;
+				const int32 Applied = FUnrealMcpPropertyJson::ApplyProperties(Actor, Props, Errors);
+				return MakeModifyResult(FString::Printf(TEXT("actor '%s'"), *Actor->GetActorLabel()), Applied, Errors);
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// actor-set-parent — attach / detach.
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("actor-set-parent"))
+			.Title(TEXT("Set Actor Parent"))
+			.Description(TEXT("Attach an actor to a parent actor (optionally at a named socket), or detach it "
+			                  "when 'parent' is omitted/empty. World transform is preserved by default."))
+			.ParamString(TEXT("actor"), TEXT("Child actor label / name / path."), EUnrealMcpParamRequirement::Required)
+			.ParamString(TEXT("parent"), TEXT("Parent actor label / name / path. Omit or leave empty to detach."))
+			.ParamString(TEXT("socket"), TEXT("Optional socket/bone name on the parent to attach to."))
+			.ParamBool(TEXT("keepWorldTransform"), TEXT("Preserve the child's world transform across the (de)attach. Defaults to true."))
+			.DestructiveHint(false)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				FUnrealMcpToolResult Err; bool bFailed = false;
+				AActor* Child = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				if (bFailed) return Err;
+
+				const bool bKeepWorld = Call.GetBool(TEXT("keepWorldTransform"), true);
+				const FString ParentRef = Call.GetString(TEXT("parent"));
+
+				if (ParentRef.IsEmpty())
+				{
+					Child->DetachFromActor(bKeepWorld
+						? FDetachmentTransformRules::KeepWorldTransform
+						: FDetachmentTransformRules::KeepRelativeTransform);
+					return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Detached '%s' from its parent."), *Child->GetActorLabel()));
+				}
+
+				AActor* Parent = FUnrealMcpObjectRef::ResolveActor(ParentRef);
+				if (!Parent)
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No parent actor matched '%s'."), *ParentRef));
+				if (Parent == Child)
+					return FUnrealMcpToolResult::Error(TEXT("An actor cannot be parented to itself."));
+
+				const FAttachmentTransformRules Rules = bKeepWorld
+					? FAttachmentTransformRules::KeepWorldTransform
+					: FAttachmentTransformRules::KeepRelativeTransform;
+				const FName Socket(*Call.GetString(TEXT("socket")));
+				Child->AttachToActor(Parent, Rules, Socket);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Attached '%s' to '%s'."), *Child->GetActorLabel(), *Parent->GetActorLabel()));
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// actor-component-add
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("actor-component-add"))
+			.Title(TEXT("Add Component"))
+			.Description(TEXT("Add a new component (by class path/name) to an actor as an instance component. "
+			                  "Scene components attach to the actor's root, or become the root if it has none."))
+			.ParamString(TEXT("actor"), TEXT("Owning actor label / name / path."), EUnrealMcpParamRequirement::Required)
+			.ParamString(TEXT("componentClass"), TEXT("Component class path/name (e.g. 'StaticMeshComponent')."), EUnrealMcpParamRequirement::Required)
+			.ParamString(TEXT("name"), TEXT("Optional component name. Auto-generated when omitted."))
+			.DestructiveHint(false)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				FUnrealMcpToolResult Err; bool bFailed = false;
+				AActor* Actor = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				if (bFailed) return Err;
+
+				const FString ClassRef = Call.GetString(TEXT("componentClass"));
+				UClass* CompClass = FUnrealMcpObjectRef::ResolveClass(ClassRef);
+				if (!CompClass || !CompClass->IsChildOf(UActorComponent::StaticClass()))
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("'%s' is not a UActorComponent class."), *ClassRef));
+				if (CompClass->HasAnyClassFlags(CLASS_Abstract))
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("'%s' is abstract and cannot be instantiated."), *ClassRef));
+
+				const FString NameArg = Call.GetString(TEXT("name"));
+				const FName CompName = NameArg.IsEmpty()
+					? MakeUniqueObjectName(Actor, CompClass, CompClass->GetFName())
+					: FName(*NameArg);
+
+				Actor->Modify();
+				UActorComponent* NewComp = NewObject<UActorComponent>(Actor, CompClass, CompName, RF_Transactional);
+				if (!NewComp)
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to construct component '%s'."), *ClassRef));
+
+				Actor->AddInstanceComponent(NewComp);
+				if (USceneComponent* SceneComp = Cast<USceneComponent>(NewComp))
+				{
+					if (USceneComponent* Root = Actor->GetRootComponent())
+						SceneComp->AttachToComponent(Root, FAttachmentTransformRules::KeepRelativeTransform);
+					else
+						Actor->SetRootComponent(SceneComp);
+				}
+				NewComp->OnComponentCreated();
+				NewComp->RegisterComponent();
+				Actor->MarkPackageDirty();
+
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Added %s '%s' to '%s'."), *CompClass->GetName(), *NewComp->GetName(), *Actor->GetActorLabel()),
+					FUnrealMcpObjectRef::ComponentIdentity(NewComp));
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// actor-component-destroy
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("actor-component-destroy"))
+			.Title(TEXT("Destroy Component"))
+			.Description(TEXT("Remove a component (by name) from an actor."))
+			.ParamString(TEXT("actor"), TEXT("Owning actor label / name / path."), EUnrealMcpParamRequirement::Required)
+			.ParamString(TEXT("component"), TEXT("Component name to destroy."), EUnrealMcpParamRequirement::Required)
+			.DestructiveHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				FUnrealMcpToolResult Err; bool bFailed = false;
+				AActor* Actor = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				if (bFailed) return Err;
+
+				const FString CompRef = Call.GetString(TEXT("component"));
+				UActorComponent* Comp = FUnrealMcpObjectRef::ResolveComponent(Actor, CompRef);
+				if (!Comp)
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No component matched '%s' on '%s'."), *CompRef, *Actor->GetActorLabel()));
+
+				const FString CompName = Comp->GetName();
+				Actor->Modify();
+				Actor->RemoveInstanceComponent(Comp);
+				Comp->DestroyComponent();
+				Actor->MarkPackageDirty();
+				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Destroyed component '%s' on '%s'."), *CompName, *Actor->GetActorLabel()));
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// actor-component-get — scoped reads (§3.2).
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("actor-component-get"))
+			.Title(TEXT("Get Component Data"))
+			.Description(TEXT("Read a component's reflected properties, optionally scoped to the dotted 'paths' filter."))
+			.ParamString(TEXT("actor"), TEXT("Owning actor label / name / path."), EUnrealMcpParamRequirement::Required)
+			.ParamString(TEXT("component"), TEXT("Component name to read."), EUnrealMcpParamRequirement::Required)
+			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include (scoped read). Full object when omitted."), EUnrealMcpParamRequirement::Optional, MakeStringArraySchema(TEXT("Dotted property paths to include (scoped read).")))
+			.ReadOnlyHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				FUnrealMcpToolResult Err; bool bFailed = false;
+				AActor* Actor = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				if (bFailed) return Err;
+
+				const FString CompRef = Call.GetString(TEXT("component"));
+				UActorComponent* Comp = FUnrealMcpObjectRef::ResolveComponent(Actor, CompRef);
+				if (!Comp)
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No component matched '%s' on '%s'."), *CompRef, *Actor->GetActorLabel()));
+
+				const TArray<FString> Paths = GetStringArray(Call, TEXT("paths"));
+				TSharedPtr<FJsonObject> Data = FUnrealMcpObjectRef::ComponentIdentity(Comp);
+				Data->SetObjectField(TEXT("data"), FUnrealMcpPropertyJson::SerializeObject(Comp, Paths));
+				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Read component '%s'."), *Comp->GetName()), Data);
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// actor-component-modify — FProperty writes (incl. relative transform) on a component.
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("actor-component-modify"))
+			.Title(TEXT("Modify Component"))
+			.Description(TEXT("Write reflected properties on a component. Scene components additionally accept "
+			                  "'relativeLocation' {x,y,z}, 'relativeRotation' {pitch,yaw,roll}, and "
+			                  "'relativeScale3D' {x,y,z} routed to the relative-transform APIs."))
+			.ParamString(TEXT("actor"), TEXT("Owning actor label / name / path."), EUnrealMcpParamRequirement::Required)
+			.ParamString(TEXT("component"), TEXT("Component name to modify."), EUnrealMcpParamRequirement::Required)
+			.Param(TEXT("properties"), TEXT("object"), TEXT("Property bag of name -> value to write."), EUnrealMcpParamRequirement::Required, MakePropertyBagSchema(TEXT("Property bag of name -> value to write.")))
+			.DestructiveHint(false)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				FUnrealMcpToolResult Err; bool bFailed = false;
+				AActor* Actor = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				if (bFailed) return Err;
+
+				const FString CompRef = Call.GetString(TEXT("component"));
+				UActorComponent* Comp = FUnrealMcpObjectRef::ResolveComponent(Actor, CompRef);
+				if (!Comp)
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No component matched '%s' on '%s'."), *CompRef, *Actor->GetActorLabel()));
+
+				TSharedPtr<FJsonObject> Props = GetPropertiesArg(Call);
+				if (!Props.IsValid())
+					return FUnrealMcpToolResult::Error(TEXT("Missing required 'properties' object."));
+
+				TArray<FString> Errors;
+				const int32 Applied = FUnrealMcpPropertyJson::ApplyProperties(Comp, Props, Errors);
+				return MakeModifyResult(FString::Printf(TEXT("component '%s'"), *Comp->GetName()), Applied, Errors);
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// actor-component-list-all — paginated concrete UActorComponent classes.
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("actor-component-list-all"))
+			.Title(TEXT("List Component Classes"))
+			.Description(TEXT("List concrete (non-abstract) UActorComponent classes available to add, filtered "
+			                  "by an optional name substring and paginated via offset/limit."))
+			.ParamString(TEXT("search"), TEXT("Case-insensitive substring matched against class names."))
+			.ParamInt(TEXT("offset"), TEXT("Number of matching classes to skip. Defaults to 0."))
+			.ParamInt(TEXT("limit"), TEXT("Maximum number of classes to return. Defaults to 100."))
+			.ReadOnlyHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const FString Search = Call.GetString(TEXT("search"));
+				const int32 Offset = FMath::Max(0, static_cast<int32>(Call.GetInt(TEXT("offset"), 0)));
+				const int32 Limit = static_cast<int32>(Call.GetInt(TEXT("limit"), 100));
+
+				// Collect first so total/pagination are stable and class order is deterministic by name.
+				TArray<UClass*> Matches;
+				for (TObjectIterator<UClass> It; It; ++It)
+				{
+					UClass* Class = *It;
+					if (!Class || !Class->IsChildOf(UActorComponent::StaticClass()))
+						continue;
+					if (Class->HasAnyClassFlags(CLASS_Abstract | CLASS_Deprecated | CLASS_NewerVersionExists))
+						continue;
+					if (!Search.IsEmpty() && !Class->GetName().Contains(Search, ESearchCase::IgnoreCase))
+						continue;
+					Matches.Add(Class);
+				}
+				Matches.Sort([](const UClass& A, const UClass& B) { return A.GetName() < B.GetName(); });
+
+				TArray<TSharedPtr<FJsonValue>> Page;
+				for (int32 i = Offset; i < Matches.Num() && (Limit <= 0 || Page.Num() < Limit); ++i)
+				{
+					TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+					Entry->SetStringField(TEXT("name"), Matches[i]->GetName());
+					Entry->SetStringField(TEXT("path"), Matches[i]->GetPathName());
+					Page.Add(MakeShared<FJsonValueObject>(Entry));
+				}
+
+				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+				Structured->SetNumberField(TEXT("total"), Matches.Num());
+				Structured->SetNumberField(TEXT("offset"), Offset);
+				Structured->SetNumberField(TEXT("count"), Page.Num());
+				Structured->SetArrayField(TEXT("components"), Page);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("%d component class(es) total; returned %d."), Matches.Num(), Page.Num()), Structured);
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// object-get-data — read a generic UObject by path (or live actor by label).
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("object-get-data"))
+			.Title(TEXT("Get Object Data"))
+			.Description(TEXT("Read the reflected properties of any UObject resolved by object path "
+			                  "('/Game/Folder/Asset.Asset') or, for scene objects, by actor label. Optionally "
+			                  "scoped to the dotted 'paths' filter."))
+			.ParamString(TEXT("object"), TEXT("Object path or actor label/name/path."), EUnrealMcpParamRequirement::Required)
+			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include (scoped read). Full object when omitted."), EUnrealMcpParamRequirement::Optional, MakeStringArraySchema(TEXT("Dotted property paths to include (scoped read).")))
+			.ReadOnlyHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const FString Ref = Call.GetString(TEXT("object"));
+				if (Ref.IsEmpty())
+					return FUnrealMcpToolResult::Error(TEXT("Missing required 'object' reference."));
+
+				UObject* Object = FUnrealMcpObjectRef::ResolveObject(Ref, FUnrealMcpObjectRef::GetEditorWorld());
+				if (!Object)
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No object matched '%s'."), *Ref));
+
+				const TArray<FString> Paths = GetStringArray(Call, TEXT("paths"));
+				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+				Structured->SetStringField(TEXT("name"), Object->GetName());
+				Structured->SetStringField(TEXT("class"), Object->GetClass() ? Object->GetClass()->GetPathName() : FString());
+				Structured->SetStringField(TEXT("path"), Object->GetPathName());
+				Structured->SetObjectField(TEXT("data"), FUnrealMcpPropertyJson::SerializeObject(Object, Paths));
+				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Read object '%s'."), *Object->GetName()), Structured);
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// object-modify — FProperty writes on a generic UObject by path.
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("object-modify"))
+			.Title(TEXT("Modify Object"))
+			.Description(TEXT("Write reflected properties on any UObject resolved by object path or actor label. "
+			                  "Transform keys are honored when the object is an actor or scene component."))
+			.ParamString(TEXT("object"), TEXT("Object path or actor label/name/path."), EUnrealMcpParamRequirement::Required)
+			.Param(TEXT("properties"), TEXT("object"), TEXT("Property bag of name -> value to write."), EUnrealMcpParamRequirement::Required, MakePropertyBagSchema(TEXT("Property bag of name -> value to write.")))
+			.DestructiveHint(false)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const FString Ref = Call.GetString(TEXT("object"));
+				if (Ref.IsEmpty())
+					return FUnrealMcpToolResult::Error(TEXT("Missing required 'object' reference."));
+
+				UObject* Object = FUnrealMcpObjectRef::ResolveObject(Ref, FUnrealMcpObjectRef::GetEditorWorld());
+				if (!Object)
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No object matched '%s'."), *Ref));
+
+				TSharedPtr<FJsonObject> Props = GetPropertiesArg(Call);
+				if (!Props.IsValid())
+					return FUnrealMcpToolResult::Error(TEXT("Missing required 'properties' object."));
+
+				TArray<FString> Errors;
+				const int32 Applied = FUnrealMcpPropertyJson::ApplyProperties(Object, Props, Errors);
+				return MakeModifyResult(FString::Printf(TEXT("object '%s'"), *Object->GetName()), Applied, Errors);
+			});
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpActorTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpActorTools.cpp
@@ -15,6 +15,7 @@
 #include "Components/ActorComponent.h"
 #include "Components/SceneComponent.h"
 #include "UObject/UObjectIterator.h"
+#include "UObject/UObjectGlobals.h"   // StaticFindObjectFast
 
 /**
  * The actor & component tool family (docs/ARCHITECTURE.md §10 "actor family", declared via §3.3).
@@ -171,6 +172,21 @@ namespace UnrealMcpActorTools
 				const FVector Location = Call.GetVector(TEXT("location"), FVector::ZeroVector);
 				const FRotator Rotation = Call.GetRotator(TEXT("rotation"), FRotator::ZeroRotator);
 
+				// Resolve the parent (if requested) BEFORE spawning: resolving after the spawn would leak an
+				// orphan actor on a bad ref and the error would carry no identity for the leaked actor.
+				AActor* Parent = nullptr;
+				if (Call.Has(TEXT("parentActor")))
+				{
+					const FString ParentRef = Call.GetString(TEXT("parentActor"));
+					if (!ParentRef.IsEmpty())
+					{
+						Parent = FUnrealMcpObjectRef::ResolveActor(ParentRef);
+						if (!Parent)
+							return FUnrealMcpToolResult::Error(FString::Printf(
+								TEXT("Parent actor '%s' was not found; nothing was spawned."), *ParentRef));
+					}
+				}
+
 				// Spawn through the engine UWorld path (not UEditorActorSubsystem): the actor still lands in
 				// the editor world (outliner-visible), and this avoids the editor viewport-snapping code that
 				// is unsafe under headless -nullrhi automation. SpawnParameters get a transactional, dirtyable actor.
@@ -187,18 +203,8 @@ namespace UnrealMcpActorTools
 						Actor->SetActorLabel(Label);
 				}
 
-				if (Call.Has(TEXT("parentActor")))
-				{
-					const FString ParentRef = Call.GetString(TEXT("parentActor"));
-					if (!ParentRef.IsEmpty())
-					{
-						if (AActor* Parent = FUnrealMcpObjectRef::ResolveActor(ParentRef))
-							Actor->AttachToActor(Parent, FAttachmentTransformRules::KeepWorldTransform);
-						else
-							return FUnrealMcpToolResult::Error(FString::Printf(
-								TEXT("Actor spawned but parent '%s' was not found for attachment."), *ParentRef));
-					}
-				}
+				if (Parent)
+					Actor->AttachToActor(Parent, FAttachmentTransformRules::KeepWorldTransform);
 
 				return FUnrealMcpToolResult::Success(
 					FString::Printf(TEXT("Spawned %s '%s'."), *Class->GetName(), *Actor->GetActorLabel()),
@@ -262,11 +268,16 @@ namespace UnrealMcpActorTools
 				if (!Dup)
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to duplicate actor '%s'."), *Source->GetActorLabel()));
 
-				if (Call.Has(TEXT("name")))
+				const FString NameArg = Call.GetString(TEXT("name"));
+				if (!NameArg.IsEmpty())
 				{
-					const FString Label = Call.GetString(TEXT("name"));
-					if (!Label.IsEmpty())
-						Dup->SetActorLabel(Label);
+					Dup->SetActorLabel(NameArg);
+				}
+				else
+				{
+					// The spawn template copies the source's label verbatim, so two actors would share a
+					// label and ResolveActor could not disambiguate them. Give the duplicate a unique label.
+					FActorLabelUtilities::SetActorLabelUnique(Dup, Source->GetActorLabel());
 				}
 				return FUnrealMcpToolResult::Success(
 					FString::Printf(TEXT("Duplicated '%s' as '%s'."), *Source->GetActorLabel(), *Dup->GetActorLabel()),
@@ -395,12 +406,23 @@ namespace UnrealMcpActorTools
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No parent actor matched '%s'."), *ParentRef));
 				if (Parent == Child)
 					return FUnrealMcpToolResult::Error(TEXT("An actor cannot be parented to itself."));
+				// Reject a cycle up front: attaching to a descendant would be silently dropped by the engine.
+				if (Parent->IsAttachedTo(Child))
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("Cannot attach '%s' to '%s': '%s' is already a descendant (would create a cycle)."),
+						*Child->GetActorLabel(), *Parent->GetActorLabel(), *Parent->GetActorLabel()));
 
 				const FAttachmentTransformRules Rules = bKeepWorld
 					? FAttachmentTransformRules::KeepWorldTransform
 					: FAttachmentTransformRules::KeepRelativeTransform;
 				const FName Socket(*Call.GetString(TEXT("socket")));
 				Child->AttachToActor(Parent, Rules, Socket);
+				// AttachToActor returns void and silently no-ops on rejection (e.g. missing root component);
+				// verify the attachment actually took rather than reporting a false success.
+				if (Child->GetAttachParentActor() != Parent)
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("Engine rejected attaching '%s' to '%s' (missing root component or invalid attachment)."),
+						*Child->GetActorLabel(), *Parent->GetActorLabel()));
 				return FUnrealMcpToolResult::Success(
 					FString::Printf(TEXT("Attached '%s' to '%s'."), *Child->GetActorLabel(), *Parent->GetActorLabel()));
 			});
@@ -430,9 +452,22 @@ namespace UnrealMcpActorTools
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("'%s' is abstract and cannot be instantiated."), *ClassRef));
 
 				const FString NameArg = Call.GetString(TEXT("name"));
-				const FName CompName = NameArg.IsEmpty()
-					? MakeUniqueObjectName(Actor, CompClass, CompClass->GetFName())
-					: FName(*NameArg);
+				FName CompName;
+				if (NameArg.IsEmpty())
+				{
+					CompName = MakeUniqueObjectName(Actor, CompClass, CompClass->GetFName());
+				}
+				else
+				{
+					CompName = FName(*NameArg);
+					// Reject a name collision BEFORE NewObject: reusing an existing subobject name under the
+					// actor re-allocates it in place — a different class triggers a StaticAllocateObject fatal
+					// assert (editor crash); the same class silently clobbers. Surface a structured error.
+					if (StaticFindObjectFast(nullptr, Actor, CompName))
+						return FUnrealMcpToolResult::Error(FString::Printf(
+							TEXT("A component named '%s' already exists on '%s'; choose a different name."),
+							*NameArg, *Actor->GetActorLabel()));
+				}
 
 				Actor->Modify();
 				UActorComponent* NewComp = NewObject<UActorComponent>(Actor, CompClass, CompName, RF_Transactional);
@@ -475,6 +510,14 @@ namespace UnrealMcpActorTools
 				UActorComponent* Comp = FUnrealMcpObjectRef::ResolveComponent(Actor, CompRef);
 				if (!Comp)
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No component matched '%s' on '%s'."), *CompRef, *Actor->GetActorLabel()));
+
+				// Only instance components can be destroyed cleanly: a native/inherited component would no-op
+				// RemoveInstanceComponent yet still proceed to DestroyComponent, leaving a broken (possibly
+				// rootless) actor while reporting success. Reject it explicitly instead.
+				if (!Actor->GetInstanceComponents().Contains(Comp))
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("Component '%s' on '%s' is not an instance component (native/inherited components cannot be destroyed this way)."),
+						*CompRef, *Actor->GetActorLabel()));
 
 				const FString CompName = Comp->GetName();
 				Actor->Modify();

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpActorTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpActorTools.cpp
@@ -9,6 +9,7 @@
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
 #include "Editor.h"
+#include "ScopedTransaction.h"      // FScopedTransaction — gives the per-handler Modify() snapshots an open transaction to record into
 #include "EngineUtils.h"            // TActorIterator
 #include "Engine/World.h"
 #include "GameFramework/Actor.h"
@@ -190,6 +191,7 @@ namespace UnrealMcpActorTools
 				// Spawn through the engine UWorld path (not UEditorActorSubsystem): the actor still lands in
 				// the editor world (outliner-visible), and this avoids the editor viewport-snapping code that
 				// is unsafe under headless -nullrhi automation. SpawnParameters get a transactional, dirtyable actor.
+				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorCreate", "MCP: Create Actor"));
 				FActorSpawnParameters SpawnParams;
 				SpawnParams.ObjectFlags |= RF_Transactional;
 				AActor* Actor = World->SpawnActor<AActor>(Class, Location, Rotation, SpawnParams);
@@ -199,8 +201,10 @@ namespace UnrealMcpActorTools
 				if (Call.Has(TEXT("name")))
 				{
 					const FString Label = Call.GetString(TEXT("name"));
+					// SetActorLabelUnique (not SetActorLabel): a user-supplied label that collides with an
+					// existing actor's label would otherwise make both ambiguous to ResolveActor.
 					if (!Label.IsEmpty())
-						Actor->SetActorLabel(Label);
+						FActorLabelUtilities::SetActorLabelUnique(Actor, Label);
 				}
 
 				if (Parent)
@@ -230,6 +234,7 @@ namespace UnrealMcpActorTools
 				if (!World)
 					return FUnrealMcpToolResult::Error(TEXT("Actor has no world."));
 
+				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorDestroy", "MCP: Destroy Actor"));
 				const FString Label = Actor->GetActorLabel();
 				if (!World->EditorDestroyActor(Actor, /*bShouldModifyLevel*/ true))
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to destroy actor '%s'."), *Label));
@@ -259,6 +264,7 @@ namespace UnrealMcpActorTools
 
 				// Duplicate by spawning the same class with the source as a property template (engine path,
 				// headless-safe), then apply the requested location offset.
+				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorDuplicate", "MCP: Duplicate Actor"));
 				const FVector Offset = Call.GetVector(TEXT("offset"), FVector::ZeroVector);
 				FActorSpawnParameters SpawnParams;
 				SpawnParams.Template = Source;
@@ -269,16 +275,10 @@ namespace UnrealMcpActorTools
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to duplicate actor '%s'."), *Source->GetActorLabel()));
 
 				const FString NameArg = Call.GetString(TEXT("name"));
-				if (!NameArg.IsEmpty())
-				{
-					Dup->SetActorLabel(NameArg);
-				}
-				else
-				{
-					// The spawn template copies the source's label verbatim, so two actors would share a
-					// label and ResolveActor could not disambiguate them. Give the duplicate a unique label.
-					FActorLabelUtilities::SetActorLabelUnique(Dup, Source->GetActorLabel());
-				}
+				// The spawn template copies the source's label verbatim, so two actors would share a label and
+				// ResolveActor could not disambiguate them. SetActorLabelUnique guarantees a unique label whether
+				// the caller supplied one explicitly or we fall back to the source's label.
+				FActorLabelUtilities::SetActorLabelUnique(Dup, NameArg.IsEmpty() ? Source->GetActorLabel() : NameArg);
 				return FUnrealMcpToolResult::Success(
 					FString::Printf(TEXT("Duplicated '%s' as '%s'."), *Source->GetActorLabel(), *Dup->GetActorLabel()),
 					FUnrealMcpObjectRef::ActorIdentity(Dup));
@@ -367,6 +367,7 @@ namespace UnrealMcpActorTools
 				if (!Props.IsValid())
 					return FUnrealMcpToolResult::Error(TEXT("Missing required 'properties' object."));
 
+				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorModify", "MCP: Modify Actor"));
 				TArray<FString> Errors;
 				const int32 Applied = FUnrealMcpPropertyJson::ApplyProperties(Actor, Props, Errors);
 				return MakeModifyResult(FString::Printf(TEXT("actor '%s'"), *Actor->GetActorLabel()), Applied, Errors);
@@ -390,6 +391,7 @@ namespace UnrealMcpActorTools
 				AActor* Child = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
 				if (bFailed) return Err;
 
+				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorSetParent", "MCP: Set Actor Parent"));
 				const bool bKeepWorld = Call.GetBool(TEXT("keepWorldTransform"), true);
 				const FString ParentRef = Call.GetString(TEXT("parent"));
 
@@ -469,6 +471,7 @@ namespace UnrealMcpActorTools
 							*NameArg, *Actor->GetActorLabel()));
 				}
 
+				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ComponentAdd", "MCP: Add Component"));
 				Actor->Modify();
 				UActorComponent* NewComp = NewObject<UActorComponent>(Actor, CompClass, CompName, RF_Transactional);
 				if (!NewComp)
@@ -519,6 +522,7 @@ namespace UnrealMcpActorTools
 						TEXT("Component '%s' on '%s' is not an instance component (native/inherited components cannot be destroyed this way)."),
 						*CompRef, *Actor->GetActorLabel()));
 
+				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ComponentDestroy", "MCP: Destroy Component"));
 				const FString CompName = Comp->GetName();
 				Actor->Modify();
 				Actor->RemoveInstanceComponent(Comp);
@@ -581,6 +585,7 @@ namespace UnrealMcpActorTools
 				if (!Props.IsValid())
 					return FUnrealMcpToolResult::Error(TEXT("Missing required 'properties' object."));
 
+				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ComponentModify", "MCP: Modify Component"));
 				TArray<FString> Errors;
 				const int32 Applied = FUnrealMcpPropertyJson::ApplyProperties(Comp, Props, Errors);
 				return MakeModifyResult(FString::Printf(TEXT("component '%s'"), *Comp->GetName()), Applied, Errors);
@@ -690,6 +695,7 @@ namespace UnrealMcpActorTools
 				if (!Props.IsValid())
 					return FUnrealMcpToolResult::Error(TEXT("Missing required 'properties' object."));
 
+				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ObjectModify", "MCP: Modify Object"));
 				TArray<FString> Errors;
 				const int32 Applied = FUnrealMcpPropertyJson::ApplyProperties(Object, Props, Errors);
 				return MakeModifyResult(FString::Printf(TEXT("object '%s'"), *Object->GetName()), Applied, Errors);

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpObjectRef.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpObjectRef.cpp
@@ -33,7 +33,9 @@ namespace FUnrealMcpObjectRef
 
 		// 2. Load as a generic object: the ref may point at a UClass directly, or at a UBlueprint asset
 		//    (`/Game/BP/BP_Foo.BP_Foo`) whose GeneratedClass is what callers actually want to spawn.
-		if (UObject* Loaded = StaticLoadObject(UObject::StaticClass(), nullptr, *ClassRef))
+		//    LOAD_NoWarn | LOAD_Quiet: short, unqualified names (`PointLight`) reach here and fail this load
+		//    before succeeding at step 3 — without the flags each emits a spurious LogUObjectGlobals warning.
+		if (UObject* Loaded = StaticLoadObject(UObject::StaticClass(), nullptr, *ClassRef, nullptr, LOAD_NoWarn | LOAD_Quiet))
 		{
 			if (UClass* AsClass = Cast<UClass>(Loaded))
 				return AsClass;
@@ -57,13 +59,15 @@ namespace FUnrealMcpObjectRef
 		if (!World)
 			return nullptr;
 
-		// Exact match on label / name / full path first (deterministic).
+		// Exact (case-SENSITIVE) match on label / name / full path first (deterministic). FString::operator==
+		// is case-INSENSITIVE in UE, so an explicit ESearchCase::CaseSensitive Equals is required to make the
+		// exact-first preference real and keep the case-insensitive fallback below reachable.
 		for (TActorIterator<AActor> It(World); It; ++It)
 		{
 			AActor* Actor = *It;
-			if (Actor->GetActorLabel() == ActorRef
-				|| Actor->GetName() == ActorRef
-				|| Actor->GetPathName() == ActorRef)
+			if (Actor->GetActorLabel().Equals(ActorRef, ESearchCase::CaseSensitive)
+				|| Actor->GetName().Equals(ActorRef, ESearchCase::CaseSensitive)
+				|| Actor->GetPathName().Equals(ActorRef, ESearchCase::CaseSensitive))
 			{
 				return Actor;
 			}
@@ -88,9 +92,10 @@ namespace FUnrealMcpObjectRef
 		{
 			if (!Component)
 				continue;
+			// FString::operator== is case-insensitive in UE, so this already matches loosely-cased component
+			// names — no separate IgnoreCase clause is needed.
 			if (Component->GetName() == ComponentRef
-				|| Component->GetReadableName() == ComponentRef
-				|| Component->GetName().Equals(ComponentRef, ESearchCase::IgnoreCase))
+				|| Component->GetReadableName() == ComponentRef)
 			{
 				return Component;
 			}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpObjectRef.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpObjectRef.cpp
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpObjectRef.h"
+
+#include "Dom/JsonObject.h"
+#include "Editor.h"
+#include "Engine/Blueprint.h"
+#include "EngineUtils.h"            // TActorIterator
+#include "GameFramework/Actor.h"
+#include "Components/ActorComponent.h"
+#include "UObject/SoftObjectPath.h"
+#include "UObject/UObjectGlobals.h"
+
+namespace FUnrealMcpObjectRef
+{
+	UWorld* GetEditorWorld()
+	{
+		if (!GEditor)
+			return nullptr;
+		return GEditor->GetEditorWorldContext().World();
+	}
+
+	UClass* ResolveClass(const FString& ClassRef)
+	{
+		if (ClassRef.IsEmpty())
+			return nullptr;
+
+		// 1. Soft class path — handles native (`/Script/Engine.PointLight`) and generated Blueprint
+		//    classes (`/Game/BP/BP_Foo.BP_Foo_C`) without forcing a synchronous asset scan first.
+		if (UClass* Loaded = FSoftClassPath(ClassRef).TryLoadClass<UObject>())
+			return Loaded;
+
+		// 2. Load as a generic object: the ref may point at a UClass directly, or at a UBlueprint asset
+		//    (`/Game/BP/BP_Foo.BP_Foo`) whose GeneratedClass is what callers actually want to spawn.
+		if (UObject* Loaded = StaticLoadObject(UObject::StaticClass(), nullptr, *ClassRef))
+		{
+			if (UClass* AsClass = Cast<UClass>(Loaded))
+				return AsClass;
+			if (const UBlueprint* AsBlueprint = Cast<UBlueprint>(Loaded))
+				return AsBlueprint->GeneratedClass;
+		}
+
+		// 3. Short, unqualified native type name (`StaticMeshActor`, `PointLightComponent`).
+		if (UClass* Found = UClass::TryFindTypeSlow<UClass>(ClassRef))
+			return Found;
+
+		return FindFirstObject<UClass>(*ClassRef, EFindFirstObjectOptions::None);
+	}
+
+	AActor* ResolveActor(const FString& ActorRef, UWorld* World)
+	{
+		if (ActorRef.IsEmpty())
+			return nullptr;
+		if (!World)
+			World = GetEditorWorld();
+		if (!World)
+			return nullptr;
+
+		// Exact match on label / name / full path first (deterministic).
+		for (TActorIterator<AActor> It(World); It; ++It)
+		{
+			AActor* Actor = *It;
+			if (Actor->GetActorLabel() == ActorRef
+				|| Actor->GetName() == ActorRef
+				|| Actor->GetPathName() == ActorRef)
+			{
+				return Actor;
+			}
+		}
+
+		// Case-insensitive label fallback (LLM-supplied labels are often loosely cased).
+		for (TActorIterator<AActor> It(World); It; ++It)
+		{
+			if (It->GetActorLabel().Equals(ActorRef, ESearchCase::IgnoreCase))
+				return *It;
+		}
+
+		return nullptr;
+	}
+
+	UActorComponent* ResolveComponent(AActor* Actor, const FString& ComponentRef)
+	{
+		if (!Actor || ComponentRef.IsEmpty())
+			return nullptr;
+
+		for (UActorComponent* Component : Actor->GetComponents())
+		{
+			if (!Component)
+				continue;
+			if (Component->GetName() == ComponentRef
+				|| Component->GetReadableName() == ComponentRef
+				|| Component->GetName().Equals(ComponentRef, ESearchCase::IgnoreCase))
+			{
+				return Component;
+			}
+		}
+		return nullptr;
+	}
+
+	UObject* ResolveObject(const FString& ObjectRef, UWorld* World)
+	{
+		if (ObjectRef.IsEmpty())
+			return nullptr;
+
+		// A live actor (by label/name/path) takes precedence so `object-*` can target scene actors.
+		if (AActor* Actor = ResolveActor(ObjectRef, World))
+			return Actor;
+
+		// Already-loaded object by path.
+		if (UObject* Found = FindObject<UObject>(nullptr, *ObjectRef))
+			return Found;
+
+		// Soft path load (asset on disk not yet in memory).
+		if (UObject* Loaded = FSoftObjectPath(ObjectRef).TryLoad())
+			return Loaded;
+
+		return StaticLoadObject(UObject::StaticClass(), nullptr, *ObjectRef);
+	}
+
+	TSharedPtr<FJsonObject> ActorIdentity(const AActor* Actor)
+	{
+		TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+		if (!Actor)
+			return Json;
+		Json->SetStringField(TEXT("name"), Actor->GetName());
+		Json->SetStringField(TEXT("label"), Actor->GetActorLabel());
+		Json->SetStringField(TEXT("class"), Actor->GetClass() ? Actor->GetClass()->GetPathName() : FString());
+		Json->SetStringField(TEXT("path"), Actor->GetPathName());
+		return Json;
+	}
+
+	TSharedPtr<FJsonObject> ComponentIdentity(const UActorComponent* Component)
+	{
+		TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+		if (!Component)
+			return Json;
+		Json->SetStringField(TEXT("name"), Component->GetName());
+		Json->SetStringField(TEXT("class"), Component->GetClass() ? Component->GetClass()->GetPathName() : FString());
+		Json->SetStringField(TEXT("path"), Component->GetPathName());
+		return Json;
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpObjectRef.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpObjectRef.cpp
@@ -115,6 +115,8 @@ namespace FUnrealMcpObjectRef
 		if (UObject* Loaded = FSoftObjectPath(ObjectRef).TryLoad())
 			return Loaded;
 
+		// Last-resort fallback for refs that FSoftObjectPath's strict parsing rejects (e.g. legacy
+		// `Package.Object` short forms). Overlaps TryLoad for well-formed paths; kept for that long tail.
 		return StaticLoadObject(UObject::StaticClass(), nullptr, *ObjectRef);
 	}
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpObjectRef.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpObjectRef.cpp
@@ -122,7 +122,9 @@ namespace FUnrealMcpObjectRef
 
 		// Last-resort fallback for refs that FSoftObjectPath's strict parsing rejects (e.g. legacy
 		// `Package.Object` short forms). Overlaps TryLoad for well-formed paths; kept for that long tail.
-		return StaticLoadObject(UObject::StaticClass(), nullptr, *ObjectRef);
+		// LOAD_NoWarn | LOAD_Quiet (matching ResolveClass): every object-get-data/object-modify miss funnels
+		// through here, so without the flags a legitimate "not found" emits a spurious LogUObjectGlobals warning.
+		return StaticLoadObject(UObject::StaticClass(), nullptr, *ObjectRef, nullptr, LOAD_NoWarn | LOAD_Quiet);
 	}
 
 	TSharedPtr<FJsonObject> ActorIdentity(const AActor* Actor)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpObjectRef.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpObjectRef.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class AActor;
+class UActorComponent;
+class UWorld;
+
+/**
+ * Object-reference resolution for tool handlers (docs/ARCHITECTURE.md §3.2 — the "path-or-name string
+ * ref" rule). The analog of Unity-MCP's `ObjectRef`: a single string identifies a class, an asset, an
+ * actor, or a component, resolved with a label → FindObject → soft-path-load fallback chain.
+ *
+ * Shared by the actor family (and reused by the asset/blueprint families as they land), so it lives in
+ * a self-contained Private/Tools header. Every method runs ON the game thread (it touches the editor
+ * world and the UObject graph); call it only from a dispatched tool body (§4).
+ */
+namespace FUnrealMcpObjectRef
+{
+	/** The editor world the tool family operates on (GEditor's editor-context world). Null outside the editor. */
+	UNREALMCPEDITOR_API UWorld* GetEditorWorld();
+
+	/**
+	 * Resolve a class reference to a UClass*. Accepts, in order:
+	 *   - a soft class path (`/Script/Engine.PointLight`, `/Game/BP/BP_Foo.BP_Foo_C`),
+	 *   - a loadable object path that is itself a UClass or a UBlueprint (returns its GeneratedClass),
+	 *   - a short native type name (`StaticMeshActor`, `PointLight`).
+	 * Returns null when nothing matches.
+	 */
+	UNREALMCPEDITOR_API UClass* ResolveClass(const FString& ClassRef);
+
+	/**
+	 * Resolve an actor reference within @p World. Matches (case-sensitive first, then case-insensitive
+	 * on the label) the actor label, the object name, or the full path name. Returns null when no actor
+	 * matches. When @p World is null the editor world is used.
+	 */
+	UNREALMCPEDITOR_API AActor* ResolveActor(const FString& ActorRef, UWorld* World = nullptr);
+
+	/** Resolve a component on @p Actor by component name or readable name. Null when not found. */
+	UNREALMCPEDITOR_API UActorComponent* ResolveComponent(AActor* Actor, const FString& ComponentRef);
+
+	/**
+	 * Resolve a generic UObject by object path (`/Game/Folder/Asset.Asset`) or, when @p World is given,
+	 * by an actor reference first (so `object-get-data` can target a live actor by label). Returns null
+	 * when nothing matches.
+	 */
+	UNREALMCPEDITOR_API UObject* ResolveObject(const FString& ObjectRef, UWorld* World = nullptr);
+
+	/** A short JSON identity block for an actor: { name, label, class, path }. */
+	UNREALMCPEDITOR_API TSharedPtr<FJsonObject> ActorIdentity(const AActor* Actor);
+
+	/** A short JSON identity block for a component: { name, class, path }. */
+	UNREALMCPEDITOR_API TSharedPtr<FJsonObject> ComponentIdentity(const UActorComponent* Component);
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpPropertyJson.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpPropertyJson.cpp
@@ -155,8 +155,12 @@ namespace FUnrealMcpPropertyJson
 		USceneComponent* AsScene = Cast<USceneComponent>(Object);
 
 		// Snapshot the pre-change state for the transaction buffer BEFORE mutating. Calling Modify() after
-		// the writes (as before) records the already-changed values, making undo a no-op.
+		// the writes (as before) records the already-changed values, making undo a no-op. PreEditChange(nullptr)
+		// completes the standard editor edit protocol (PreEditChange -> write -> PostEditChange at line ~256):
+		// properties whose edit hooks tear down state up front (component render-state/registration guards,
+		// cached-data invalidation) can misbehave when raw memory is written without the pre-notify.
 		Object->Modify();
+		Object->PreEditChange(nullptr);
 
 		int32 Applied = 0;
 		for (const TPair<FString, TSharedPtr<FJsonValue>>& Field : Properties->Values)
@@ -251,11 +255,13 @@ namespace FUnrealMcpPropertyJson
 			}
 		}
 
+		// PostEditChange MUST pair the PreEditChange(nullptr) above on every path (it re-registers a component
+		// and re-runs the edit hooks that the pre-notify tore down) — calling it only when Applied>0 would
+		// leave a zero-applied object stranded mid-edit (e.g. an unregistered component). Only dirty the
+		// package when something actually changed.
+		Object->PostEditChange();
 		if (Applied > 0)
-		{
-			Object->PostEditChange();
 			Object->MarkPackageDirty();
-		}
 		return Applied;
 	}
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpPropertyJson.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpPropertyJson.cpp
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpPropertyJson.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "JsonObjectConverter.h"
+#include "GameFramework/Actor.h"
+#include "Components/SceneComponent.h"
+#include "UObject/UnrealType.h"
+#include "UObject/Class.h"
+
+namespace
+{
+	/** Read a {x,y,z} object into an FVector; returns false when the value is not such an object. */
+	bool JsonToVector(const TSharedPtr<FJsonValue>& Value, FVector& Out)
+	{
+		const TSharedPtr<FJsonObject>* Obj;
+		if (!Value.IsValid() || !Value->TryGetObject(Obj) || !Obj->IsValid())
+			return false;
+		double C;
+		if ((*Obj)->TryGetNumberField(TEXT("x"), C)) Out.X = C;
+		if ((*Obj)->TryGetNumberField(TEXT("y"), C)) Out.Y = C;
+		if ((*Obj)->TryGetNumberField(TEXT("z"), C)) Out.Z = C;
+		return true;
+	}
+
+	/** Read a {pitch,yaw,roll} object into an FRotator; returns false when not such an object. */
+	bool JsonToRotator(const TSharedPtr<FJsonValue>& Value, FRotator& Out)
+	{
+		const TSharedPtr<FJsonObject>* Obj;
+		if (!Value.IsValid() || !Value->TryGetObject(Obj) || !Obj->IsValid())
+			return false;
+		double C;
+		if ((*Obj)->TryGetNumberField(TEXT("pitch"), C)) Out.Pitch = C;
+		if ((*Obj)->TryGetNumberField(TEXT("yaw"),   C)) Out.Yaw = C;
+		if ((*Obj)->TryGetNumberField(TEXT("roll"),  C)) Out.Roll = C;
+		return true;
+	}
+
+	/** Find a reflected property by its JSON key (case-insensitive — keys are lower-first-cased, §3.2). */
+	FProperty* FindPropertyByJsonName(const UStruct* Struct, const FString& Key)
+	{
+		for (TFieldIterator<FProperty> It(Struct); It; ++It)
+		{
+			if (It->GetName().Equals(Key, ESearchCase::IgnoreCase))
+				return *It;
+		}
+		return nullptr;
+	}
+}
+
+namespace FUnrealMcpPropertyJson
+{
+	TSharedPtr<FJsonObject> SerializeObject(const UObject* Object, const TArray<FString>& Paths)
+	{
+		TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+		if (!Object)
+			return Json;
+
+		// Skip transient/deprecated and editor-only-noise properties from the schema-facing output.
+		const int64 SkipFlags = CPF_Transient | CPF_Deprecated;
+		FJsonObjectConverter::UStructToJsonObject(Object->GetClass(), Object, Json.ToSharedRef(), /*CheckFlags*/ 0, SkipFlags);
+
+		return Paths.Num() > 0 ? FilterByPaths(Json, Paths) : Json;
+	}
+
+	TSharedPtr<FJsonObject> FilterByPaths(const TSharedPtr<FJsonObject>& Source, const TArray<FString>& Paths)
+	{
+		if (!Source.IsValid())
+			return MakeShared<FJsonObject>();
+		if (Paths.Num() == 0)
+			return Source;
+
+		TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+		for (const FString& Path : Paths)
+		{
+			TArray<FString> Segments;
+			Path.ParseIntoArray(Segments, TEXT("."), /*CullEmpty*/ true);
+			if (Segments.Num() == 0)
+				continue;
+
+			// Walk the source object segment by segment; mirror the structure into Out so the caller gets
+			// the requested leaf at the same nesting depth it lives at in the full serialization.
+			TSharedPtr<FJsonObject> SrcCursor = Source;
+			TSharedPtr<FJsonObject> OutCursor = Out;
+			bool bResolved = true;
+			for (int32 i = 0; i < Segments.Num(); ++i)
+			{
+				const FString& Seg = Segments[i];
+				const bool bLeaf = (i == Segments.Num() - 1);
+
+				// Case-insensitive field match (paths may be loosely cased like property writes).
+				FString MatchedKey;
+				TSharedPtr<FJsonValue> MatchedValue;
+				for (const TPair<FString, TSharedPtr<FJsonValue>>& Field : SrcCursor->Values)
+				{
+					if (Field.Key.Equals(Seg, ESearchCase::IgnoreCase))
+					{
+						MatchedKey = Field.Key;
+						MatchedValue = Field.Value;
+						break;
+					}
+				}
+				if (!MatchedValue.IsValid())
+				{
+					bResolved = false;
+					break;
+				}
+
+				if (bLeaf)
+				{
+					OutCursor->SetField(MatchedKey, MatchedValue);
+					break;
+				}
+
+				const TSharedPtr<FJsonObject>* NextSrc;
+				if (!MatchedValue->TryGetObject(NextSrc) || !NextSrc->IsValid())
+				{
+					bResolved = false;
+					break;
+				}
+
+				// Reuse an existing nested object in Out (so two paths under the same parent merge).
+				TSharedPtr<FJsonObject> NextOut;
+				const TSharedPtr<FJsonObject>* ExistingOut;
+				if (OutCursor->TryGetObjectField(MatchedKey, ExistingOut) && ExistingOut->IsValid())
+				{
+					NextOut = *ExistingOut;
+				}
+				else
+				{
+					NextOut = MakeShared<FJsonObject>();
+					OutCursor->SetObjectField(MatchedKey, NextOut);
+				}
+				SrcCursor = *NextSrc;
+				OutCursor = NextOut;
+			}
+			(void)bResolved; // an unresolved path simply contributes nothing — not an error.
+		}
+		return Out;
+	}
+
+	int32 ApplyProperties(UObject* Object, const TSharedPtr<FJsonObject>& Properties, TArray<FString>& OutErrors)
+	{
+		if (!Object || !Properties.IsValid())
+			return 0;
+
+		AActor* AsActor = Cast<AActor>(Object);
+		USceneComponent* AsScene = Cast<USceneComponent>(Object);
+
+		int32 Applied = 0;
+		for (const TPair<FString, TSharedPtr<FJsonValue>>& Field : Properties->Values)
+		{
+			const FString& Key = Field.Key;
+			const TSharedPtr<FJsonValue>& Value = Field.Value;
+
+			// --- Actor transform special-cases (not single FProperties) ---
+			if (AsActor)
+			{
+				if (Key.Equals(TEXT("location"), ESearchCase::IgnoreCase))
+				{
+					FVector V = AsActor->GetActorLocation();
+					if (JsonToVector(Value, V)) { AsActor->SetActorLocation(V); ++Applied; continue; }
+				}
+				else if (Key.Equals(TEXT("rotation"), ESearchCase::IgnoreCase))
+				{
+					FRotator R = AsActor->GetActorRotation();
+					if (JsonToRotator(Value, R)) { AsActor->SetActorRotation(R); ++Applied; continue; }
+				}
+				else if (Key.Equals(TEXT("scale"), ESearchCase::IgnoreCase))
+				{
+					FVector S = AsActor->GetActorScale3D();
+					if (JsonToVector(Value, S)) { AsActor->SetActorScale3D(S); ++Applied; continue; }
+				}
+			}
+
+			// --- Scene-component relative-transform special-cases ---
+			if (AsScene)
+			{
+				if (Key.Equals(TEXT("relativeLocation"), ESearchCase::IgnoreCase))
+				{
+					FVector V = AsScene->GetRelativeLocation();
+					if (JsonToVector(Value, V)) { AsScene->SetRelativeLocation(V); ++Applied; continue; }
+				}
+				else if (Key.Equals(TEXT("relativeRotation"), ESearchCase::IgnoreCase))
+				{
+					FRotator R = AsScene->GetRelativeRotation();
+					if (JsonToRotator(Value, R)) { AsScene->SetRelativeRotation(R); ++Applied; continue; }
+				}
+				else if (Key.Equals(TEXT("relativeScale3D"), ESearchCase::IgnoreCase)
+					|| Key.Equals(TEXT("relativeScale"), ESearchCase::IgnoreCase))
+				{
+					FVector S = AsScene->GetRelativeScale3D();
+					if (JsonToVector(Value, S)) { AsScene->SetRelativeScale3D(S); ++Applied; continue; }
+				}
+			}
+
+			// --- Generic reflected FProperty write ---
+			FProperty* Prop = FindPropertyByJsonName(Object->GetClass(), Key);
+			if (!Prop)
+			{
+				OutErrors.Add(FString::Printf(TEXT("unknown property '%s'"), *Key));
+				continue;
+			}
+			if (Prop->HasAnyPropertyFlags(CPF_EditConst) || !Prop->HasAnyPropertyFlags(CPF_Edit | CPF_BlueprintVisible))
+			{
+				// Allow editable / blueprint-visible properties only; reject read-only ones explicitly so
+				// the caller gets a clear reason rather than a silent no-op.
+				OutErrors.Add(FString::Printf(TEXT("property '%s' is not writable"), *Key));
+				continue;
+			}
+
+			void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(Object);
+			if (FJsonObjectConverter::JsonValueToUProperty(Value, Prop, ValuePtr, /*CheckFlags*/ 0, /*SkipFlags*/ 0))
+			{
+				++Applied;
+			}
+			else
+			{
+				OutErrors.Add(FString::Printf(TEXT("could not set property '%s' from the provided value"), *Key));
+			}
+		}
+
+		if (Applied > 0)
+		{
+			Object->Modify();
+			Object->PostEditChange();
+			Object->MarkPackageDirty();
+		}
+		return Applied;
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpPropertyJson.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpPropertyJson.cpp
@@ -13,30 +13,34 @@
 
 namespace
 {
-	/** Read a {x,y,z} object into an FVector; returns false when the value is not such an object. */
+	/** Read a {x,y,z} object into an FVector; returns true only when ≥1 recognized axis key was present
+	 *  (an empty or typo'd object must NOT count as an applied no-op write). */
 	bool JsonToVector(const TSharedPtr<FJsonValue>& Value, FVector& Out)
 	{
 		const TSharedPtr<FJsonObject>* Obj;
 		if (!Value.IsValid() || !Value->TryGetObject(Obj) || !Obj->IsValid())
 			return false;
+		bool bAny = false;
 		double C;
-		if ((*Obj)->TryGetNumberField(TEXT("x"), C)) Out.X = C;
-		if ((*Obj)->TryGetNumberField(TEXT("y"), C)) Out.Y = C;
-		if ((*Obj)->TryGetNumberField(TEXT("z"), C)) Out.Z = C;
-		return true;
+		if ((*Obj)->TryGetNumberField(TEXT("x"), C)) { Out.X = C; bAny = true; }
+		if ((*Obj)->TryGetNumberField(TEXT("y"), C)) { Out.Y = C; bAny = true; }
+		if ((*Obj)->TryGetNumberField(TEXT("z"), C)) { Out.Z = C; bAny = true; }
+		return bAny;
 	}
 
-	/** Read a {pitch,yaw,roll} object into an FRotator; returns false when not such an object. */
+	/** Read a {pitch,yaw,roll} object into an FRotator; returns true only when ≥1 recognized key was
+	 *  present (an empty or typo'd object must NOT count as an applied no-op write). */
 	bool JsonToRotator(const TSharedPtr<FJsonValue>& Value, FRotator& Out)
 	{
 		const TSharedPtr<FJsonObject>* Obj;
 		if (!Value.IsValid() || !Value->TryGetObject(Obj) || !Obj->IsValid())
 			return false;
+		bool bAny = false;
 		double C;
-		if ((*Obj)->TryGetNumberField(TEXT("pitch"), C)) Out.Pitch = C;
-		if ((*Obj)->TryGetNumberField(TEXT("yaw"),   C)) Out.Yaw = C;
-		if ((*Obj)->TryGetNumberField(TEXT("roll"),  C)) Out.Roll = C;
-		return true;
+		if ((*Obj)->TryGetNumberField(TEXT("pitch"), C)) { Out.Pitch = C; bAny = true; }
+		if ((*Obj)->TryGetNumberField(TEXT("yaw"),   C)) { Out.Yaw = C; bAny = true; }
+		if ((*Obj)->TryGetNumberField(TEXT("roll"),  C)) { Out.Roll = C; bAny = true; }
+		return bAny;
 	}
 
 	/** Find a reflected property by its JSON key (case-insensitive — keys are lower-first-cased, §3.2). */
@@ -150,6 +154,10 @@ namespace FUnrealMcpPropertyJson
 		AActor* AsActor = Cast<AActor>(Object);
 		USceneComponent* AsScene = Cast<USceneComponent>(Object);
 
+		// Snapshot the pre-change state for the transaction buffer BEFORE mutating. Calling Modify() after
+		// the writes (as before) records the already-changed values, making undo a no-op.
+		Object->Modify();
+
 		int32 Applied = 0;
 		for (const TPair<FString, TSharedPtr<FJsonValue>>& Field : Properties->Values)
 		{
@@ -204,10 +212,13 @@ namespace FUnrealMcpPropertyJson
 				OutErrors.Add(FString::Printf(TEXT("unknown property '%s'"), *Key));
 				continue;
 			}
-			if (Prop->HasAnyPropertyFlags(CPF_EditConst) || !Prop->HasAnyPropertyFlags(CPF_Edit | CPF_BlueprintVisible))
+			// Writable iff editable-and-not-const, OR blueprint-visible-and-not-blueprint-read-only. The old
+			// gate admitted BlueprintReadOnly props (CPF_BlueprintVisible set, no CPF_Edit, no CPF_EditConst).
+			const bool bEditable = Prop->HasAnyPropertyFlags(CPF_Edit) && !Prop->HasAnyPropertyFlags(CPF_EditConst);
+			const bool bBlueprintWritable = Prop->HasAnyPropertyFlags(CPF_BlueprintVisible) && !Prop->HasAnyPropertyFlags(CPF_BlueprintReadOnly);
+			if (!bEditable && !bBlueprintWritable)
 			{
-				// Allow editable / blueprint-visible properties only; reject read-only ones explicitly so
-				// the caller gets a clear reason rather than a silent no-op.
+				// Reject read-only properties explicitly so the caller gets a clear reason, not a silent no-op.
 				OutErrors.Add(FString::Printf(TEXT("property '%s' is not writable"), *Key));
 				continue;
 			}
@@ -225,7 +236,6 @@ namespace FUnrealMcpPropertyJson
 
 		if (Applied > 0)
 		{
-			Object->Modify();
 			Object->PostEditChange();
 			Object->MarkPackageDirty();
 		}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpPropertyJson.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpPropertyJson.cpp
@@ -165,43 +165,60 @@ namespace FUnrealMcpPropertyJson
 			const TSharedPtr<FJsonValue>& Value = Field.Value;
 
 			// --- Actor transform special-cases (not single FProperties) ---
+			// Each transform key is handled TERMINALLY: on a parse success we apply and count it; on a
+			// parse failure (empty {} or all-typo'd keys) we record an error and `continue`. Falling through
+			// to the generic FProperty path would either count an empty-object no-op as applied (the scene
+			// component RelativeLocation/etc. FProperties exist and JsonObjectToUStruct returns true for {})
+			// or emit a misleading "unknown property" error for the actor pseudo-keys.
 			if (AsActor)
 			{
 				if (Key.Equals(TEXT("location"), ESearchCase::IgnoreCase))
 				{
 					FVector V = AsActor->GetActorLocation();
-					if (JsonToVector(Value, V)) { AsActor->SetActorLocation(V); ++Applied; continue; }
+					if (JsonToVector(Value, V)) { AsActor->SetActorLocation(V); ++Applied; }
+					else OutErrors.Add(FString::Printf(TEXT("'%s' expects a {x,y,z} object with at least one numeric axis"), *Key));
+					continue;
 				}
-				else if (Key.Equals(TEXT("rotation"), ESearchCase::IgnoreCase))
+				if (Key.Equals(TEXT("rotation"), ESearchCase::IgnoreCase))
 				{
 					FRotator R = AsActor->GetActorRotation();
-					if (JsonToRotator(Value, R)) { AsActor->SetActorRotation(R); ++Applied; continue; }
+					if (JsonToRotator(Value, R)) { AsActor->SetActorRotation(R); ++Applied; }
+					else OutErrors.Add(FString::Printf(TEXT("'%s' expects a {pitch,yaw,roll} object with at least one numeric key"), *Key));
+					continue;
 				}
-				else if (Key.Equals(TEXT("scale"), ESearchCase::IgnoreCase))
+				if (Key.Equals(TEXT("scale"), ESearchCase::IgnoreCase))
 				{
 					FVector S = AsActor->GetActorScale3D();
-					if (JsonToVector(Value, S)) { AsActor->SetActorScale3D(S); ++Applied; continue; }
+					if (JsonToVector(Value, S)) { AsActor->SetActorScale3D(S); ++Applied; }
+					else OutErrors.Add(FString::Printf(TEXT("'%s' expects a {x,y,z} object with at least one numeric axis"), *Key));
+					continue;
 				}
 			}
 
-			// --- Scene-component relative-transform special-cases ---
+			// --- Scene-component relative-transform special-cases (also handled terminally) ---
 			if (AsScene)
 			{
 				if (Key.Equals(TEXT("relativeLocation"), ESearchCase::IgnoreCase))
 				{
 					FVector V = AsScene->GetRelativeLocation();
-					if (JsonToVector(Value, V)) { AsScene->SetRelativeLocation(V); ++Applied; continue; }
+					if (JsonToVector(Value, V)) { AsScene->SetRelativeLocation(V); ++Applied; }
+					else OutErrors.Add(FString::Printf(TEXT("'%s' expects a {x,y,z} object with at least one numeric axis"), *Key));
+					continue;
 				}
-				else if (Key.Equals(TEXT("relativeRotation"), ESearchCase::IgnoreCase))
+				if (Key.Equals(TEXT("relativeRotation"), ESearchCase::IgnoreCase))
 				{
 					FRotator R = AsScene->GetRelativeRotation();
-					if (JsonToRotator(Value, R)) { AsScene->SetRelativeRotation(R); ++Applied; continue; }
+					if (JsonToRotator(Value, R)) { AsScene->SetRelativeRotation(R); ++Applied; }
+					else OutErrors.Add(FString::Printf(TEXT("'%s' expects a {pitch,yaw,roll} object with at least one numeric key"), *Key));
+					continue;
 				}
-				else if (Key.Equals(TEXT("relativeScale3D"), ESearchCase::IgnoreCase)
+				if (Key.Equals(TEXT("relativeScale3D"), ESearchCase::IgnoreCase)
 					|| Key.Equals(TEXT("relativeScale"), ESearchCase::IgnoreCase))
 				{
 					FVector S = AsScene->GetRelativeScale3D();
-					if (JsonToVector(Value, S)) { AsScene->SetRelativeScale3D(S); ++Applied; continue; }
+					if (JsonToVector(Value, S)) { AsScene->SetRelativeScale3D(S); ++Applied; }
+					else OutErrors.Add(FString::Printf(TEXT("'%s' expects a {x,y,z} object with at least one numeric axis"), *Key));
+					continue;
 				}
 			}
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpPropertyJson.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpPropertyJson.h
@@ -31,7 +31,8 @@ namespace FUnrealMcpPropertyJson
 	 */
 	UNREALMCPEDITOR_API TSharedPtr<FJsonObject> SerializeObject(const UObject* Object, const TArray<FString>& Paths);
 
-	/** Filter @p Source down to the requested dotted @p Paths, preserving nesting. Empty Paths → a clone of Source. */
+	/** Filter @p Source down to the requested dotted @p Paths, preserving nesting. Empty Paths → @p Source
+	 *  returned as-is (no copy — callers must not mutate the result in that case). */
 	UNREALMCPEDITOR_API TSharedPtr<FJsonObject> FilterByPaths(const TSharedPtr<FJsonObject>& Source, const TArray<FString>& Paths);
 
 	/**

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpPropertyJson.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpPropertyJson.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class UObject;
+
+/**
+ * FProperty <-> JSON helpers for tool handlers (docs/ARCHITECTURE.md §3.2). Wraps FJsonObjectConverter
+ * with two Unity-MCP-parity behaviours:
+ *   - **Scoped reads**: a `paths` filter applied AFTER serialization (post-serialization JSON-path
+ *     filtering, §3.2) so `*-get-data` tools can return only the requested dotted keys and save tokens.
+ *   - **Transform writes**: `actor-modify`/`actor-component-modify` accept `location`/`rotation`/`scale`
+ *     (and the component-relative variants) and route them through the SetActor / SetRelative APIs,
+ *     because an actor/component transform is not a single writable FProperty.
+ *
+ * FJsonObjectConverter standardizes the first character of every key to lowercase, so serialized output
+ * matches the §3.2 wire convention (`location`, `relativeLocation`, `{x,y,z}`) and the same lowercase
+ * keys are accepted on write (property lookup is case-insensitive).
+ *
+ * All functions run ON the game thread — call only from a dispatched tool body (§4).
+ */
+namespace FUnrealMcpPropertyJson
+{
+	/**
+	 * Serialize @p Object's reflected properties to a JSON object (§3.2 mapping). When @p Paths is
+	 * non-empty, only those dotted paths (e.g. `rootComponent.relativeLocation`, `staticMesh`) are
+	 * retained in the result (scoped read). Returns an empty object when @p Object is null.
+	 */
+	UNREALMCPEDITOR_API TSharedPtr<FJsonObject> SerializeObject(const UObject* Object, const TArray<FString>& Paths);
+
+	/** Filter @p Source down to the requested dotted @p Paths, preserving nesting. Empty Paths → a clone of Source. */
+	UNREALMCPEDITOR_API TSharedPtr<FJsonObject> FilterByPaths(const TSharedPtr<FJsonObject>& Source, const TArray<FString>& Paths);
+
+	/**
+	 * Apply each field of @p Properties to @p Object via reflection (§3.2). Actor transform keys
+	 * (`location`/`rotation`/`scale`) and scene-component relative-transform keys
+	 * (`relativeLocation`/`relativeRotation`/`relativeScale3D`) are special-cased to the transform APIs;
+	 * everything else is set through FJsonObjectConverter::JsonValueToUProperty. Returns the number of
+	 * fields successfully applied; appends a one-line reason per failed field to @p OutErrors. Marks the
+	 * object modified / dirty and fires PostEditChange when at least one field changed.
+	 */
+	UNREALMCPEDITOR_API int32 ApplyProperties(UObject* Object, const TSharedPtr<FJsonObject>& Properties, TArray<FString>& OutErrors);
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpToolRegistry.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpToolRegistry.cpp
@@ -113,7 +113,9 @@ TSharedPtr<FJsonObject> FUnrealMcpRegisteredTool::BuildInputSchema() const
 
 	for (const FUnrealMcpParamSpec& Param : Params)
 	{
-		TSharedPtr<FJsonObject> ParamSchema = Param.JsonType == TEXT("object") && Param.ObjectSchema.IsValid()
+		// A custom schema (object/array/exotic types built via the generic Param()) is used verbatim;
+		// the simple scalar types fall back to a {type,description} schema.
+		TSharedPtr<FJsonObject> ParamSchema = Param.ObjectSchema.IsValid()
 			? Param.ObjectSchema
 			: MakeTypedSchema(Param.JsonType, Param.Description);
 
@@ -182,6 +184,11 @@ FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::ParamVector(const FString& Name, c
 {
 	FUnrealMcpParamSpec Spec{ Name, TEXT("object"), Desc, Req, MakeVectorSchema(Desc) };
 	Tool.Params.Add(Spec);
+	return *this;
+}
+FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::Param(const FString& Name, const FString& JsonType, const FString& Desc, EUnrealMcpParamRequirement Req, TSharedPtr<FJsonObject> CustomSchema)
+{
+	Tool.Params.Add(FUnrealMcpParamSpec{ Name, JsonType, Desc, Req, CustomSchema });
 	return *this;
 }
 FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::ReadOnlyHint(bool bValue) { Tool.bReadOnlyHint = bValue; return *this; }
@@ -261,7 +268,7 @@ bool FUnrealMcpToolRegistry::ValidateTool(const FUnrealMcpRegisteredTool& InTool
 		return false;
 	}
 
-	static const TCHAR* const KnownTypes[] = { TEXT("string"), TEXT("integer"), TEXT("number"), TEXT("boolean"), TEXT("object") };
+	static const TCHAR* const KnownTypes[] = { TEXT("string"), TEXT("integer"), TEXT("number"), TEXT("boolean"), TEXT("object"), TEXT("array") };
 	TSet<FString> SeenParams;
 	for (const FUnrealMcpParamSpec& Param : InTool.Params)
 	{
@@ -283,10 +290,10 @@ bool FUnrealMcpToolRegistry::ValidateTool(const FUnrealMcpRegisteredTool& InTool
 			return false;
 		}
 
-		if (Param.JsonType == TEXT("object") && !Param.ObjectSchema.IsValid())
+		if ((Param.JsonType == TEXT("object") || Param.JsonType == TEXT("array")) && !Param.ObjectSchema.IsValid())
 		{
-			OutError = FString::Printf(TEXT("tool '%s' object parameter '%s' has no schema (malformed schema)"),
-				*InTool.Name, *Param.Name);
+			OutError = FString::Printf(TEXT("tool '%s' %s parameter '%s' has no schema (malformed schema)"),
+				*InTool.Name, *Param.JsonType, *Param.Name);
 			return false;
 		}
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -29,6 +29,7 @@ void FUnrealMcpRuntime::Startup()
 
 	Registry = MakeUnique<FUnrealMcpToolRegistry>();
 	UnrealMcpPingTool::Register(*Registry);
+	UnrealMcpActorTools::Register(*Registry);
 
 	Dispatcher = MakeUnique<FUnrealMcpGameThreadDispatcher>();
 	BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(*Registry, *Dispatcher);

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpCoreTools.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpCoreTools.h
@@ -16,3 +16,16 @@ namespace UnrealMcpPingTool
 {
 	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry);
 }
+
+/**
+ * The actor & component tool family (docs/ARCHITECTURE.md §10 "actor family"): actor lifecycle
+ * (create/destroy/duplicate), scoped reads + FProperty writes (find/modify), parent/attachment,
+ * component management (add/destroy/get/modify/list-all), and generic UObject access
+ * (object-get-data/object-modify). ~13 native C++ tools, all declared via the §3.3 builder and run
+ * on the GameThread dispatcher. Exported so the runtime wires it on boot AND the Automation specs
+ * can register + exercise it in isolation.
+ */
+namespace UnrealMcpActorTools
+{
+	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry);
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
@@ -28,7 +28,7 @@ enum class EUnrealMcpParamRequirement : uint8
 struct UNREALMCPEDITOR_API FUnrealMcpParamSpec
 {
 	FString Name;
-	FString JsonType;        // "string" | "integer" | "number" | "boolean" | "object"
+	FString JsonType;        // "string" | "integer" | "number" | "boolean" | "object" | "array"
 	FString Description;
 	EUnrealMcpParamRequirement Requirement = EUnrealMcpParamRequirement::Optional;
 	TSharedPtr<FJsonObject> ObjectSchema; // verbatim custom schema for object/array/exotic params (e.g. FVector → {x,y,z}, paths → array of string); null for plain scalars

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
@@ -31,7 +31,7 @@ struct UNREALMCPEDITOR_API FUnrealMcpParamSpec
 	FString JsonType;        // "string" | "integer" | "number" | "boolean" | "object"
 	FString Description;
 	EUnrealMcpParamRequirement Requirement = EUnrealMcpParamRequirement::Optional;
-	TSharedPtr<FJsonObject> ObjectSchema; // for "object" params (e.g. FVector → {x,y,z})
+	TSharedPtr<FJsonObject> ObjectSchema; // verbatim custom schema for object/array/exotic params (e.g. FVector → {x,y,z}, paths → array of string); null for plain scalars
 };
 
 /**
@@ -132,6 +132,13 @@ public:
 	FUnrealMcpToolBuilder& ParamNumber(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req = EUnrealMcpParamRequirement::Optional);
 	FUnrealMcpToolBuilder& ParamBool(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req = EUnrealMcpParamRequirement::Optional);
 	FUnrealMcpToolBuilder& ParamVector(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req = EUnrealMcpParamRequirement::Optional);
+	/**
+	 * Generic escape hatch for params whose JSON Schema the typed helpers above do not cover (e.g.
+	 * `{pitch,yaw,roll}` rotators, free-form `object` property bags, `array` lists). Pass the fully
+	 * built schema in @p CustomSchema; it is used verbatim as the param's schema. Families build their
+	 * own schemas locally so the shared builder surface stays small (one method, not one per math type).
+	 */
+	FUnrealMcpToolBuilder& Param(const FString& Name, const FString& JsonType, const FString& Desc, EUnrealMcpParamRequirement Req, TSharedPtr<FJsonObject> CustomSchema = nullptr);
 	FUnrealMcpToolBuilder& ReadOnlyHint(bool bValue);
 	FUnrealMcpToolBuilder& DestructiveHint(bool bValue);
 	FUnrealMcpToolBuilder& IdempotentHint(bool bValue);

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpActorToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpActorToolsSpec.cpp
@@ -9,6 +9,8 @@
 #include "UnrealMcpToolRegistry.h"
 #include "Dom/JsonObject.h"
 #include "Editor.h"
+#include "EngineUtils.h"            // TActorIterator
+#include "Engine/World.h"
 #include "GameFramework/Actor.h"
 
 /**
@@ -130,6 +132,19 @@ void FUnrealMcpActorToolsSpec::Define()
 				TestTrue(TEXT("modify success"), R.bSuccess);
 				double Applied = 0; if (R.Structured.IsValid()) R.Structured->TryGetNumberField(TEXT("applied"), Applied);
 				TestTrue(TEXT("at least one property applied"), Applied >= 1.0);
+
+				// Read the location back: a silent transform-routing no-op would still report applied>=1,
+				// so confirm the actor actually moved to the requested world location.
+				UWorld* World = GEditor->GetEditorWorldContext().World();
+				AActor* Moved = nullptr;
+				for (TActorIterator<AActor> It(World); It; ++It)
+				{
+					if (It->GetActorLabel() == Label) { Moved = *It; break; }
+				}
+				TestNotNull(TEXT("modified actor found"), Moved);
+				if (Moved)
+					TestTrue(TEXT("location write took effect"),
+						Moved->GetActorLocation().Equals(FVector(100.0, 200.0, 50.0), 0.5));
 			}
 
 			// add a component

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpActorToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpActorToolsSpec.cpp
@@ -1,0 +1,321 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "UnrealMcpCoreTools.h"
+#include "UnrealMcpToolRegistry.h"
+#include "Dom/JsonObject.h"
+#include "Editor.h"
+#include "GameFramework/Actor.h"
+
+/**
+ * Actor & component tool family specs (docs/ARCHITECTURE.md §10). Registration shape + per-tool
+ * happy/error paths, executed in EditorContext so GEditor + the editor world are live. Each scene-
+ * mutating test cleans up the actors it spawns so tests stay order-independent.
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpActorToolsSpec, "UnrealMcp.Tools.Actor",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	// Helpers ------------------------------------------------------------------------------------
+	static TSharedPtr<FJsonObject> Args() { return MakeShared<FJsonObject>(); }
+
+	/** Run a tool by name with the given args object through a freshly-registered actor registry. */
+	FUnrealMcpToolResult Run(FUnrealMcpToolRegistry& Reg, const FString& Tool, const TSharedPtr<FJsonObject>& A)
+	{
+		return Reg.Execute(Tool, FUnrealMcpToolCall(A));
+	}
+
+	/** Pull the structured "name"/"label" identity field from a result (empty when absent). */
+	static FString StructString(const FUnrealMcpToolResult& R, const FString& Key)
+	{
+		FString V;
+		if (R.Structured.IsValid())
+			R.Structured->TryGetStringField(Key, V);
+		return V;
+	}
+
+END_DEFINE_SPEC(FUnrealMcpActorToolsSpec)
+
+void FUnrealMcpActorToolsSpec::Define()
+{
+	Describe("registration", [this]()
+	{
+		It("registers the full actor family as core tools and bumps the revision", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			const int32 Before = Registry.GetRevision();
+			UnrealMcpActorTools::Register(Registry);
+
+			const TCHAR* const Expected[] = {
+				TEXT("actor-create"), TEXT("actor-destroy"), TEXT("actor-duplicate"), TEXT("actor-find"),
+				TEXT("actor-modify"), TEXT("actor-set-parent"), TEXT("actor-component-add"),
+				TEXT("actor-component-destroy"), TEXT("actor-component-get"), TEXT("actor-component-modify"),
+				TEXT("actor-component-list-all"), TEXT("object-get-data"), TEXT("object-modify")
+			};
+			for (const TCHAR* Name : Expected)
+				TestTrue(FString::Printf(TEXT("has %s"), Name), Registry.HasTool(Name));
+
+			TestEqual(TEXT("tool count"), Registry.Num(), (int32)UE_ARRAY_COUNT(Expected));
+			TestTrue(TEXT("revision bumped"), Registry.GetRevision() > Before);
+
+			// Every tool stays under the core extension id and surfaces in the manifest with a schema hash.
+			const FUnrealMcpRegisteredTool* Create = Registry.Find(TEXT("actor-create"));
+			TestTrue(TEXT("actor-create found"), Create != nullptr);
+			if (Create)
+			{
+				TestEqual(TEXT("core extension id"), Create->ExtensionId, FString(TEXT("core")));
+				TestFalse(TEXT("schema hash non-empty"), Create->SchemaHash.IsEmpty());
+			}
+		});
+
+		It("declares destructive/read-only hints that match each tool's behavior", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpActorTools::Register(Registry);
+			TestTrue(TEXT("actor-destroy destructive"), Registry.Find(TEXT("actor-destroy"))->bDestructiveHint);
+			TestTrue(TEXT("actor-find read-only"), Registry.Find(TEXT("actor-find"))->bReadOnlyHint);
+			TestTrue(TEXT("actor-component-list-all read-only"), Registry.Find(TEXT("actor-component-list-all"))->bReadOnlyHint);
+			TestFalse(TEXT("actor-create not read-only"), Registry.Find(TEXT("actor-create"))->bReadOnlyHint);
+		});
+	});
+
+	Describe("lifecycle round-trip", [this]()
+	{
+		It("creates -> finds -> modifies -> adds component -> reads -> destroys an actor", [this]()
+		{
+			if (!GEditor) { AddError(TEXT("GEditor unavailable")); return; }
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpActorTools::Register(Registry);
+
+			const FString Label = FString::Printf(TEXT("McpSpecActor_%s"), *FGuid::NewGuid().ToString(EGuidFormats::Short));
+
+			// create
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("classPath"), TEXT("/Script/Engine.StaticMeshActor"));
+				A->SetStringField(TEXT("name"), Label);
+				const FUnrealMcpToolResult R = Run(Registry, TEXT("actor-create"), A);
+				TestTrue(TEXT("create success"), R.bSuccess);
+				TestEqual(TEXT("created label"), StructString(R, TEXT("label")), Label);
+			}
+
+			// find by label + class
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("labelFilter"), Label);
+				A->SetStringField(TEXT("classFilter"), TEXT("StaticMeshActor"));
+				const FUnrealMcpToolResult R = Run(Registry, TEXT("actor-find"), A);
+				TestTrue(TEXT("find success"), R.bSuccess);
+				int32 Total = 0;
+				if (R.Structured.IsValid())
+				{
+					double D = 0; R.Structured->TryGetNumberField(TEXT("total"), D); Total = (int32)D;
+				}
+				TestEqual(TEXT("found exactly one"), Total, 1);
+			}
+
+			// modify transform (location) + a reflected bool
+			{
+				TSharedPtr<FJsonObject> Loc = Args();
+				Loc->SetNumberField(TEXT("x"), 100.0); Loc->SetNumberField(TEXT("y"), 200.0); Loc->SetNumberField(TEXT("z"), 50.0);
+				TSharedPtr<FJsonObject> Props = Args();
+				Props->SetObjectField(TEXT("location"), Loc);
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("actor"), Label);
+				A->SetObjectField(TEXT("properties"), Props);
+				const FUnrealMcpToolResult R = Run(Registry, TEXT("actor-modify"), A);
+				TestTrue(TEXT("modify success"), R.bSuccess);
+				double Applied = 0; if (R.Structured.IsValid()) R.Structured->TryGetNumberField(TEXT("applied"), Applied);
+				TestTrue(TEXT("at least one property applied"), Applied >= 1.0);
+			}
+
+			// add a component
+			FString CompName;
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("actor"), Label);
+				A->SetStringField(TEXT("componentClass"), TEXT("/Script/Engine.PointLightComponent"));
+				A->SetStringField(TEXT("name"), TEXT("McpSpecLight"));
+				const FUnrealMcpToolResult R = Run(Registry, TEXT("actor-component-add"), A);
+				TestTrue(TEXT("component-add success"), R.bSuccess);
+				CompName = StructString(R, TEXT("name"));
+				TestFalse(TEXT("component name non-empty"), CompName.IsEmpty());
+			}
+
+			// read the component back (scoped paths optional → full)
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("actor"), Label);
+				A->SetStringField(TEXT("component"), CompName);
+				const FUnrealMcpToolResult R = Run(Registry, TEXT("actor-component-get"), A);
+				TestTrue(TEXT("component-get success"), R.bSuccess);
+				TestTrue(TEXT("component-get has data"), R.Structured.IsValid() && R.Structured->HasField(TEXT("data")));
+			}
+
+			// object-get-data on the same actor by label
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("object"), Label);
+				const FUnrealMcpToolResult R = Run(Registry, TEXT("object-get-data"), A);
+				TestTrue(TEXT("object-get-data success"), R.bSuccess);
+			}
+
+			// destroy
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("actor"), Label);
+				const FUnrealMcpToolResult R = Run(Registry, TEXT("actor-destroy"), A);
+				TestTrue(TEXT("destroy success"), R.bSuccess);
+			}
+
+			// confirm gone
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("labelFilter"), Label);
+				const FUnrealMcpToolResult R = Run(Registry, TEXT("actor-find"), A);
+				int32 Total = 0; double D = 0;
+				if (R.Structured.IsValid() && R.Structured->TryGetNumberField(TEXT("total"), D)) Total = (int32)D;
+				TestEqual(TEXT("no actor remains"), Total, 0);
+			}
+		});
+
+		It("attaches and detaches actors via actor-set-parent", [this]()
+		{
+			if (!GEditor) { AddError(TEXT("GEditor unavailable")); return; }
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpActorTools::Register(Registry);
+
+			const FString Parent = FString::Printf(TEXT("McpSpecParent_%s"), *FGuid::NewGuid().ToString(EGuidFormats::Short));
+			const FString Child = FString::Printf(TEXT("McpSpecChild_%s"), *FGuid::NewGuid().ToString(EGuidFormats::Short));
+			for (const FString& Lbl : { Parent, Child })
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("classPath"), TEXT("/Script/Engine.StaticMeshActor"));
+				A->SetStringField(TEXT("name"), Lbl);
+				TestTrue(TEXT("spawn"), Run(Registry, TEXT("actor-create"), A).bSuccess);
+			}
+
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("actor"), Child);
+				A->SetStringField(TEXT("parent"), Parent);
+				TestTrue(TEXT("attach success"), Run(Registry, TEXT("actor-set-parent"), A).bSuccess);
+			}
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("actor"), Child); // no parent => detach
+				TestTrue(TEXT("detach success"), Run(Registry, TEXT("actor-set-parent"), A).bSuccess);
+			}
+
+			for (const FString& Lbl : { Child, Parent })
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("actor"), Lbl);
+				Run(Registry, TEXT("actor-destroy"), A);
+			}
+		});
+
+		It("duplicates an actor with a location offset", [this]()
+		{
+			if (!GEditor) { AddError(TEXT("GEditor unavailable")); return; }
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpActorTools::Register(Registry);
+
+			const FString Src = FString::Printf(TEXT("McpSpecDup_%s"), *FGuid::NewGuid().ToString(EGuidFormats::Short));
+			const FString Dup = Src + TEXT("_copy");
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("classPath"), TEXT("/Script/Engine.StaticMeshActor"));
+				A->SetStringField(TEXT("name"), Src);
+				TestTrue(TEXT("spawn src"), Run(Registry, TEXT("actor-create"), A).bSuccess);
+			}
+			{
+				TSharedPtr<FJsonObject> Off = Args();
+				Off->SetNumberField(TEXT("x"), 500.0);
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("actor"), Src);
+				A->SetStringField(TEXT("name"), Dup);
+				A->SetObjectField(TEXT("offset"), Off);
+				const FUnrealMcpToolResult R = Run(Registry, TEXT("actor-duplicate"), A);
+				TestTrue(TEXT("duplicate success"), R.bSuccess);
+				TestEqual(TEXT("dup label"), StructString(R, TEXT("label")), Dup);
+			}
+			for (const FString& Lbl : { Src, Dup })
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("actor"), Lbl);
+				Run(Registry, TEXT("actor-destroy"), A);
+			}
+		});
+	});
+
+	Describe("component class listing", [this]()
+	{
+		It("lists concrete component classes including StaticMeshComponent and paginates", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpActorTools::Register(Registry);
+
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("search"), TEXT("StaticMeshComponent"));
+			const FUnrealMcpToolResult R = Run(Registry, TEXT("actor-component-list-all"), A);
+			TestTrue(TEXT("list success"), R.bSuccess);
+			double Total = 0; if (R.Structured.IsValid()) R.Structured->TryGetNumberField(TEXT("total"), Total);
+			TestTrue(TEXT("at least one match"), Total >= 1.0);
+
+			const TArray<TSharedPtr<FJsonValue>>* Comps = nullptr;
+			bool bFoundSMC = false;
+			if (R.Structured.IsValid() && R.Structured->TryGetArrayField(TEXT("components"), Comps))
+			{
+				for (const TSharedPtr<FJsonValue>& V : *Comps)
+				{
+					FString Name;
+					if (V->AsObject().IsValid() && V->AsObject()->TryGetStringField(TEXT("name"), Name) && Name == TEXT("StaticMeshComponent"))
+						bFoundSMC = true;
+				}
+			}
+			TestTrue(TEXT("found StaticMeshComponent"), bFoundSMC);
+		});
+	});
+
+	Describe("error paths", [this]()
+	{
+		It("rejects an unspawnable class on actor-create", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpActorTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("classPath"), TEXT("/Script/Engine.NotARealClassXYZ"));
+			const FUnrealMcpToolResult R = Run(Registry, TEXT("actor-create"), A);
+			TestFalse(TEXT("create fails for bad class"), R.bSuccess);
+		});
+
+		It("errors when actor-modify targets a missing actor", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpActorTools::Register(Registry);
+			TSharedPtr<FJsonObject> Props = Args();
+			Props->SetBoolField(TEXT("bHidden"), true);
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("actor"), TEXT("DefinitelyMissingActor_ZZZ"));
+			A->SetObjectField(TEXT("properties"), Props);
+			const FUnrealMcpToolResult R = Run(Registry, TEXT("actor-modify"), A);
+			TestFalse(TEXT("modify fails for missing actor"), R.bSuccess);
+		});
+
+		It("errors when object-get-data targets a missing object", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpActorTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("object"), TEXT("/Game/DoesNotExist/Nope.Nope"));
+			const FUnrealMcpToolResult R = Run(Registry, TEXT("object-get-data"), A);
+			TestFalse(TEXT("object-get-data fails for missing object"), R.bSuccess);
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpActorToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpActorToolsSpec.cpp
@@ -77,10 +77,24 @@ void FUnrealMcpActorToolsSpec::Define()
 		{
 			FUnrealMcpToolRegistry Registry;
 			UnrealMcpActorTools::Register(Registry);
-			TestTrue(TEXT("actor-destroy destructive"), Registry.Find(TEXT("actor-destroy"))->bDestructiveHint);
-			TestTrue(TEXT("actor-find read-only"), Registry.Find(TEXT("actor-find"))->bReadOnlyHint);
-			TestTrue(TEXT("actor-component-list-all read-only"), Registry.Find(TEXT("actor-component-list-all"))->bReadOnlyHint);
-			TestFalse(TEXT("actor-create not read-only"), Registry.Find(TEXT("actor-create"))->bReadOnlyHint);
+
+			// Resolve each tool through a null-guarded lookup so a renamed/missing tool fails the assertion
+			// instead of crashing the whole automation run on a null deref.
+			auto Lookup = [this, &Registry](const TCHAR* ToolId) -> const FUnrealMcpRegisteredTool*
+			{
+				const FUnrealMcpRegisteredTool* Tool = Registry.Find(ToolId);
+				TestTrue(FString::Printf(TEXT("%s found"), ToolId), Tool != nullptr);
+				return Tool;
+			};
+
+			if (const FUnrealMcpRegisteredTool* Tool = Lookup(TEXT("actor-destroy")))
+				TestTrue(TEXT("actor-destroy destructive"), Tool->bDestructiveHint);
+			if (const FUnrealMcpRegisteredTool* Tool = Lookup(TEXT("actor-find")))
+				TestTrue(TEXT("actor-find read-only"), Tool->bReadOnlyHint);
+			if (const FUnrealMcpRegisteredTool* Tool = Lookup(TEXT("actor-component-list-all")))
+				TestTrue(TEXT("actor-component-list-all read-only"), Tool->bReadOnlyHint);
+			if (const FUnrealMcpRegisteredTool* Tool = Lookup(TEXT("actor-create")))
+				TestFalse(TEXT("actor-create not read-only"), Tool->bReadOnlyHint);
 		});
 	});
 

--- a/UnrealMCP/Source/UnrealMcpEditorTests/UnrealMcpEditorTests.Build.cs
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/UnrealMcpEditorTests.Build.cs
@@ -15,7 +15,7 @@ public class UnrealMcpEditorTests : ModuleRules
 			"Core",
 			"CoreUObject",
 			"Engine",
-			"UnrealEd",       // GEditor + UEditorActorSubsystem for the actor-family specs (§10)
+			"UnrealEd",       // GEditor (editor-world access) for the actor-family specs (§10)
 			"Json",
 			"UnrealMcpEditor",
 		});

--- a/UnrealMCP/Source/UnrealMcpEditorTests/UnrealMcpEditorTests.Build.cs
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/UnrealMcpEditorTests.Build.cs
@@ -15,6 +15,7 @@ public class UnrealMcpEditorTests : ModuleRules
 			"Core",
 			"CoreUObject",
 			"Engine",
+			"UnrealEd",       // GEditor + UEditorActorSubsystem for the actor-family specs (§10)
 			"Json",
 			"UnrealMcpEditor",
 		});


### PR DESCRIPTION
## Summary
- Implements the ~13-tool actor & component family (docs/ARCHITECTURE.md §10), declared via the §3.3 builder and registered as CORE tools on boot: `actor-create/destroy/duplicate/find/modify/set-parent`, `actor-component-add/destroy/get/modify/list-all`, `object-get-data/object-modify`.
- Adds shared §3.2 helpers: `FUnrealMcpObjectRef` (label → FindObject → soft-path resolution + identity blocks) and `FUnrealMcpPropertyJson` (reflected serialization with post-serialization scoped-read `paths` filtering; FProperty writes incl. actor/scene-component transform special-casing).
- Spawn/destroy/duplicate use the engine `UWorld` path (headless-safe) instead of `UEditorActorSubsystem` (whose viewport-snapping path divides-by-zero under `-nullrhi` automation); actors still land in the editor world. Tool bodies run on the GameThread dispatcher (the bridge dispatches `Registry.Execute`, §4).
- Registry gains a generic `Param(jsonType, customSchema)` escape hatch and accepts the `array` schema type.
- Additive — no version or NuGet-pin bumps.

## Test plan
- [x] Suite 1 — UBT build `UnrealTestProjectEditor` (exit 0).
- [x] Suite 2 — headless boot smoke (`[Unreal-MCP] plugin loaded`).
- [x] Suite 3 — Automation `UnrealMcp.` filter: 42 succeeded, 9 succeededWithWarnings, 0 failed (51 total); 9 new `UnrealMcp.Tools.Actor` specs incl. the full lifecycle round-trip (create → find → modify → component-add → read → destroy), attach/detach, duplicate, component listing, and error paths.
- [x] Live headless e2e through the bridge: the real `unreal-mcp-bridge` sidecar dialed the plugin IPC listener (127.0.0.1:31947), handshake accepted, manifest (incl. all 13 actor tools) pushed; sidecar self-exited on editor shutdown (no orphan).

Closes #9