### PR TITLE
feat(tools): C++ source-* tool family (ARCHITECTURE §10)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpSourceTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpSourceTools.cpp
@@ -331,6 +331,13 @@ namespace UnrealMcpSourceTools
 
 				TArray<FString> AllLines;
 				Content.ParseIntoArrayLines(AllLines, /*InCullEmpty*/ false);
+				// ParseIntoArrayLines appends a phantom trailing empty element for a newline-terminated
+				// file ("A\nB\n" -> ["A","B",""]); drop it so totalLines counts real lines (not lines+1)
+				// and the 1-based window below addresses only real lines.
+				if (Content.EndsWith(TEXT("\n")) && AllLines.Num() > 0 && AllLines.Last().IsEmpty())
+				{
+					AllLines.Pop();
+				}
 				const int32 TotalLines = AllLines.Num();
 
 				const bool bWindowed = Call.Has(TEXT("startLine")) || Call.Has(TEXT("endLine"));
@@ -532,13 +539,26 @@ namespace UnrealMcpSourceTools
 					const bool bTrailingNewline = Existing.EndsWith(TEXT("\n"));
 					TArray<FString> Lines;
 					Existing.ParseIntoArrayLines(Lines, /*InCullEmpty*/ false);
-					const int32 StartLine = (int32)Call.GetInt(TEXT("startLine"), 1);
-					const int32 EndLine = (int32)Call.GetInt(TEXT("endLine"), 1);
-					if (StartLine < 1 || EndLine < StartLine || StartLine > Lines.Num() || EndLine > Lines.Num())
+					// ParseIntoArrayLines appends a phantom trailing empty element for a newline-terminated
+					// file ("A\nB\n" -> ["A","B",""]). Drop it so (a) the addressable range is the real line
+					// count and (b) the trailing-EOL re-add below does not double the file's final newline
+					// (the phantom would otherwise contribute one EOL via the Join, plus another from bTrailingNewline).
+					if (bTrailingNewline && Lines.Num() > 0 && Lines.Last().IsEmpty())
+					{
+						Lines.Pop();
+					}
+					// Validate the range in int64 BEFORE narrowing — a huge value (e.g. 4294967297) would
+					// otherwise wrap to a small in-range int32 and silently splice the WRONG lines. A silent
+					// mis-edit on the write path is worse than the read path's over-read, so reject here.
+					const int64 StartLine64 = Call.GetInt(TEXT("startLine"), 1);
+					const int64 EndLine64 = Call.GetInt(TEXT("endLine"), 1);
+					if (StartLine64 < 1 || EndLine64 < StartLine64 || StartLine64 > Lines.Num() || EndLine64 > Lines.Num())
 					{
 						return FUnrealMcpToolResult::Error(FString::Printf(
-							TEXT("Invalid line range [%d..%d] for '%s' (%d line(s))."), StartLine, EndLine, *Jailed.RelPath, Lines.Num()));
+							TEXT("Invalid line range [%lld..%lld] for '%s' (%d line(s))."), StartLine64, EndLine64, *Jailed.RelPath, Lines.Num()));
 					}
+					const int32 StartLine = (int32)StartLine64;
+					const int32 EndLine = (int32)EndLine64;
 					TArray<FString> Replacement;
 					NewContent.ParseIntoArrayLines(Replacement, /*InCullEmpty*/ false);
 					TArray<FString> Result;
@@ -647,7 +667,7 @@ namespace UnrealMcpSourceTools
 
 				TArray<FString> Extensions;
 				const TArray<TSharedPtr<FJsonValue>>* ExtArray = nullptr;
-				if (Call.Arguments->TryGetArrayField(TEXT("extensions"), ExtArray))
+				if (Call.Arguments.IsValid() && Call.Arguments->TryGetArrayField(TEXT("extensions"), ExtArray))
 				{
 					for (const TSharedPtr<FJsonValue>& Value : *ExtArray)
 					{
@@ -776,10 +796,11 @@ namespace UnrealMcpSourceTools
 						// Live Coding surfaces a coarse enum, not per-diagnostic rows; the UBT path carries
 						// the full {file,line,severity,message} report.
 						Structured->SetArrayField(TEXT("diagnostics"), {});
-						// On a hard Failure, DON'T return the diagnostic-less enum — fall through to the UBT
-						// path below for the full structured report (success/compileClean already model the
-						// locked-DLL relink failure UBT will then hit).
-						if (Result != ELiveCodingCompileResult::Failure)
+						// Fall through to the UBT path below — for the full structured report — on a hard
+						// Failure OR when Compile() never started (bStarted == false, leaving Result at its
+						// NotStarted init): in both cases the coarse enum carries no actionable diagnostics,
+						// and success/compileClean already model the locked-DLL relink failure UBT will hit.
+						if (bStarted && Result != ELiveCodingCompileResult::Failure)
 						{
 							return FUnrealMcpToolResult::Success(
 								FString::Printf(TEXT("Live Coding compile: %s."), ResultText), Structured);

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpSourceTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpSourceTools.cpp
@@ -355,7 +355,11 @@ namespace UnrealMcpSourceTools
 					{
 						Window.Add(AllLines[Index]);
 					}
-					Content = FString::Join(Window, TEXT("\n"));
+					// Rejoin on the file's dominant line ending so a windowed read of a CRLF file returns
+					// CRLF (matching an unwindowed read, which returns the raw bytes) instead of silently
+					// normalizing to LF. Same detection source-update uses to preserve EOL on a splice.
+					const TCHAR* Eol = Content.Contains(TEXT("\r\n")) ? TEXT("\r\n") : TEXT("\n");
+					Content = FString::Join(Window, Eol);
 				}
 
 				// Byte-cap on the UTF-8 encoding (binary-search the longest prefix that fits).
@@ -365,7 +369,10 @@ namespace UnrealMcpSourceTools
 				if (Utf8Len(Content) > MaxBytes)
 				{
 					int32 Lo = 0;
-					int32 Hi = Content.Len();
+					// Every UTF-16 code unit encodes to >=1 UTF-8 byte, so a prefix that fits in MaxBytes
+					// bytes can be at most MaxBytes code units long — cap Hi there to avoid converting huge
+					// prefixes of a near-cap file to UTF-8 on the game thread during the search.
+					int32 Hi = FMath::Min(Content.Len(), MaxBytes);
 					while (Lo < Hi)
 					{
 						const int32 Mid = (Lo + Hi + 1) / 2;
@@ -468,6 +475,10 @@ namespace UnrealMcpSourceTools
 				}
 				if (!FFileHelper::SaveStringToFile(CppText, *CppPath.FullPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
 				{
+					// Roll back the just-written header so the scaffold is effectively atomic — a stranded
+					// half-scaffold (header on disk, cpp missing) would otherwise block a clean retry without
+					// 'force':true.
+					IFileManager::Get().Delete(*HeaderPath.FullPath, /*RequireExists*/ false, /*EvenReadOnly*/ true);
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to write cpp '%s'."), *CppPath.RelPath));
 				}
 
@@ -533,6 +544,9 @@ namespace UnrealMcpSourceTools
 					{
 						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to read '%s'."), *Jailed.RelPath));
 					}
+					// Note: a range splice on a UTF-8-BOM file drops the BOM (LoadFileToString consumes it and
+					// the write below forces ForceUTF8WithoutBOM). This is intentional — BOM-less UTF-8 is the
+					// project source convention — and consistent with full-file writes, which also emit no BOM.
 					// Preserve the file's dominant line ending and trailing newline so a one-line splice
 					// produces a one-line diff, not a whole-file CRLF->LF rewrite that drops the final EOL.
 					const TCHAR* Eol = Existing.Contains(TEXT("\r\n")) ? TEXT("\r\n") : TEXT("\n");
@@ -561,6 +575,15 @@ namespace UnrealMcpSourceTools
 					const int32 EndLine = (int32)EndLine64;
 					TArray<FString> Replacement;
 					NewContent.ParseIntoArrayLines(Replacement, /*InCullEmpty*/ false);
+					// Mirror the phantom-trailing-empty drop on the REPLACEMENT side: a newline-terminated
+					// 'content' ("X2\n" -> ["X2",""]) would otherwise contribute its own EOL via the Join
+					// below AND re-add the file's trailing EOL, splicing a spurious blank line per edit (the
+					// same accumulation bug fixed above for the existing file's lines). AI callers very
+					// commonly send newline-terminated content, so guard the write path symmetrically.
+					if (NewContent.EndsWith(TEXT("\n")) && Replacement.Num() > 0 && Replacement.Last().IsEmpty())
+					{
+						Replacement.Pop();
+					}
 					TArray<FString> Result;
 					Result.Append(Lines.GetData(), StartLine - 1);
 					Result.Append(Replacement);

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpSourceTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpSourceTools.cpp
@@ -88,6 +88,9 @@ namespace UnrealMcpSourceTools
 		// Best-effort junction/symlink jail: resolve the deepest EXISTING ancestor's real on-disk path
 		// (fixes case and, where the platform supports it, follows reparse points) and re-check
 		// containment, so a junction placed INSIDE Source/ that targets outside is still rejected.
+		// NOTE: this is a PATH-level check, so a TOCTOU window exists between it and the later file op
+		// (a junction could be swapped in after we validate). UE's file API offers no handle-based
+		// re-verify, and the documented threat model (a local AI editing project source) accepts it.
 		{
 			IFileManager& FM = IFileManager::Get();
 			FString Existing = Full;
@@ -116,10 +119,22 @@ namespace UnrealMcpSourceTools
 			}
 		}
 
-		Out.bOk = true;
 		Out.FullPath = Full;
 		Out.RelPath = Full;
 		FPaths::MakePathRelativeTo(Out.RelPath, *(Root + TEXT("/")));
+
+		// Reject NTFS alternate-data-stream syntax ("Foo.cpp:stream"): a ':' in the path RELATIVE to the
+		// jail root would otherwise let a write create/read an ADS that survives canonicalization. The
+		// drive-letter colon lives in the jail root, not the remainder, so checking RelPath is safe.
+		if (Out.RelPath.Contains(TEXT(":")))
+		{
+			Out.FullPath.Reset();
+			Out.RelPath.Reset();
+			Out.Error = FString::Printf(TEXT("'%s' contains an illegal ':' (alternate data stream)."), *InPath);
+			return Out;
+		}
+
+		Out.bOk = true;
 		return Out;
 	}
 
@@ -134,9 +149,11 @@ namespace UnrealMcpSourceTools
 
 		// MSVC:  C:\path\File.cpp(42): error C2065: 'Foo': undeclared identifier
 		//        File.cpp(42,5): warning C4101: ...   (newer toolchains may add a column)
-		const FRegexPattern MsvcPattern(TEXT("^\\s*(.+?)\\((\\d+)(?:,\\d+)?\\)\\s*:\\s*(error|warning)\\s+(.+?)\\s*$"));
-		// clang: File.cpp:42:5: error: ...
-		const FRegexPattern ClangPattern(TEXT("^\\s*(.+?):(\\d+):(?:\\d+:)?\\s*(error|warning):\\s*(.+?)\\s*$"));
+		//        File.cpp(1): fatal error C1083: ...   (a missing/typo'd #include — the optional
+		//        "fatal " prefix is consumed and the severity normalized to "error")
+		const FRegexPattern MsvcPattern(TEXT("^\\s*(.+?)\\((\\d+)(?:,\\d+)?\\)\\s*:\\s*(?:fatal\\s+)?(error|warning)\\s+(.+?)\\s*$"));
+		// clang: File.cpp:42:5: error: ...   (also "File.cpp:1:10: fatal error: 'X.h' file not found")
+		const FRegexPattern ClangPattern(TEXT("^\\s*(.+?):(\\d+):(?:\\d+:)?\\s*(?:fatal\\s+)?(error|warning):\\s*(.+?)\\s*$"));
 
 		TSet<FString> Seen;
 		auto AddMatch = [&OutDiagnostics, &Seen](const FString& File, const FString& LineStr, const FString& Sev, const FString& Msg)
@@ -295,6 +312,17 @@ namespace UnrealMcpSourceTools
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No source file at '%s'."), *Jailed.RelPath));
 				}
 
+				// Refuse absurdly large files BEFORE reading the whole thing into memory — the byte cap only
+				// bounds the RETURNED slice, not the read. 64 MiB is far above any sane source file.
+				static constexpr int64 MaxReadableBytes = 64ll * 1024 * 1024;
+				const int64 OnDiskSize = IFileManager::Get().FileSize(*Jailed.FullPath);
+				if (OnDiskSize > MaxReadableBytes)
+				{
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("'%s' is %lld bytes; refusing to read files larger than %lld bytes."),
+						*Jailed.RelPath, OnDiskSize, MaxReadableBytes));
+				}
+
 				FString Content;
 				if (!FFileHelper::LoadFileToString(Content, *Jailed.FullPath))
 				{
@@ -310,8 +338,10 @@ namespace UnrealMcpSourceTools
 				int32 EndLine = TotalLines;
 				if (bWindowed)
 				{
-					StartLine = FMath::Clamp((int32)Call.GetInt(TEXT("startLine"), 1), 1, FMath::Max(1, TotalLines));
-					EndLine = FMath::Clamp((int32)Call.GetInt(TEXT("endLine"), TotalLines), StartLine, FMath::Max(1, TotalLines));
+					// Clamp in int64 BEFORE narrowing — a huge value (e.g. 4294967297) would otherwise wrap
+					// to a small in-range int32 before the clamp ever ran.
+					StartLine = (int32)FMath::Clamp<int64>(Call.GetInt(TEXT("startLine"), 1), 1, FMath::Max(1, TotalLines));
+					EndLine = (int32)FMath::Clamp<int64>(Call.GetInt(TEXT("endLine"), TotalLines), StartLine, FMath::Max(1, TotalLines));
 
 					TArray<FString> Window;
 					for (int32 Index = StartLine - 1; Index < EndLine && Index < TotalLines; ++Index)
@@ -322,7 +352,7 @@ namespace UnrealMcpSourceTools
 				}
 
 				// Byte-cap on the UTF-8 encoding (binary-search the longest prefix that fits).
-				const int32 MaxBytes = FMath::Clamp((int32)Call.GetInt(TEXT("maxBytes"), 262144), 1, 4194304);
+				const int32 MaxBytes = (int32)FMath::Clamp<int64>(Call.GetInt(TEXT("maxBytes"), 262144), 1, 4194304);
 				auto Utf8Len = [](const FString& S) { return FTCHARToUTF8(*S).Length(); };
 				bool bTruncated = false;
 				if (Utf8Len(Content) > MaxBytes)
@@ -333,6 +363,13 @@ namespace UnrealMcpSourceTools
 					{
 						const int32 Mid = (Lo + Hi + 1) / 2;
 						if (Utf8Len(Content.Left(Mid)) <= MaxBytes) { Lo = Mid; } else { Hi = Mid - 1; }
+					}
+					// Don't slice between a UTF-16 surrogate pair: if the last kept code unit is a high
+					// surrogate (U+D800..U+DBFF) its low half is at index Lo (excluded), so drop it too.
+					if (Lo > 0 && Lo < Content.Len())
+					{
+						const TCHAR Prev = Content[Lo - 1];
+						if (Prev >= (TCHAR)0xD800 && Prev <= (TCHAR)0xDBFF) { --Lo; }
 					}
 					Content = Content.Left(Lo);
 					bTruncated = true;
@@ -489,6 +526,10 @@ namespace UnrealMcpSourceTools
 					{
 						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to read '%s'."), *Jailed.RelPath));
 					}
+					// Preserve the file's dominant line ending and trailing newline so a one-line splice
+					// produces a one-line diff, not a whole-file CRLF->LF rewrite that drops the final EOL.
+					const TCHAR* Eol = Existing.Contains(TEXT("\r\n")) ? TEXT("\r\n") : TEXT("\n");
+					const bool bTrailingNewline = Existing.EndsWith(TEXT("\n"));
 					TArray<FString> Lines;
 					Existing.ParseIntoArrayLines(Lines, /*InCullEmpty*/ false);
 					const int32 StartLine = (int32)Call.GetInt(TEXT("startLine"), 1);
@@ -507,7 +548,11 @@ namespace UnrealMcpSourceTools
 					{
 						Result.Add(Lines[Index]);
 					}
-					Final = FString::Join(Result, TEXT("\n"));
+					Final = FString::Join(Result, Eol);
+					if (bTrailingNewline)
+					{
+						Final += Eol;
+					}
 					Mode = FString::Printf(TEXT("range [%d..%d]"), StartLine, EndLine);
 				}
 				else
@@ -731,8 +776,14 @@ namespace UnrealMcpSourceTools
 						// Live Coding surfaces a coarse enum, not per-diagnostic rows; the UBT path carries
 						// the full {file,line,severity,message} report.
 						Structured->SetArrayField(TEXT("diagnostics"), {});
-						return FUnrealMcpToolResult::Success(
-							FString::Printf(TEXT("Live Coding compile: %s."), ResultText), Structured);
+						// On a hard Failure, DON'T return the diagnostic-less enum — fall through to the UBT
+						// path below for the full structured report (success/compileClean already model the
+						// locked-DLL relink failure UBT will then hit).
+						if (Result != ELiveCodingCompileResult::Failure)
+						{
+							return FUnrealMcpToolResult::Success(
+								FString::Printf(TEXT("Live Coding compile: %s."), ResultText), Structured);
+						}
 					}
 				}
 #endif
@@ -747,6 +798,24 @@ namespace UnrealMcpSourceTools
 				if (Configuration.IsEmpty())
 				{
 					Configuration = TEXT("Development");
+				}
+
+				// target/platform/configuration are pasted verbatim into the UBT command line, so each must
+				// be a single identifier-like token (no whitespace, quotes, or dash-prefixed flags) — else a
+				// value like "UnrealTestProjectEditor Win64 Development -Clean" would inject arbitrary UBT
+				// arguments (e.g. -Clean wipes Binaries/Intermediate). Mirrors IsValidIdentifier used for
+				// generated class/module names. All real targets/platforms/configs are bare identifiers.
+				if (!IsValidIdentifier(TargetName))
+				{
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("'%s' is not a valid build target name."), *TargetName));
+				}
+				if (!IsValidIdentifier(Platform))
+				{
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("'%s' is not a valid build platform."), *Platform));
+				}
+				if (!IsValidIdentifier(Configuration))
+				{
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("'%s' is not a valid build configuration."), *Configuration));
 				}
 
 				FString UProject;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpSourceTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpSourceTools.cpp
@@ -1,0 +1,832 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "Tools/UnrealMcpSourceTools.h"
+#include "UnrealMcpCoreTools.h"
+#include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpLog.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Misc/Paths.h"
+#include "Misc/App.h"
+#include "Misc/FileHelper.h"
+#include "Internationalization/Regex.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformProcess.h"
+#include "HAL/PlatformTime.h"
+
+#if WITH_UNREAL_MCP_LIVE_CODING
+#include "ILiveCodingModule.h"
+#include "Modules/ModuleManager.h"
+#endif
+
+/**
+ * The C++ source / script tool family (docs/ARCHITECTURE.md §10 "source family", issue #18).
+ *
+ * Six native CORE tools — source-read / source-create-class / source-update / source-delete /
+ * source-list / source-compile — declared via the §3.3 builder and run on the game-thread dispatcher
+ * (§4). The defining value of the family is source-compile's structured `{file,line,severity,message}`
+ * build report (§3): the machine-readable feedback loop an AI iterates against until the code builds.
+ *
+ * Every file operation is JAILED to the loaded project's `Source/` directory: ResolveJailedPath
+ * canonicalizes the caller path, collapses `..`, and rejects anything that escapes (plus a best-effort
+ * junction/symlink check). `Plugins/`, `Config/` and engine paths are never reachable.
+ *
+ * source-compile runs synchronously inside the handler (ARCHITECTURE §4 envisions async-chaining once
+ * the registry grows a TFuture handler surface; until then a compile blocks the game thread for its
+ * duration — fine for the headless test gate, and a no-op "up to date" build returns in seconds). It
+ * prefers Live Coding when the editor is interactive and Live Coding is live, else invokes UBT on the
+ * project's Editor target. A loaded editor holds its module DLL, so a plain UBT relink fails to write
+ * it — therefore `success` (process return code 0) is reported SEPARATELY from `compileClean`
+ * (zero compiler-error diagnostics): the AI feedback loop keys off compiler diagnostics, which are
+ * emitted before the link stage and are unaffected by the DLL lock.
+ */
+namespace UnrealMcpSourceTools
+{
+	// --- Jail + path helpers --------------------------------------------------------------------
+
+	FString GetProjectSourceRoot()
+	{
+		FString Root = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir() / TEXT("Source"));
+		FPaths::NormalizeDirectoryName(Root);
+		return Root;
+	}
+
+	FString ModuleApiMacro(const FString& ModuleName)
+	{
+		return ModuleName.ToUpper() + TEXT("_API");
+	}
+
+	FJailedPath ResolveJailedPath(const FString& JailRoot, const FString& InPath)
+	{
+		FJailedPath Out;
+
+		FString Root = FPaths::ConvertRelativePathToFull(JailRoot);
+		FPaths::NormalizeDirectoryName(Root);
+
+		FString Cleaned = InPath;
+		Cleaned.TrimStartAndEndInline();
+		if (Cleaned.IsEmpty())
+		{
+			Out.Error = TEXT("path is empty.");
+			return Out;
+		}
+		FPaths::NormalizeFilename(Cleaned); // backslashes -> forward slashes
+
+		const FString Combined = FPaths::IsRelative(Cleaned) ? (Root / Cleaned) : Cleaned;
+		FString Full = FPaths::ConvertRelativePathToFull(Combined); // collapses '.' and '..'
+		FPaths::NormalizeFilename(Full);
+
+		// Path-level jail: after collapsing traversal, the result must be the root itself or under it.
+		if (!Full.Equals(Root, ESearchCase::IgnoreCase) && !FPaths::IsUnderDirectory(Full, Root))
+		{
+			Out.Error = FString::Printf(TEXT("'%s' escapes the project Source/ jail."), *InPath);
+			return Out;
+		}
+
+		// Best-effort junction/symlink jail: resolve the deepest EXISTING ancestor's real on-disk path
+		// (fixes case and, where the platform supports it, follows reparse points) and re-check
+		// containment, so a junction placed INSIDE Source/ that targets outside is still rejected.
+		{
+			IFileManager& FM = IFileManager::Get();
+			FString Existing = Full;
+			while (!Existing.Equals(Root, ESearchCase::IgnoreCase)
+				&& !FM.FileExists(*Existing) && !FM.DirectoryExists(*Existing))
+			{
+				const FString Parent = FPaths::GetPath(Existing);
+				if (Parent.IsEmpty() || Parent.Equals(Existing, ESearchCase::IgnoreCase))
+				{
+					break;
+				}
+				Existing = Parent;
+			}
+			if (FM.FileExists(*Existing) || FM.DirectoryExists(*Existing))
+			{
+				FString OnDisk = FPaths::ConvertRelativePathToFull(FM.GetFilenameOnDisk(*Existing));
+				FPaths::NormalizeFilename(OnDisk);
+				FString RootOnDisk = FPaths::ConvertRelativePathToFull(FM.GetFilenameOnDisk(*Root));
+				FPaths::NormalizeFilename(RootOnDisk);
+				FPaths::NormalizeDirectoryName(RootOnDisk);
+				if (!OnDisk.Equals(RootOnDisk, ESearchCase::IgnoreCase) && !FPaths::IsUnderDirectory(OnDisk, RootOnDisk))
+				{
+					Out.Error = FString::Printf(TEXT("'%s' resolves through a link that escapes the project Source/ jail."), *InPath);
+					return Out;
+				}
+			}
+		}
+
+		Out.bOk = true;
+		Out.FullPath = Full;
+		Out.RelPath = Full;
+		FPaths::MakePathRelativeTo(Out.RelPath, *(Root + TEXT("/")));
+		return Out;
+	}
+
+	// --- Compiler-diagnostic parser -------------------------------------------------------------
+
+	void ParseDiagnostics(const FString& BuildOutput, TArray<FSourceDiagnostic>& OutDiagnostics)
+	{
+		OutDiagnostics.Reset();
+
+		TArray<FString> Lines;
+		BuildOutput.ParseIntoArrayLines(Lines, /*InCullEmpty*/ false);
+
+		// MSVC:  C:\path\File.cpp(42): error C2065: 'Foo': undeclared identifier
+		//        File.cpp(42,5): warning C4101: ...   (newer toolchains may add a column)
+		const FRegexPattern MsvcPattern(TEXT("^\\s*(.+?)\\((\\d+)(?:,\\d+)?\\)\\s*:\\s*(error|warning)\\s+(.+?)\\s*$"));
+		// clang: File.cpp:42:5: error: ...
+		const FRegexPattern ClangPattern(TEXT("^\\s*(.+?):(\\d+):(?:\\d+:)?\\s*(error|warning):\\s*(.+?)\\s*$"));
+
+		TSet<FString> Seen;
+		auto AddMatch = [&OutDiagnostics, &Seen](const FString& File, const FString& LineStr, const FString& Sev, const FString& Msg)
+		{
+			FSourceDiagnostic D;
+			D.File = File;
+			D.File.TrimStartAndEndInline();
+			D.Line = FCString::Atoi(*LineStr);
+			D.Severity = Sev.ToLower();
+			D.Message = Msg;
+			D.Message.TrimStartAndEndInline();
+			const FString Key = FString::Printf(TEXT("%s|%d|%s|%s"), *D.File, D.Line, *D.Severity, *D.Message);
+			if (!Seen.Contains(Key))
+			{
+				Seen.Add(Key);
+				OutDiagnostics.Add(MoveTemp(D));
+			}
+		};
+
+		for (const FString& Line : Lines)
+		{
+			if (Line.IsEmpty())
+			{
+				continue;
+			}
+			FRegexMatcher Msvc(MsvcPattern, Line);
+			if (Msvc.FindNext())
+			{
+				AddMatch(Msvc.GetCaptureGroup(1), Msvc.GetCaptureGroup(2), Msvc.GetCaptureGroup(3), Msvc.GetCaptureGroup(4));
+				continue;
+			}
+			FRegexMatcher Clang(ClangPattern, Line);
+			if (Clang.FindNext())
+			{
+				AddMatch(Clang.GetCaptureGroup(1), Clang.GetCaptureGroup(2), Clang.GetCaptureGroup(3), Clang.GetCaptureGroup(4));
+			}
+		}
+	}
+
+	// --- Local file-op helpers ------------------------------------------------------------------
+
+	static const TCHAR* FileHeaderComment()
+	{
+		return TEXT("// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.\n")
+		       TEXT("// See the LICENSE file in the repository root for more information.\n");
+	}
+
+	/** True if @p Name is a legal C++ identifier (so a generated class name can never inject syntax). */
+	static bool IsValidIdentifier(const FString& Name)
+	{
+		if (Name.IsEmpty())
+		{
+			return false;
+		}
+		for (int32 Index = 0; Index < Name.Len(); ++Index)
+		{
+			const TCHAR Ch = Name[Index];
+			const bool bAlpha = (Ch >= TEXT('A') && Ch <= TEXT('Z')) || (Ch >= TEXT('a') && Ch <= TEXT('z')) || Ch == TEXT('_');
+			const bool bDigit = (Ch >= TEXT('0') && Ch <= TEXT('9'));
+			if (!bAlpha && !(bDigit && Index > 0))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/** Resolved class-scaffold parameters for one of the supported parent kinds. */
+	struct FClassTemplate
+	{
+		FString Prefix;        // "U" / "A" / "F"
+		FString ParentSymbol;  // "UObject" / "AActor" / "UActorComponent" / "" (plain)
+		FString ParentHeader;  // include path, empty for plain
+		bool bUClass = false;
+	};
+
+	static bool ResolveClassTemplate(const FString& InParent, FClassTemplate& Out, FString& OutError)
+	{
+		const FString P = InParent.TrimStartAndEnd();
+		if (P.IsEmpty() || P.Equals(TEXT("UObject"), ESearchCase::IgnoreCase) || P.Equals(TEXT("Object"), ESearchCase::IgnoreCase))
+		{
+			Out = { TEXT("U"), TEXT("UObject"), TEXT("UObject/NoExportTypes.h"), true };
+			return true;
+		}
+		if (P.Equals(TEXT("AActor"), ESearchCase::IgnoreCase) || P.Equals(TEXT("Actor"), ESearchCase::IgnoreCase))
+		{
+			Out = { TEXT("A"), TEXT("AActor"), TEXT("GameFramework/Actor.h"), true };
+			return true;
+		}
+		if (P.Equals(TEXT("UActorComponent"), ESearchCase::IgnoreCase) || P.Equals(TEXT("ActorComponent"), ESearchCase::IgnoreCase))
+		{
+			Out = { TEXT("U"), TEXT("UActorComponent"), TEXT("Components/ActorComponent.h"), true };
+			return true;
+		}
+		if (P.Equals(TEXT("None"), ESearchCase::IgnoreCase) || P.Equals(TEXT("Empty"), ESearchCase::IgnoreCase) || P.Equals(TEXT("Plain"), ESearchCase::IgnoreCase))
+		{
+			Out = { TEXT("F"), FString(), FString(), false };
+			return true;
+		}
+		OutError = FString::Printf(
+			TEXT("Unsupported parentClass '%s'. Supported: UObject, Actor, ActorComponent, None (plain class)."), *InParent);
+		return false;
+	}
+
+	static FString BuildHeader(const FClassTemplate& Tpl, const FString& ClassName, const FString& ApiMacro)
+	{
+		const FString Symbol = Tpl.Prefix + ClassName;
+		if (Tpl.bUClass)
+		{
+			return FString::Printf(
+				TEXT("%s\n#pragma once\n\n#include \"CoreMinimal.h\"\n#include \"%s\"\n#include \"%s.generated.h\"\n\n")
+				TEXT("UCLASS()\nclass %s %s : public %s\n{\n\tGENERATED_BODY()\n};\n"),
+				FileHeaderComment(), *Tpl.ParentHeader, *ClassName, *ApiMacro, *Symbol, *Tpl.ParentSymbol);
+		}
+		return FString::Printf(
+			TEXT("%s\n#pragma once\n\n#include \"CoreMinimal.h\"\n\nclass %s %s\n{\n};\n"),
+			FileHeaderComment(), *ApiMacro, *Symbol);
+	}
+
+	static FString BuildCpp(const FString& ClassName)
+	{
+		return FString::Printf(TEXT("%s\n#include \"%s.h\"\n"), FileHeaderComment(), *ClassName);
+	}
+
+	// --- Tool registration ----------------------------------------------------------------------
+
+	void Register(FUnrealMcpToolRegistry& Registry)
+	{
+		// source-read ------------------------------------------------------------------------------
+		Registry.Tool(TEXT("source-read"))
+			.Title(TEXT("Read Source File"))
+			.Description(TEXT("Read a project C++/C# source file. 'path' is relative to the project Source/ "
+			                  "directory (e.g. 'MyGame/MyActor.cpp') or an absolute path inside it; all access is "
+			                  "JAILED to <Project>/Source. Optionally window the result by 1-based 'startLine'/"
+			                  "'endLine' (inclusive). The returned text is byte-capped by 'maxBytes' (default "
+			                  "262144, hard cap 4194304); 'truncated' reports whether the cap clipped it."))
+			.ParamString(TEXT("path"), TEXT("Source file path relative to <Project>/Source (or absolute, inside it)."), EUnrealMcpParamRequirement::Required)
+			.ParamInt(TEXT("startLine"), TEXT("1-based first line to return (inclusive). Default 1."))
+			.ParamInt(TEXT("endLine"), TEXT("1-based last line to return (inclusive). Default: end of file."))
+			.ParamInt(TEXT("maxBytes"), TEXT("Maximum bytes of content to return (1..4194304). Default 262144."))
+			.ReadOnlyHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const FString Path = Call.GetString(TEXT("path"));
+				if (Path.IsEmpty())
+				{
+					return FUnrealMcpToolResult::Error(TEXT("'path' is required."));
+				}
+				const FJailedPath Jailed = ResolveJailedPath(GetProjectSourceRoot(), Path);
+				if (!Jailed.bOk)
+				{
+					return FUnrealMcpToolResult::Error(Jailed.Error);
+				}
+				if (!FPaths::FileExists(Jailed.FullPath))
+				{
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No source file at '%s'."), *Jailed.RelPath));
+				}
+
+				FString Content;
+				if (!FFileHelper::LoadFileToString(Content, *Jailed.FullPath))
+				{
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to read '%s'."), *Jailed.RelPath));
+				}
+
+				TArray<FString> AllLines;
+				Content.ParseIntoArrayLines(AllLines, /*InCullEmpty*/ false);
+				const int32 TotalLines = AllLines.Num();
+
+				const bool bWindowed = Call.Has(TEXT("startLine")) || Call.Has(TEXT("endLine"));
+				int32 StartLine = 1;
+				int32 EndLine = TotalLines;
+				if (bWindowed)
+				{
+					StartLine = FMath::Clamp((int32)Call.GetInt(TEXT("startLine"), 1), 1, FMath::Max(1, TotalLines));
+					EndLine = FMath::Clamp((int32)Call.GetInt(TEXT("endLine"), TotalLines), StartLine, FMath::Max(1, TotalLines));
+
+					TArray<FString> Window;
+					for (int32 Index = StartLine - 1; Index < EndLine && Index < TotalLines; ++Index)
+					{
+						Window.Add(AllLines[Index]);
+					}
+					Content = FString::Join(Window, TEXT("\n"));
+				}
+
+				// Byte-cap on the UTF-8 encoding (binary-search the longest prefix that fits).
+				const int32 MaxBytes = FMath::Clamp((int32)Call.GetInt(TEXT("maxBytes"), 262144), 1, 4194304);
+				auto Utf8Len = [](const FString& S) { return FTCHARToUTF8(*S).Length(); };
+				bool bTruncated = false;
+				if (Utf8Len(Content) > MaxBytes)
+				{
+					int32 Lo = 0;
+					int32 Hi = Content.Len();
+					while (Lo < Hi)
+					{
+						const int32 Mid = (Lo + Hi + 1) / 2;
+						if (Utf8Len(Content.Left(Mid)) <= MaxBytes) { Lo = Mid; } else { Hi = Mid - 1; }
+					}
+					Content = Content.Left(Lo);
+					bTruncated = true;
+				}
+
+				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+				Structured->SetStringField(TEXT("path"), Jailed.RelPath);
+				Structured->SetStringField(TEXT("content"), Content);
+				Structured->SetNumberField(TEXT("totalLines"), TotalLines);
+				Structured->SetNumberField(TEXT("startLine"), StartLine);
+				Structured->SetNumberField(TEXT("endLine"), bWindowed ? EndLine : TotalLines);
+				Structured->SetNumberField(TEXT("returnedBytes"), Utf8Len(Content));
+				Structured->SetBoolField(TEXT("truncated"), bTruncated);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Read '%s' (%d line(s)%s)."), *Jailed.RelPath, TotalLines, bTruncated ? TEXT(", truncated") : TEXT("")),
+					Structured);
+			});
+
+		// source-create-class ----------------------------------------------------------------------
+		Registry.Tool(TEXT("source-create-class"))
+			.Title(TEXT("Create C++ Class"))
+			.Description(TEXT("Scaffold a new C++ class — header + cpp generated from templates into "
+			                  "Source/<module>/, mirroring the editor's 'New C++ Class'. 'className' is the bare "
+			                  "name WITHOUT the U/A/F prefix (the prefix is derived from the parent). 'parentClass' "
+			                  "is one of: UObject (default), Actor, ActorComponent, None (a plain non-UCLASS class). "
+			                  "'module' defaults to the project's primary module. Refuses to overwrite existing "
+			                  "files unless 'force':true. All writes are JAILED to <Project>/Source."))
+			.ParamString(TEXT("className"), TEXT("Bare class name (no U/A/F prefix), e.g. 'MyActor'."), EUnrealMcpParamRequirement::Required)
+			.ParamString(TEXT("parentClass"), TEXT("Parent kind: UObject (default), Actor, ActorComponent, or None."))
+			.ParamString(TEXT("module"), TEXT("Target module folder under Source/. Defaults to the project's primary module."))
+			.ParamBool(TEXT("force"), TEXT("Overwrite existing header/cpp at the destination. Default false."))
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const FString ClassName = Call.GetString(TEXT("className"));
+				if (!IsValidIdentifier(ClassName))
+				{
+					return FUnrealMcpToolResult::Error(
+						FString::Printf(TEXT("'%s' is not a valid C++ class name (letters/digits/underscore, not leading digit; no prefix)."), *ClassName));
+				}
+				FString Module = Call.GetString(TEXT("module"));
+				if (Module.IsEmpty())
+				{
+					Module = FApp::GetProjectName();
+				}
+				if (!IsValidIdentifier(Module))
+				{
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("'%s' is not a valid module name."), *Module));
+				}
+
+				FClassTemplate Tpl;
+				FString TemplateError;
+				if (!ResolveClassTemplate(Call.GetString(TEXT("parentClass")), Tpl, TemplateError))
+				{
+					return FUnrealMcpToolResult::Error(TemplateError);
+				}
+
+				const FString Root = GetProjectSourceRoot();
+				const FJailedPath ModuleDir = ResolveJailedPath(Root, Module);
+				if (!ModuleDir.bOk)
+				{
+					return FUnrealMcpToolResult::Error(ModuleDir.Error);
+				}
+				if (!FPaths::DirectoryExists(ModuleDir.FullPath))
+				{
+					return FUnrealMcpToolResult::Error(
+						FString::Printf(TEXT("Module folder '%s' does not exist under Source/. Create the module first."), *Module));
+				}
+
+				const FJailedPath HeaderPath = ResolveJailedPath(Root, Module / (ClassName + TEXT(".h")));
+				const FJailedPath CppPath = ResolveJailedPath(Root, Module / (ClassName + TEXT(".cpp")));
+				if (!HeaderPath.bOk || !CppPath.bOk)
+				{
+					return FUnrealMcpToolResult::Error(HeaderPath.bOk ? CppPath.Error : HeaderPath.Error);
+				}
+
+				const bool bForce = Call.GetBool(TEXT("force"), false);
+				if (!bForce && (FPaths::FileExists(HeaderPath.FullPath) || FPaths::FileExists(CppPath.FullPath)))
+				{
+					return FUnrealMcpToolResult::Error(
+						FString::Printf(TEXT("'%s.h'/'%s.cpp' already exist in module '%s'. Pass 'force':true to overwrite."), *ClassName, *ClassName, *Module));
+				}
+
+				const FString ApiMacro = ModuleApiMacro(Module);
+				const FString HeaderText = BuildHeader(Tpl, ClassName, ApiMacro);
+				const FString CppText = BuildCpp(ClassName);
+				if (!FFileHelper::SaveStringToFile(HeaderText, *HeaderPath.FullPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
+				{
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to write header '%s'."), *HeaderPath.RelPath));
+				}
+				if (!FFileHelper::SaveStringToFile(CppText, *CppPath.FullPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
+				{
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to write cpp '%s'."), *CppPath.RelPath));
+				}
+
+				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+				Structured->SetStringField(TEXT("className"), Tpl.Prefix + ClassName);
+				Structured->SetStringField(TEXT("module"), Module);
+				Structured->SetStringField(TEXT("parentClass"), Tpl.bUClass ? Tpl.ParentSymbol : TEXT("(none)"));
+				Structured->SetStringField(TEXT("header"), HeaderPath.RelPath);
+				Structured->SetStringField(TEXT("cpp"), CppPath.RelPath);
+				Structured->SetBoolField(TEXT("isUClass"), Tpl.bUClass);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Created %s%s (%s.h + %s.cpp) in module '%s'. Run source-compile to build it."),
+						*Tpl.Prefix, *ClassName, *ClassName, *ClassName, *Module),
+					Structured);
+			});
+
+		// source-update ----------------------------------------------------------------------------
+		Registry.Tool(TEXT("source-update"))
+			.Title(TEXT("Update Source File"))
+			.Description(TEXT("Replace an existing source file's full contents, or a 1-based inclusive line range. "
+			                  "Pass 'content' (the replacement text). Omit 'startLine'/'endLine' to replace the "
+			                  "whole file; pass both to splice 'content' over that line range. The file must already "
+			                  "exist (use source-create-class for new files). JAILED to <Project>/Source."))
+			.ParamString(TEXT("path"), TEXT("Source file path relative to <Project>/Source (or absolute, inside it)."), EUnrealMcpParamRequirement::Required)
+			.ParamString(TEXT("content"), TEXT("Replacement text."), EUnrealMcpParamRequirement::Required)
+			.ParamInt(TEXT("startLine"), TEXT("1-based first line to replace (inclusive). Requires 'endLine'."))
+			.ParamInt(TEXT("endLine"), TEXT("1-based last line to replace (inclusive). Requires 'startLine'."))
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const FString Path = Call.GetString(TEXT("path"));
+				if (Path.IsEmpty())
+				{
+					return FUnrealMcpToolResult::Error(TEXT("'path' is required."));
+				}
+				if (!Call.Has(TEXT("content")))
+				{
+					return FUnrealMcpToolResult::Error(TEXT("'content' is required."));
+				}
+				const FString NewContent = Call.GetString(TEXT("content"));
+
+				const FJailedPath Jailed = ResolveJailedPath(GetProjectSourceRoot(), Path);
+				if (!Jailed.bOk)
+				{
+					return FUnrealMcpToolResult::Error(Jailed.Error);
+				}
+				if (!FPaths::FileExists(Jailed.FullPath))
+				{
+					return FUnrealMcpToolResult::Error(
+						FString::Printf(TEXT("No source file at '%s' (use source-create-class to create new files)."), *Jailed.RelPath));
+				}
+
+				const bool bRange = Call.Has(TEXT("startLine")) || Call.Has(TEXT("endLine"));
+				FString Final;
+				FString Mode;
+				if (bRange)
+				{
+					if (!Call.Has(TEXT("startLine")) || !Call.Has(TEXT("endLine")))
+					{
+						return FUnrealMcpToolResult::Error(TEXT("A line-range update requires BOTH 'startLine' and 'endLine'."));
+					}
+					FString Existing;
+					if (!FFileHelper::LoadFileToString(Existing, *Jailed.FullPath))
+					{
+						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to read '%s'."), *Jailed.RelPath));
+					}
+					TArray<FString> Lines;
+					Existing.ParseIntoArrayLines(Lines, /*InCullEmpty*/ false);
+					const int32 StartLine = (int32)Call.GetInt(TEXT("startLine"), 1);
+					const int32 EndLine = (int32)Call.GetInt(TEXT("endLine"), 1);
+					if (StartLine < 1 || EndLine < StartLine || StartLine > Lines.Num() || EndLine > Lines.Num())
+					{
+						return FUnrealMcpToolResult::Error(FString::Printf(
+							TEXT("Invalid line range [%d..%d] for '%s' (%d line(s))."), StartLine, EndLine, *Jailed.RelPath, Lines.Num()));
+					}
+					TArray<FString> Replacement;
+					NewContent.ParseIntoArrayLines(Replacement, /*InCullEmpty*/ false);
+					TArray<FString> Result;
+					Result.Append(Lines.GetData(), StartLine - 1);
+					Result.Append(Replacement);
+					for (int32 Index = EndLine; Index < Lines.Num(); ++Index)
+					{
+						Result.Add(Lines[Index]);
+					}
+					Final = FString::Join(Result, TEXT("\n"));
+					Mode = FString::Printf(TEXT("range [%d..%d]"), StartLine, EndLine);
+				}
+				else
+				{
+					Final = NewContent;
+					Mode = TEXT("full");
+				}
+
+				if (!FFileHelper::SaveStringToFile(Final, *Jailed.FullPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
+				{
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to write '%s'."), *Jailed.RelPath));
+				}
+
+				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+				Structured->SetStringField(TEXT("path"), Jailed.RelPath);
+				Structured->SetStringField(TEXT("mode"), bRange ? TEXT("range") : TEXT("full"));
+				Structured->SetNumberField(TEXT("bytesWritten"), FTCHARToUTF8(*Final).Length());
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Updated '%s' (%s)."), *Jailed.RelPath, *Mode), Structured);
+			});
+
+		// source-delete ----------------------------------------------------------------------------
+		Registry.Tool(TEXT("source-delete"))
+			.Title(TEXT("Delete Source File"))
+			.Description(TEXT("Delete a source file. JAILED to <Project>/Source — refuses directories and any path "
+			                  "outside the jail. Destructive and not undoable from MCP."))
+			.ParamString(TEXT("path"), TEXT("Source file path relative to <Project>/Source (or absolute, inside it)."), EUnrealMcpParamRequirement::Required)
+			.DestructiveHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const FString Path = Call.GetString(TEXT("path"));
+				if (Path.IsEmpty())
+				{
+					return FUnrealMcpToolResult::Error(TEXT("'path' is required."));
+				}
+				const FJailedPath Jailed = ResolveJailedPath(GetProjectSourceRoot(), Path);
+				if (!Jailed.bOk)
+				{
+					return FUnrealMcpToolResult::Error(Jailed.Error);
+				}
+				if (FPaths::DirectoryExists(Jailed.FullPath))
+				{
+					return FUnrealMcpToolResult::Error(
+						FString::Printf(TEXT("'%s' is a directory; source-delete only removes files."), *Jailed.RelPath));
+				}
+				if (!FPaths::FileExists(Jailed.FullPath))
+				{
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No source file at '%s'."), *Jailed.RelPath));
+				}
+				if (!IFileManager::Get().Delete(*Jailed.FullPath, /*RequireExists*/ false, /*EvenReadOnly*/ true))
+				{
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to delete '%s'."), *Jailed.RelPath));
+				}
+				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+				Structured->SetStringField(TEXT("path"), Jailed.RelPath);
+				Structured->SetBoolField(TEXT("deleted"), true);
+				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Deleted '%s'."), *Jailed.RelPath), Structured);
+			});
+
+		// source-list ------------------------------------------------------------------------------
+		Registry.Tool(TEXT("source-list"))
+			.Title(TEXT("List Source Files"))
+			.Description(TEXT("Enumerate source files with their byte sizes. Scoped to 'module' (a folder under "
+			                  "Source/) when given, else the whole <Project>/Source tree. 'recursive' (default true) "
+			                  "walks sub-folders. By default lists .h/.cpp/.cs; pass 'extensions' (array of extensions "
+			                  "without the dot) to override. JAILED to <Project>/Source."))
+			.ParamString(TEXT("module"), TEXT("Module folder under Source/ to scope the listing. Omit for the whole tree."))
+			.ParamBool(TEXT("recursive"), TEXT("Recurse sub-folders. Default true."))
+			.Param(TEXT("extensions"), TEXT("array"), TEXT("Extensions to include (without the dot). Default ['h','cpp','cs']."),
+				EUnrealMcpParamRequirement::Optional, nullptr)
+			.ReadOnlyHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const FString Root = GetProjectSourceRoot();
+				FString BaseDir = Root;
+				FString BaseRel;
+				const FString Module = Call.GetString(TEXT("module"));
+				if (!Module.IsEmpty())
+				{
+					const FJailedPath Jailed = ResolveJailedPath(Root, Module);
+					if (!Jailed.bOk)
+					{
+						return FUnrealMcpToolResult::Error(Jailed.Error);
+					}
+					if (!FPaths::DirectoryExists(Jailed.FullPath))
+					{
+						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Module folder '%s' does not exist under Source/."), *Module));
+					}
+					BaseDir = Jailed.FullPath;
+					BaseRel = Jailed.RelPath;
+				}
+
+				TArray<FString> Extensions;
+				const TArray<TSharedPtr<FJsonValue>>* ExtArray = nullptr;
+				if (Call.Arguments->TryGetArrayField(TEXT("extensions"), ExtArray))
+				{
+					for (const TSharedPtr<FJsonValue>& Value : *ExtArray)
+					{
+						FString Ext;
+						if (Value.IsValid() && Value->TryGetString(Ext) && !Ext.IsEmpty())
+						{
+							Extensions.AddUnique(Ext.Replace(TEXT("."), TEXT("")).ToLower());
+						}
+					}
+				}
+				if (Extensions.Num() == 0)
+				{
+					Extensions = { TEXT("h"), TEXT("cpp"), TEXT("cs") };
+				}
+
+				const bool bRecursive = Call.GetBool(TEXT("recursive"), true);
+				IFileManager& FM = IFileManager::Get();
+				TArray<FString> Found;
+				for (const FString& Ext : Extensions)
+				{
+					TArray<FString> Matches;
+					const FString Wildcard = FString::Printf(TEXT("*.%s"), *Ext);
+					if (bRecursive)
+					{
+						FM.FindFilesRecursive(Matches, *BaseDir, *Wildcard, /*Files*/ true, /*Dirs*/ false, /*bClearFileNames*/ false);
+					}
+					else
+					{
+						TArray<FString> Names;
+						FM.FindFiles(Names, *(BaseDir / Wildcard), /*Files*/ true, /*Dirs*/ false);
+						for (const FString& Name : Names)
+						{
+							Matches.Add(BaseDir / Name);
+						}
+					}
+					Found.Append(Matches);
+				}
+
+				Found.Sort();
+				int64 TotalBytes = 0;
+				TArray<TSharedPtr<FJsonValue>> Files;
+				for (const FString& Full : Found)
+				{
+					FString Rel = FPaths::ConvertRelativePathToFull(Full);
+					FPaths::NormalizeFilename(Rel);
+					FPaths::MakePathRelativeTo(Rel, *(Root + TEXT("/")));
+					const int64 Bytes = FM.FileSize(*Full);
+					if (Bytes >= 0)
+					{
+						TotalBytes += Bytes;
+					}
+					TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+					Entry->SetStringField(TEXT("path"), Rel);
+					Entry->SetNumberField(TEXT("bytes"), (double)Bytes);
+					Files.Add(MakeShared<FJsonValueObject>(Entry));
+				}
+
+				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+				Structured->SetStringField(TEXT("root"), Module.IsEmpty() ? TEXT("Source") : (TEXT("Source/") + BaseRel));
+				Structured->SetNumberField(TEXT("count"), Files.Num());
+				Structured->SetNumberField(TEXT("totalBytes"), (double)TotalBytes);
+				Structured->SetArrayField(TEXT("files"), Files);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Listed %d source file(s) (%lld bytes)."), Files.Num(), TotalBytes), Structured);
+			});
+
+		// source-compile ---------------------------------------------------------------------------
+		Registry.Tool(TEXT("source-compile"))
+			.Title(TEXT("Compile Project C++"))
+			.Description(TEXT("Compile the project's C++ and return a STRUCTURED diagnostic report — the AI feedback "
+			                  "loop. Prefers Live Coding when the editor is interactive and Live Coding is active, "
+			                  "otherwise invokes UnrealBuildTool on the project's Editor target ('target' overrides; "
+			                  "default '<Project>Editor'). The result carries 'diagnostics' (an array of "
+			                  "{file,line,severity,message}), 'errorCount'/'warningCount', the process 'returnCode', "
+			                  "'success' (returnCode==0) and 'compileClean' (zero compiler errors — true even when a "
+			                  "running editor holds the module DLL so the link stage cannot relink it). Set "
+			                  "'useLiveCoding':false to force the UBT path."))
+			.ParamString(TEXT("target"), TEXT("Build target name. Default '<Project>Editor'."))
+			.ParamString(TEXT("configuration"), TEXT("Build configuration. Default 'Development'."))
+			.ParamString(TEXT("platform"), TEXT("Build platform. Default the host platform (e.g. 'Win64')."))
+			.ParamBool(TEXT("useLiveCoding"), TEXT("Prefer Live Coding when available (interactive editor only). Default true."))
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const bool bUseLiveCoding = Call.GetBool(TEXT("useLiveCoding"), true);
+
+				const FString ProjectName = FApp::GetProjectName();
+				FString TargetName = Call.GetString(TEXT("target"));
+				if (TargetName.IsEmpty())
+				{
+					TargetName = ProjectName + TEXT("Editor");
+				}
+
+#if WITH_UNREAL_MCP_LIVE_CODING
+				// Live Coding patches the RUNNING editor in place — the only way to apply C++ changes
+				// without relinking the locked module DLL. Only viable interactively (the console must be
+				// up); headless/unattended runs fall through to UBT.
+				if (bUseLiveCoding && !FApp::IsUnattended())
+				{
+					ILiveCodingModule* LiveCoding = FModuleManager::GetModulePtr<ILiveCodingModule>(FName(LIVE_CODING_MODULE_NAME));
+					if (LiveCoding && LiveCoding->IsEnabledForSession() && LiveCoding->HasStarted() && !LiveCoding->IsCompiling())
+					{
+						ELiveCodingCompileResult Result = ELiveCodingCompileResult::NotStarted;
+						const bool bStarted = LiveCoding->Compile(ELiveCodingCompileFlags::WaitForCompletion, &Result);
+						const bool bLcSuccess = bStarted
+							&& (Result == ELiveCodingCompileResult::Success || Result == ELiveCodingCompileResult::NoChanges);
+
+						const TCHAR* ResultText = TEXT("Unknown");
+						switch (Result)
+						{
+							case ELiveCodingCompileResult::Success: ResultText = TEXT("Success"); break;
+							case ELiveCodingCompileResult::NoChanges: ResultText = TEXT("NoChanges"); break;
+							case ELiveCodingCompileResult::InProgress: ResultText = TEXT("InProgress"); break;
+							case ELiveCodingCompileResult::CompileStillActive: ResultText = TEXT("CompileStillActive"); break;
+							case ELiveCodingCompileResult::NotStarted: ResultText = TEXT("NotStarted"); break;
+							case ELiveCodingCompileResult::Failure: ResultText = TEXT("Failure"); break;
+							case ELiveCodingCompileResult::Cancelled: ResultText = TEXT("Cancelled"); break;
+						}
+
+						TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+						Structured->SetStringField(TEXT("method"), TEXT("live-coding"));
+						Structured->SetStringField(TEXT("result"), ResultText);
+						Structured->SetBoolField(TEXT("success"), bLcSuccess);
+						Structured->SetBoolField(TEXT("compileClean"), bLcSuccess);
+						Structured->SetNumberField(TEXT("errorCount"), bLcSuccess ? 0 : 1);
+						Structured->SetNumberField(TEXT("warningCount"), 0);
+						// Live Coding surfaces a coarse enum, not per-diagnostic rows; the UBT path carries
+						// the full {file,line,severity,message} report.
+						Structured->SetArrayField(TEXT("diagnostics"), {});
+						return FUnrealMcpToolResult::Success(
+							FString::Printf(TEXT("Live Coding compile: %s."), ResultText), Structured);
+					}
+				}
+#endif
+
+				// UBT path -------------------------------------------------------------------------
+				FString Platform = Call.GetString(TEXT("platform"));
+				if (Platform.IsEmpty())
+				{
+					Platform = FPlatformProcess::GetBinariesSubdirectory();
+				}
+				FString Configuration = Call.GetString(TEXT("configuration"));
+				if (Configuration.IsEmpty())
+				{
+					Configuration = TEXT("Development");
+				}
+
+				FString UProject;
+				if (FPaths::IsProjectFilePathSet())
+				{
+					UProject = FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath());
+				}
+				else
+				{
+					UProject = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir() / (ProjectName + TEXT(".uproject")));
+				}
+
+#if PLATFORM_WINDOWS
+				const FString Ubt = FPaths::ConvertRelativePathToFull(
+					FPaths::EngineDir() / TEXT("Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.exe"));
+#else
+				const FString Ubt = FPaths::ConvertRelativePathToFull(
+					FPaths::EngineDir() / TEXT("Build/BatchFiles/RunUBT.sh"));
+#endif
+				if (!FPaths::FileExists(Ubt))
+				{
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("UnrealBuildTool not found at '%s'."), *Ubt));
+				}
+
+				const FString Params = FString::Printf(TEXT("%s %s %s -project=\"%s\" -WaitMutex"),
+					*TargetName, *Platform, *Configuration, *UProject);
+
+				int32 ReturnCode = -1;
+				FString StdOut;
+				FString StdErr;
+				const double Start = FPlatformTime::Seconds();
+				const bool bLaunched = FPlatformProcess::ExecProcess(*Ubt, *Params, &ReturnCode, &StdOut, &StdErr);
+				const double Elapsed = FPlatformTime::Seconds() - Start;
+				if (!bLaunched)
+				{
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to launch UnrealBuildTool '%s'."), *Ubt));
+				}
+
+				const FString Combined = StdOut + TEXT("\n") + StdErr;
+				TArray<FSourceDiagnostic> Diagnostics;
+				ParseDiagnostics(Combined, Diagnostics);
+
+				int32 ErrorCount = 0;
+				int32 WarningCount = 0;
+				TArray<TSharedPtr<FJsonValue>> DiagJson;
+				for (const FSourceDiagnostic& Diag : Diagnostics)
+				{
+					if (Diag.Severity == TEXT("error")) { ++ErrorCount; }
+					else if (Diag.Severity == TEXT("warning")) { ++WarningCount; }
+					TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+					Entry->SetStringField(TEXT("file"), Diag.File);
+					Entry->SetNumberField(TEXT("line"), Diag.Line);
+					Entry->SetStringField(TEXT("severity"), Diag.Severity);
+					Entry->SetStringField(TEXT("message"), Diag.Message);
+					DiagJson.Add(MakeShared<FJsonValueObject>(Entry));
+				}
+
+				const bool bSuccess = (ReturnCode == 0);
+				const bool bCompileClean = (ErrorCount == 0);
+
+				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+				Structured->SetStringField(TEXT("method"), TEXT("ubt"));
+				Structured->SetStringField(TEXT("target"), TargetName);
+				Structured->SetStringField(TEXT("configuration"), Configuration);
+				Structured->SetStringField(TEXT("platform"), Platform);
+				Structured->SetNumberField(TEXT("returnCode"), ReturnCode);
+				Structured->SetBoolField(TEXT("success"), bSuccess);
+				Structured->SetBoolField(TEXT("compileClean"), bCompileClean);
+				Structured->SetNumberField(TEXT("errorCount"), ErrorCount);
+				Structured->SetNumberField(TEXT("warningCount"), WarningCount);
+				Structured->SetNumberField(TEXT("durationSeconds"), Elapsed);
+				Structured->SetArrayField(TEXT("diagnostics"), DiagJson);
+				// A bounded tail of the raw output aids debugging when no diagnostic matched (e.g. a link
+				// failure, or a UBT configuration error) without flooding the response.
+				Structured->SetStringField(TEXT("outputTail"), Combined.Right(4000));
+
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Compile (%s, UBT): %d error(s), %d warning(s); return code %d in %.0fs."),
+						*TargetName, ErrorCount, WarningCount, ReturnCode, Elapsed),
+					Structured);
+			});
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpSourceTools.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpSourceTools.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FUnrealMcpToolRegistry;
+
+/**
+ * The C++ source / script tool family (docs/ARCHITECTURE.md §10 "source family", issue #18).
+ *
+ * Six kebab-case CORE tools that let an AI scaffold, read, edit, list and compile project C++ and
+ * receive a machine-readable build report — the static-compile reinterpretation of Unity-MCP's
+ * `Script.*` family. Every file operation is JAILED to the loaded project's `Source/` directory.
+ *
+ * The jail helper and the compiler-diagnostic parser are exported here (separate from the family's
+ * Register entry point in UnrealMcpCoreTools.h) so the Automation specs in the sibling
+ * UnrealMcpEditorTests module can exercise them directly, fast and deterministically, without a
+ * live editor or a real UBT invoke.
+ */
+namespace UnrealMcpSourceTools
+{
+	/** One parsed compiler diagnostic — a single row of the §3 structured build report. */
+	struct UNREALMCPEDITOR_API FSourceDiagnostic
+	{
+		FString File;        // absolute or build-relative source path the compiler reported
+		int32 Line = 0;      // 1-based line, 0 when the format carried none
+		FString Severity;    // "error" | "warning"
+		FString Message;     // the compiler text (code + description), trimmed
+	};
+
+	/** Outcome of resolving a caller-supplied path against the project Source/ jail. */
+	struct UNREALMCPEDITOR_API FJailedPath
+	{
+		bool bOk = false;
+		FString FullPath;    // canonicalized absolute path (valid only when bOk)
+		FString RelPath;     // path relative to the jail root, '/'-separated (valid only when bOk)
+		FString Error;       // human-readable reason (valid only when !bOk)
+	};
+
+	/** Absolute, normalized jail root = <Project>/Source for the currently loaded project. */
+	UNREALMCPEDITOR_API FString GetProjectSourceRoot();
+
+	/**
+	 * Canonicalize @p InPath (relative to the jail root, or absolute) and confirm it stays inside the
+	 * jail. Rejects `..` traversal and absolute paths that escape, and — best effort — a junction /
+	 * symlink whose on-disk target escapes the jail. @p JailRoot lets specs supply a temp root.
+	 */
+	UNREALMCPEDITOR_API FJailedPath ResolveJailedPath(const FString& JailRoot, const FString& InPath);
+
+	/** Compute the MODULE_API export macro token for a module name (e.g. "MyGame" -> "MYGAME_API"). */
+	UNREALMCPEDITOR_API FString ModuleApiMacro(const FString& ModuleName);
+
+	/**
+	 * Parse compiler diagnostics out of raw build output (MSVC `file(line): error Cxxxx: msg` and
+	 * clang `file:line:col: error: msg` forms). Pure + deterministic: link-stage failures
+	 * (`LINK : fatal error LNK....`, which carry no `file(line)`) are intentionally NOT reported as
+	 * compiler diagnostics, so a "compiler-clean but the loaded editor DLL is locked" build still
+	 * reports zero errors. Duplicate rows are collapsed.
+	 */
+	UNREALMCPEDITOR_API void ParseDiagnostics(const FString& BuildOutput, TArray<FSourceDiagnostic>& OutDiagnostics);
+
+	/** Register the source family into @p Registry (docs/ARCHITECTURE.md §3.3). */
+	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry);
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -32,6 +32,7 @@ void FUnrealMcpRuntime::Startup()
 	UnrealMcpActorTools::Register(*Registry);
 	UnrealMcpBlueprintTools::Register(*Registry); // §10 flagship Blueprint family (CORE)
 	UnrealMcpAssetTools::Register(*Registry); // §10 asset / Content-Browser family (issue #10)
+	UnrealMcpSourceTools::Register(*Registry); // §10 C++ source / script family (issue #18)
 
 	Dispatcher = MakeUnique<FUnrealMcpGameThreadDispatcher>();
 	BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(*Registry, *Dispatcher);

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpCoreTools.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpCoreTools.h
@@ -50,3 +50,16 @@ namespace UnrealMcpAssetTools
 {
 	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry);
 }
+
+/**
+ * The C++ source / script tool family (docs/ARCHITECTURE.md §10 "source family", issue #18): six
+ * kebab-case CORE tools — source-read / source-create-class / source-update / source-delete /
+ * source-list / source-compile — that scaffold, read, edit, list and compile project C++. All file
+ * operations are jailed to <Project>/Source; source-compile returns a structured §3
+ * {file,line,severity,message} build report (the AI feedback loop). Registered in the boot path
+ * alongside the other families; also exercised in isolation by Automation specs.
+ */
+namespace UnrealMcpSourceTools
+{
+	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry);
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
+++ b/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
@@ -50,5 +50,19 @@ public class UnrealMcpEditor : ModuleRules
 			"BlueprintGraph",
 			"KismetCompiler",
 		});
+
+		// C++ source / script tool family (docs/ARCHITECTURE.md §10, issue #18): source-compile prefers
+		// Live Coding to patch a running editor when interactive. The LiveCoding module is Windows-only
+		// (Engine/Source/Developer/Windows/LiveCoding); gate the dependency + the WITH_UNREAL_MCP_LIVE_CODING
+		// guard so non-Windows builds (and the UBT fallback path) compile cleanly without it.
+		if (Target.Platform == UnrealTargetPlatform.Win64)
+		{
+			PrivateDependencyModuleNames.Add("LiveCoding");
+			PublicDefinitions.Add("WITH_UNREAL_MCP_LIVE_CODING=1");
+		}
+		else
+		{
+			PublicDefinitions.Add("WITH_UNREAL_MCP_LIVE_CODING=0");
+		}
 	}
 }

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSourceToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSourceToolsSpec.cpp
@@ -273,6 +273,84 @@ void FUnrealMcpSourceToolsSpec::Define()
 			TestFalse(TEXT("header gone"), FPaths::FileExists(UnrealMcpSourceTools::GetProjectSourceRoot() / HeaderRel));
 		});
 
+		It("splices a line range with exact bytes and never accumulates blank lines across edits", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpSourceTools::Register(Registry);
+
+			// A newline-terminated, LF, 4-line file. The phantom trailing empty element that
+			// ParseIntoArrayLines yields for such a file used to double the final newline on EVERY range
+			// splice (accumulating one blank line per edit) and inflate the addressable range by 1.
+			const FString FileRel = TempModule / TEXT("Range.cpp");
+			const FString FileAbs = UnrealMcpSourceTools::GetProjectSourceRoot() / FileRel;
+			TestTrue(TEXT("seed file written"),
+				FFileHelper::SaveStringToFile(FString(TEXT("L1\nL2\nL3\nL4\n")), *FileAbs, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM));
+
+			auto SpliceLine = [&](int32 Line, const TCHAR* Text) -> bool
+			{
+				TSharedPtr<FJsonObject> Args = SourceArgs();
+				Args->SetStringField(TEXT("path"), FileRel);
+				Args->SetStringField(TEXT("content"), Text);
+				Args->SetNumberField(TEXT("startLine"), Line);
+				Args->SetNumberField(TEXT("endLine"), Line);
+				return RunSourceTool(Registry, TEXT("source-update"), Args).bSuccess;
+			};
+
+			TestTrue(TEXT("first range splice ok"), SpliceLine(2, TEXT("X2")));
+			TestTrue(TEXT("second range splice ok"), SpliceLine(3, TEXT("X3")));
+
+			FString OnDisk;
+			TestTrue(TEXT("read seed back"), FFileHelper::LoadFileToString(OnDisk, *FileAbs));
+			// Exactly the two edits applied, single trailing newline, NO extra blank lines accumulated.
+			TestEqual(TEXT("exact bytes after two consecutive range edits"), OnDisk, FString(TEXT("L1\nX2\nX3\nL4\n")));
+
+			// The phantom no longer inflates the addressable range: line 5 (== real lines + 1) is rejected.
+			TSharedPtr<FJsonObject> OutOfRange = SourceArgs();
+			OutOfRange->SetStringField(TEXT("path"), FileRel);
+			OutOfRange->SetStringField(TEXT("content"), TEXT("X"));
+			OutOfRange->SetNumberField(TEXT("startLine"), 5);
+			OutOfRange->SetNumberField(TEXT("endLine"), 5);
+			TestFalse(TEXT("line 5 (real lines + 1) rejected"), RunSourceTool(Registry, TEXT("source-update"), OutOfRange).bSuccess);
+
+			// A huge startLine must be rejected in int64 BEFORE narrowing — a raw (int32) cast wraps
+			// 4294967297 -> 1, which would otherwise splice line 1. Validate-then-narrow rejects it.
+			TSharedPtr<FJsonObject> Wrap = SourceArgs();
+			Wrap->SetStringField(TEXT("path"), FileRel);
+			Wrap->SetStringField(TEXT("content"), TEXT("X"));
+			Wrap->SetNumberField(TEXT("startLine"), 4294967297.0);
+			Wrap->SetNumberField(TEXT("endLine"), 4294967297.0);
+			TestFalse(TEXT("wraparound startLine rejected"), RunSourceTool(Registry, TEXT("source-update"), Wrap).bSuccess);
+
+			// The rejected edits left the file byte-identical.
+			FString StillOnDisk;
+			TestTrue(TEXT("re-read after rejected edits"), FFileHelper::LoadFileToString(StillOnDisk, *FileAbs));
+			TestEqual(TEXT("file unchanged after rejected edits"), StillOnDisk, FString(TEXT("L1\nX2\nX3\nL4\n")));
+		});
+
+		It("reports totalLines as real lines for newline-terminated and unterminated files", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpSourceTools::Register(Registry);
+
+			auto ReadTotalLines = [&](const TCHAR* Body, const TCHAR* Name) -> int32
+			{
+				const FString Rel = TempModule / Name;
+				const FString Abs = UnrealMcpSourceTools::GetProjectSourceRoot() / Rel;
+				FFileHelper::SaveStringToFile(FString(Body), *Abs, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
+				TSharedPtr<FJsonObject> Args = SourceArgs();
+				Args->SetStringField(TEXT("path"), Rel);
+				const FUnrealMcpToolResult R = RunSourceTool(Registry, TEXT("source-read"), Args);
+				int32 Total = -1;
+				if (R.Structured.IsValid()) { R.Structured->TryGetNumberField(TEXT("totalLines"), Total); }
+				return Total;
+			};
+
+			// Both hold three visible lines; the phantom trailing empty element previously made the
+			// newline-terminated file over-report 4.
+			TestEqual(TEXT("newline-terminated -> 3 lines"), ReadTotalLines(TEXT("A\nB\nC\n"), TEXT("Term.cpp")), 3);
+			TestEqual(TEXT("unterminated -> 3 lines"), ReadTotalLines(TEXT("A\nB\nC"), TEXT("Unterm.cpp")), 3);
+		});
+
 		It("rejects jail escapes on every file op", [this]()
 		{
 			FUnrealMcpToolRegistry Registry;

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSourceToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSourceToolsSpec.cpp
@@ -165,6 +165,32 @@ void FUnrealMcpSourceToolsSpec::Define()
 			}
 		});
 
+		It("parses MSVC and clang 'fatal error' compiler diagnostics (e.g. C1083 missing include)", [this]()
+		{
+			// A missing/typo'd #include is one of the most common AI-edit failures; both toolchains
+			// emit it as a file(line)-attributed "fatal error" that must surface as a normal error row.
+			const FString Output =
+				TEXT("C:\\proj\\Source\\MyGame\\MyActor.cpp(1): fatal error C1083: Cannot open include file: 'X.h': No such file or directory\n")
+				TEXT("/proj/Source/MyGame/Other.cpp:10:10: fatal error: 'Y.h' file not found\n")
+				TEXT("LINK : fatal error LNK1104: cannot open file 'UnrealEditor-UnrealTestProject.dll'\n");
+
+			TArray<UnrealMcpSourceTools::FSourceDiagnostic> Diags;
+			UnrealMcpSourceTools::ParseDiagnostics(Output, Diags);
+
+			// The two compiler-stage fatals are reported; the LNK link-stage fatal is still excluded.
+			TestEqual(TEXT("two fatal compiler diagnostics (LNK excluded)"), Diags.Num(), 2);
+			if (Diags.Num() == 2)
+			{
+				TestEqual(TEXT("msvc fatal file"), Diags[0].File, FString(TEXT("C:\\proj\\Source\\MyGame\\MyActor.cpp")));
+				TestEqual(TEXT("msvc fatal line"), Diags[0].Line, 1);
+				TestEqual(TEXT("msvc fatal severity normalized to error"), Diags[0].Severity, FString(TEXT("error")));
+				TestTrue(TEXT("msvc fatal message carries code"), Diags[0].Message.Contains(TEXT("C1083")));
+				TestEqual(TEXT("clang fatal file"), Diags[1].File, FString(TEXT("/proj/Source/MyGame/Other.cpp")));
+				TestEqual(TEXT("clang fatal line"), Diags[1].Line, 10);
+				TestEqual(TEXT("clang fatal severity normalized to error"), Diags[1].Severity, FString(TEXT("error")));
+			}
+		});
+
 		It("returns no diagnostics for clean output", [this]()
 		{
 			const FString Output = TEXT("Building UnrealTestProjectEditor...\nTarget is up to date\n");
@@ -273,6 +299,35 @@ void FUnrealMcpSourceToolsSpec::Define()
 		});
 	});
 
+	Describe("compile arg validation", [this]()
+	{
+		It("rejects injection in target/platform/configuration before launching UBT", [this]()
+		{
+			// target/platform/configuration are pasted into the UBT command line; a value carrying
+			// whitespace, a quote, or a dash-prefixed flag would inject arbitrary UBT args (e.g. -Clean
+			// wipes Binaries). Each must be rejected as a single identifier token BEFORE any process
+			// launch — so these calls fail fast and never invoke a real build.
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpSourceTools::Register(Registry);
+
+			TSharedPtr<FJsonObject> BadTarget = SourceArgs();
+			BadTarget->SetStringField(TEXT("target"), TEXT("UnrealTestProjectEditor Win64 Development -Clean"));
+			TestFalse(TEXT("whitespace/flag target rejected"), RunSourceTool(Registry, TEXT("source-compile"), BadTarget).bSuccess);
+
+			TSharedPtr<FJsonObject> DashTarget = SourceArgs();
+			DashTarget->SetStringField(TEXT("target"), TEXT("-Mode=QueryTargets"));
+			TestFalse(TEXT("dash-prefixed target rejected"), RunSourceTool(Registry, TEXT("source-compile"), DashTarget).bSuccess);
+
+			TSharedPtr<FJsonObject> BadPlatform = SourceArgs();
+			BadPlatform->SetStringField(TEXT("platform"), TEXT("Win64 -Clean"));
+			TestFalse(TEXT("whitespace platform rejected"), RunSourceTool(Registry, TEXT("source-compile"), BadPlatform).bSuccess);
+
+			TSharedPtr<FJsonObject> BadConfig = SourceArgs();
+			BadConfig->SetStringField(TEXT("configuration"), TEXT("Development\" -project=\"x"));
+			TestFalse(TEXT("quote-injection configuration rejected"), RunSourceTool(Registry, TEXT("source-compile"), BadConfig).bSuccess);
+		});
+	});
+
 	// Heavy, real-UBT round-trip — only when explicitly requested (kept out of the default fast suite).
 	if (!FPlatformMisc::GetEnvironmentVariable(TEXT("UNREAL_MCP_RUN_LIVE_COMPILE")).IsEmpty())
 	{
@@ -294,6 +349,10 @@ void FUnrealMcpSourceToolsSpec::Define()
 					IFileManager::Get().Delete(*HeaderAbs, false, true, true);
 					IFileManager::Get().Delete(*CppAbs, false, true, true);
 				};
+				// WARNING: this env-gated spec writes a probe class into the REAL primary module's Source/.
+				// AfterEach-style cleanup runs only if the It-body completes; an abort/crash between the
+				// "break" and "fix" steps below strands invalid C++ that would break subsequent builds.
+				// This leading Cleanup() pre-clean removes any such stranded probe from a prior aborted run.
 				Cleanup();
 
 				auto Compile = [&](int32& OutErrors) -> FUnrealMcpToolResult
@@ -326,6 +385,29 @@ void FUnrealMcpSourceToolsSpec::Define()
 
 				FUnrealMcpToolResult BrokenResult = Compile(Errors);
 				TestTrue(TEXT("errors reported when broken"), Errors > 0);
+				// Strengthen the structured-report proof: at least one diagnostic row must carry the
+				// probe cpp's file path and a real (1-based) line number, not just a non-zero count.
+				bool bHasLocatedDiag = false;
+				if (BrokenResult.Structured.IsValid())
+				{
+					const TArray<TSharedPtr<FJsonValue>>* DiagArray = nullptr;
+					if (BrokenResult.Structured->TryGetArrayField(TEXT("diagnostics"), DiagArray))
+					{
+						for (const TSharedPtr<FJsonValue>& Entry : *DiagArray)
+						{
+							const TSharedPtr<FJsonObject> Obj = Entry.IsValid() ? Entry->AsObject() : nullptr;
+							if (Obj.IsValid())
+							{
+								FString File;
+								int32 LineNo = 0;
+								Obj->TryGetStringField(TEXT("file"), File);
+								Obj->TryGetNumberField(TEXT("line"), LineNo);
+								if (!File.IsEmpty() && LineNo > 0) { bHasLocatedDiag = true; break; }
+							}
+						}
+					}
+				}
+				TestTrue(TEXT("a diagnostic row carries file + line"), bHasLocatedDiag);
 
 				// fix -> compile: compiler-clean again.
 				TSharedPtr<FJsonObject> Fix = SourceArgs();

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSourceToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSourceToolsSpec.cpp
@@ -1,0 +1,345 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/Paths.h"
+#include "Misc/App.h"
+#include "Misc/FileHelper.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformProcess.h"
+#include "HAL/PlatformMisc.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+
+#include "UnrealMcpCoreTools.h"
+#include "UnrealMcpToolRegistry.h"
+#include "Tools/UnrealMcpSourceTools.h"
+
+/**
+ * C++ source / script tool family specs (docs/ARCHITECTURE.md §10, issue #18).
+ *
+ * Fast + deterministic groups (no real UBT invoke):
+ *  - registration   — all six tools present with kebab-case ids and the expected hints.
+ *  - jail           — ResolveJailedPath accepts in-jail paths and rejects `..` traversal /
+ *    absolute-outside escapes (the security-critical surface, proven without a live editor).
+ *  - diagnostics    — ParseDiagnostics turns canned MSVC + clang build output into exact
+ *    {file,line,severity,message} rows and excludes link-stage (LNK) failures — this is the
+ *    structured-report proof for the compile feedback loop.
+ *  - file ops       — create-class -> read -> list -> update -> delete round-trip against a temp
+ *    module folder under the testbed Source/, plus per-tool jail-escape rejection. The temp folder
+ *    is removed in AfterEach so the testbed working tree stays clean.
+ *
+ * Heavy, env-gated group (real editor + real UBT, only when UNREAL_MCP_RUN_LIVE_COMPILE is set):
+ *  - live compile   — create class -> compile (compiler-clean) -> break -> compile (structured
+ *    errors with file/line) -> fix -> compile (compiler-clean). Asserts on compiler-error count, not
+ *    the process return code: a running editor holds the module DLL, so the link stage cannot relink
+ *    it, but the compiler diagnostics (the AI feedback loop) are emitted before linking.
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpSourceToolsSpec, "UnrealMcp.Tools.Source",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+	FString TempModule;     // temp module folder name under Source/ for the file-op round-trip
+	FString TempModuleDir;  // absolute path of that folder
+	void RemoveTempModule();
+END_DEFINE_SPEC(FUnrealMcpSourceToolsSpec)
+
+namespace
+{
+	// Uniquely named (not just `Run`/`Obj`) so the helpers never collide with the identically-shaped
+	// helpers in the sibling family specs under a UE unity build.
+	FUnrealMcpToolResult RunSourceTool(FUnrealMcpToolRegistry& Registry, const FString& Name, const TSharedPtr<FJsonObject>& Args)
+	{
+		return Registry.Execute(Name, FUnrealMcpToolCall(Args));
+	}
+
+	TSharedPtr<FJsonObject> SourceArgs() { return MakeShared<FJsonObject>(); }
+}
+
+void FUnrealMcpSourceToolsSpec::RemoveTempModule()
+{
+	if (!TempModuleDir.IsEmpty() && IFileManager::Get().DirectoryExists(*TempModuleDir))
+	{
+		IFileManager::Get().DeleteDirectory(*TempModuleDir, /*RequireExists*/ false, /*Tree*/ true);
+	}
+}
+
+void FUnrealMcpSourceToolsSpec::Define()
+{
+	Describe("registration", [this]()
+	{
+		It("registers all six source tools with kebab-case ids", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpSourceTools::Register(Registry);
+
+			const TArray<FString> Expected = {
+				TEXT("source-read"), TEXT("source-create-class"), TEXT("source-update"),
+				TEXT("source-delete"), TEXT("source-list"), TEXT("source-compile")
+			};
+			for (const FString& Name : Expected)
+			{
+				TestTrue(FString::Printf(TEXT("has %s"), *Name), Registry.HasTool(Name));
+				TestTrue(FString::Printf(TEXT("%s is valid kebab id"), *Name), FUnrealMcpToolRegistry::IsValidToolName(Name));
+			}
+			TestEqual(TEXT("exactly six tools"), Registry.Num(), Expected.Num());
+		});
+
+		It("marks source-delete destructive and source-read/list read-only", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpSourceTools::Register(Registry);
+			TestTrue(TEXT("delete destructive"), Registry.Find(TEXT("source-delete"))->bDestructiveHint);
+			TestTrue(TEXT("read read-only"), Registry.Find(TEXT("source-read"))->bReadOnlyHint);
+			TestTrue(TEXT("list read-only"), Registry.Find(TEXT("source-list"))->bReadOnlyHint);
+		});
+	});
+
+	Describe("jail", [this]()
+	{
+		It("accepts a path inside the jail and reports a normalized relative path", [this]()
+		{
+			const FString Root = UnrealMcpSourceTools::GetProjectSourceRoot();
+			const UnrealMcpSourceTools::FJailedPath R = UnrealMcpSourceTools::ResolveJailedPath(Root, TEXT("MyGame/MyActor.cpp"));
+			TestTrue(TEXT("accepted"), R.bOk);
+			TestEqual(TEXT("relpath"), R.RelPath, FString(TEXT("MyGame/MyActor.cpp")));
+		});
+
+		It("rejects parent-directory traversal", [this]()
+		{
+			const FString Root = UnrealMcpSourceTools::GetProjectSourceRoot();
+			TestFalse(TEXT("../ escapes"), UnrealMcpSourceTools::ResolveJailedPath(Root, TEXT("../Config/secret.ini")).bOk);
+			TestFalse(TEXT("deep ../ escapes"), UnrealMcpSourceTools::ResolveJailedPath(Root, TEXT("MyGame/../../../Windows/System32/x")).bOk);
+		});
+
+		It("rejects an absolute path outside the jail", [this]()
+		{
+			const FString Root = UnrealMcpSourceTools::GetProjectSourceRoot();
+			TestFalse(TEXT("absolute outside"), UnrealMcpSourceTools::ResolveJailedPath(Root, TEXT("C:/Windows/System32/drivers/etc/hosts")).bOk);
+		});
+
+		It("rejects an empty path", [this]()
+		{
+			const FString Root = UnrealMcpSourceTools::GetProjectSourceRoot();
+			TestFalse(TEXT("empty rejected"), UnrealMcpSourceTools::ResolveJailedPath(Root, TEXT("")).bOk);
+		});
+	});
+
+	Describe("diagnostics", [this]()
+	{
+		It("parses MSVC errors and warnings and excludes link failures", [this]()
+		{
+			const FString Output =
+				TEXT("Building UnrealTestProjectEditor...\n")
+				TEXT("C:\\proj\\Source\\MyGame\\MyActor.cpp(12): error C2065: 'Foo': undeclared identifier\n")
+				TEXT("C:\\proj\\Source\\MyGame\\MyActor.cpp(8): warning C4101: 'x': unreferenced local variable\n")
+				TEXT("LINK : fatal error LNK1104: cannot open file 'UnrealEditor-UnrealTestProject.dll'\n");
+
+			TArray<UnrealMcpSourceTools::FSourceDiagnostic> Diags;
+			UnrealMcpSourceTools::ParseDiagnostics(Output, Diags);
+
+			TestEqual(TEXT("two compiler diagnostics (LNK excluded)"), Diags.Num(), 2);
+			if (Diags.Num() == 2)
+			{
+				TestEqual(TEXT("error file"), Diags[0].File, FString(TEXT("C:\\proj\\Source\\MyGame\\MyActor.cpp")));
+				TestEqual(TEXT("error line"), Diags[0].Line, 12);
+				TestEqual(TEXT("error severity"), Diags[0].Severity, FString(TEXT("error")));
+				TestTrue(TEXT("error message carries code"), Diags[0].Message.Contains(TEXT("C2065")));
+				TestEqual(TEXT("warning severity"), Diags[1].Severity, FString(TEXT("warning")));
+				TestEqual(TEXT("warning line"), Diags[1].Line, 8);
+			}
+		});
+
+		It("parses clang-style diagnostics", [this]()
+		{
+			const FString Output = TEXT("/proj/Source/MyGame/MyActor.cpp:5:9: error: use of undeclared identifier 'Foo'\n");
+			TArray<UnrealMcpSourceTools::FSourceDiagnostic> Diags;
+			UnrealMcpSourceTools::ParseDiagnostics(Output, Diags);
+			TestEqual(TEXT("one diagnostic"), Diags.Num(), 1);
+			if (Diags.Num() == 1)
+			{
+				TestEqual(TEXT("file"), Diags[0].File, FString(TEXT("/proj/Source/MyGame/MyActor.cpp")));
+				TestEqual(TEXT("line"), Diags[0].Line, 5);
+				TestEqual(TEXT("severity"), Diags[0].Severity, FString(TEXT("error")));
+			}
+		});
+
+		It("returns no diagnostics for clean output", [this]()
+		{
+			const FString Output = TEXT("Building UnrealTestProjectEditor...\nTarget is up to date\n");
+			TArray<UnrealMcpSourceTools::FSourceDiagnostic> Diags;
+			UnrealMcpSourceTools::ParseDiagnostics(Output, Diags);
+			TestEqual(TEXT("no diagnostics"), Diags.Num(), 0);
+		});
+	});
+
+	Describe("file ops", [this]()
+	{
+		BeforeEach([this]()
+		{
+			TempModule = TEXT("__UnrealMcpSourceSpec__");
+			TempModuleDir = UnrealMcpSourceTools::GetProjectSourceRoot() / TempModule;
+			RemoveTempModule();
+			IFileManager::Get().MakeDirectory(*TempModuleDir, /*Tree*/ true);
+		});
+
+		AfterEach([this]()
+		{
+			RemoveTempModule();
+		});
+
+		It("creates a class, reads it back, lists it, updates and deletes it", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpSourceTools::Register(Registry);
+
+			// create-class (Actor parent -> A-prefix, UCLASS).
+			TSharedPtr<FJsonObject> Create = SourceArgs();
+			Create->SetStringField(TEXT("className"), TEXT("SpecPawnThing"));
+			Create->SetStringField(TEXT("module"), TempModule);
+			Create->SetStringField(TEXT("parentClass"), TEXT("Actor"));
+			const FUnrealMcpToolResult CreateResult = RunSourceTool(Registry, TEXT("source-create-class"), Create);
+			TestTrue(TEXT("create succeeded"), CreateResult.bSuccess);
+			const FString HeaderRel = TempModule / TEXT("SpecPawnThing.h");
+			TestTrue(TEXT("header on disk"), FPaths::FileExists(UnrealMcpSourceTools::GetProjectSourceRoot() / HeaderRel));
+
+			// create-class refuses to overwrite without force.
+			TestFalse(TEXT("no overwrite without force"), RunSourceTool(Registry, TEXT("source-create-class"), Create).bSuccess);
+
+			// read the header back and confirm the generated symbol + UCLASS.
+			TSharedPtr<FJsonObject> Read = SourceArgs();
+			Read->SetStringField(TEXT("path"), HeaderRel);
+			const FUnrealMcpToolResult ReadResult = RunSourceTool(Registry, TEXT("source-read"), Read);
+			TestTrue(TEXT("read succeeded"), ReadResult.bSuccess);
+			FString Content;
+			if (ReadResult.Structured.IsValid()) { ReadResult.Structured->TryGetStringField(TEXT("content"), Content); }
+			// The MODULE_API macro is derived from the (temp) module name, so assert the
+			// module-independent parts: the prefixed symbol, the parent, and the UCLASS marker.
+			TestTrue(TEXT("declares ASpecPawnThing : public AActor"), Content.Contains(TEXT("ASpecPawnThing : public AActor")));
+			TestTrue(TEXT("is a UCLASS"), Content.Contains(TEXT("UCLASS()")));
+
+			// list the temp module and confirm both files are present with sizes.
+			TSharedPtr<FJsonObject> List = SourceArgs();
+			List->SetStringField(TEXT("module"), TempModule);
+			const FUnrealMcpToolResult ListResult = RunSourceTool(Registry, TEXT("source-list"), List);
+			TestTrue(TEXT("list succeeded"), ListResult.bSuccess);
+			int32 ListCount = 0;
+			if (ListResult.Structured.IsValid()) { ListResult.Structured->TryGetNumberField(TEXT("count"), ListCount); }
+			TestEqual(TEXT("two files listed"), ListCount, 2);
+
+			// update the cpp with full-content replacement.
+			TSharedPtr<FJsonObject> Update = SourceArgs();
+			Update->SetStringField(TEXT("path"), TempModule / TEXT("SpecPawnThing.cpp"));
+			Update->SetStringField(TEXT("content"), TEXT("// replaced\n"));
+			TestTrue(TEXT("update succeeded"), RunSourceTool(Registry, TEXT("source-update"), Update).bSuccess);
+
+			// update refuses a missing file (use create instead).
+			TSharedPtr<FJsonObject> UpdateMissing = SourceArgs();
+			UpdateMissing->SetStringField(TEXT("path"), TempModule / TEXT("DoesNotExist.cpp"));
+			UpdateMissing->SetStringField(TEXT("content"), TEXT("x"));
+			TestFalse(TEXT("update missing file fails"), RunSourceTool(Registry, TEXT("source-update"), UpdateMissing).bSuccess);
+
+			// delete the header.
+			TSharedPtr<FJsonObject> Delete = SourceArgs();
+			Delete->SetStringField(TEXT("path"), HeaderRel);
+			TestTrue(TEXT("delete succeeded"), RunSourceTool(Registry, TEXT("source-delete"), Delete).bSuccess);
+			TestFalse(TEXT("header gone"), FPaths::FileExists(UnrealMcpSourceTools::GetProjectSourceRoot() / HeaderRel));
+		});
+
+		It("rejects jail escapes on every file op", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpSourceTools::Register(Registry);
+			const FString Escape = TEXT("../Config/DefaultEngine.ini");
+
+			TSharedPtr<FJsonObject> Read = SourceArgs();
+			Read->SetStringField(TEXT("path"), Escape);
+			TestFalse(TEXT("read escape rejected"), RunSourceTool(Registry, TEXT("source-read"), Read).bSuccess);
+
+			TSharedPtr<FJsonObject> Update = SourceArgs();
+			Update->SetStringField(TEXT("path"), Escape);
+			Update->SetStringField(TEXT("content"), TEXT("pwned"));
+			TestFalse(TEXT("update escape rejected"), RunSourceTool(Registry, TEXT("source-update"), Update).bSuccess);
+
+			TSharedPtr<FJsonObject> Delete = SourceArgs();
+			Delete->SetStringField(TEXT("path"), Escape);
+			TestFalse(TEXT("delete escape rejected"), RunSourceTool(Registry, TEXT("source-delete"), Delete).bSuccess);
+
+			TSharedPtr<FJsonObject> Create = SourceArgs();
+			Create->SetStringField(TEXT("className"), TEXT("Evil"));
+			Create->SetStringField(TEXT("module"), TEXT("../../../Windows"));
+			TestFalse(TEXT("create escape rejected"), RunSourceTool(Registry, TEXT("source-create-class"), Create).bSuccess);
+		});
+	});
+
+	// Heavy, real-UBT round-trip — only when explicitly requested (kept out of the default fast suite).
+	if (!FPlatformMisc::GetEnvironmentVariable(TEXT("UNREAL_MCP_RUN_LIVE_COMPILE")).IsEmpty())
+	{
+		Describe("live compile", [this]()
+		{
+			It("compiles a new class, reports structured errors when broken, and recovers", [this]()
+			{
+				FUnrealMcpToolRegistry Registry;
+				UnrealMcpSourceTools::Register(Registry);
+				const FString Module = FApp::GetProjectName();
+				const FString ClassName = TEXT("UnrealMcpLiveCompileProbe");
+				const FString HeaderRel = Module / (ClassName + TEXT(".h"));
+				const FString CppRel = Module / (ClassName + TEXT(".cpp"));
+				const FString HeaderAbs = UnrealMcpSourceTools::GetProjectSourceRoot() / HeaderRel;
+				const FString CppAbs = UnrealMcpSourceTools::GetProjectSourceRoot() / CppRel;
+
+				auto Cleanup = [&]()
+				{
+					IFileManager::Get().Delete(*HeaderAbs, false, true, true);
+					IFileManager::Get().Delete(*CppAbs, false, true, true);
+				};
+				Cleanup();
+
+				auto Compile = [&](int32& OutErrors) -> FUnrealMcpToolResult
+				{
+					TSharedPtr<FJsonObject> Args = SourceArgs();
+					Args->SetBoolField(TEXT("useLiveCoding"), false);
+					const FUnrealMcpToolResult Result = RunSourceTool(Registry, TEXT("source-compile"), Args);
+					OutErrors = -1;
+					if (Result.Structured.IsValid()) { Result.Structured->TryGetNumberField(TEXT("errorCount"), OutErrors); }
+					return Result;
+				};
+
+				// create -> compile: the new (empty UObject) class must be compiler-clean.
+				TSharedPtr<FJsonObject> Create = SourceArgs();
+				Create->SetStringField(TEXT("className"), ClassName);
+				Create->SetStringField(TEXT("module"), Module);
+				Create->SetStringField(TEXT("parentClass"), TEXT("UObject"));
+				TestTrue(TEXT("create succeeded"), RunSourceTool(Registry, TEXT("source-create-class"), Create).bSuccess);
+
+				int32 Errors = -1;
+				Compile(Errors);
+				TestEqual(TEXT("clean after create"), Errors, 0);
+
+				// break the cpp -> compile: structured errors with file + line.
+				TSharedPtr<FJsonObject> Break = SourceArgs();
+				Break->SetStringField(TEXT("path"), CppRel);
+				Break->SetStringField(TEXT("content"),
+					FString::Printf(TEXT("#include \"%s.h\"\nthis is not valid c++ ;\n"), *ClassName));
+				TestTrue(TEXT("break update succeeded"), RunSourceTool(Registry, TEXT("source-update"), Break).bSuccess);
+
+				FUnrealMcpToolResult BrokenResult = Compile(Errors);
+				TestTrue(TEXT("errors reported when broken"), Errors > 0);
+
+				// fix -> compile: compiler-clean again.
+				TSharedPtr<FJsonObject> Fix = SourceArgs();
+				Fix->SetStringField(TEXT("path"), CppRel);
+				Fix->SetStringField(TEXT("content"), FString::Printf(TEXT("#include \"%s.h\"\n"), *ClassName));
+				TestTrue(TEXT("fix update succeeded"), RunSourceTool(Registry, TEXT("source-update"), Fix).bSuccess);
+
+				Compile(Errors);
+				TestEqual(TEXT("clean after fix"), Errors, 0);
+
+				Cleanup();
+			});
+		});
+	}
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSourceToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSourceToolsSpec.cpp
@@ -327,6 +327,41 @@ void FUnrealMcpSourceToolsSpec::Define()
 			TestEqual(TEXT("file unchanged after rejected edits"), StillOnDisk, FString(TEXT("L1\nX2\nX3\nL4\n")));
 		});
 
+		It("splices NEWLINE-TERMINATED replacement content without inserting a blank line per edit", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpSourceTools::Register(Registry);
+
+			// AI callers very commonly send newline-terminated 'content' ("X2\n"). ParseIntoArrayLines
+			// yields ["X2",""] for it; without dropping that phantom trailing empty element on the
+			// REPLACEMENT side, each splice would contribute its own EOL via the Join AND re-add the file's
+			// trailing EOL, inserting a spurious blank line per edit (the accumulation bug, on the write
+			// side). The other range test splices UNTERMINATED text, so it cannot catch this — assert the
+			// terminated case end-to-end with exact bytes across two consecutive edits.
+			const FString FileRel = TempModule / TEXT("RangeTerminated.cpp");
+			const FString FileAbs = UnrealMcpSourceTools::GetProjectSourceRoot() / FileRel;
+			TestTrue(TEXT("seed file written"),
+				FFileHelper::SaveStringToFile(FString(TEXT("L1\nL2\nL3\nL4\n")), *FileAbs, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM));
+
+			auto SpliceLineTerminated = [&](int32 Line, const TCHAR* Text) -> bool
+			{
+				TSharedPtr<FJsonObject> Args = SourceArgs();
+				Args->SetStringField(TEXT("path"), FileRel);
+				Args->SetStringField(TEXT("content"), Text); // caller-supplied, newline-terminated
+				Args->SetNumberField(TEXT("startLine"), Line);
+				Args->SetNumberField(TEXT("endLine"), Line);
+				return RunSourceTool(Registry, TEXT("source-update"), Args).bSuccess;
+			};
+
+			TestTrue(TEXT("first terminated splice ok"), SpliceLineTerminated(2, TEXT("X2\n")));
+			TestTrue(TEXT("second terminated splice ok"), SpliceLineTerminated(3, TEXT("X3\n")));
+
+			FString OnDisk;
+			TestTrue(TEXT("read seed back"), FFileHelper::LoadFileToString(OnDisk, *FileAbs));
+			// Exactly the two edits, single trailing newline, and NO blank line accumulated between them.
+			TestEqual(TEXT("exact bytes after two newline-terminated range edits"), OnDisk, FString(TEXT("L1\nX2\nX3\nL4\n")));
+		});
+
 		It("reports totalLines as real lines for newline-terminated and unterminated files", [this]()
 		{
 			FUnrealMcpToolRegistry Registry;


### PR DESCRIPTION
## Summary
- Add the six native C++ source/script CORE tools per `docs/ARCHITECTURE.md` §10 "source family": `source-read`, `source-create-class`, `source-update`, `source-delete`, `source-list`, `source-compile`.
- `source-compile` returns a structured §3 `{file,line,severity,message}` build report (Live Coding when interactive, else a UBT invoke of the project Editor target) — the AI compile-feedback loop.
- All file operations are jailed to `<Project>/Source` (canonicalize + collapse traversal + reject absolute/junction escapes); `Plugins/`, `Config/` and engine paths are unreachable. Union-merged into the boot registration. Additive only — no version bumps.

## Test plan
- [x] Suite 1 UBT build (`UnrealTestProjectEditor Win64 Development`) — exit 0.
- [x] Suite 2 headless boot smoke — `[Unreal-MCP] plugin loaded`.
- [x] Suite 3 Automation (`UnrealMcp.` filter) — 82 succeeded + 10 warnings, 0 failed (11 new `UnrealMcp.Tools.Source` specs: registration, jail accept/reject, MSVC+clang diagnostic parser, file-op round-trip, per-tool jail-escape rejection).
- [x] Suite 7 live bridge e2e — server ⇄ bridge ⇄ live headless editor; create-class/read/update/delete/list exercised over HTTP, jail-escape rejected over the wire, real `source-compile` returned a structured report (returnCode 0, compileClean), clean no-orphan teardown.

Closes #18