### PR TITLE
feat(tools): add editor-state, console, selection, and reflection tool family

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpEditorTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpEditorTools.cpp
@@ -1,0 +1,634 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpCoreTools.h"
+#include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpObjectRef.h"
+#include "UnrealMcpLogCollector.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "JsonObjectConverter.h"
+#include "Editor.h"
+#include "Editor/EditorEngine.h"
+#include "Engine/Engine.h"
+#include "Selection.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "Misc/PackageName.h"
+#include "Misc/StringOutputDevice.h"
+#include "PlayInEditorDataTypes.h"
+#include "ScopedTransaction.h"
+#include "UObject/Class.h"
+#include "UObject/UnrealType.h"
+#include "UObject/UObjectIterator.h"
+
+/**
+ * The editor / console / reflection tool family (docs/ARCHITECTURE.md §10 "editor/reflection family").
+ *
+ * Nine native C++ tools, all declared via the §3.3 builder and run ON the game thread (the bridge
+ * dispatches Registry.Execute through FUnrealMcpGameThreadDispatcher, §4):
+ *   - editor-application-get-state / editor-application-set-state — PIE state snapshot + start/stop/
+ *     pause/resume. Transitions are LATENT (RequestPlaySession/RequestEndPlayMap fire next tick), so
+ *     set-state returns an honest `pending` rather than a false "done".
+ *   - editor-selection-get / editor-selection-set — actor selection read/write via §3.2 refs.
+ *   - console-get-logs / console-clear-logs — filtered/paginated slices of the FUnrealMcpLogCollector
+ *     GLog ring buffer (registered at module startup), and a clear.
+ *   - console-run-command — GEngine->Exec with captured output.
+ *   - reflection-method-find / reflection-method-call — UFunction discovery + safety-gated invocation
+ *     (ProcessEvent over a constructed param frame; §3.2 JSON arg mapping).
+ */
+namespace
+{
+	// --- Local schema builders -------------------------------------------------------------------
+
+	/** An `array` of strings (the §3.2 refs list for editor-selection-set). */
+	TSharedPtr<FJsonObject> MakeEditorStringArraySchema(const FString& Desc)
+	{
+		TSharedPtr<FJsonObject> Items = MakeShared<FJsonObject>();
+		Items->SetStringField(TEXT("type"), TEXT("string"));
+
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), TEXT("array"));
+		if (!Desc.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Desc);
+		Schema->SetObjectField(TEXT("items"), Items);
+		return Schema;
+	}
+
+	/** A free-form `{ key: value }` argument bag (reflection-method-call's `args`). */
+	TSharedPtr<FJsonObject> MakeArgsBagSchema(const FString& Desc)
+	{
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), TEXT("object"));
+		if (!Desc.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Desc);
+		Schema->SetBoolField(TEXT("additionalProperties"), true);
+		return Schema;
+	}
+
+	// --- Small helpers ---------------------------------------------------------------------------
+
+	/** Read a string-array argument; non-string entries fail via OutError (the array is cleared). */
+	TArray<FString> GetEditorStringArray(const FUnrealMcpToolCall& Call, const FString& Key, FString& OutError)
+	{
+		TArray<FString> Out;
+		const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
+		if (Call.Arguments->TryGetArrayField(Key, Arr) && Arr)
+		{
+			for (const TSharedPtr<FJsonValue>& V : *Arr)
+			{
+				FString S;
+				if (V.IsValid() && V->TryGetString(S))
+				{
+					Out.Add(S);
+				}
+				else
+				{
+					OutError = FString::Printf(TEXT("'%s' must be an array of strings; a non-string entry was provided."), *Key);
+					Out.Reset();
+					return Out;
+				}
+			}
+		}
+		return Out;
+	}
+
+	/** The §3.2 JSON-schema type token for a reflected FProperty (best-effort, for discovery output). */
+	FString PropertyTypeName(const FProperty* Prop)
+	{
+		if (!Prop) return TEXT("null");
+		if (Prop->IsA<FBoolProperty>()) return TEXT("boolean");
+		if (Prop->IsA<FFloatProperty>() || Prop->IsA<FDoubleProperty>()) return TEXT("number");
+		if (Prop->IsA<FByteProperty>() || Prop->IsA<FIntProperty>() || Prop->IsA<FInt64Property>()
+			|| Prop->IsA<FUInt32Property>() || Prop->IsA<FInt8Property>() || Prop->IsA<FInt16Property>()
+			|| Prop->IsA<FUInt16Property>() || Prop->IsA<FUInt64Property>())
+			return TEXT("integer");
+		if (Prop->IsA<FEnumProperty>()) return TEXT("string");
+		if (Prop->IsA<FStrProperty>() || Prop->IsA<FNameProperty>() || Prop->IsA<FTextProperty>()) return TEXT("string");
+		if (Prop->IsA<FObjectPropertyBase>() || Prop->IsA<FClassProperty>() || Prop->IsA<FSoftObjectProperty>()) return TEXT("string");
+		if (Prop->IsA<FArrayProperty>() || Prop->IsA<FSetProperty>()) return TEXT("array");
+		if (Prop->IsA<FStructProperty>() || Prop->IsA<FMapProperty>()) return TEXT("object");
+		return TEXT("string");
+	}
+
+	/** Whether @p Function is safe to invoke from a tool (the §10 safety gate). */
+	bool IsCallableFunction(const UFunction* Function)
+	{
+		if (!Function)
+			return false;
+		if (Function->HasAnyFunctionFlags(FUNC_BlueprintCallable))
+			return true;
+#if WITH_EDITORONLY_DATA
+		// CallInEditor UFUNCTIONs are explicitly editor-invocable even when not BlueprintCallable.
+		if (Function->GetBoolMetaData(TEXT("CallInEditor")))
+			return true;
+#endif
+		return false;
+	}
+
+	/** JSON identity for one selected actor (§3.2 ref shape; reuses the actor-family identity block). */
+	TSharedPtr<FJsonObject> SelectionIdentity(const AActor* Actor)
+	{
+		return FUnrealMcpObjectRef::ActorIdentity(Actor);
+	}
+
+	/** Build the per-function discovery descriptor for reflection-method-find. */
+	TSharedPtr<FJsonObject> DescribeFunction(UFunction* Function)
+	{
+		TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+		Json->SetStringField(TEXT("name"), Function->GetName());
+		Json->SetStringField(TEXT("class"), Function->GetOwnerClass() ? Function->GetOwnerClass()->GetName() : FString());
+		Json->SetBoolField(TEXT("isStatic"), Function->HasAnyFunctionFlags(FUNC_Static));
+		Json->SetBoolField(TEXT("isBlueprintCallable"), Function->HasAnyFunctionFlags(FUNC_BlueprintCallable));
+		Json->SetBoolField(TEXT("isPure"), Function->HasAnyFunctionFlags(FUNC_BlueprintPure));
+		Json->SetBoolField(TEXT("isNative"), Function->HasAnyFunctionFlags(FUNC_Native));
+#if WITH_EDITORONLY_DATA
+		Json->SetBoolField(TEXT("isCallInEditor"), Function->GetBoolMetaData(TEXT("CallInEditor")));
+#else
+		Json->SetBoolField(TEXT("isCallInEditor"), false);
+#endif
+		Json->SetBoolField(TEXT("isCallable"), IsCallableFunction(Function));
+
+		TArray<TSharedPtr<FJsonValue>> Params;
+		TSharedPtr<FJsonObject> ReturnParam;
+		for (TFieldIterator<FProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
+		{
+			FProperty* Prop = *It;
+			TSharedPtr<FJsonObject> P = MakeShared<FJsonObject>();
+			P->SetStringField(TEXT("name"), Prop->GetName());
+			P->SetStringField(TEXT("type"), PropertyTypeName(Prop));
+			P->SetStringField(TEXT("cppType"), Prop->GetCPPType());
+			const bool bReturn = Prop->HasAnyPropertyFlags(CPF_ReturnParm);
+			const bool bOut = Prop->HasAnyPropertyFlags(CPF_OutParm);
+			P->SetBoolField(TEXT("isReturn"), bReturn);
+			P->SetBoolField(TEXT("isOut"), bOut && !bReturn);
+			if (bReturn)
+				ReturnParam = P;
+			else
+				Params.Add(MakeShared<FJsonValueObject>(P));
+		}
+		Json->SetArrayField(TEXT("params"), Params);
+		if (ReturnParam.IsValid())
+			Json->SetObjectField(TEXT("returnType"), ReturnParam);
+		return Json;
+	}
+}
+
+namespace UnrealMcpEditorTools
+{
+	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry)
+	{
+		// ============================================================================================
+		// editor-application-get-state — PIE / editor state snapshot.
+		// ============================================================================================
+		Registry.Tool(TEXT("editor-application-get-state"))
+			.Title(TEXT("Get Editor Application State"))
+			.Description(TEXT("Snapshot of the editor play state: whether Play-In-Editor is running, paused, "
+			                  "or simulating, plus the current editor map. Read-only."))
+			.ReadOnlyHint(true)
+			.IdempotentHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				if (!GEditor)
+					return FUnrealMcpToolResult::Error(TEXT("No editor available (not running in the editor)."));
+
+				const bool bPlaying = GEditor->IsPlaySessionInProgress();
+				const bool bSimulating = GEditor->IsSimulateInEditorInProgress();
+				bool bPaused = false;
+				if (GEditor->PlayWorld)
+					bPaused = GEditor->PlayWorld->bDebugPauseExecution;
+
+				UWorld* EditorWorld = FUnrealMcpObjectRef::GetEditorWorld();
+				const FString MapName = EditorWorld ? FPackageName::GetShortName(EditorWorld->GetOutermost()->GetName()) : FString();
+
+				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
+				S->SetBoolField(TEXT("isPlaying"), bPlaying);
+				S->SetBoolField(TEXT("isPaused"), bPaused);
+				S->SetBoolField(TEXT("isSimulating"), bSimulating);
+				S->SetStringField(TEXT("editorMap"), MapName);
+
+				const FString Summary = bPlaying
+					? FString::Printf(TEXT("PIE %s (map '%s')."), bPaused ? TEXT("paused") : TEXT("running"), *MapName)
+					: FString::Printf(TEXT("Editor idle (map '%s')."), *MapName);
+				return FUnrealMcpToolResult::Success(Summary, S);
+			});
+
+		// ============================================================================================
+		// editor-application-set-state — start/stop/pause/resume PIE (latent — honest 'pending').
+		// ============================================================================================
+		Registry.Tool(TEXT("editor-application-set-state"))
+			.Title(TEXT("Set Editor Application State"))
+			.Description(TEXT("Drive Play-In-Editor: action = 'start' | 'stop' | 'pause' | 'resume'. PIE "
+			                  "transitions are deferred to the next editor tick, so this returns a structured "
+			                  "'pending' result; poll editor-application-get-state to confirm the transition. "
+			                  "Invalid transitions (e.g. pause while not playing) return a structured error."))
+			.ParamString(TEXT("action"), TEXT("'start' | 'stop' | 'pause' | 'resume'."), EUnrealMcpParamRequirement::Required)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				if (!GEditor)
+					return FUnrealMcpToolResult::Error(TEXT("No editor available (not running in the editor)."));
+
+				const FString Action = Call.GetString(TEXT("action")).ToLower();
+				const bool bPlaying = GEditor->IsPlaySessionInProgress();
+				const bool bPaused = GEditor->PlayWorld && GEditor->PlayWorld->bDebugPauseExecution;
+
+				auto Pending = [&Action](const FString& Note) -> FUnrealMcpToolResult
+				{
+					TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
+					S->SetStringField(TEXT("action"), Action);
+					S->SetBoolField(TEXT("pending"), true);
+					S->SetStringField(TEXT("note"), Note);
+					return FUnrealMcpToolResult::Success(Note, S);
+				};
+
+				if (Action == TEXT("start"))
+				{
+					if (bPlaying)
+						return FUnrealMcpToolResult::Error(TEXT("PIE is already running; stop it before starting again."));
+					FRequestPlaySessionParams Params;
+					Params.SessionDestination = EPlaySessionDestinationType::InProcess;
+					GEditor->RequestPlaySession(Params);
+					return Pending(TEXT("PIE start requested; it begins on the next editor tick (poll editor-application-get-state)."));
+				}
+				if (Action == TEXT("stop"))
+				{
+					if (!bPlaying)
+						return FUnrealMcpToolResult::Error(TEXT("PIE is not running; nothing to stop."));
+					GEditor->RequestEndPlayMap();
+					return Pending(TEXT("PIE stop requested; it ends on the next editor tick (poll editor-application-get-state)."));
+				}
+				if (Action == TEXT("pause"))
+				{
+					if (!bPlaying)
+						return FUnrealMcpToolResult::Error(TEXT("PIE is not running; cannot pause."));
+					if (bPaused)
+						return FUnrealMcpToolResult::Error(TEXT("PIE is already paused."));
+					GEditor->SetPIEWorldsPaused(true);
+					return Pending(TEXT("PIE pause requested."));
+				}
+				if (Action == TEXT("resume"))
+				{
+					if (!bPlaying)
+						return FUnrealMcpToolResult::Error(TEXT("PIE is not running; cannot resume."));
+					if (!bPaused)
+						return FUnrealMcpToolResult::Error(TEXT("PIE is not paused; nothing to resume."));
+					GEditor->SetPIEWorldsPaused(false);
+					return Pending(TEXT("PIE resume requested."));
+				}
+				return FUnrealMcpToolResult::Error(FString::Printf(
+					TEXT("Unknown action '%s'. Use 'start', 'stop', 'pause', or 'resume'."), *Action));
+			});
+
+		// ============================================================================================
+		// editor-selection-get — currently selected actors (§3.2 identity refs).
+		// ============================================================================================
+		Registry.Tool(TEXT("editor-selection-get"))
+			.Title(TEXT("Get Editor Selection"))
+			.Description(TEXT("List the actors currently selected in the editor, each as a §3.2 identity ref "
+			                  "{ name, label, class, path }. Read-only."))
+			.ReadOnlyHint(true)
+			.IdempotentHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				if (!GEditor)
+					return FUnrealMcpToolResult::Error(TEXT("No editor available (not running in the editor)."));
+
+				USelection* Selection = GEditor->GetSelectedActors();
+				TArray<TSharedPtr<FJsonValue>> Actors;
+				if (Selection)
+				{
+					TArray<AActor*> Selected;
+					Selection->GetSelectedObjects<AActor>(Selected);
+					for (const AActor* Actor : Selected)
+					{
+						if (Actor)
+							Actors.Add(MakeShared<FJsonValueObject>(SelectionIdentity(Actor)));
+					}
+				}
+
+				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
+				S->SetNumberField(TEXT("count"), Actors.Num());
+				S->SetArrayField(TEXT("actors"), Actors);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("%d actor(s) selected."), Actors.Num()), S);
+			});
+
+		// ============================================================================================
+		// editor-selection-set — select actors by §3.2 ref (or clear).
+		// ============================================================================================
+		Registry.Tool(TEXT("editor-selection-set"))
+			.Title(TEXT("Set Editor Selection"))
+			.Description(TEXT("Replace the editor's actor selection with the actors named by 'actors' (label / "
+			                  "name / path refs, §3.2). Pass an empty list or clear=true to deselect everything."))
+			.Param(TEXT("actors"), TEXT("array"), TEXT("Actor refs to select (label / name / path)."), EUnrealMcpParamRequirement::Optional, MakeEditorStringArraySchema(TEXT("Actor refs to select.")))
+			.ParamBool(TEXT("clear"), TEXT("Deselect all actors. When true, 'actors' is ignored."))
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				if (!GEditor)
+					return FUnrealMcpToolResult::Error(TEXT("No editor available (not running in the editor)."));
+
+				FString ArrErr;
+				const TArray<FString> Refs = GetEditorStringArray(Call, TEXT("actors"), ArrErr);
+				if (!ArrErr.IsEmpty())
+					return FUnrealMcpToolResult::Error(ArrErr);
+
+				const bool bClear = Call.GetBool(TEXT("clear"));
+
+				// Resolve every requested actor BEFORE mutating the selection: a bad ref aborts the whole
+				// call so the editor's selection is never left half-applied.
+				TArray<AActor*> Resolved;
+				if (!bClear)
+				{
+					for (const FString& Ref : Refs)
+					{
+						AActor* Actor = FUnrealMcpObjectRef::ResolveActor(Ref);
+						if (!Actor)
+							return FUnrealMcpToolResult::Error(FString::Printf(
+								TEXT("No actor matched '%s' (by label/name/path); selection unchanged."), *Ref));
+						Resolved.Add(Actor);
+					}
+				}
+
+				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "EditorSelectionSet", "MCP: Set Selection"));
+				GEditor->SelectNone(/*bNoteSelectionChange*/ false, /*bDeselectBSPSurfs*/ true);
+				for (AActor* Actor : Resolved)
+					GEditor->SelectActor(Actor, /*bInSelected*/ true, /*bNotify*/ false);
+				GEditor->NoteSelectionChange();
+
+				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
+				S->SetNumberField(TEXT("count"), Resolved.Num());
+				return FUnrealMcpToolResult::Success(
+					bClear ? TEXT("Selection cleared.")
+					       : FString::Printf(TEXT("Selected %d actor(s)."), Resolved.Num()), S);
+			});
+
+		// ============================================================================================
+		// console-get-logs — filtered/paginated ring-buffer slice.
+		// ============================================================================================
+		Registry.Tool(TEXT("console-get-logs"))
+			.Title(TEXT("Get Console Logs"))
+			.Description(TEXT("Read recent engine log lines captured by the plugin's GLog ring buffer "
+			                  "(capped at 10000). Filter by minimum severity ('Error'|'Warning'|'Display'|"
+			                  "'Log'|'Verbose'|'VeryVerbose'|'All'), exact category, and a message substring; "
+			                  "'limit' returns the most-recent N after filtering. Read-only."))
+			.ParamString(TEXT("verbosity"), TEXT("Minimum severity to include (default 'All')."))
+			.ParamString(TEXT("category"), TEXT("Exact log category (e.g. 'LogTemp'); empty = all."))
+			.ParamString(TEXT("search"), TEXT("Case-insensitive message substring; empty = all."))
+			.ParamInt(TEXT("limit"), TEXT("Max entries to return (most-recent first-trimmed); default 100, <=0 = all."))
+			.ReadOnlyHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				ELogVerbosity::Type MinVerbosity = ELogVerbosity::All;
+				if (Call.Has(TEXT("verbosity")))
+				{
+					const FString Token = Call.GetString(TEXT("verbosity"));
+					if (!Token.IsEmpty() && !FUnrealMcpLogCollector::ParseVerbosity(Token, MinVerbosity))
+						return FUnrealMcpToolResult::Error(FString::Printf(
+							TEXT("Unknown verbosity '%s'. Use Error/Warning/Display/Log/Verbose/VeryVerbose/All."), *Token));
+				}
+				const FString Category = Call.GetString(TEXT("category"));
+				const FString Search = Call.GetString(TEXT("search"));
+				const int32 Limit = (int32)Call.GetInt(TEXT("limit"), 100);
+
+				const FUnrealMcpLogCollector& Collector = FUnrealMcpLogCollector::Get();
+				const TArray<FUnrealMcpLogEntry> Slice = Collector.Snapshot(MinVerbosity, Category, Search, Limit);
+
+				TArray<TSharedPtr<FJsonValue>> Lines;
+				for (const FUnrealMcpLogEntry& Entry : Slice)
+				{
+					TSharedPtr<FJsonObject> L = MakeShared<FJsonObject>();
+					L->SetStringField(TEXT("timestamp"), Entry.Timestamp.ToIso8601());
+					L->SetStringField(TEXT("verbosity"), FUnrealMcpLogCollector::VerbosityToString(Entry.Verbosity));
+					L->SetStringField(TEXT("category"), Entry.Category.ToString());
+					L->SetStringField(TEXT("message"), Entry.Message);
+					Lines.Add(MakeShared<FJsonValueObject>(L));
+				}
+
+				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
+				S->SetNumberField(TEXT("count"), Lines.Num());
+				S->SetNumberField(TEXT("totalBuffered"), Collector.Num());
+				S->SetArrayField(TEXT("logs"), Lines);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Returned %d log line(s) (%d buffered)."), Lines.Num(), Collector.Num()), S);
+			});
+
+		// ============================================================================================
+		// console-clear-logs — empty the ring buffer.
+		// ============================================================================================
+		Registry.Tool(TEXT("console-clear-logs"))
+			.Title(TEXT("Clear Console Logs"))
+			.Description(TEXT("Clear the plugin's GLog ring buffer. Returns how many entries were dropped."))
+			.DestructiveHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const int32 Removed = FUnrealMcpLogCollector::Get().Clear();
+				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
+				S->SetNumberField(TEXT("cleared"), Removed);
+				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Cleared %d log entry(ies)."), Removed), S);
+			});
+
+		// ============================================================================================
+		// console-run-command — GEngine->Exec with captured output.
+		// ============================================================================================
+		Registry.Tool(TEXT("console-run-command"))
+			.Title(TEXT("Run Console Command"))
+			.Description(TEXT("Execute an Unreal console command (incl. CVars, e.g. 'stat fps', 'r.ScreenPercentage 80') "
+			                  "via GEngine->Exec against the editor world, returning any captured output text."))
+			.ParamString(TEXT("command"), TEXT("The console command line to execute."), EUnrealMcpParamRequirement::Required)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const FString Command = Call.GetString(TEXT("command"));
+				if (Command.IsEmpty())
+					return FUnrealMcpToolResult::Error(TEXT("Missing required 'command'."));
+				if (!GEngine)
+					return FUnrealMcpToolResult::Error(TEXT("No engine available."));
+
+				UWorld* World = FUnrealMcpObjectRef::GetEditorWorld();
+
+				FStringOutputDevice Output;
+				Output.SetAutoEmitLineTerminator(true);
+				const bool bHandled = GEngine->Exec(World, *Command, Output);
+
+				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
+				S->SetStringField(TEXT("command"), Command);
+				S->SetBoolField(TEXT("handled"), bHandled);
+				S->SetStringField(TEXT("output"), Output);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Ran '%s' (%s)."), *Command, bHandled ? TEXT("handled") : TEXT("not handled")), S);
+			});
+
+		// ============================================================================================
+		// reflection-method-find — UFunction discovery by class (+ optional name filter).
+		// ============================================================================================
+		Registry.Tool(TEXT("reflection-method-find"))
+			.Title(TEXT("Find Reflection Method"))
+			.Description(TEXT("Discover UFunctions on a class (native class path, short name, or Blueprint asset/"
+			                  "generated-class path, §3.2). Returns signatures: params (name/type), return type, "
+			                  "and flags (static/instance, BlueprintCallable, pure, CallInEditor, callable). "
+			                  "Optional 'name' filters by case-insensitive substring. Read-only."))
+			.ParamString(TEXT("class"), TEXT("Class ref to search (native path/name or Blueprint path)."), EUnrealMcpParamRequirement::Required)
+			.ParamString(TEXT("name"), TEXT("Optional case-insensitive substring to match the function name."))
+			.ParamInt(TEXT("limit"), TEXT("Max functions to return; default 100, <=0 = all."))
+			.ReadOnlyHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const FString ClassRef = Call.GetString(TEXT("class"));
+				UClass* Class = FUnrealMcpObjectRef::ResolveClass(ClassRef);
+				if (!Class)
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Class '%s' was not found."), *ClassRef));
+
+				const FString NameFilter = Call.GetString(TEXT("name"));
+				const int32 Limit = (int32)Call.GetInt(TEXT("limit"), 100);
+
+				TArray<TSharedPtr<FJsonValue>> Methods;
+				int32 Matched = 0;
+				for (TFieldIterator<UFunction> It(Class, EFieldIteratorFlags::IncludeSuper); It; ++It)
+				{
+					UFunction* Function = *It;
+					if (!NameFilter.IsEmpty() && !Function->GetName().Contains(NameFilter, ESearchCase::IgnoreCase))
+						continue;
+					++Matched;
+					if (Limit > 0 && Methods.Num() >= Limit)
+						continue; // keep counting Matched for an honest total, but stop materializing
+					Methods.Add(MakeShared<FJsonValueObject>(DescribeFunction(Function)));
+				}
+
+				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
+				S->SetStringField(TEXT("class"), Class->GetPathName());
+				S->SetNumberField(TEXT("matched"), Matched);
+				S->SetNumberField(TEXT("returned"), Methods.Num());
+				S->SetArrayField(TEXT("methods"), Methods);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Found %d method(s) on '%s' (returned %d)."), Matched, *Class->GetName(), Methods.Num()), S);
+			});
+
+		// ============================================================================================
+		// reflection-method-call — safety-gated ProcessEvent over a constructed param frame.
+		// ============================================================================================
+		Registry.Tool(TEXT("reflection-method-call"))
+			.Title(TEXT("Call Reflection Method"))
+			.Description(TEXT("Invoke a UFunction by name. Provide EITHER 'target' (an object/actor ref, §3.2 — "
+			                  "the function is resolved and called on it) OR 'class' (the function is called on "
+			                  "that class's CDO — use for static/CallInEditor functions). 'args' is a JSON object "
+			                  "mapping parameter names to values (§3.2). SAFETY: only BlueprintCallable or "
+			                  "CallInEditor functions may be called; anything else is rejected. Returns the "
+			                  "function's return value and any out-params."))
+			.ParamString(TEXT("target"), TEXT("Object/actor ref to call the method on (instance methods)."))
+			.ParamString(TEXT("class"), TEXT("Class ref whose CDO to call on (static/CallInEditor methods)."))
+			.ParamString(TEXT("method"), TEXT("The UFunction name to invoke."), EUnrealMcpParamRequirement::Required)
+			.Param(TEXT("args"), TEXT("object"), TEXT("Parameter name -> value map (§3.2)."), EUnrealMcpParamRequirement::Optional, MakeArgsBagSchema(TEXT("Parameter name -> value map.")))
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const FString MethodName = Call.GetString(TEXT("method"));
+				if (MethodName.IsEmpty())
+					return FUnrealMcpToolResult::Error(TEXT("Missing required 'method'."));
+
+				const FString TargetRef = Call.GetString(TEXT("target"));
+				const FString ClassRef = Call.GetString(TEXT("class"));
+				if (TargetRef.IsEmpty() && ClassRef.IsEmpty())
+					return FUnrealMcpToolResult::Error(TEXT("Provide either 'target' (instance) or 'class' (CDO/static)."));
+
+				// Resolve the receiving object: an explicit instance ref, else the class CDO.
+				UObject* Target = nullptr;
+				if (!TargetRef.IsEmpty())
+				{
+					Target = FUnrealMcpObjectRef::ResolveObject(TargetRef);
+					if (!Target)
+						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Target '%s' was not found."), *TargetRef));
+				}
+				else
+				{
+					UClass* Class = FUnrealMcpObjectRef::ResolveClass(ClassRef);
+					if (!Class)
+						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Class '%s' was not found."), *ClassRef));
+					Target = Class->GetDefaultObject();
+					if (!Target)
+						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Class '%s' has no default object."), *ClassRef));
+				}
+
+				UFunction* Function = Target->FindFunction(FName(*MethodName));
+				if (!Function)
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("Method '%s' was not found on '%s'."), *MethodName, *Target->GetClass()->GetName()));
+
+				// SAFETY GATE (§10): reject anything that is not explicitly callable. An unguarded ProcessEvent
+				// surface would let an agent invoke arbitrary native engine functions — a security finding.
+				if (!IsCallableFunction(Function))
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("Method '%s' is not BlueprintCallable or CallInEditor; refusing to call it."), *MethodName));
+
+				const TSharedPtr<FJsonObject>* ArgsPtr = nullptr;
+				TSharedPtr<FJsonObject> Args = (Call.Arguments->TryGetObjectField(TEXT("args"), ArgsPtr) && ArgsPtr) ? *ArgsPtr : MakeShared<FJsonObject>();
+
+				// Build + own a parameter frame for the duration of the call (init -> import -> call -> read -> destroy).
+				TArray<uint8> ParmFrame;
+				ParmFrame.SetNumZeroed(FMath::Max<int32>(Function->ParmsSize, 1));
+				uint8* Frame = ParmFrame.GetData();
+
+				for (TFieldIterator<FProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
+					It->InitializeValue_InContainer(Frame);
+
+				// Import inputs (everything that is not the return value; out-params may also be seeded).
+				FString ImportError;
+				for (TFieldIterator<FProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
+				{
+					FProperty* Prop = *It;
+					if (Prop->HasAnyPropertyFlags(CPF_ReturnParm))
+						continue;
+					const TSharedPtr<FJsonValue> Field = Args->TryGetField(Prop->GetName());
+					if (!Field.IsValid())
+						continue; // absent -> zero/default; UE handles optional/defaulted params
+					void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(Frame);
+					FText Fail;
+					if (!FJsonObjectConverter::JsonValueToUProperty(Field, Prop, ValuePtr, 0, 0, false, &Fail))
+					{
+						ImportError = FString::Printf(TEXT("Failed to convert argument '%s': %s"), *Prop->GetName(), *Fail.ToString());
+						break;
+					}
+				}
+
+				if (ImportError.IsEmpty())
+				{
+					Target->ProcessEvent(Function, Frame);
+				}
+
+				// Read the return value + any out-params back into JSON (before destroying the frame).
+				TSharedPtr<FJsonObject> Returned = MakeShared<FJsonObject>();
+				TSharedPtr<FJsonValue> ReturnValue;
+				if (ImportError.IsEmpty())
+				{
+					for (TFieldIterator<FProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
+					{
+						FProperty* Prop = *It;
+						const bool bReturn = Prop->HasAnyPropertyFlags(CPF_ReturnParm);
+						const bool bOut = Prop->HasAnyPropertyFlags(CPF_OutParm);
+						if (!bReturn && !bOut)
+							continue;
+						const void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(Frame);
+						TSharedPtr<FJsonValue> JV = FJsonObjectConverter::UPropertyToJsonValue(Prop, ValuePtr);
+						if (bReturn)
+							ReturnValue = JV;
+						else
+							Returned->SetField(Prop->GetName(), JV);
+					}
+				}
+
+				// Always destroy the frame (init succeeded for every param above).
+				for (TFieldIterator<FProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
+					It->DestroyValue_InContainer(Frame);
+
+				if (!ImportError.IsEmpty())
+					return FUnrealMcpToolResult::Error(ImportError);
+
+				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
+				S->SetStringField(TEXT("method"), MethodName);
+				S->SetStringField(TEXT("target"), Target->GetPathName());
+				if (ReturnValue.IsValid())
+					S->SetField(TEXT("returnValue"), ReturnValue);
+				S->SetObjectField(TEXT("outParams"), Returned);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Called '%s' on '%s'."), *MethodName, *Target->GetName()), S);
+			});
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpEditorTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpEditorTools.cpp
@@ -346,7 +346,7 @@ namespace UnrealMcpEditorTools
 		Registry.Tool(TEXT("editor-selection-set"))
 			.Title(TEXT("Set Editor Selection"))
 			.Description(TEXT("Replace the editor's actor selection with the actors named by 'actors' (label / "
-			                  "name / path refs, §3.2). Pass an empty list or clear=true to deselect everything."))
+			                  "name / path refs, §3.2). Pass clear=true to deselect everything."))
 			.Param(TEXT("actors"), TEXT("array"), TEXT("Actor refs to select (label / name / path)."), EUnrealMcpParamRequirement::Optional, MakeEditorStringArraySchema(TEXT("Actor refs to select.")))
 			.ParamBool(TEXT("clear"), TEXT("Deselect all actors. When true, 'actors' is ignored."))
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
@@ -360,6 +360,13 @@ namespace UnrealMcpEditorTools
 					return FUnrealMcpToolResult::Error(ArrErr);
 
 				const bool bClear = Call.GetBool(TEXT("clear"));
+
+				// Require explicit intent to deselect: a call with no actor refs and no clear flag would
+				// otherwise silently wipe the whole selection and still report success. Make the caller say
+				// clear=true so a malformed/empty call can't quietly nuke the user's selection.
+				if (!bClear && Refs.Num() == 0)
+					return FUnrealMcpToolResult::Error(TEXT(
+						"No actors to select. Provide 'actors' with at least one ref, or pass clear=true to deselect everything."));
 
 				// Resolve every requested actor BEFORE mutating the selection: a bad ref aborts the whole
 				// call so the editor's selection is never left half-applied.

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpEditorTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpEditorTools.cpp
@@ -20,6 +20,7 @@
 #include "PlayInEditorDataTypes.h"
 #include "ScopedTransaction.h"
 #include "UObject/Class.h"
+#include "UObject/Script.h"
 #include "UObject/UnrealType.h"
 #include "UObject/UObjectIterator.h"
 
@@ -90,6 +91,12 @@ namespace
 					return Out;
 				}
 			}
+		}
+		else if (Call.Arguments->HasField(Key))
+		{
+			// Present but not an array (a bare string/object/number): error rather than returning an empty
+			// list, which the caller would read as "select nothing" and use to silently clear the selection.
+			OutError = FString::Printf(TEXT("'%s' must be an array of strings."), *Key);
 		}
 		return Out;
 	}
@@ -388,9 +395,9 @@ namespace UnrealMcpEditorTools
 		Registry.Tool(TEXT("console-get-logs"))
 			.Title(TEXT("Get Console Logs"))
 			.Description(TEXT("Read recent engine log lines captured by the plugin's GLog ring buffer "
-			                  "(capped at 10000). Filter by minimum severity ('Error'|'Warning'|'Display'|"
-			                  "'Log'|'Verbose'|'VeryVerbose'|'All'), exact category, and a message substring; "
-			                  "'limit' returns the most-recent N after filtering. Read-only."))
+			                  "(capped at 10000). Filter by minimum severity ('Fatal'|'Error'|'Warning'|"
+			                  "'Display'|'Log'|'Verbose'|'VeryVerbose'|'All'), exact category, and a message "
+			                  "substring; 'limit' returns the most-recent N after filtering. Read-only."))
 			.ParamString(TEXT("verbosity"), TEXT("Minimum severity to include (default 'All')."))
 			.ParamString(TEXT("category"), TEXT("Exact log category (e.g. 'LogTemp'); empty = all."))
 			.ParamString(TEXT("search"), TEXT("Case-insensitive message substring; empty = all."))
@@ -404,7 +411,7 @@ namespace UnrealMcpEditorTools
 					const FString Token = Call.GetString(TEXT("verbosity"));
 					if (!Token.IsEmpty() && !FUnrealMcpLogCollector::ParseVerbosity(Token, MinVerbosity))
 						return FUnrealMcpToolResult::Error(FString::Printf(
-							TEXT("Unknown verbosity '%s'. Use Error/Warning/Display/Log/Verbose/VeryVerbose/All."), *Token));
+							TEXT("Unknown verbosity '%s'. Use Fatal/Error/Warning/Display/Log/Verbose/VeryVerbose/All."), *Token));
 				}
 				const FString Category = Call.GetString(TEXT("category"));
 				const FString Search = Call.GetString(TEXT("search"));
@@ -603,8 +610,13 @@ namespace UnrealMcpEditorTools
 						TEXT("Method '%s' is an instance method; call it via 'target' (an instance), not 'class' "
 						     "(whose CDO is only for static/CallInEditor functions)."), *MethodName));
 
+				// 'args' is optional; absent -> an empty bag (every param defaults). But a PRESENT-but-non-object
+				// 'args' (e.g. an array or a bare string) is a malformed call — error rather than silently
+				// dropping it to an empty bag, which would zero every parameter without telling the caller.
 				const TSharedPtr<FJsonObject>* ArgsPtr = nullptr;
-				TSharedPtr<FJsonObject> Args = (Call.Arguments->TryGetObjectField(TEXT("args"), ArgsPtr) && ArgsPtr) ? *ArgsPtr : MakeShared<FJsonObject>();
+				if (Call.Arguments->HasField(TEXT("args")) && !(Call.Arguments->TryGetObjectField(TEXT("args"), ArgsPtr) && ArgsPtr))
+					return FUnrealMcpToolResult::Error(TEXT("'args' must be a JSON object mapping parameter names to values."));
+				TSharedPtr<FJsonObject> Args = ArgsPtr ? *ArgsPtr : MakeShared<FJsonObject>();
 
 				// Build + own a parameter frame for the duration of the call (init -> import -> call -> read -> destroy).
 				TArray<uint8> ParmFrame;
@@ -635,6 +647,14 @@ namespace UnrealMcpEditorTools
 
 				if (ImportError.IsEmpty())
 				{
+					// AActor::ProcessEvent gates script execution in the editor: for an actor in the editor
+					// world (not PIE, not a CDO) a plain BlueprintCallable (non-CallInEditor) function is
+					// SILENTLY SKIPPED unless GAllowActorScriptExecutionInEditor is set — the tool would
+					// otherwise return Success with a zeroed return/out-params. Scope the call in the same
+					// guard the editor's own details-panel / CallInEditor invocations use (it also resets the
+					// runaway-loop counter). The §10 safety gate above remains the authorization layer; this
+					// only lets an already-authorized call actually run.
+					FEditorScriptExecutionGuard ScriptGuard;
 					Target->ProcessEvent(Function, Frame);
 				}
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpEditorTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpEditorTools.cpp
@@ -127,6 +127,25 @@ namespace
 		return false;
 	}
 
+	/**
+	 * Whether @p Function may be invoked on a class CDO (the 'class' path of reflection-method-call).
+	 * Only static or CallInEditor functions are safe there: a plain instance method run on the default
+	 * object mutates the shared class defaults (CDO pollution that serializes into new instances) and a
+	 * world-dependent instance method can crash on a world-less CDO. Instance methods must go via 'target'.
+	 */
+	bool IsCdoCallableFunction(const UFunction* Function)
+	{
+		if (!Function)
+			return false;
+		if (Function->HasAnyFunctionFlags(FUNC_Static))
+			return true;
+#if WITH_EDITORONLY_DATA
+		if (Function->GetBoolMetaData(TEXT("CallInEditor")))
+			return true;
+#endif
+		return false;
+	}
+
 	/** JSON identity for one selected actor (§3.2 ref shape; reuses the actor-family identity block). */
 	TSharedPtr<FJsonObject> SelectionIdentity(const AActor* Actor)
 	{
@@ -483,9 +502,16 @@ namespace UnrealMcpEditorTools
 
 				TArray<TSharedPtr<FJsonValue>> Methods;
 				int32 Matched = 0;
+				TSet<FName> SeenNames;
 				for (TFieldIterator<UFunction> It(Class, EFieldIteratorFlags::IncludeSuper); It; ++It)
 				{
 					UFunction* Function = *It;
+					// IncludeSuper walks most-derived first, so an override appears once per declaring class
+					// in the hierarchy. Keep only the first (most-derived) occurrence of each name.
+					bool bAlreadySeen = false;
+					SeenNames.Add(Function->GetFName(), &bAlreadySeen);
+					if (bAlreadySeen)
+						continue;
 					if (!NameFilter.IsEmpty() && !Function->GetName().Contains(NameFilter, ESearchCase::IgnoreCase))
 						continue;
 					++Matched;
@@ -512,7 +538,10 @@ namespace UnrealMcpEditorTools
 			                  "the function is resolved and called on it) OR 'class' (the function is called on "
 			                  "that class's CDO — use for static/CallInEditor functions). 'args' is a JSON object "
 			                  "mapping parameter names to values (§3.2). SAFETY: only BlueprintCallable or "
-			                  "CallInEditor functions may be called; anything else is rejected. Returns the "
+			                  "CallInEditor functions may be called; anything else is rejected — and the 'class' "
+			                  "(CDO) path additionally requires static/CallInEditor (instance methods must use "
+			                  "'target'). ACCEPTED RISK: callable functions can still be destructive (QuitGame, "
+			                  "console exec, DestroyActor), consistent with console-run-command. Returns the "
 			                  "function's return value and any out-params."))
 			.ParamString(TEXT("target"), TEXT("Object/actor ref to call the method on (instance methods)."))
 			.ParamString(TEXT("class"), TEXT("Class ref whose CDO to call on (static/CallInEditor methods)."))
@@ -528,8 +557,12 @@ namespace UnrealMcpEditorTools
 				const FString ClassRef = Call.GetString(TEXT("class"));
 				if (TargetRef.IsEmpty() && ClassRef.IsEmpty())
 					return FUnrealMcpToolResult::Error(TEXT("Provide either 'target' (instance) or 'class' (CDO/static)."));
+				// The receiver is EITHER/OR — reject an ambiguous pair instead of silently preferring one.
+				if (!TargetRef.IsEmpty() && !ClassRef.IsEmpty())
+					return FUnrealMcpToolResult::Error(TEXT("Provide EITHER 'target' (instance) OR 'class' (CDO/static), not both."));
 
 				// Resolve the receiving object: an explicit instance ref, else the class CDO.
+				const bool bViaCDO = TargetRef.IsEmpty();
 				UObject* Target = nullptr;
 				if (!TargetRef.IsEmpty())
 				{
@@ -554,9 +587,21 @@ namespace UnrealMcpEditorTools
 
 				// SAFETY GATE (§10): reject anything that is not explicitly callable. An unguarded ProcessEvent
 				// surface would let an agent invoke arbitrary native engine functions — a security finding.
+				// ACCEPTED RISK: BlueprintCallable/CallInEditor still includes destructive functions
+				// (UKismetSystemLibrary::QuitGame, ExecuteConsoleCommand, AActor::K2_DestroyActor, the editor
+				// scripting libraries). console-run-command already grants equivalent power, so this is in
+				// keeping with the family's purpose rather than a separate escalation — gated by intent, not
+				// by an allow-list of individual functions.
 				if (!IsCallableFunction(Function))
 					return FUnrealMcpToolResult::Error(FString::Printf(
 						TEXT("Method '%s' is not BlueprintCallable or CallInEditor; refusing to call it."), *MethodName));
+
+				// The 'class' path runs on the CDO, which is only safe for static / CallInEditor functions
+				// (see IsCdoCallableFunction). Reject a plain instance method here and steer it to 'target'.
+				if (bViaCDO && !IsCdoCallableFunction(Function))
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("Method '%s' is an instance method; call it via 'target' (an instance), not 'class' "
+						     "(whose CDO is only for static/CallInEditor functions)."), *MethodName));
 
 				const TSharedPtr<FJsonObject>* ArgsPtr = nullptr;
 				TSharedPtr<FJsonObject> Args = (Call.Arguments->TryGetObjectField(TEXT("args"), ArgsPtr) && ArgsPtr) ? *ArgsPtr : MakeShared<FJsonObject>();

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLogCollector.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLogCollector.cpp
@@ -71,9 +71,12 @@ void FUnrealMcpLogCollector::Capture(const TCHAR* Message, ELogVerbosity::Type V
 	Entries.Add(MoveTemp(Entry));
 	if (Entries.Num() > MaxEntries)
 	{
-		// Evict the oldest overflow in one shot (keeps the newest MaxEntries). No shrink — the buffer
-		// stays warm at its cap so steady-state logging does no reallocation.
-		Entries.RemoveAt(0, Entries.Num() - MaxEntries, EAllowShrinking::No);
+		// Amortize the O(N) head-eviction: dropping a single entry per line at the cap would memmove the
+		// whole ~MaxEntries buffer on every log call. Instead drop a whole EvictChunk from the front in
+		// one shot, so eviction runs ~once per EvictChunk lines (O(1) amortized). The buffer never
+		// exceeds MaxEntries — it floats between MaxEntries-EvictChunk and MaxEntries. No shrink keeps the
+		// allocation warm so steady-state logging does no reallocation.
+		Entries.RemoveAt(0, FMath::Min(EvictChunk, Entries.Num()), EAllowShrinking::No);
 	}
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLogCollector.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLogCollector.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpLogCollector.h"
+
+FUnrealMcpLogCollector& FUnrealMcpLogCollector::Get()
+{
+	// Function-local static: constructed on first use, destroyed at program exit — strictly after GLog,
+	// so a missed Shutdown() can never leave GLog holding a freed pointer (Shutdown() still runs in the
+	// normal module-teardown path; this only bounds the worst case).
+	static FUnrealMcpLogCollector Instance;
+	return Instance;
+}
+
+FUnrealMcpLogCollector::~FUnrealMcpLogCollector()
+{
+	// Defensive: never outlive our GLog registration. Normal teardown calls Shutdown() explicitly.
+	Shutdown();
+}
+
+void FUnrealMcpLogCollector::Startup()
+{
+	if (bRegistered)
+		return;
+	if (GLog)
+	{
+		GLog->AddOutputDevice(this);
+		bRegistered = true;
+	}
+}
+
+void FUnrealMcpLogCollector::Shutdown()
+{
+	if (!bRegistered)
+		return;
+	// Clear the flag first so any concurrent Serialize() that already passed the GLog dispatch is the
+	// last to touch us; GLog->RemoveOutputDevice flushes in-flight callers before returning.
+	bRegistered = false;
+	if (GLog)
+		GLog->RemoveOutputDevice(this);
+}
+
+void FUnrealMcpLogCollector::Serialize(const TCHAR* Message, ELogVerbosity::Type Verbosity, const FName& Category)
+{
+	Capture(Message, Verbosity, Category);
+}
+
+void FUnrealMcpLogCollector::Serialize(const TCHAR* Message, ELogVerbosity::Type Verbosity, const FName& Category, double /*Time*/)
+{
+	Capture(Message, Verbosity, Category);
+}
+
+void FUnrealMcpLogCollector::Capture(const TCHAR* Message, ELogVerbosity::Type Verbosity, const FName& Category)
+{
+	// SetColor / control verbosities carry no message payload — never buffer them.
+	const ELogVerbosity::Type Type = (ELogVerbosity::Type)(Verbosity & ELogVerbosity::VerbosityMask);
+	if (Type == ELogVerbosity::SetColor || Type == ELogVerbosity::NoLogging || Message == nullptr)
+		return;
+
+	FUnrealMcpLogEntry Entry;
+	Entry.Timestamp = FDateTime::UtcNow();
+	Entry.Verbosity = Type;
+	Entry.Category = Category;
+	Entry.Message = Message;
+
+	FScopeLock ScopeLock(&Lock);
+	Entries.Add(MoveTemp(Entry));
+	if (Entries.Num() > MaxEntries)
+	{
+		// Evict the oldest overflow in one shot (keeps the newest MaxEntries). No shrink — the buffer
+		// stays warm at its cap so steady-state logging does no reallocation.
+		Entries.RemoveAt(0, Entries.Num() - MaxEntries, EAllowShrinking::No);
+	}
+}
+
+int32 FUnrealMcpLogCollector::Clear()
+{
+	FScopeLock ScopeLock(&Lock);
+	const int32 Removed = Entries.Num();
+	Entries.Reset();
+	return Removed;
+}
+
+int32 FUnrealMcpLogCollector::Num() const
+{
+	FScopeLock ScopeLock(&Lock);
+	return Entries.Num();
+}
+
+TArray<FUnrealMcpLogEntry> FUnrealMcpLogCollector::Snapshot(ELogVerbosity::Type MinVerbosity,
+	const FString& CategoryFilter, const FString& Search, int32 Limit) const
+{
+	TArray<FUnrealMcpLogEntry> Out;
+
+	FScopeLock ScopeLock(&Lock);
+	for (const FUnrealMcpLogEntry& Entry : Entries)
+	{
+		// Lower numeric verbosity == more severe (Fatal=1 … VeryVerbose=7). Keep at-or-more-severe.
+		if (MinVerbosity != ELogVerbosity::All && Entry.Verbosity > MinVerbosity)
+			continue;
+		if (!CategoryFilter.IsEmpty() && !Entry.Category.ToString().Equals(CategoryFilter, ESearchCase::IgnoreCase))
+			continue;
+		if (!Search.IsEmpty() && !Entry.Message.Contains(Search, ESearchCase::IgnoreCase))
+			continue;
+		Out.Add(Entry);
+	}
+
+	// Keep the most-recent Limit after filtering (the buffer is oldest-first, so trim the front).
+	if (Limit > 0 && Out.Num() > Limit)
+		Out.RemoveAt(0, Out.Num() - Limit, EAllowShrinking::No);
+
+	return Out;
+}
+
+FString FUnrealMcpLogCollector::VerbosityToString(ELogVerbosity::Type Verbosity)
+{
+	switch (Verbosity & ELogVerbosity::VerbosityMask)
+	{
+	case ELogVerbosity::Fatal:       return TEXT("Fatal");
+	case ELogVerbosity::Error:       return TEXT("Error");
+	case ELogVerbosity::Warning:     return TEXT("Warning");
+	case ELogVerbosity::Display:     return TEXT("Display");
+	case ELogVerbosity::Log:         return TEXT("Log");
+	case ELogVerbosity::Verbose:     return TEXT("Verbose");
+	case ELogVerbosity::VeryVerbose: return TEXT("VeryVerbose");
+	default:                         return TEXT("Log");
+	}
+}
+
+bool FUnrealMcpLogCollector::ParseVerbosity(const FString& Token, ELogVerbosity::Type& OutVerbosity)
+{
+	if (Token.Equals(TEXT("Fatal"), ESearchCase::IgnoreCase))            { OutVerbosity = ELogVerbosity::Fatal; return true; }
+	if (Token.Equals(TEXT("Error"), ESearchCase::IgnoreCase))           { OutVerbosity = ELogVerbosity::Error; return true; }
+	if (Token.Equals(TEXT("Warning"), ESearchCase::IgnoreCase))         { OutVerbosity = ELogVerbosity::Warning; return true; }
+	if (Token.Equals(TEXT("Display"), ESearchCase::IgnoreCase))         { OutVerbosity = ELogVerbosity::Display; return true; }
+	if (Token.Equals(TEXT("Log"), ESearchCase::IgnoreCase))             { OutVerbosity = ELogVerbosity::Log; return true; }
+	if (Token.Equals(TEXT("Verbose"), ESearchCase::IgnoreCase))         { OutVerbosity = ELogVerbosity::Verbose; return true; }
+	if (Token.Equals(TEXT("VeryVerbose"), ESearchCase::IgnoreCase))     { OutVerbosity = ELogVerbosity::VeryVerbose; return true; }
+	if (Token.Equals(TEXT("All"), ESearchCase::IgnoreCase))             { OutVerbosity = ELogVerbosity::All; return true; }
+	return false;
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLogCollector.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLogCollector.cpp
@@ -3,11 +3,15 @@
 
 #include "UnrealMcpLogCollector.h"
 
+#include "Algo/Reverse.h"
+
 FUnrealMcpLogCollector& FUnrealMcpLogCollector::Get()
 {
-	// Function-local static: constructed on first use, destroyed at program exit — strictly after GLog,
-	// so a missed Shutdown() can never leave GLog holding a freed pointer (Shutdown() still runs in the
-	// normal module-teardown path; this only bounds the worst case).
+	// Function-local static: constructed on first use during module startup, AFTER GLog's
+	// FOutputDeviceRedirector singleton already exists. Statics are destroyed in reverse construction
+	// order, so this collector is torn down BEFORE GLog — which is exactly why the destructor's
+	// Shutdown() -> GLog->RemoveOutputDevice(this) is safe (GLog is still alive when we deregister).
+	// Shutdown() still runs in the normal module-teardown path; the destructor only bounds the worst case.
 	static FUnrealMcpLogCollector Instance;
 	return Instance;
 }
@@ -93,8 +97,12 @@ TArray<FUnrealMcpLogEntry> FUnrealMcpLogCollector::Snapshot(ELogVerbosity::Type 
 	TArray<FUnrealMcpLogEntry> Out;
 
 	FScopeLock ScopeLock(&Lock);
-	for (const FUnrealMcpLogEntry& Entry : Entries)
+	// Walk newest-first so we can stop as soon as the requested Limit is satisfied — this bounds both
+	// the copy work and the lock-hold time (a full 10k buffer with limit=100 copies 100 entries, not
+	// 10k). Entries is oldest-first, so reverse the result below to restore the newest-last contract.
+	for (int32 Idx = Entries.Num() - 1; Idx >= 0; --Idx)
 	{
+		const FUnrealMcpLogEntry& Entry = Entries[Idx];
 		// Lower numeric verbosity == more severe (Fatal=1 … VeryVerbose=7). Keep at-or-more-severe.
 		if (MinVerbosity != ELogVerbosity::All && Entry.Verbosity > MinVerbosity)
 			continue;
@@ -103,12 +111,12 @@ TArray<FUnrealMcpLogEntry> FUnrealMcpLogCollector::Snapshot(ELogVerbosity::Type 
 		if (!Search.IsEmpty() && !Entry.Message.Contains(Search, ESearchCase::IgnoreCase))
 			continue;
 		Out.Add(Entry);
+		if (Limit > 0 && Out.Num() >= Limit)
+			break;
 	}
 
-	// Keep the most-recent Limit after filtering (the buffer is oldest-first, so trim the front).
-	if (Limit > 0 && Out.Num() > Limit)
-		Out.RemoveAt(0, Out.Num() - Limit, EAllowShrinking::No);
-
+	// Out is currently newest-first; the documented contract is newest-last, so reverse in place.
+	Algo::Reverse(Out);
 	return Out;
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLogCollector.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLogCollector.h
@@ -30,10 +30,11 @@ struct FUnrealMcpLogEntry
  * guarded by a critical section and `CanBeUsedOnAnyThread()` returns true. The capture path NEVER logs
  * (that would recurse through `GLog` back into `Serialize`).
  *
- * Lifecycle: a function-local singleton (lives until program exit, i.e. strictly longer than `GLog`).
- * `Startup()`/`Shutdown()` register/deregister with `GLog` and are idempotent — `Shutdown()` MUST run
- * at module teardown so no dangling listener remains on `GLog` (an orphaned device crashes the editor
- * on exit).
+ * Lifecycle: a function-local singleton constructed during module startup (after `GLog` already
+ * exists) and destroyed in reverse construction order — i.e. BEFORE `GLog` — so the destructor can
+ * safely deregister itself from a still-live `GLog`. `Startup()`/`Shutdown()` register/deregister and
+ * are idempotent — `Shutdown()` MUST still run at module teardown so no dangling listener lingers on
+ * `GLog` while the editor keeps running (an orphaned device crashes the editor on exit).
  */
 class UNREALMCPEDITOR_API FUnrealMcpLogCollector : public FOutputDevice
 {

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLogCollector.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLogCollector.h
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Misc/OutputDevice.h"
+#include "Misc/DateTime.h"
+#include "HAL/CriticalSection.h"
+
+/**
+ * Captured log line (docs/ARCHITECTURE.md §10 editor/reflection family — the Godot `GodotLogCollector`
+ * analog). One ring-buffer entry: severity + category + message + a wall-clock capture timestamp.
+ */
+struct FUnrealMcpLogEntry
+{
+	FDateTime Timestamp;                 // wall-clock (UTC) at capture
+	ELogVerbosity::Type Verbosity = ELogVerbosity::Log;
+	FName Category;
+	FString Message;
+};
+
+/**
+ * Process-wide `GLog` listener feeding `console-get-logs` / `console-clear-logs`
+ * (docs/ARCHITECTURE.md §10). An `FOutputDevice` registered with `GLog` at module startup; every
+ * engine log line is mirrored into a capped ring buffer (default 10k entries) carrying severity,
+ * category and timestamp. Tool handlers read filtered/paginated slices on the game thread.
+ *
+ * Thread-safety: `GLog->Serialize` is called from arbitrary threads, so every buffer mutation/read is
+ * guarded by a critical section and `CanBeUsedOnAnyThread()` returns true. The capture path NEVER logs
+ * (that would recurse through `GLog` back into `Serialize`).
+ *
+ * Lifecycle: a function-local singleton (lives until program exit, i.e. strictly longer than `GLog`).
+ * `Startup()`/`Shutdown()` register/deregister with `GLog` and are idempotent — `Shutdown()` MUST run
+ * at module teardown so no dangling listener remains on `GLog` (an orphaned device crashes the editor
+ * on exit).
+ */
+class UNREALMCPEDITOR_API FUnrealMcpLogCollector : public FOutputDevice
+{
+public:
+	/** Max retained entries before the oldest are evicted (ring-buffer cap, §10 "strictly capped"). */
+	static constexpr int32 MaxEntries = 10000;
+
+	/** The process singleton. */
+	static FUnrealMcpLogCollector& Get();
+
+	virtual ~FUnrealMcpLogCollector() override;
+
+	/** Register with `GLog` (idempotent — a second call is a no-op). */
+	void Startup();
+
+	/** Deregister from `GLog` (idempotent, safe at module shutdown). */
+	void Shutdown();
+
+	/** True once registered with `GLog`. */
+	bool IsRegistered() const { return bRegistered; }
+
+	// --- FOutputDevice ---------------------------------------------------------------------------
+	virtual void Serialize(const TCHAR* Message, ELogVerbosity::Type Verbosity, const FName& Category) override;
+	virtual void Serialize(const TCHAR* Message, ELogVerbosity::Type Verbosity, const FName& Category, double Time) override;
+	virtual bool CanBeUsedOnAnyThread() const override { return true; }
+	virtual bool CanBeUsedOnMultipleThreads() const override { return true; }
+
+	/** Drop every retained entry. Returns the number removed. */
+	int32 Clear();
+
+	/** Current retained entry count. */
+	int32 Num() const;
+
+	/**
+	 * Copy a filtered, newest-last snapshot of the buffer under the lock.
+	 * @param MinVerbosity   keep entries at this severity or MORE severe (lower numeric value); pass
+	 *                       `ELogVerbosity::All` to keep everything.
+	 * @param CategoryFilter case-insensitive exact category match; empty keeps all categories.
+	 * @param Search         case-insensitive substring match on the message; empty keeps all.
+	 * @param Limit          max entries returned (the most-recent @p Limit after filtering); <=0 → all.
+	 */
+	TArray<FUnrealMcpLogEntry> Snapshot(ELogVerbosity::Type MinVerbosity, const FString& CategoryFilter,
+		const FString& Search, int32 Limit) const;
+
+	/** Human-readable severity token for a verbosity ("Error", "Warning", "Display", "Log", …). */
+	static FString VerbosityToString(ELogVerbosity::Type Verbosity);
+
+	/** Parse a severity token (case-insensitive) into a verbosity; returns false on an unknown token. */
+	static bool ParseVerbosity(const FString& Token, ELogVerbosity::Type& OutVerbosity);
+
+private:
+	FUnrealMcpLogCollector() = default;
+
+	void Capture(const TCHAR* Message, ELogVerbosity::Type Verbosity, const FName& Category);
+
+	mutable FCriticalSection Lock;
+	TArray<FUnrealMcpLogEntry> Entries;   // oldest-first; evicts from the front past MaxEntries
+	bool bRegistered = false;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLogCollector.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLogCollector.h
@@ -42,6 +42,15 @@ public:
 	/** Max retained entries before the oldest are evicted (ring-buffer cap, §10 "strictly capped"). */
 	static constexpr int32 MaxEntries = 10000;
 
+	/**
+	 * Eviction batch size. Head-eviction shifts every surviving element, so trimming one entry per line
+	 * at the cap would memmove the whole buffer on every log call. Instead, once the cap is reached the
+	 * oldest `EvictChunk` entries are dropped in a single memmove, so eviction runs ~once per `EvictChunk`
+	 * lines (O(1) amortized) rather than every line. The buffer never exceeds `MaxEntries`; it floats
+	 * between `MaxEntries - EvictChunk` and `MaxEntries`.
+	 */
+	static constexpr int32 EvictChunk = MaxEntries / 10;
+
 	/** The process singleton. */
 	static FUnrealMcpLogCollector& Get();
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -10,6 +10,7 @@
 #include "Bridge/UnrealMcpBridgeServer.h"
 #include "Sidecar/UnrealMcpSidecarManager.h"
 #include "Extensions/UnrealMcpExtensionManager.h"
+#include "Tools/UnrealMcpLogCollector.h"
 
 #include "Misc/CoreDelegates.h"
 #include "Misc/Paths.h"
@@ -27,11 +28,16 @@ void FUnrealMcpRuntime::Startup()
 		return;
 	bStarted = true;
 
+	// §10 editor/reflection family: start the GLog ring-buffer collector BEFORE anything else so the
+	// earliest startup log lines are already captured for console-get-logs. Shutdown() deregisters it.
+	FUnrealMcpLogCollector::Get().Startup();
+
 	Registry = MakeUnique<FUnrealMcpToolRegistry>();
 	UnrealMcpPingTool::Register(*Registry);
 	UnrealMcpActorTools::Register(*Registry);
 	UnrealMcpBlueprintTools::Register(*Registry); // §10 flagship Blueprint family (CORE)
 	UnrealMcpAssetTools::Register(*Registry); // §10 asset / Content-Browser family (issue #10)
+	UnrealMcpEditorTools::Register(*Registry); // §10 editor / console / reflection family (issue #19)
 
 	Dispatcher = MakeUnique<FUnrealMcpGameThreadDispatcher>();
 	BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(*Registry, *Dispatcher);
@@ -131,4 +137,8 @@ void FUnrealMcpRuntime::Shutdown()
 
 	Dispatcher.Reset();
 	Registry.Reset();
+
+	// §10 editor/reflection family: deregister the GLog listener LAST so no dangling FOutputDevice remains
+	// on GLog — an orphaned device crashes the editor on exit. Idempotent (safe if Startup never ran).
+	FUnrealMcpLogCollector::Get().Shutdown();
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpCoreTools.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpCoreTools.h
@@ -50,3 +50,15 @@ namespace UnrealMcpAssetTools
 {
 	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry);
 }
+
+/**
+ * The editor / console / reflection tool family (docs/ARCHITECTURE.md §10 "editor/reflection family",
+ * issue #19): ~9 kebab-case tools — editor-application-get/set-state (PIE), editor-selection-get/set,
+ * console-get/clear-logs (backed by the module-startup FUnrealMcpLogCollector GLog ring buffer),
+ * console-run-command, and reflection-method-find/call (safety-gated UFunction discovery + ProcessEvent).
+ * Registered in the boot path alongside the other CORE families; also exercised in isolation by specs.
+ */
+namespace UnrealMcpEditorTools
+{
+	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry);
+}

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorToolsSpec.cpp
@@ -292,6 +292,45 @@ void FUnrealMcpEditorToolsSpec::Define()
 			BadMethod->SetStringField(TEXT("method"), TEXT("NoSuchMethod_zzz"));
 			TestFalse(TEXT("unknown method is an error"), Run(Registry, TEXT("reflection-method-call"), BadMethod).bSuccess);
 		});
+
+		It("rejects an ambiguous target+class pair instead of silently preferring one", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+			TSharedPtr<FJsonObject> Both = Args();
+			Both->SetStringField(TEXT("class"), TEXT("KismetMathLibrary"));
+			Both->SetStringField(TEXT("target"), TEXT("AnyObject"));
+			Both->SetStringField(TEXT("method"), TEXT("Add_IntInt"));
+			TestFalse(TEXT("both target and class is an error"), Run(Registry, TEXT("reflection-method-call"), Both).bSuccess);
+		});
+
+		It("refuses an instance method on the class CDO path (steer to 'target')", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+
+			// Find a BlueprintCallable, non-static, non-CallInEditor UFunction on AActor — exactly the
+			// case the CDO path must refuse (it would mutate the shared class defaults / need a world).
+			UClass* ActorClass = AActor::StaticClass();
+			FString InstanceName;
+			for (TFieldIterator<UFunction> It(ActorClass, EFieldIteratorFlags::IncludeSuper); It; ++It)
+			{
+				UFunction* Fn = *It;
+				if (!Fn->HasAnyFunctionFlags(FUNC_BlueprintCallable) || Fn->HasAnyFunctionFlags(FUNC_Static))
+					continue;
+#if WITH_EDITORONLY_DATA
+				if (Fn->GetBoolMetaData(TEXT("CallInEditor")))
+					continue;
+#endif
+				InstanceName = Fn->GetName();
+				break;
+			}
+			TestTrue(TEXT("found a BlueprintCallable instance method to probe the CDO gate"), !InstanceName.IsEmpty());
+			if (InstanceName.IsEmpty()) return;
+
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("class"), TEXT("Actor"));
+			A->SetStringField(TEXT("method"), InstanceName);
+			TestFalse(TEXT("instance method via 'class' is rejected"), Run(Registry, TEXT("reflection-method-call"), A).bSuccess);
+		});
 	});
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorToolsSpec.cpp
@@ -162,6 +162,14 @@ void FUnrealMcpEditorToolsSpec::Define()
 			A->SetArrayField(TEXT("actors"), Refs);
 			TestFalse(TEXT("unknown ref is an error"), Run(Registry, TEXT("editor-selection-set"), A).bSuccess);
 		});
+
+		It("rejects a non-array 'actors' argument instead of silently clearing the selection", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("actors"), TEXT("not-an-array")); // present but a string, not an array
+			TestFalse(TEXT("string 'actors' is an error"), Run(Registry, TEXT("editor-selection-set"), A).bSuccess);
+		});
 	});
 
 	Describe("console", [this]()
@@ -248,6 +256,48 @@ void FUnrealMcpEditorToolsSpec::Define()
 				double Ret = 0; R.Structured->TryGetNumberField(TEXT("returnValue"), Ret);
 				TestEqual(TEXT("2 + 3 == 5"), (int32)Ret, 5);
 			}
+		});
+
+		It("invokes an INSTANCE BlueprintCallable method on an editor-world actor and gets a real (non-default) result", [this]()
+		{
+			// Regression guard for the FEditorScriptExecutionGuard around ProcessEvent. An editor-world actor's
+			// BlueprintCallable (non-CallInEditor) INSTANCE method is silently skipped by AActor::ProcessEvent
+			// unless script execution in the editor is enabled — without the guard the call would still report
+			// success but return the zero-initialized default (false here). Proving a 'true' result proves the
+			// method actually executed. (The static-via-CDO path above bypasses this gate, so it can't catch it.)
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+
+			AActor* Actor = SpawnTemp(TEXT("McpReflectInstance"));
+			TestTrue(TEXT("spawned a target actor"), Actor != nullptr);
+			if (!Actor) return;
+			Actor->Tags.Add(FName(TEXT("McpReflectProbe")));
+
+			TSharedPtr<FJsonObject> CallArgs = Args();
+			CallArgs->SetStringField(TEXT("target"), TEXT("McpReflectInstance"));
+			CallArgs->SetStringField(TEXT("method"), TEXT("ActorHasTag")); // BlueprintCallable instance method, bool return
+			TSharedPtr<FJsonObject> Inner = MakeShared<FJsonObject>();
+			Inner->SetStringField(TEXT("Tag"), TEXT("McpReflectProbe"));
+			CallArgs->SetObjectField(TEXT("args"), Inner);
+
+			const FUnrealMcpToolResult R = Run(Registry, TEXT("reflection-method-call"), CallArgs);
+			TestTrue(TEXT("instance call succeeds"), R.bSuccess);
+			bool bRet = false;
+			if (R.Structured.IsValid())
+				R.Structured->TryGetBoolField(TEXT("returnValue"), bRet);
+			TestTrue(TEXT("ActorHasTag returned true (method ran under the editor script guard)"), bRet);
+
+			Actor->Destroy();
+		});
+
+		It("rejects a non-object 'args' argument instead of silently zeroing every parameter", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("class"), TEXT("KismetMathLibrary"));
+			A->SetStringField(TEXT("method"), TEXT("Add_IntInt"));
+			TArray<TSharedPtr<FJsonValue>> ArgsArr; ArgsArr.Add(MakeShared<FJsonValueNumber>(1));
+			A->SetArrayField(TEXT("args"), ArgsArr); // present but an array, not an object
+			TestFalse(TEXT("non-object 'args' is an error"), Run(Registry, TEXT("reflection-method-call"), A).bSuccess);
 		});
 
 		It("refuses to call a non-BlueprintCallable / non-CallInEditor function (safety gate)", [this]()

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorToolsSpec.cpp
@@ -170,6 +170,14 @@ void FUnrealMcpEditorToolsSpec::Define()
 			A->SetStringField(TEXT("actors"), TEXT("not-an-array")); // present but a string, not an array
 			TestFalse(TEXT("string 'actors' is an error"), Run(Registry, TEXT("editor-selection-set"), A).bSuccess);
 		});
+
+		It("rejects a no-arg call (no actors, no clear) instead of silently deselecting everything", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+			// Neither 'actors' nor clear=true: must be an explicit error, not a silent SelectNone reported
+			// as success — deselecting the whole selection requires the explicit clear=true intent.
+			TestFalse(TEXT("empty no-arg call is an error"), Run(Registry, TEXT("editor-selection-set"), Args()).bSuccess);
+		});
 	});
 
 	Describe("console", [this]()
@@ -189,6 +197,11 @@ void FUnrealMcpEditorToolsSpec::Define()
 			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
 
 			// Drive the collector directly (the runtime that normally Startup()s it is not running in specs).
+			// NOTE: the collector is a process-wide singleton. Running this spec inside a LIVE editor session
+			// (rather than a throwaway -nullrhi automation process) is DESTRUCTIVE to the runtime's buffered
+			// logs — the Clear() below and console-clear-logs wipe the shared buffer. Registration state is
+			// snapshotted/restored at the end, but buffer CONTENTS are not. Acceptable for automation; do not
+			// run against a session whose captured logs you need to keep.
 			FUnrealMcpLogCollector& Collector = FUnrealMcpLogCollector::Get();
 			const bool bWasRegistered = Collector.IsRegistered();
 			Collector.Startup();

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorToolsSpec.cpp
@@ -1,0 +1,298 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "UnrealMcpCoreTools.h"
+#include "UnrealMcpToolRegistry.h"
+#include "Tools/UnrealMcpLogCollector.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+
+/**
+ * Editor / console / reflection tool family specs (docs/ARCHITECTURE.md §10, issue #19). Registration
+ * shape + per-tool happy/error paths, executed in EditorContext so GEditor + the editor world are live.
+ *
+ * PIE state TRANSITIONS are NOT driven here: starting a play session under headless `-nullrhi` automation
+ * emits engine Errors (which count as Automation failures) and cannot tick to completion. Only the
+ * deterministic validation/error branches of editor-application-set-state are asserted; the real PIE
+ * paths are proven honestly in the live bridge e2e (see targets/unreal-mcp/test.md Suite 7).
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpEditorToolsSpec, "UnrealMcp.Tools.EditorReflection",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	static TSharedPtr<FJsonObject> Args() { return MakeShared<FJsonObject>(); }
+
+	FUnrealMcpToolResult Run(FUnrealMcpToolRegistry& Reg, const FString& Tool, const TSharedPtr<FJsonObject>& A)
+	{
+		return Reg.Execute(Tool, FUnrealMcpToolCall(A));
+	}
+
+	/** A throwaway actor in the editor world, cleaned up by the caller. */
+	AActor* SpawnTemp(const FString& Label)
+	{
+		UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+		if (!World) return nullptr;
+		AActor* Actor = World->SpawnActor<AActor>();
+		if (Actor) Actor->SetActorLabel(Label);
+		return Actor;
+	}
+
+END_DEFINE_SPEC(FUnrealMcpEditorToolsSpec)
+
+void FUnrealMcpEditorToolsSpec::Define()
+{
+	Describe("registration", [this]()
+	{
+		It("registers the full editor/console/reflection family as core tools and bumps the revision", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			const int32 Before = Registry.GetRevision();
+			UnrealMcpEditorTools::Register(Registry);
+
+			const TCHAR* const Expected[] = {
+				TEXT("editor-application-get-state"), TEXT("editor-application-set-state"),
+				TEXT("editor-selection-get"), TEXT("editor-selection-set"),
+				TEXT("console-get-logs"), TEXT("console-clear-logs"), TEXT("console-run-command"),
+				TEXT("reflection-method-find"), TEXT("reflection-method-call")
+			};
+			for (const TCHAR* Name : Expected)
+				TestTrue(FString::Printf(TEXT("has %s"), Name), Registry.HasTool(Name));
+
+			TestEqual(TEXT("tool count"), Registry.Num(), (int32)UE_ARRAY_COUNT(Expected));
+			TestTrue(TEXT("revision bumped"), Registry.GetRevision() > Before);
+
+			const FUnrealMcpRegisteredTool* GetState = Registry.Find(TEXT("editor-application-get-state"));
+			TestTrue(TEXT("get-state found"), GetState != nullptr);
+			if (GetState)
+			{
+				TestEqual(TEXT("core extension id"), GetState->ExtensionId, FString(TEXT("core")));
+				TestFalse(TEXT("schema hash non-empty"), GetState->SchemaHash.IsEmpty());
+				TestTrue(TEXT("get-state is read-only"), GetState->bReadOnlyHint);
+			}
+		});
+	});
+
+	Describe("editor-application", [this]()
+	{
+		It("reports an idle (not playing) editor state", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+			const FUnrealMcpToolResult R = Run(Registry, TEXT("editor-application-get-state"), Args());
+			TestTrue(TEXT("succeeds"), R.bSuccess);
+			if (R.Structured.IsValid())
+			{
+				bool bPlaying = true;
+				R.Structured->TryGetBoolField(TEXT("isPlaying"), bPlaying);
+				TestFalse(TEXT("not playing in an idle editor"), bPlaying);
+			}
+		});
+
+		It("rejects invalid PIE transitions and unknown actions without starting a play session", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+
+			auto SetState = [&](const TCHAR* Action) -> FUnrealMcpToolResult
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("action"), Action);
+				return Run(Registry, TEXT("editor-application-set-state"), A);
+			};
+
+			TestFalse(TEXT("stop while idle is an error"), SetState(TEXT("stop")).bSuccess);
+			TestFalse(TEXT("pause while idle is an error"), SetState(TEXT("pause")).bSuccess);
+			TestFalse(TEXT("resume while idle is an error"), SetState(TEXT("resume")).bSuccess);
+			TestFalse(TEXT("unknown action is an error"), SetState(TEXT("frobnicate")).bSuccess);
+		});
+	});
+
+	Describe("editor-selection", [this]()
+	{
+		It("sets, reads back, and clears the actor selection by ref", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+
+			AActor* Actor = SpawnTemp(TEXT("McpSelTarget"));
+			TestTrue(TEXT("spawned a target actor"), Actor != nullptr);
+			if (!Actor) return;
+
+			// Select by label.
+			TSharedPtr<FJsonObject> SetArgs = Args();
+			TArray<TSharedPtr<FJsonValue>> Refs; Refs.Add(MakeShared<FJsonValueString>(TEXT("McpSelTarget")));
+			SetArgs->SetArrayField(TEXT("actors"), Refs);
+			const FUnrealMcpToolResult SetR = Run(Registry, TEXT("editor-selection-set"), SetArgs);
+			TestTrue(TEXT("selection-set succeeds"), SetR.bSuccess);
+
+			// Read it back.
+			const FUnrealMcpToolResult GetR = Run(Registry, TEXT("editor-selection-get"), Args());
+			TestTrue(TEXT("selection-get succeeds"), GetR.bSuccess);
+			int32 Count = 0;
+			if (GetR.Structured.IsValid())
+			{
+				double C = 0; GetR.Structured->TryGetNumberField(TEXT("count"), C); Count = (int32)C;
+			}
+			TestEqual(TEXT("one actor selected"), Count, 1);
+
+			// Clear.
+			TSharedPtr<FJsonObject> ClearArgs = Args(); ClearArgs->SetBoolField(TEXT("clear"), true);
+			const FUnrealMcpToolResult ClearR = Run(Registry, TEXT("editor-selection-set"), ClearArgs);
+			TestTrue(TEXT("clear succeeds"), ClearR.bSuccess);
+
+			const FUnrealMcpToolResult GetR2 = Run(Registry, TEXT("editor-selection-get"), Args());
+			int32 Count2 = -1;
+			if (GetR2.Structured.IsValid())
+			{
+				double C = 0; GetR2.Structured->TryGetNumberField(TEXT("count"), C); Count2 = (int32)C;
+			}
+			TestEqual(TEXT("selection cleared"), Count2, 0);
+
+			Actor->Destroy();
+		});
+
+		It("rejects an unknown actor ref and leaves the selection unchanged", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			TArray<TSharedPtr<FJsonValue>> Refs; Refs.Add(MakeShared<FJsonValueString>(TEXT("NoSuchActor_zzz")));
+			A->SetArrayField(TEXT("actors"), Refs);
+			TestFalse(TEXT("unknown ref is an error"), Run(Registry, TEXT("editor-selection-set"), A).bSuccess);
+		});
+	});
+
+	Describe("console", [this]()
+	{
+		It("runs a console command and captures handled/output", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("command"), TEXT("r.ScreenPercentage")); // read-only CVar query — prints its value
+			const FUnrealMcpToolResult R = Run(Registry, TEXT("console-run-command"), A);
+			TestTrue(TEXT("command runs"), R.bSuccess);
+			TestTrue(TEXT("missing command is rejected"), !Run(Registry, TEXT("console-run-command"), Args()).bSuccess);
+		});
+
+		It("captures GLog lines into the ring buffer, filters them, and clears", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+
+			// Drive the collector directly (the runtime that normally Startup()s it is not running in specs).
+			FUnrealMcpLogCollector& Collector = FUnrealMcpLogCollector::Get();
+			const bool bWasRegistered = Collector.IsRegistered();
+			Collector.Startup();
+			Collector.Clear();
+
+			const FString Needle = TEXT("McpLogProbe_4d9f");
+			UE_LOG(LogTemp, Display, TEXT("%s once"), *Needle);
+			GLog->Flush();
+
+			TSharedPtr<FJsonObject> GetArgs = Args();
+			GetArgs->SetStringField(TEXT("search"), Needle);
+			const FUnrealMcpToolResult GetR = Run(Registry, TEXT("console-get-logs"), GetArgs);
+			TestTrue(TEXT("get-logs succeeds"), GetR.bSuccess);
+			int32 Found = 0;
+			if (GetR.Structured.IsValid())
+			{
+				double C = 0; GetR.Structured->TryGetNumberField(TEXT("count"), C); Found = (int32)C;
+			}
+			TestTrue(TEXT("probe line captured"), Found >= 1);
+
+			const FUnrealMcpToolResult ClearR = Run(Registry, TEXT("console-clear-logs"), Args());
+			TestTrue(TEXT("clear succeeds"), ClearR.bSuccess);
+			TestEqual(TEXT("buffer empty after clear"), Collector.Num(), 0);
+
+			// Restore the registration state we found (don't leave a dangling GLog device across specs).
+			if (!bWasRegistered)
+				Collector.Shutdown();
+		});
+	});
+
+	Describe("reflection", [this]()
+	{
+		It("discovers a known BlueprintCallable static method with signature + flags", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("class"), TEXT("KismetMathLibrary"));
+			A->SetStringField(TEXT("name"), TEXT("Add_IntInt"));
+			const FUnrealMcpToolResult R = Run(Registry, TEXT("reflection-method-find"), A);
+			TestTrue(TEXT("find succeeds"), R.bSuccess);
+
+			int32 Matched = 0;
+			if (R.Structured.IsValid())
+			{
+				double M = 0; R.Structured->TryGetNumberField(TEXT("matched"), M); Matched = (int32)M;
+			}
+			TestTrue(TEXT("at least one Add_IntInt match"), Matched >= 1);
+		});
+
+		It("invokes a safe pure BlueprintCallable method and returns its result", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+			TSharedPtr<FJsonObject> CallArgs = Args();
+			CallArgs->SetStringField(TEXT("class"), TEXT("KismetMathLibrary"));
+			CallArgs->SetStringField(TEXT("method"), TEXT("Add_IntInt"));
+			TSharedPtr<FJsonObject> Inner = MakeShared<FJsonObject>();
+			Inner->SetNumberField(TEXT("A"), 2);
+			Inner->SetNumberField(TEXT("B"), 3);
+			CallArgs->SetObjectField(TEXT("args"), Inner);
+
+			const FUnrealMcpToolResult R = Run(Registry, TEXT("reflection-method-call"), CallArgs);
+			TestTrue(TEXT("call succeeds"), R.bSuccess);
+			if (R.Structured.IsValid())
+			{
+				double Ret = 0; R.Structured->TryGetNumberField(TEXT("returnValue"), Ret);
+				TestEqual(TEXT("2 + 3 == 5"), (int32)Ret, 5);
+			}
+		});
+
+		It("refuses to call a non-BlueprintCallable / non-CallInEditor function (safety gate)", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+
+			// Find a concrete non-callable UFunction on AActor at runtime (deterministic: lifecycle/native
+			// helpers exist that are neither BlueprintCallable nor CallInEditor) and prove the gate rejects
+			// it BEFORE any ProcessEvent runs.
+			UClass* ActorClass = AActor::StaticClass();
+			FString TargetName;
+			for (TFieldIterator<UFunction> It(ActorClass, EFieldIteratorFlags::IncludeSuper); It; ++It)
+			{
+				UFunction* Fn = *It;
+				const bool bCallable = Fn->HasAnyFunctionFlags(FUNC_BlueprintCallable)
+#if WITH_EDITORONLY_DATA
+					|| Fn->GetBoolMetaData(TEXT("CallInEditor"))
+#endif
+					;
+				if (!bCallable) { TargetName = Fn->GetName(); break; }
+			}
+			TestTrue(TEXT("found a non-callable function to probe the gate with"), !TargetName.IsEmpty());
+			if (TargetName.IsEmpty()) return;
+
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("class"), TEXT("Actor"));
+			A->SetStringField(TEXT("method"), TargetName);
+			const FUnrealMcpToolResult R = Run(Registry, TEXT("reflection-method-call"), A);
+			TestFalse(TEXT("non-callable function is rejected"), R.bSuccess);
+		});
+
+		It("errors on a missing method and on a missing target/class", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
+
+			TSharedPtr<FJsonObject> NoTarget = Args();
+			NoTarget->SetStringField(TEXT("method"), TEXT("Add_IntInt"));
+			TestFalse(TEXT("no target/class is an error"), Run(Registry, TEXT("reflection-method-call"), NoTarget).bSuccess);
+
+			TSharedPtr<FJsonObject> BadMethod = Args();
+			BadMethod->SetStringField(TEXT("class"), TEXT("KismetMathLibrary"));
+			BadMethod->SetStringField(TEXT("method"), TEXT("NoSuchMethod_zzz"));
+			TestFalse(TEXT("unknown method is an error"), Run(Registry, TEXT("reflection-method-call"), BadMethod).bSuccess);
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS


### PR DESCRIPTION
## Summary
- Adds the §10 editor/reflection tool family — 9 kebab-case CORE tools (editor-application get/set-state, editor-selection get/set, console get/clear-logs, console-run-command, reflection-method find/call), declared via the §3.3 builder and GameThread-dispatched.
- New `FUnrealMcpLogCollector`: a capped (10k) `GLog` `FOutputDevice` ring buffer registered at module startup and deregistered cleanly at shutdown, backing `console-get-logs` (filtered/paginated) and `console-clear-logs`.
- `reflection-method-call` is safety-gated: only BlueprintCallable / CallInEditor functions may be invoked via `ProcessEvent` over a constructed param frame (§3.2 JSON arg mapping). Union-merged boot registration. Additive only — no version bumps.

## Test plan
- [x] Suite 1 UBT build — exit 0
- [x] Suite 2 headless boot smoke — `[Unreal-MCP] plugin loaded`
- [x] Suite 3 Automation `UnrealMcp.` — 92 total, 0 failed (11 new EditorReflection specs, all green; PIE transitions guarded under -nullrhi)
- [x] Suite 7 live bridge e2e — console round-trip, selection get/set, reflection find + safe call, safety-gate rejection proven over HTTP; clean no-orphan teardown

Closes #19