### PR TITLE
feat(ui): Build the AI Game Developer Slate main window for Unreal-MCP

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
@@ -30,6 +30,11 @@ namespace
 	const FString TypeToolResponse = TEXT("tool-response");
 	const FString TypeToolCancel = TEXT("tool-cancel");
 	const FString TypeConfig = TEXT("config");
+	const FString TypeStatus = TEXT("status");
+	const FString TypeDeviceAuth = TEXT("device-auth");
+	const FString TypeAuthStart = TEXT("auth-start");
+	const FString TypeAuthCancel = TEXT("auth-cancel");
+	const FString TypeAuthRevoke = TEXT("auth-revoke");
 	const FString TypePing = TEXT("ping");
 	const FString TypePong = TEXT("pong");
 	const FString TypeShutdown = TEXT("shutdown");
@@ -325,6 +330,19 @@ void FUnrealMcpBridgeServer::HandleLine(const FString& Line, int32 Generation)
 	else if (Type == TypePong)
 	{
 		// liveness already refreshed in Run()
+	}
+	else if (Type == TypeStatus || Type == TypeDeviceAuth)
+	{
+		// §1.3 / §7: the live UI feed. Hand it to the registered sink (the view-model) WITHOUT touching any
+		// Slate/engine state here — the sink marshals onto the game thread (M9b). Copy the sink out under the
+		// lock so a concurrent window-close clear never invalidates the TFunction mid-call.
+		TFunction<void(const FString&, TSharedPtr<FJsonObject>)> SinkCopy;
+		{
+			FScopeLock Lock(&StatusSinkMutex);
+			SinkCopy = StatusSink;
+		}
+		if (SinkCopy)
+			SinkCopy(Type, Message);
 	}
 	else
 	{
@@ -649,6 +667,29 @@ void FUnrealMcpBridgeServer::SetEffectiveConfig(const TSharedPtr<FJsonObject>& I
 		EffectiveConfig = CloneJsonObject(InEffectiveConfig);
 	}
 	PushConfig(); // "on change" (§8) — no-op when no sidecar is connected
+}
+
+bool FUnrealMcpBridgeServer::SendAuthMessage(const FString& AuthType)
+{
+	// Only the three §1.3 auth verbs are valid here; reject anything else so a UI bug cannot smuggle an
+	// arbitrary message type onto the wire.
+	if (AuthType != TypeAuthStart && AuthType != TypeAuthCancel && AuthType != TypeAuthRevoke)
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] refusing to send unknown auth message type '%s'."), *AuthType);
+		return false;
+	}
+	if (!bClientConnected || !bHandshakeOk)
+		return false;
+
+	TSharedPtr<FJsonObject> Message = MakeShared<FJsonObject>();
+	Message->SetStringField(TEXT("type"), AuthType);
+	return SendMessage(Message);
+}
+
+void FUnrealMcpBridgeServer::SetStatusSink(TFunction<void(const FString&, TSharedPtr<FJsonObject>)> InSink)
+{
+	FScopeLock Lock(&StatusSinkMutex);
+	StatusSink = MoveTemp(InSink);
 }
 
 void FUnrealMcpBridgeServer::CloseActiveConnection()

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.h
@@ -64,6 +64,22 @@ public:
 	/** Push the current §1.3 `config` message to the connected sidecar. No-op when disconnected. */
 	void PushConfig();
 
+	/**
+	 * Send a §1.3 auth message (`auth-start` / `auth-cancel` / `auth-revoke`) to the connected sidecar
+	 * (the §7 Cloud device-code controls). Thread-safe; no-op (returns false) when disconnected. The UI
+	 * calls this on the game thread; the frame is serialized through the shared WriteMutex like any other.
+	 */
+	bool SendAuthMessage(const FString& AuthType);
+
+	/**
+	 * Register a sink for the inbound sidecar→plugin `status` and `device-auth` feed (§1.3 / §7). The sink
+	 * is invoked ON THE IPC READER THREAD with the message type and parsed object — the caller (the §7
+	 * view-model) MUST marshal onto the game thread (AsyncTask(GameThread)) before touching any Slate state
+	 * (the M9b main-thread-marshalled-subscriptions rule). Pass an unbound TFunction to clear it (window
+	 * close). Thread-safe; the previous sink is replaced.
+	 */
+	void SetStatusSink(TFunction<void(const FString& /*Type*/, TSharedPtr<FJsonObject> /*Message*/)> InSink);
+
 	/** Deterministic IPC port for a project path (§1.1): 30000 + sha(path) % 10000. */
 	static int32 ComputeDeterministicPort(const FString& ProjectPath);
 
@@ -119,6 +135,11 @@ private:
 	// guarded by ConfigMutex. A deep copy is stored so the caller's object can change without racing a send.
 	mutable FCriticalSection ConfigMutex;
 	TSharedPtr<FJsonObject> EffectiveConfig;
+
+	// Sink for the inbound `status` / `device-auth` feed (§1.3 / §7). Set/cleared on the game thread (window
+	// open/close), invoked on the reader thread; guarded so a window-close clear cannot race a reader invoke.
+	mutable FCriticalSection StatusSinkMutex;
+	TFunction<void(const FString&, TSharedPtr<FJsonObject>)> StatusSink;
 
 	FThreadSafeBool bStopRequested = false;
 	FThreadSafeBool bClientConnected = false;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -1,0 +1,535 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UI/SUnrealMcpMainWindow.h"
+#include "UnrealMcpLog.h"
+
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SScrollBox.h"
+#include "Widgets/Layout/SSeparator.h"
+#include "Widgets/Layout/SUniformGridPanel.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SEditableTextBox.h"
+#include "Widgets/Input/SCheckBox.h"
+#include "Widgets/Colors/SColorBlock.h"
+#include "Styling/AppStyle.h"
+#include "Styling/SlateTypes.h"
+#include "Misc/Attribute.h"
+#include "Misc/Paths.h"
+#include "HAL/PlatformProcess.h"
+#include "HAL/PlatformApplicationMisc.h"
+
+#define LOCTEXT_NAMESPACE "UnrealMcp"
+
+namespace
+{
+	const FString DiscordUrl = TEXT("https://discord.gg/");
+	const FString IssuesUrl = TEXT("https://github.com/IvanMurzak/Unreal-MCP/issues");
+	const FString StarUrl = TEXT("https://github.com/IvanMurzak/Unreal-MCP");
+}
+
+void SUnrealMcpMainWindow::Construct(const FArguments& InArgs)
+{
+	ViewModel = InArgs._ViewModel;
+	PluginVersion = InArgs._PluginVersion;
+	OnRestartBridge = InArgs._OnRestartBridge;
+	BridgeStatusProvider = InArgs._BridgeStatusProvider;
+
+	ChildSlot
+	[
+		SNew(SScrollBox)
+		+ SScrollBox::Slot().Padding(8.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildHeaderSection() ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildConnectionSection() ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildModeToggleSection() ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildCloudAuthSection() ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildCustomAuthSection() ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildBridgeStatusSection() ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildAiAgentsSection() ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildFooterSection() ]
+		]
+	];
+}
+
+TSharedRef<SWidget> SUnrealMcpMainWindow::SectionHeader(const FText& Title)
+{
+	return SNew(STextBlock)
+		.Text(Title)
+		.Font(FCoreStyle::GetDefaultFontStyle("Bold", 11));
+}
+
+TSharedRef<SWidget> SUnrealMcpMainWindow::BuildHeaderSection()
+{
+	const FString Version = PluginVersion.IsEmpty() ? TEXT("0.1.0") : PluginVersion;
+	return SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+		.Padding(8.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight()
+			[
+				SNew(STextBlock)
+				.Text(FText::Format(LOCTEXT("HeaderTitle", "AI Game Developer  —  v{0}"), FText::FromString(Version)))
+				.Font(FCoreStyle::GetDefaultFontStyle("Bold", 13))
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(SHorizontalBox)
+				+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 6, 0)
+				[
+					SNew(SButton)
+					.Text(LOCTEXT("OpenLog", "Open log file"))
+					.OnClicked_Lambda([]()
+					{
+						const FString ProjectLogPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectLogDir());
+						FPlatformProcess::ExploreFolder(*ProjectLogPath);
+						return FReply::Handled();
+					})
+				]
+				+ SHorizontalBox::Slot().AutoWidth()
+				[
+					SNew(SButton)
+					.Text(LOCTEXT("RestartBridge", "Restart bridge"))
+					.OnClicked_Lambda([this]()
+					{
+						OnRestartBridge.ExecuteIfBound();
+						return FReply::Handled();
+					})
+				]
+			]
+		];
+}
+
+TSharedRef<SWidget> SUnrealMcpMainWindow::BuildConnectionSection()
+{
+	return SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+		.Padding(8.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight()[ SectionHeader(LOCTEXT("ConnHeader", "Connection")) ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(SHorizontalBox)
+				// Status dot.
+				+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(0, 0, 8, 0)
+				[
+					SNew(SColorBlock)
+					.Size(FVector2D(14.0f, 14.0f))
+					.Color_Lambda([this]()
+					{
+						return IsViewModelValid()
+							? FUnrealMcpEditorViewModel::GetStatusColor(ViewModel->GetConnectionState())
+							: FLinearColor::Gray;
+					})
+				]
+				// Status label.
+				+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
+				[
+					SNew(STextBlock)
+					.Text_Lambda([this]()
+					{
+						return IsViewModelValid()
+							? FUnrealMcpEditorViewModel::GetStatusLabel(ViewModel->GetConnectionState())
+							: FText::GetEmpty();
+					})
+				]
+				// Connect / Disconnect / Stop button.
+				+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center)
+				[
+					SNew(SButton)
+					.Text_Lambda([this]()
+					{
+						return IsViewModelValid()
+							? FUnrealMcpEditorViewModel::GetButtonText(ViewModel->GetConnectionState())
+							: FText::GetEmpty();
+					})
+					.OnClicked(this, &SUnrealMcpMainWindow::OnConnectClicked)
+				]
+			]
+			// Custom-mode server URL field (only shown in Custom mode).
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)
+			[
+				SNew(SVerticalBox)
+				.Visibility_Lambda([this]()
+				{
+					return IsViewModelValid() && ViewModel->GetConnectionMode() == EUnrealMcpConnectionMode::Custom
+						? EVisibility::Visible : EVisibility::Collapsed;
+				})
+				+ SVerticalBox::Slot().AutoHeight()
+				[
+					SNew(STextBlock).Text(LOCTEXT("ServerUrl", "Server URL"))
+				]
+				+ SVerticalBox::Slot().AutoHeight().Padding(0, 2, 0, 0)
+				[
+					SAssignNew(CustomHostBox, SEditableTextBox)
+					.Text_Lambda([this]()
+					{
+						return IsViewModelValid() ? FText::FromString(ViewModel->GetCustomHost()) : FText::GetEmpty();
+					})
+					.OnTextCommitted_Lambda([this](const FText& NewText, ETextCommit::Type)
+					{
+						if (IsViewModelValid())
+							ViewModel->SetCustomHost(NewText.ToString());
+					})
+				]
+				// Inline validation error.
+				+ SVerticalBox::Slot().AutoHeight().Padding(0, 2, 0, 0)
+				[
+					SNew(STextBlock)
+					.ColorAndOpacity(FLinearColor(0.95f, 0.4f, 0.4f))
+					.Text_Lambda([this]()
+					{
+						if (!IsViewModelValid())
+							return FText::GetEmpty();
+						FString Error;
+						return FUnrealMcpEditorViewModel::ValidateServerUrl(ViewModel->GetCustomHost(), Error)
+							? FText::GetEmpty() : FText::FromString(Error);
+					})
+				]
+			]
+		];
+}
+
+TSharedRef<SWidget> SUnrealMcpMainWindow::BuildModeToggleSection()
+{
+	auto MakeModeButton = [this](const FText& Label, EUnrealMcpConnectionMode Mode)
+	{
+		return SNew(SCheckBox)
+			.Style(FAppStyle::Get(), "ToggleButtonCheckbox")
+			.IsChecked_Lambda([this, Mode]()
+			{
+				return IsViewModelValid() && ViewModel->GetConnectionMode() == Mode
+					? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+			})
+			.OnCheckStateChanged_Lambda([this, Mode](ECheckBoxState NewState)
+			{
+				if (NewState == ECheckBoxState::Checked && IsViewModelValid())
+					ViewModel->SetConnectionMode(Mode);
+			})
+			.Padding(FMargin(12, 4))
+			[
+				SNew(STextBlock).Text(Label)
+			];
+	};
+
+	return SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+		.Padding(8.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight()[ SectionHeader(LOCTEXT("ModeHeader", "Connection mode")) ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(SHorizontalBox)
+				+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 6, 0)[ MakeModeButton(LOCTEXT("ModeCloud", "Cloud"), EUnrealMcpConnectionMode::Cloud) ]
+				+ SHorizontalBox::Slot().AutoWidth()[ MakeModeButton(LOCTEXT("ModeCustom", "Custom"), EUnrealMcpConnectionMode::Custom) ]
+			]
+		];
+}
+
+TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCloudAuthSection()
+{
+	TSharedRef<SBorder> Section = SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+		.Padding(8.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight()[ SectionHeader(LOCTEXT("CloudAuthHeader", "Cloud authorization")) ]
+			// Buttons row.
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(SHorizontalBox)
+				+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 6, 0)
+				[
+					SNew(SButton)
+					.Text(LOCTEXT("Authorize", "Authorize"))
+					.IsEnabled_Lambda([this]()
+					{
+						return IsViewModelValid() && ViewModel->GetDeviceAuthState() != EUnrealMcpDeviceAuthState::Pending;
+					})
+					.OnClicked_Lambda([this]()
+					{
+						if (IsViewModelValid()) ViewModel->Authorize();
+						return FReply::Handled();
+					})
+				]
+				+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 6, 0)
+				[
+					SNew(SButton)
+					.Text(LOCTEXT("CancelAuth", "Cancel"))
+					.Visibility_Lambda([this]()
+					{
+						return IsViewModelValid() && ViewModel->GetDeviceAuthState() == EUnrealMcpDeviceAuthState::Pending
+							? EVisibility::Visible : EVisibility::Collapsed;
+					})
+					.OnClicked_Lambda([this]()
+					{
+						if (IsViewModelValid()) ViewModel->CancelAuth();
+						return FReply::Handled();
+					})
+				]
+				+ SHorizontalBox::Slot().AutoWidth()
+				[
+					SNew(SButton)
+					.Text(LOCTEXT("Revoke", "Revoke"))
+					.Visibility_Lambda([this]()
+					{
+						return IsViewModelValid() && ViewModel->HasCloudToken()
+							? EVisibility::Visible : EVisibility::Collapsed;
+					})
+					.OnClicked_Lambda([this]()
+					{
+						if (IsViewModelValid()) ViewModel->Revoke();
+						return FReply::Handled();
+					})
+				]
+			]
+			// Device-code instructions (verification URL + user code), shown while pending.
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(SVerticalBox)
+				.Visibility_Lambda([this]()
+				{
+					return IsViewModelValid() && ViewModel->GetDeviceAuthState() == EUnrealMcpDeviceAuthState::Pending
+						? EVisibility::Visible : EVisibility::Collapsed;
+				})
+				+ SVerticalBox::Slot().AutoHeight()
+				[
+					SNew(STextBlock).AutoWrapText(true)
+					.Text(LOCTEXT("DeviceInstr", "Complete authorization in your browser, then enter this code:"))
+				]
+				+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
+				[
+					SNew(SHorizontalBox)
+					+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center)
+					[
+						SNew(STextBlock)
+						.Font(FCoreStyle::GetDefaultFontStyle("Bold", 14))
+						.Text_Lambda([this]()
+						{
+							return IsViewModelValid() ? FText::FromString(ViewModel->GetDeviceUserCode()) : FText::GetEmpty();
+						})
+					]
+					+ SHorizontalBox::Slot().AutoWidth().Padding(8, 0, 0, 0).VAlign(VAlign_Center)
+					[
+						SNew(SButton)
+						.Text(LOCTEXT("CopyCode", "Copy code"))
+						.OnClicked_Lambda([this]()
+						{
+							if (IsViewModelValid())
+								FPlatformApplicationMisc::ClipboardCopy(*ViewModel->GetDeviceUserCode());
+							return FReply::Handled();
+						})
+					]
+					+ SHorizontalBox::Slot().AutoWidth().Padding(8, 0, 0, 0).VAlign(VAlign_Center)
+					[
+						SNew(SButton)
+						.Text(LOCTEXT("OpenVerify", "Open verification page"))
+						.OnClicked_Lambda([this]()
+						{
+							if (IsViewModelValid())
+							{
+								const FString Url = ViewModel->GetDeviceVerificationUrl();
+								if (!Url.IsEmpty())
+									FPlatformProcess::LaunchURL(*Url, nullptr, nullptr);
+							}
+							return FReply::Handled();
+						})
+					]
+				]
+			]
+			// Authorized indicator.
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(STextBlock)
+				.ColorAndOpacity(FLinearColor(0.16f, 0.74f, 0.30f))
+				.Visibility_Lambda([this]()
+				{
+					return IsViewModelValid() && ViewModel->GetDeviceAuthState() == EUnrealMcpDeviceAuthState::Authorized
+						? EVisibility::Visible : EVisibility::Collapsed;
+				})
+				.Text(LOCTEXT("Authorized", "Authorized — cloud token stored."))
+			]
+		];
+
+	Section->SetVisibility(MakeAttributeLambda([this]() -> EVisibility
+	{
+		return IsViewModelValid() && ViewModel->GetConnectionMode() == EUnrealMcpConnectionMode::Cloud
+			? EVisibility::Visible : EVisibility::Collapsed;
+	}));
+	return Section;
+}
+
+TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCustomAuthSection()
+{
+	TSharedRef<SBorder> Section = SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+		.Padding(8.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight()[ SectionHeader(LOCTEXT("CustomAuthHeader", "Server authorization")) ]
+			// none / required toggle.
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(SCheckBox)
+				.IsChecked_Lambda([this]()
+				{
+					return IsViewModelValid() && ViewModel->GetAuthOption() == EUnrealMcpAuthOption::Required
+						? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+				})
+				.OnCheckStateChanged_Lambda([this](ECheckBoxState NewState)
+				{
+					if (IsViewModelValid())
+						ViewModel->SetAuthOption(NewState == ECheckBoxState::Checked ? EUnrealMcpAuthOption::Required : EUnrealMcpAuthOption::None);
+				})
+				[
+					SNew(STextBlock).Text(LOCTEXT("AuthRequired", "Require a bearer token"))
+				]
+			]
+			// Masked token field + Generate, shown only when auth is required.
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(SHorizontalBox)
+				.Visibility_Lambda([this]()
+				{
+					return IsViewModelValid() && ViewModel->GetAuthOption() == EUnrealMcpAuthOption::Required
+						? EVisibility::Visible : EVisibility::Collapsed;
+				})
+				+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
+				[
+					SNew(SEditableTextBox)
+					// IsPassword renders the token as dots natively — the raw value is never drawn unless revealed (§8).
+					.IsPassword_Lambda([this]() { return !bRevealToken; })
+					.Text_Lambda([this]()
+					{
+						return IsViewModelValid() ? FText::FromString(ViewModel->GetCustomToken()) : FText::GetEmpty();
+					})
+					.OnTextCommitted_Lambda([this](const FText& NewText, ETextCommit::Type)
+					{
+						if (IsViewModelValid())
+							ViewModel->SetCustomToken(NewText.ToString());
+					})
+				]
+				+ SHorizontalBox::Slot().AutoWidth().Padding(6, 0, 0, 0).VAlign(VAlign_Center)
+				[
+					SNew(SButton)
+					.Text(LOCTEXT("Reveal", "Reveal"))
+					.OnClicked_Lambda([this]()
+					{
+						bRevealToken = !bRevealToken;
+						return FReply::Handled();
+					})
+				]
+				+ SHorizontalBox::Slot().AutoWidth().Padding(6, 0, 0, 0).VAlign(VAlign_Center)
+				[
+					SNew(SButton)
+					.Text(LOCTEXT("Generate", "Generate"))
+					.OnClicked_Lambda([this]()
+					{
+						if (IsViewModelValid()) ViewModel->GenerateCustomToken();
+						return FReply::Handled();
+					})
+				]
+			]
+		];
+
+	Section->SetVisibility(MakeAttributeLambda([this]() -> EVisibility
+	{
+		return IsViewModelValid() && ViewModel->GetConnectionMode() == EUnrealMcpConnectionMode::Custom
+			? EVisibility::Visible : EVisibility::Collapsed;
+	}));
+	return Section;
+}
+
+TSharedRef<SWidget> SUnrealMcpMainWindow::BuildBridgeStatusSection()
+{
+	return SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+		.Padding(8.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight()[ SectionHeader(LOCTEXT("BridgeHeader", "Bridge (sidecar)")) ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(STextBlock)
+				.Text_Lambda([this]()
+				{
+					if (BridgeStatusProvider)
+						return FText::FromString(BridgeStatusProvider());
+					return LOCTEXT("BridgeUnknown", "Sidecar status unavailable.");
+				})
+			]
+		];
+}
+
+TSharedRef<SWidget> SUnrealMcpMainWindow::BuildAiAgentsSection()
+{
+	return SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+		.Padding(8.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight()[ SectionHeader(LOCTEXT("AgentsHeader", "AI agents")) ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(STextBlock)
+				.AutoWrapText(true)
+				.Text_Lambda([this]()
+				{
+					if (!IsViewModelValid() || ViewModel->GetAiAgents().Num() == 0)
+						return LOCTEXT("NoAgents", "No AI agents connected.");
+					return FText::FromString(FString::Join(ViewModel->GetAiAgents(), TEXT(", ")));
+				})
+			]
+		];
+}
+
+TSharedRef<SWidget> SUnrealMcpMainWindow::BuildFooterSection()
+{
+	auto MakeLinkButton = [](const FText& Label, const FString& Url)
+	{
+		return SNew(SButton)
+			.Text(Label)
+			.OnClicked_Lambda([Url]()
+			{
+				FPlatformProcess::LaunchURL(*Url, nullptr, nullptr);
+				return FReply::Handled();
+			});
+	};
+
+	return SNew(SVerticalBox)
+		+ SVerticalBox::Slot().AutoHeight()[ SNew(SSeparator) ]
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 6, 0)[ MakeLinkButton(LOCTEXT("Discord", "Discord"), DiscordUrl) ]
+			+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 6, 0)[ MakeLinkButton(LOCTEXT("Issues", "Issues"), IssuesUrl) ]
+			+ SHorizontalBox::Slot().AutoWidth()[ MakeLinkButton(LOCTEXT("Star", "Star on GitHub"), StarUrl) ]
+		]
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+		[
+			SNew(STextBlock)
+			.AutoWrapText(true)
+			.Text(LOCTEXT("Thanks", "Thank you for using Unreal-MCP — built by Ivan Murzak and contributors."))
+		];
+}
+
+FReply SUnrealMcpMainWindow::OnConnectClicked()
+{
+	if (!IsViewModelValid())
+		return FReply::Handled();
+
+	// Tri-state: Disconnected → Connect; anything else (Connecting/Connected/Degraded) → Disconnect/Stop.
+	if (ViewModel->GetConnectionState() == EUnrealMcpConnectionState::Disconnected)
+		ViewModel->Connect();
+	else
+		ViewModel->Disconnect();
+	return FReply::Handled();
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -419,11 +419,12 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCustomAuthSection()
 				[
 					SNew(SButton)
 					.Text(LOCTEXT("Reveal", "Reveal"))
-					.OnClicked_Lambda([this]()
-					{
-						bRevealToken = !bRevealToken;
-						return FReply::Handled();
-					})
+					.ToolTipText(LOCTEXT("RevealHint", "Press and hold to reveal the token; it re-masks on release."))
+					// Reveal-on-HOLD (not a sticky toggle): the raw bearer is only ever drawn while the button is
+					// physically held, then immediately re-masked — the AC's "never rendered unmasked" default
+					// always holds (§8). OnPressed/OnReleased drive bRevealToken, which gates IsPassword above.
+					.OnPressed_Lambda([this]() { bRevealToken = true; })
+					.OnReleased_Lambda([this]() { bRevealToken = false; })
 				]
 				+ SHorizontalBox::Slot().AutoWidth().Padding(6, 0, 0, 0).VAlign(VAlign_Center)
 				[

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -166,7 +166,7 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildConnectionSection()
 				]
 				+ SVerticalBox::Slot().AutoHeight().Padding(0, 2, 0, 0)
 				[
-					SAssignNew(CustomHostBox, SEditableTextBox)
+					SNew(SEditableTextBox)
 					.Text_Lambda([this]()
 					{
 						return IsViewModelValid() ? FText::FromString(ViewModel->GetCustomHost()) : FText::GetEmpty();
@@ -354,6 +354,23 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCloudAuthSection()
 						? EVisibility::Visible : EVisibility::Collapsed;
 				})
 				.Text(LOCTEXT("Authorized", "Authorized — cloud token stored."))
+			]
+			// Failure reason (denial / expiry / no sidecar) — without this the pending instructions just
+			// collapse on failure and the window shows no feedback for an AC-level flow.
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(STextBlock)
+				.AutoWrapText(true)
+				.ColorAndOpacity(FLinearColor(0.95f, 0.4f, 0.4f))
+				.Visibility_Lambda([this]()
+				{
+					return IsViewModelValid() && ViewModel->GetDeviceAuthState() == EUnrealMcpDeviceAuthState::Failed
+						? EVisibility::Visible : EVisibility::Collapsed;
+				})
+				.Text_Lambda([this]()
+				{
+					return IsViewModelValid() ? FText::FromString(ViewModel->GetDeviceAuthError()) : FText::GetEmpty();
+				})
 			]
 		];
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
@@ -8,8 +8,6 @@
 #include "Widgets/DeclarativeSyntaxSupport.h"
 #include "UI/UnrealMcpEditorViewModel.h"
 
-class SEditableTextBox;
-
 /**
  * The "AI Game Developer" main window (docs/ARCHITECTURE.md §7), a pure-Slate compound widget — NO UMG /
  * editor-utility dependency. Hosted in the nomad dockable tab registered by FUnrealMcpMainWindowTab. Every
@@ -45,7 +43,6 @@ private:
 
 	// Whether the masked Custom-mode token field is currently revealed (reveal-on-hold, §8).
 	bool bRevealToken = false;
-	TSharedPtr<SEditableTextBox> CustomHostBox;
 
 	// Section builders (each returns a Slate widget; kept separate so §7's ordering reads top-to-bottom).
 	TSharedRef<SWidget> BuildHeaderSection();

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "UI/UnrealMcpEditorViewModel.h"
+
+class SEditableTextBox;
+
+/**
+ * The "AI Game Developer" main window (docs/ARCHITECTURE.md §7), a pure-Slate compound widget — NO UMG /
+ * editor-utility dependency. Hosted in the nomad dockable tab registered by FUnrealMcpMainWindowTab. Every
+ * widget binds (via TAttribute lambdas) to the shared FUnrealMcpEditorViewModel, which owns all state; this
+ * widget is a thin view. Sections, top to bottom: header/settings, connection panel, connection-mode toggle,
+ * Cloud device-code auth, Custom server auth, bridge status, AI agents, footer.
+ *
+ * Lifetime: the view-model outlives the widget (it is owned by the runtime); the widget keeps only a weak-ish
+ * shared ref and reads it under IsValid guards. The status feed is marshalled to the game thread by the
+ * runtime before it reaches the view-model, so every Slate read here is already game-thread-safe.
+ */
+class SUnrealMcpMainWindow : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SUnrealMcpMainWindow) {}
+		/** The shared view-model (owned by the runtime). Required. */
+		SLATE_ARGUMENT(TSharedPtr<FUnrealMcpEditorViewModel>, ViewModel)
+		/** Optional: plugin version string for the header. */
+		SLATE_ARGUMENT(FString, PluginVersion)
+		/** Optional: restart-bridge action (§7 item 1/7). */
+		SLATE_EVENT(FSimpleDelegate, OnRestartBridge)
+		/** Optional: a provider for the one-line bridge status string (§7 item 7). */
+		SLATE_ARGUMENT(TFunction<FString()>, BridgeStatusProvider)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	TSharedPtr<FUnrealMcpEditorViewModel> ViewModel;
+	FString PluginVersion;
+	FSimpleDelegate OnRestartBridge;
+	TFunction<FString()> BridgeStatusProvider;
+
+	// Whether the masked Custom-mode token field is currently revealed (reveal-on-hold, §8).
+	bool bRevealToken = false;
+	TSharedPtr<SEditableTextBox> CustomHostBox;
+
+	// Section builders (each returns a Slate widget; kept separate so §7's ordering reads top-to-bottom).
+	TSharedRef<SWidget> BuildHeaderSection();
+	TSharedRef<SWidget> BuildConnectionSection();
+	TSharedRef<SWidget> BuildModeToggleSection();
+	TSharedRef<SWidget> BuildCloudAuthSection();
+	TSharedRef<SWidget> BuildCustomAuthSection();
+	TSharedRef<SWidget> BuildBridgeStatusSection();
+	TSharedRef<SWidget> BuildAiAgentsSection();
+	TSharedRef<SWidget> BuildFooterSection();
+
+	// A bold section header row.
+	static TSharedRef<SWidget> SectionHeader(const FText& Title);
+
+	// Common handlers.
+	FReply OnConnectClicked();
+	bool IsViewModelValid() const { return ViewModel.IsValid(); }
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -89,11 +89,13 @@ void FUnrealMcpEditorViewModel::Disconnect()
 
 void FUnrealMcpEditorViewModel::Authorize()
 {
-	DeviceAuthState = EUnrealMcpDeviceAuthState::Pending;
 	DeviceVerificationUrl.Reset();
 	DeviceUserCode.Reset();
-	if (OnSendAuth)
-		OnSendAuth(TEXT("auth-start"));
+	// Only enter Pending if the auth-start frame actually reached the sidecar. SendAuthMessage returns false
+	// when no sidecar is connected/handshaken; entering Pending regardless would wedge the UI showing
+	// "Complete authorization in your browser…" with an empty user code until the user manually cancels.
+	const bool bSent = OnSendAuth ? OnSendAuth(TEXT("auth-start")) : false;
+	DeviceAuthState = bSent ? EUnrealMcpDeviceAuthState::Pending : EUnrealMcpDeviceAuthState::Failed;
 }
 
 void FUnrealMcpEditorViewModel::CancelAuth()
@@ -179,10 +181,17 @@ void FUnrealMcpEditorViewModel::ApplyDeviceAuth(const TSharedPtr<FJsonObject>& D
 		if (StateRaw.Equals(TEXT("authorized"), ESearchCase::IgnoreCase) || StateRaw.Equals(TEXT("success"), ESearchCase::IgnoreCase))
 		{
 			DeviceAuthState = EUnrealMcpDeviceAuthState::Authorized;
-			// The sidecar stored the token; mirror its presence so the UI flips to the Revoke affordance.
+			// The sidecar stored the token; mirror its presence so the UI flips to the Revoke affordance, and
+			// PERSIST + PUSH it (like Revoke does): without this the bearer is lost on editor restart (never
+			// written to the §8 config store) and the bridge's effective config never learns it, so a "Restart
+			// bridge" re-pushes a token-less config and silently drops the authorized session. Guard on change
+			// so a repeated `authorized` poll update does not churn the store / re-push every tick.
 			FString Token;
-			if (DeviceAuth->TryGetStringField(TEXT("token"), Token) && !Token.IsEmpty())
+			if (DeviceAuth->TryGetStringField(TEXT("token"), Token) && !Token.IsEmpty() && Config.CloudToken != Token)
+			{
 				Config.CloudToken = Token;
+				PersistAndPush();
+			}
 		}
 		else if (StateRaw.Equals(TEXT("failed"), ESearchCase::IgnoreCase) || StateRaw.Equals(TEXT("denied"), ESearchCase::IgnoreCase) || StateRaw.Equals(TEXT("expired"), ESearchCase::IgnoreCase))
 		{

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -91,11 +91,15 @@ void FUnrealMcpEditorViewModel::Authorize()
 {
 	DeviceVerificationUrl.Reset();
 	DeviceUserCode.Reset();
+	DeviceAuthError.Reset();
 	// Only enter Pending if the auth-start frame actually reached the sidecar. SendAuthMessage returns false
 	// when no sidecar is connected/handshaken; entering Pending regardless would wedge the UI showing
 	// "Complete authorization in your browser…" with an empty user code until the user manually cancels.
 	const bool bSent = OnSendAuth ? OnSendAuth(TEXT("auth-start")) : false;
 	DeviceAuthState = bSent ? EUnrealMcpDeviceAuthState::Pending : EUnrealMcpDeviceAuthState::Failed;
+	// Surface a reason for the Failed state so the window does not silently collapse the pending instructions.
+	if (!bSent)
+		DeviceAuthError = TEXT("No sidecar connected.");
 }
 
 void FUnrealMcpEditorViewModel::CancelAuth()
@@ -103,6 +107,7 @@ void FUnrealMcpEditorViewModel::CancelAuth()
 	DeviceAuthState = EUnrealMcpDeviceAuthState::Idle;
 	DeviceVerificationUrl.Reset();
 	DeviceUserCode.Reset();
+	DeviceAuthError.Reset();
 	if (OnSendAuth)
 		OnSendAuth(TEXT("auth-cancel"));
 }
@@ -113,6 +118,7 @@ void FUnrealMcpEditorViewModel::Revoke()
 	DeviceAuthState = EUnrealMcpDeviceAuthState::Idle;
 	DeviceVerificationUrl.Reset();
 	DeviceUserCode.Reset();
+	DeviceAuthError.Reset();
 	if (OnSendAuth)
 		OnSendAuth(TEXT("auth-revoke"));
 	// CloudToken changed — persist (Save restores env/.env overrides) and push the now-anonymous config.
@@ -181,6 +187,7 @@ void FUnrealMcpEditorViewModel::ApplyDeviceAuth(const TSharedPtr<FJsonObject>& D
 		if (StateRaw.Equals(TEXT("authorized"), ESearchCase::IgnoreCase) || StateRaw.Equals(TEXT("success"), ESearchCase::IgnoreCase))
 		{
 			DeviceAuthState = EUnrealMcpDeviceAuthState::Authorized;
+			DeviceAuthError.Reset();
 			// The sidecar stored the token; mirror its presence so the UI flips to the Revoke affordance, and
 			// PERSIST + PUSH it (like Revoke does): without this the bearer is lost on editor restart (never
 			// written to the §8 config store) and the bridge's effective config never learns it, so a "Restart
@@ -196,10 +203,19 @@ void FUnrealMcpEditorViewModel::ApplyDeviceAuth(const TSharedPtr<FJsonObject>& D
 		else if (StateRaw.Equals(TEXT("failed"), ESearchCase::IgnoreCase) || StateRaw.Equals(TEXT("denied"), ESearchCase::IgnoreCase) || StateRaw.Equals(TEXT("expired"), ESearchCase::IgnoreCase))
 		{
 			DeviceAuthState = EUnrealMcpDeviceAuthState::Failed;
+			// Surface the sidecar's human-readable reason (DeviceAuthMessage.Message — "Authorization was
+			// denied." / "The authorization request expired." / "Could not start authorization.") so the
+			// window shows feedback instead of silently collapsing the pending instructions.
+			FString Message;
+			if (DeviceAuth->TryGetStringField(TEXT("message"), Message) && !Message.IsEmpty())
+				DeviceAuthError = Message;
+			else if (DeviceAuthError.IsEmpty())
+				DeviceAuthError = TEXT("Authorization failed.");
 		}
 		else if (StateRaw.Equals(TEXT("pending"), ESearchCase::IgnoreCase))
 		{
 			DeviceAuthState = EUnrealMcpDeviceAuthState::Pending;
+			DeviceAuthError.Reset();
 		}
 	}
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -37,11 +37,14 @@ void FUnrealMcpEditorViewModel::SetConnectionMode(EUnrealMcpConnectionMode InMod
 
 void FUnrealMcpEditorViewModel::SetCustomHost(const FString& InHost)
 {
-	// Keep the field editable as the user types, but only persist/push a host that validates — pushing a
+	// Trim before storing: validation already trims internally, so "  http://host  " would validate yet get
+	// persisted + pushed padded — the sidecar would then dial the untrimmed target. Store the trimmed form so
+	// the field, the §8 store, and the dial target stay consistent. Only push a host that validates — pushing a
 	// malformed URL to the sidecar would just make it dial nowhere (§7 validated field).
-	Config.CustomHost = InHost;
+	const FString Trimmed = InHost.TrimStartAndEnd();
+	Config.CustomHost = Trimmed;
 	FString Error;
-	if (ValidateServerUrl(InHost, Error))
+	if (ValidateServerUrl(Trimmed, Error))
 	{
 		PersistAndPush();
 	}
@@ -104,7 +107,10 @@ void FUnrealMcpEditorViewModel::Authorize()
 
 void FUnrealMcpEditorViewModel::CancelAuth()
 {
-	DeviceAuthState = EUnrealMcpDeviceAuthState::Idle;
+	// Cancelling an in-progress RE-authorize must not hide an already-stored cloud token: InitializeConfig maps
+	// token-present → Authorized, so dropping to Idle here would lose the "Authorized"/Revoke affordance until
+	// restart. Fall back to Authorized when a bearer is still stored; only a token-less cancel returns to Idle.
+	DeviceAuthState = HasCloudToken() ? EUnrealMcpDeviceAuthState::Authorized : EUnrealMcpDeviceAuthState::Idle;
 	DeviceVerificationUrl.Reset();
 	DeviceUserCode.Reset();
 	DeviceAuthError.Reset();
@@ -186,6 +192,14 @@ void FUnrealMcpEditorViewModel::ApplyDeviceAuth(const TSharedPtr<FJsonObject>& D
 	{
 		if (StateRaw.Equals(TEXT("authorized"), ESearchCase::IgnoreCase) || StateRaw.Equals(TEXT("success"), ESearchCase::IgnoreCase))
 		{
+			// Cancel-race complement (§7 item 4): the sidecar emits the authorized device-auth (token included)
+			// BEFORE its own auth-cancel/auth-revoke guard runs, and a pushed config would re-apply that bearer
+			// sidecar-side. If the user already cancelled/revoked this flow the indicator is back to Idle (a
+			// token-less cancel, or a revoke that cleared the bearer) — ignore the late authorized so we do not
+			// resurrect a token the user just dropped. (A cancel that KEPT a stored token leaves state Authorized,
+			// not Idle, so a legitimate re-confirm still applies.)
+			if (DeviceAuthState == EUnrealMcpDeviceAuthState::Idle)
+				return;
 			DeviceAuthState = EUnrealMcpDeviceAuthState::Authorized;
 			DeviceAuthError.Reset();
 			// The sidecar stored the token; mirror its presence so the UI flips to the Revoke affordance, and

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -1,0 +1,316 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UI/UnrealMcpEditorViewModel.h"
+#include "Sidecar/UnrealMcpSidecarManager.h"
+#include "UnrealMcpLog.h"
+
+#include "Dom/JsonObject.h"
+
+#define LOCTEXT_NAMESPACE "UnrealMcp"
+
+FUnrealMcpEditorViewModel::FUnrealMcpEditorViewModel() = default;
+
+void FUnrealMcpEditorViewModel::InitializeConfig(const FUnrealMcpConfig& InConfig)
+{
+	Config = InConfig;
+	// Reflect the persisted intent: keepConnected drives whether we present as armed-but-disconnected.
+	ConnectionState = Config.bKeepConnected ? EUnrealMcpConnectionState::Connecting : EUnrealMcpConnectionState::Disconnected;
+	DeviceAuthState = HasCloudToken() ? EUnrealMcpDeviceAuthState::Authorized : EUnrealMcpDeviceAuthState::Idle;
+}
+
+void FUnrealMcpEditorViewModel::PersistAndPush()
+{
+	if (OnPersistConfig)
+		OnPersistConfig(Config);
+	if (OnPushConfig)
+		OnPushConfig(Config);
+}
+
+void FUnrealMcpEditorViewModel::SetConnectionMode(EUnrealMcpConnectionMode InMode)
+{
+	if (Config.ConnectionMode == InMode)
+		return;
+	Config.ConnectionMode = InMode;
+	PersistAndPush();
+}
+
+void FUnrealMcpEditorViewModel::SetCustomHost(const FString& InHost)
+{
+	// Keep the field editable as the user types, but only persist/push a host that validates — pushing a
+	// malformed URL to the sidecar would just make it dial nowhere (§7 validated field).
+	Config.CustomHost = InHost;
+	FString Error;
+	if (ValidateServerUrl(InHost, Error))
+	{
+		PersistAndPush();
+	}
+}
+
+void FUnrealMcpEditorViewModel::SetAuthOption(EUnrealMcpAuthOption InOption)
+{
+	if (Config.AuthOption == InOption)
+		return;
+	Config.AuthOption = InOption;
+	PersistAndPush();
+}
+
+void FUnrealMcpEditorViewModel::SetCustomToken(const FString& InToken)
+{
+	Config.CustomToken = InToken;
+	PersistAndPush();
+}
+
+void FUnrealMcpEditorViewModel::GenerateCustomToken()
+{
+	Config.CustomToken = FUnrealMcpSidecarManager::GenerateToken();
+	// Generating a token only makes sense when auth is actually required — flip it so the new token is used.
+	Config.AuthOption = EUnrealMcpAuthOption::Required;
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] generated a new Custom-mode token (%s)."),
+		*FUnrealMcpConfig::MaskSecret(Config.CustomToken));
+	PersistAndPush();
+}
+
+void FUnrealMcpEditorViewModel::Connect()
+{
+	Config.bKeepConnected = true;
+	ConnectionState = EUnrealMcpConnectionState::Connecting;
+	PersistAndPush();
+}
+
+void FUnrealMcpEditorViewModel::Disconnect()
+{
+	// The Godot M9b lesson: Disconnect must GENUINELY halt the reconnect loop. keepConnected=false pushed
+	// over `config` tells the sidecar to tear down the SignalR client fully — not merely drop one link.
+	Config.bKeepConnected = false;
+	ConnectionState = EUnrealMcpConnectionState::Disconnected;
+	PersistAndPush();
+}
+
+void FUnrealMcpEditorViewModel::Authorize()
+{
+	DeviceAuthState = EUnrealMcpDeviceAuthState::Pending;
+	DeviceVerificationUrl.Reset();
+	DeviceUserCode.Reset();
+	if (OnSendAuth)
+		OnSendAuth(TEXT("auth-start"));
+}
+
+void FUnrealMcpEditorViewModel::CancelAuth()
+{
+	DeviceAuthState = EUnrealMcpDeviceAuthState::Idle;
+	DeviceVerificationUrl.Reset();
+	DeviceUserCode.Reset();
+	if (OnSendAuth)
+		OnSendAuth(TEXT("auth-cancel"));
+}
+
+void FUnrealMcpEditorViewModel::Revoke()
+{
+	Config.CloudToken.Reset();
+	DeviceAuthState = EUnrealMcpDeviceAuthState::Idle;
+	DeviceVerificationUrl.Reset();
+	DeviceUserCode.Reset();
+	if (OnSendAuth)
+		OnSendAuth(TEXT("auth-revoke"));
+	// CloudToken changed — persist (Save restores env/.env overrides) and push the now-anonymous config.
+	PersistAndPush();
+}
+
+void FUnrealMcpEditorViewModel::ApplyStatus(const TSharedPtr<FJsonObject>& Status)
+{
+	if (!Status.IsValid())
+		return;
+
+	FString StateRaw;
+	Status->TryGetStringField(TEXT("connectionState"), StateRaw);
+
+	bool bKeep = Config.bKeepConnected;
+	Status->TryGetBoolField(TEXT("keepConnected"), bKeep);
+
+	ConnectionState = ParseConnectionState(StateRaw, bKeep);
+
+	// A `status` reflecting an authorized cloud session promotes the device-auth indicator.
+	FString CloudAuthState;
+	if (Status->TryGetStringField(TEXT("cloudAuthState"), CloudAuthState))
+	{
+		if (CloudAuthState.Equals(TEXT("Authorized"), ESearchCase::IgnoreCase))
+			DeviceAuthState = EUnrealMcpDeviceAuthState::Authorized;
+	}
+
+	AiAgents.Reset();
+	const TArray<TSharedPtr<FJsonValue>>* Agents = nullptr;
+	if (Status->TryGetArrayField(TEXT("aiAgents"), Agents) && Agents)
+	{
+		for (const TSharedPtr<FJsonValue>& Agent : *Agents)
+		{
+			FString Label;
+			if (Agent.IsValid() && Agent->TryGetString(Label) && !Label.IsEmpty())
+			{
+				AiAgents.Add(Label);
+			}
+			else if (Agent.IsValid())
+			{
+				const TSharedPtr<FJsonObject>* AgentObj = nullptr;
+				if (Agent->TryGetObject(AgentObj) && AgentObj && (*AgentObj)->TryGetStringField(TEXT("label"), Label))
+					AiAgents.Add(Label);
+			}
+		}
+	}
+}
+
+void FUnrealMcpEditorViewModel::ApplyDeviceAuth(const TSharedPtr<FJsonObject>& DeviceAuth)
+{
+	if (!DeviceAuth.IsValid())
+		return;
+
+	FString Url;
+	const bool bHadUrl = !DeviceVerificationUrl.IsEmpty();
+	if (DeviceAuth->TryGetStringField(TEXT("verificationUrl"), Url) && !Url.IsEmpty())
+		DeviceVerificationUrl = Url;
+
+	FString UserCode;
+	if (DeviceAuth->TryGetStringField(TEXT("userCode"), UserCode))
+		DeviceUserCode = UserCode;
+
+	FString StateRaw;
+	if (DeviceAuth->TryGetStringField(TEXT("state"), StateRaw))
+	{
+		if (StateRaw.Equals(TEXT("authorized"), ESearchCase::IgnoreCase) || StateRaw.Equals(TEXT("success"), ESearchCase::IgnoreCase))
+		{
+			DeviceAuthState = EUnrealMcpDeviceAuthState::Authorized;
+			// The sidecar stored the token; mirror its presence so the UI flips to the Revoke affordance.
+			FString Token;
+			if (DeviceAuth->TryGetStringField(TEXT("token"), Token) && !Token.IsEmpty())
+				Config.CloudToken = Token;
+		}
+		else if (StateRaw.Equals(TEXT("failed"), ESearchCase::IgnoreCase) || StateRaw.Equals(TEXT("denied"), ESearchCase::IgnoreCase) || StateRaw.Equals(TEXT("expired"), ESearchCase::IgnoreCase))
+		{
+			DeviceAuthState = EUnrealMcpDeviceAuthState::Failed;
+		}
+		else if (StateRaw.Equals(TEXT("pending"), ESearchCase::IgnoreCase))
+		{
+			DeviceAuthState = EUnrealMcpDeviceAuthState::Pending;
+		}
+	}
+
+	// Open the verification page the first time we learn the URL (one-shot; never re-open on poll updates).
+	if (!bHadUrl && !DeviceVerificationUrl.IsEmpty() && OnOpenBrowser)
+		OnOpenBrowser(DeviceVerificationUrl);
+}
+
+// --- Pure helpers ----------------------------------------------------------------------------------
+
+bool FUnrealMcpEditorViewModel::ValidateServerUrl(const FString& Url, FString& OutError)
+{
+	const FString Trimmed = Url.TrimStartAndEnd();
+	if (Trimmed.IsEmpty())
+	{
+		OutError = TEXT("Server URL is empty.");
+		return false;
+	}
+
+	FString Scheme;
+	FString Remainder;
+	if (!Trimmed.Split(TEXT("://"), &Scheme, &Remainder))
+	{
+		OutError = TEXT("Server URL must start with http:// or https://.");
+		return false;
+	}
+
+	if (!Scheme.Equals(TEXT("http"), ESearchCase::IgnoreCase) && !Scheme.Equals(TEXT("https"), ESearchCase::IgnoreCase))
+	{
+		OutError = TEXT("Server URL scheme must be http or https.");
+		return false;
+	}
+
+	// Host is everything up to the first '/', '?' or '#'. It must be non-empty.
+	FString Host = Remainder;
+	int32 SlashIndex = INDEX_NONE;
+	for (int32 Index = 0; Index < Remainder.Len(); ++Index)
+	{
+		const TCHAR Ch = Remainder[Index];
+		if (Ch == TEXT('/') || Ch == TEXT('?') || Ch == TEXT('#'))
+		{
+			SlashIndex = Index;
+			break;
+		}
+	}
+	if (SlashIndex != INDEX_NONE)
+		Host = Remainder.Left(SlashIndex);
+
+	if (Host.TrimStartAndEnd().IsEmpty())
+	{
+		OutError = TEXT("Server URL has no host.");
+		return false;
+	}
+
+	OutError.Reset();
+	return true;
+}
+
+FString FUnrealMcpEditorViewModel::MaskTokenForDisplay(const FString& Token, bool bReveal)
+{
+	if (Token.IsEmpty())
+		return FString();
+	if (bReveal)
+		return Token;
+	// Fixed-width mask — the real length is never leaked into the UI (§8).
+	return FString::ChrN(8, TEXT('\x2022')); // U+2022 BULLET
+}
+
+FText FUnrealMcpEditorViewModel::GetButtonText(EUnrealMcpConnectionState State)
+{
+	switch (State)
+	{
+		case EUnrealMcpConnectionState::Connected:  return LOCTEXT("BtnDisconnect", "Disconnect");
+		case EUnrealMcpConnectionState::Connecting: return LOCTEXT("BtnStop", "Stop");
+		case EUnrealMcpConnectionState::Degraded:   return LOCTEXT("BtnStop", "Stop");
+		case EUnrealMcpConnectionState::Disconnected:
+		default:                                    return LOCTEXT("BtnConnect", "Connect");
+	}
+}
+
+FText FUnrealMcpEditorViewModel::GetStatusLabel(EUnrealMcpConnectionState State)
+{
+	switch (State)
+	{
+		case EUnrealMcpConnectionState::Connected:  return LOCTEXT("StatusConnected", "Unreal: Connected");
+		case EUnrealMcpConnectionState::Connecting: return LOCTEXT("StatusConnecting", "Unreal: Connecting…");
+		case EUnrealMcpConnectionState::Degraded:   return LOCTEXT("StatusDegraded", "Unreal: Reconnecting…");
+		case EUnrealMcpConnectionState::Disconnected:
+		default:                                    return LOCTEXT("StatusDisconnected", "Unreal: Disconnected");
+	}
+}
+
+FLinearColor FUnrealMcpEditorViewModel::GetStatusColor(EUnrealMcpConnectionState State)
+{
+	switch (State)
+	{
+		case EUnrealMcpConnectionState::Connected:  return FLinearColor(0.16f, 0.74f, 0.30f); // green
+		case EUnrealMcpConnectionState::Connecting: return FLinearColor(0.95f, 0.69f, 0.13f); // amber
+		case EUnrealMcpConnectionState::Degraded:   return FLinearColor(0.95f, 0.49f, 0.13f); // orange
+		case EUnrealMcpConnectionState::Disconnected:
+		default:                                    return FLinearColor(0.55f, 0.16f, 0.16f); // red
+	}
+}
+
+EUnrealMcpConnectionState FUnrealMcpEditorViewModel::ParseConnectionState(const FString& Raw, bool bKeepConnected)
+{
+	if (Raw.Equals(TEXT("Connected"), ESearchCase::IgnoreCase))
+		return EUnrealMcpConnectionState::Connected;
+	if (Raw.Equals(TEXT("Connecting"), ESearchCase::IgnoreCase) || Raw.Equals(TEXT("Reconnecting"), ESearchCase::IgnoreCase))
+		return EUnrealMcpConnectionState::Connecting;
+	if (Raw.Equals(TEXT("Degraded"), ESearchCase::IgnoreCase))
+		return EUnrealMcpConnectionState::Degraded;
+	if (Raw.Equals(TEXT("Disconnected"), ESearchCase::IgnoreCase))
+	{
+		// A reported Disconnected while still armed (keepConnected) is a background retry = Degraded, not a
+		// user-initiated stop. Only an unarmed Disconnected is a true Disconnected.
+		return bKeepConnected ? EUnrealMcpConnectionState::Degraded : EUnrealMcpConnectionState::Disconnected;
+	}
+	// Unknown/empty: fall back to the armed flag.
+	return bKeepConnected ? EUnrealMcpConnectionState::Connecting : EUnrealMcpConnectionState::Disconnected;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Config/UnrealMcpConfig.h"
+
+class FJsonObject;
+
+/**
+ * The live SignalR/connection state surfaced to the main window (docs/ARCHITECTURE.md §7, mapping
+ * Unity's GetConnectionStatusClass tri-state). Drives the status dot colour + label + the Connect/
+ * Disconnect/Stop button text.
+ */
+enum class EUnrealMcpConnectionState : uint8
+{
+	/** No SignalR link and not trying to establish one (keepConnected=false or never started). */
+	Disconnected,
+	/** Attempting to connect / re-connect (sidecar dialing the MCP server). */
+	Connecting,
+	/** SignalR connected; tools are reachable end-to-end. */
+	Connected,
+	/** Was connected, lost the link, and is auto-retrying in the background (keepConnected=true). */
+	Degraded
+};
+
+/** Cloud device-code authorization progress (docs/ARCHITECTURE.md §7 item 4 / §1.3 `device-auth`). */
+enum class EUnrealMcpDeviceAuthState : uint8
+{
+	/** No device-code flow in progress. */
+	Idle,
+	/** Authorize pressed; awaiting the user to complete verification in their browser. */
+	Pending,
+	/** The device-code flow succeeded and a cloud token was stored. */
+	Authorized,
+	/** The flow failed, was denied, or expired. */
+	Failed
+};
+
+/**
+ * Game-thread-only view-model behind the "AI Game Developer" main window (docs/ARCHITECTURE.md §7).
+ * It is the single owner of UI state: it wraps an FUnrealMcpConfig (the §8 config store), tracks the
+ * live connection / device-auth state delivered by the sidecar's `status` / `device-auth` IPC feed
+ * (marshalled to the game thread by the caller before it reaches ApplyStatus / ApplyDeviceAuth), and
+ * exposes the mutators the Slate widgets bind to.
+ *
+ * Side effects (persisting the config, pushing the §1.3 `config` message, sending `auth-*` messages)
+ * are delivered through injectable TFunction sinks so the whole view-model is drivable from the
+ * UnrealMcpEditorTests Automation specs with NO live bridge, editor world, or real files. The Slate
+ * window wires the sinks to the real FUnrealMcpBridgeServer + on-disk config; a spec wires recording
+ * stubs. All symbols are UNREALMCPEDITOR_API-exported so the Tests module links against them.
+ *
+ * Token discipline (§8): the masked token is the ONLY representation the UI ever renders or copies by
+ * default; the raw value never reaches a log line (every diagnostic uses FUnrealMcpConfig::MaskSecret).
+ */
+class FUnrealMcpEditorViewModel
+{
+public:
+	UNREALMCPEDITOR_API FUnrealMcpEditorViewModel();
+
+	// --- Side-effect sinks (injected by the window; recording stubs in specs). ---
+
+	/** Persist the current config to its on-disk store (§8). Optional; a spec may leave it unset. */
+	TFunction<void(const FUnrealMcpConfig&)> OnPersistConfig;
+	/** Push the §1.3 `config` message built from the current config to the connected sidecar. */
+	TFunction<void(const FUnrealMcpConfig&)> OnPushConfig;
+	/** Send a §1.3 auth message (auth-start / auth-cancel / auth-revoke) to the sidecar. */
+	TFunction<void(const FString& /*AuthType*/)> OnSendAuth;
+	/** Open a verification URL in the system browser (device-code flow). */
+	TFunction<void(const FString& /*Url*/)> OnOpenBrowser;
+
+	// --- Config accessors (the working §8 config the UI edits). ---
+
+	const FUnrealMcpConfig& GetConfig() const { return Config; }
+	UNREALMCPEDITOR_API void InitializeConfig(const FUnrealMcpConfig& InConfig);
+
+	EUnrealMcpConnectionMode GetConnectionMode() const { return Config.ConnectionMode; }
+	UNREALMCPEDITOR_API void SetConnectionMode(EUnrealMcpConnectionMode InMode);
+
+	const FString& GetCustomHost() const { return Config.CustomHost; }
+	/** Set the Custom-mode server URL; persists + pushes only when it is a valid URL (§7 validated field). */
+	UNREALMCPEDITOR_API void SetCustomHost(const FString& InHost);
+
+	EUnrealMcpAuthOption GetAuthOption() const { return Config.AuthOption; }
+	UNREALMCPEDITOR_API void SetAuthOption(EUnrealMcpAuthOption InOption);
+
+	const FString& GetCustomToken() const { return Config.CustomToken; }
+	UNREALMCPEDITOR_API void SetCustomToken(const FString& InToken);
+	/** Replace the Custom-mode token with a fresh CSPRNG value (§7 Generate button), then persist + push. */
+	UNREALMCPEDITOR_API void GenerateCustomToken();
+
+	// --- Connection control. ---
+
+	EUnrealMcpConnectionState GetConnectionState() const { return ConnectionState; }
+
+	/** §7 Connect: keepConnected=true, optimistic Connecting state, push the config (sidecar (re)dials). */
+	UNREALMCPEDITOR_API void Connect();
+	/**
+	 * §7 Disconnect: the Godot M9b lesson — genuinely STOP the reconnect loop. Sets keepConnected=false
+	 * and pushes the config so the sidecar fully tears down the SignalR client (not merely drops one
+	 * connection); the UI drops to Disconnected and stays there until the next explicit Connect.
+	 */
+	UNREALMCPEDITOR_API void Disconnect();
+	/** Whether a background reconnect loop is currently armed (keepConnected). False after Disconnect(). */
+	bool IsReconnectArmed() const { return Config.bKeepConnected; }
+
+	// --- Cloud device-code auth (§7 item 4 / §1.3). ---
+
+	EUnrealMcpDeviceAuthState GetDeviceAuthState() const { return DeviceAuthState; }
+	const FString& GetDeviceVerificationUrl() const { return DeviceVerificationUrl; }
+	const FString& GetDeviceUserCode() const { return DeviceUserCode; }
+
+	/** Authorize: begin the device-code flow (sends `auth-start`; the sidecar drives the real flow). */
+	UNREALMCPEDITOR_API void Authorize();
+	/** Cancel an in-progress device-code flow (sends `auth-cancel`). */
+	UNREALMCPEDITOR_API void CancelAuth();
+	/** Revoke + clear the stored cloud token (sends `auth-revoke`, clears CloudToken, persists). */
+	UNREALMCPEDITOR_API void Revoke();
+	/** Whether a cloud bearer is currently stored (drives the Authorize/Revoke button visibility). */
+	bool HasCloudToken() const { return !Config.CloudToken.IsEmpty(); }
+
+	// --- Live status feed (caller marshals these onto the game thread first, §7). ---
+
+	/** Apply a §1.3 `status` message: connectionState / keepConnected / aiAgents. */
+	UNREALMCPEDITOR_API void ApplyStatus(const TSharedPtr<FJsonObject>& Status);
+	/** Apply a §1.3 `device-auth` message: verificationUrl / userCode / state (+ open browser on first url). */
+	UNREALMCPEDITOR_API void ApplyDeviceAuth(const TSharedPtr<FJsonObject>& DeviceAuth);
+
+	/** Connected AI-agent labels surfaced in the §7 AI-agents section (from the last `status`). */
+	const TArray<FString>& GetAiAgents() const { return AiAgents; }
+
+	// --- Pure helpers (no instance state; the spec-friendly heart of the view-model). ---
+
+	/**
+	 * Validate a Custom-mode server URL (§7 validated field): non-empty, an http:// or https:// scheme,
+	 * and a non-empty host after the scheme. Returns true when valid; otherwise false + a short reason in
+	 * @p OutError. Pure — no network, no DNS.
+	 */
+	static UNREALMCPEDITOR_API bool ValidateServerUrl(const FString& Url, FString& OutError);
+
+	/**
+	 * The display form of a token for the UI (§8 — never rendered unmasked by default): empty stays empty,
+	 * otherwise a fixed-width dot mask when @p bReveal is false (the length is NOT leaked), or the raw value
+	 * when @p bReveal is true (reveal-on-hold). This is the ONLY way a token reaches a Slate text field.
+	 */
+	static UNREALMCPEDITOR_API FString MaskTokenForDisplay(const FString& Token, bool bReveal);
+
+	/** The Connect/Disconnect/Stop button label for a connection state (Unity GetButtonText tri-state). */
+	static UNREALMCPEDITOR_API FText GetButtonText(EUnrealMcpConnectionState State);
+	/** The "Unreal: <status>" label for a connection state (§7 connection panel). */
+	static UNREALMCPEDITOR_API FText GetStatusLabel(EUnrealMcpConnectionState State);
+	/** The status-dot colour for a connection state (green Connected / amber transitional / red off). */
+	static UNREALMCPEDITOR_API FLinearColor GetStatusColor(EUnrealMcpConnectionState State);
+
+	/** Parse a §1.3 connectionState string ("Connected"/"Connecting"/"Degraded"/…) into the enum. */
+	static UNREALMCPEDITOR_API EUnrealMcpConnectionState ParseConnectionState(const FString& Raw, bool bKeepConnected);
+
+private:
+	FUnrealMcpConfig Config;
+
+	EUnrealMcpConnectionState ConnectionState = EUnrealMcpConnectionState::Disconnected;
+	EUnrealMcpDeviceAuthState DeviceAuthState = EUnrealMcpDeviceAuthState::Idle;
+	FString DeviceVerificationUrl;
+	FString DeviceUserCode;
+	TArray<FString> AiAgents;
+
+	// Persist (if a sink is wired) then push the §1.3 config to the sidecar (if a sink is wired).
+	void PersistAndPush();
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
@@ -114,6 +114,8 @@ public:
 	EUnrealMcpDeviceAuthState GetDeviceAuthState() const { return DeviceAuthState; }
 	const FString& GetDeviceVerificationUrl() const { return DeviceVerificationUrl; }
 	const FString& GetDeviceUserCode() const { return DeviceUserCode; }
+	/** The human-readable failure reason surfaced while the device-code flow is Failed (empty otherwise). */
+	const FString& GetDeviceAuthError() const { return DeviceAuthError; }
 
 	/** Authorize: begin the device-code flow (sends `auth-start`; the sidecar drives the real flow). */
 	UNREALMCPEDITOR_API void Authorize();
@@ -171,6 +173,7 @@ private:
 	EUnrealMcpDeviceAuthState DeviceAuthState = EUnrealMcpDeviceAuthState::Idle;
 	FString DeviceVerificationUrl;
 	FString DeviceUserCode;
+	FString DeviceAuthError;
 	TArray<FString> AiAgents;
 
 	// Persist (if a sink is wired) then push the §1.3 config to the sidecar (if a sink is wired).

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
@@ -65,8 +65,12 @@ public:
 	TFunction<void(const FUnrealMcpConfig&)> OnPersistConfig;
 	/** Push the §1.3 `config` message built from the current config to the connected sidecar. */
 	TFunction<void(const FUnrealMcpConfig&)> OnPushConfig;
-	/** Send a §1.3 auth message (auth-start / auth-cancel / auth-revoke) to the sidecar. */
-	TFunction<void(const FString& /*AuthType*/)> OnSendAuth;
+	/**
+	 * Send a §1.3 auth message (auth-start / auth-cancel / auth-revoke) to the sidecar. Returns true when the
+	 * frame was actually handed to a connected/handshaken sidecar; false when there is no sidecar to send to
+	 * (so Authorize() can avoid wedging the UI in a code-less Pending state). A spec may leave it unset.
+	 */
+	TFunction<bool(const FString& /*AuthType*/)> OnSendAuth;
 	/** Open a verification URL in the system browser (device-code flow). */
 	TFunction<void(const FString& /*Url*/)> OnOpenBrowser;
 
@@ -140,9 +144,13 @@ public:
 	static UNREALMCPEDITOR_API bool ValidateServerUrl(const FString& Url, FString& OutError);
 
 	/**
-	 * The display form of a token for the UI (§8 — never rendered unmasked by default): empty stays empty,
+	 * The masked display form of a token (§8 — never rendered unmasked by default): empty stays empty,
 	 * otherwise a fixed-width dot mask when @p bReveal is false (the length is NOT leaked), or the raw value
-	 * when @p bReveal is true (reveal-on-hold). This is the ONLY way a token reaches a Slate text field.
+	 * when @p bReveal is true. This is the masking contract the specs lock and the form to use for any
+	 * read-only token surface. NOTE: the editable Custom-mode token field in SUnrealMcpMainWindow cannot route
+	 * through this helper — committing a mask string back would overwrite the real token — so it masks
+	 * natively via SEditableTextBox::IsPassword (revealed only while the Reveal button is held). Either path
+	 * keeps the raw value off-screen by default and out of every log line (diagnostics use MaskSecret).
 	 */
 	static UNREALMCPEDITOR_API FString MaskTokenForDisplay(const FString& Token, bool bReveal);
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.cpp
@@ -58,7 +58,16 @@ void FUnrealMcpMainWindowTab::Unregister()
 	if (!bRegistered)
 		return;
 	if (FSlateApplication::IsInitialized())
+	{
+		// Unregistering the spawner alone does NOT close an already-open tab: a live SDockTab keeps the hosted
+		// SUnrealMcpMainWindow (and its strong ref to the view-model) alive, and that widget captures raw
+		// bridge/sidecar pointers via OnRestartBridge / BridgeStatusProvider. On plugin disable / hot-reload
+		// (ShutdownModule while the editor and tab live on) those subsystems are destroyed, so a surviving tab
+		// would dereference freed memory on the next click. Close the live tab first so the widget is torn down.
+		if (TSharedPtr<SDockTab> LiveTab = FGlobalTabmanager::Get()->FindExistingLiveTab(TabId))
+			LiveTab->RequestCloseTab();
 		FGlobalTabmanager::Get()->UnregisterNomadTabSpawner(TabId);
+	}
 	bRegistered = false;
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UI/UnrealMcpMainWindowTab.h"
+#include "UI/SUnrealMcpMainWindow.h"
+#include "UI/UnrealMcpEditorViewModel.h"
+#include "UnrealMcpLog.h"
+
+#include "Framework/Docking/TabManager.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Widgets/Docking/SDockTab.h"
+#include "Styling/AppStyle.h"
+#include "Styling/SlateIconFinder.h"
+#include "Textures/SlateIcon.h"
+#include "WorkspaceMenuStructure.h"
+#include "WorkspaceMenuStructureModule.h"
+
+#define LOCTEXT_NAMESPACE "UnrealMcp"
+
+const FName FUnrealMcpMainWindowTab::TabId(TEXT("UnrealMcpMainWindow"));
+
+void FUnrealMcpMainWindowTab::Register(
+	const TSharedRef<FUnrealMcpEditorViewModel>& InViewModel,
+	const FString& InPluginVersion,
+	FSimpleDelegate InOnRestartBridge,
+	TFunction<FString()> InBridgeStatusProvider)
+{
+	if (bRegistered)
+		return;
+
+	ViewModel = InViewModel;
+	PluginVersion = InPluginVersion;
+	OnRestartBridge = InOnRestartBridge;
+	BridgeStatusProvider = MoveTemp(InBridgeStatusProvider);
+
+	// Slate may be unavailable in a commandlet / -nullrhi headless run without a slate application; guard so
+	// the Automation/smoke runs (which load the module) never crash on tab registration.
+	if (!FSlateApplication::IsInitialized())
+	{
+		UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] Slate not initialized; skipping main-window tab registration (headless)."));
+		return;
+	}
+
+	FGlobalTabmanager::Get()->RegisterNomadTabSpawner(
+		TabId,
+		FOnSpawnTab::CreateRaw(this, &FUnrealMcpMainWindowTab::SpawnTab))
+		.SetDisplayName(LOCTEXT("MainWindowTabTitle", "AI Game Developer"))
+		.SetTooltipText(LOCTEXT("MainWindowTabTooltip", "Open the AI Game Developer (Unreal-MCP) window."))
+		.SetGroup(WorkspaceMenu::GetMenuStructure().GetToolsCategory())
+		.SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "Icons.Server"));
+
+	bRegistered = true;
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] registered the AI Game Developer main-window tab."));
+}
+
+void FUnrealMcpMainWindowTab::Unregister()
+{
+	if (!bRegistered)
+		return;
+	if (FSlateApplication::IsInitialized())
+		FGlobalTabmanager::Get()->UnregisterNomadTabSpawner(TabId);
+	bRegistered = false;
+}
+
+TSharedRef<SDockTab> FUnrealMcpMainWindowTab::SpawnTab(const FSpawnTabArgs& Args)
+{
+	TSharedRef<SDockTab> Tab = SNew(SDockTab).TabRole(ETabRole::NomadTab);
+	Tab->SetContent(
+		SNew(SUnrealMcpMainWindow)
+		.ViewModel(ViewModel)
+		.PluginVersion(PluginVersion)
+		.OnRestartBridge(OnRestartBridge)
+		.BridgeStatusProvider(BridgeStatusProvider));
+	return Tab;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Delegates/Delegate.h"
+
+class FUnrealMcpEditorViewModel;
+class SDockTab;
+class FSpawnTabArgs;
+class FTabManager;
+class FWorkspaceItem;
+
+/**
+ * Registers the "AI Game Developer" main window (docs/ARCHITECTURE.md §7) as a nomad dockable tab with
+ * FGlobalTabmanager and a Window-menu entry (via a WorkspaceMenuStructure group). Owned by the runtime;
+ * Register() runs in StartupModule (after the bridge/view-model exist) and Unregister() in Shutdown so the
+ * tab spawner never dangles past module unload.
+ *
+ * The tab content (SUnrealMcpMainWindow) binds to the shared view-model passed at Register() time. The
+ * optional providers feed the §7 bridge-status line and the Restart-bridge action without coupling the
+ * widget to the runtime's subsystems directly.
+ */
+class FUnrealMcpMainWindowTab
+{
+public:
+	/** The nomad tab id (§7). */
+	static const FName TabId;
+
+	/**
+	 * Register the nomad tab spawner + Window-menu entry. @p InViewModel is the shared state model the tab
+	 * content binds to (must outlive the tab — the runtime owns it). @p InPluginVersion seeds the header.
+	 * Idempotent: a second call is a no-op.
+	 */
+	void Register(
+		const TSharedRef<FUnrealMcpEditorViewModel>& InViewModel,
+		const FString& InPluginVersion,
+		FSimpleDelegate InOnRestartBridge,
+		TFunction<FString()> InBridgeStatusProvider);
+
+	/** Unregister the tab spawner (Shutdown). Idempotent. */
+	void Unregister();
+
+private:
+	TSharedRef<SDockTab> SpawnTab(const FSpawnTabArgs& Args);
+
+	TSharedPtr<FUnrealMcpEditorViewModel> ViewModel;
+	FString PluginVersion;
+	FSimpleDelegate OnRestartBridge;
+	TFunction<FString()> BridgeStatusProvider;
+	bool bRegistered = false;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -10,10 +10,14 @@
 #include "Bridge/UnrealMcpBridgeServer.h"
 #include "Sidecar/UnrealMcpSidecarManager.h"
 #include "Extensions/UnrealMcpExtensionManager.h"
+#include "UI/UnrealMcpEditorViewModel.h"
+#include "UI/UnrealMcpMainWindowTab.h"
 
 #include "Misc/CoreDelegates.h"
 #include "Misc/Paths.h"
 #include "Misc/EngineVersion.h"
+#include "Async/Async.h"
+#include "HAL/PlatformProcess.h"
 #include "Interfaces/IPluginManager.h"
 
 // Defined here (where every subsystem type is complete) so the TUniquePtr member deleters instantiate
@@ -85,6 +89,75 @@ void FUnrealMcpRuntime::Startup()
 	SidecarManager = MakeUnique<FUnrealMcpSidecarManager>();
 	SidecarManager->StartForPort(BoundPort, Token);
 
+	// §7 UI: the main-window view-model owns all UI state; wire its side-effect sinks to the real subsystems.
+	// All config writes go config-store-first (Save) then push the §1.3 `config` to the sidecar (§7 ownership).
+	ViewModel = MakeShared<FUnrealMcpEditorViewModel>();
+	ViewModel->InitializeConfig(Config);
+
+	FUnrealMcpBridgeServer* BridgeServerPtr = BridgeServer.Get();
+	ViewModel->OnPersistConfig = [](const FUnrealMcpConfig& Cfg)
+	{
+		Cfg.Save(FUnrealMcpConfig::DefaultConfigFilePath());
+	};
+	ViewModel->OnPushConfig = [BridgeServerPtr](const FUnrealMcpConfig& Cfg)
+	{
+		if (BridgeServerPtr)
+			BridgeServerPtr->SetEffectiveConfig(Cfg.BuildEffectiveConnectionConfig());
+	};
+	ViewModel->OnSendAuth = [BridgeServerPtr](const FString& AuthType)
+	{
+		if (BridgeServerPtr)
+			BridgeServerPtr->SendAuthMessage(AuthType);
+	};
+	ViewModel->OnOpenBrowser = [](const FString& Url)
+	{
+		if (!Url.IsEmpty())
+			FPlatformProcess::LaunchURL(*Url, nullptr, nullptr);
+	};
+
+	// §7 live status feed: the bridge delivers `status` / `device-auth` on the IPC READER thread. Marshal onto
+	// the game thread before touching any view-model/Slate state (the Godot M9b main-thread-marshalled rule),
+	// and hold the view-model weakly so a late status straddling teardown is a no-op, not a use-after-free.
+	TWeakPtr<FUnrealMcpEditorViewModel> WeakViewModel = ViewModel;
+	if (BridgeServerPtr)
+	{
+		BridgeServerPtr->SetStatusSink([WeakViewModel](const FString& Type, TSharedPtr<FJsonObject> Message)
+		{
+			AsyncTask(ENamedThreads::GameThread, [WeakViewModel, Type, Message]()
+			{
+				TSharedPtr<FUnrealMcpEditorViewModel> VM = WeakViewModel.Pin();
+				if (!VM.IsValid())
+					return;
+				if (Type == TEXT("status"))
+					VM->ApplyStatus(Message);
+				else if (Type == TEXT("device-auth"))
+					VM->ApplyDeviceAuth(Message);
+			});
+		});
+	}
+
+	// Register the nomad dockable tab + Window-menu entry (§7). A manual "Restart bridge" force-relaunches the
+	// sidecar; the bridge-status line reflects the sidecar's run state.
+	FUnrealMcpSidecarManager* SidecarPtr = SidecarManager.Get();
+	MainWindowTab = MakeUnique<FUnrealMcpMainWindowTab>();
+	MainWindowTab->Register(
+		ViewModel.ToSharedRef(),
+		PluginVersion,
+		FSimpleDelegate::CreateLambda([SidecarPtr, BoundPort, Token]()
+		{
+			if (SidecarPtr)
+			{
+				SidecarPtr->Stop();
+				SidecarPtr->StartForPort(BoundPort, Token);
+			}
+		}),
+		[SidecarPtr]() -> FString
+		{
+			if (SidecarPtr && SidecarPtr->IsRunning())
+				return FString::Printf(TEXT("Running (restarts: %d)"), SidecarPtr->GetRestartCount());
+			return TEXT("Stopped");
+		});
+
 	// §1.5: tear down on editor pre-exit so the sidecar never orphans (layer 1).
 	PreExitHandle = FCoreDelegates::OnEnginePreExit.AddLambda([this]() { Shutdown(); });
 }
@@ -108,6 +181,18 @@ void FUnrealMcpRuntime::Shutdown()
 	// give the child a bounded grace to self-exit, (4) terminate as a backstop.
 	if (SidecarManager.IsValid())
 		SidecarManager->StopRestarts();
+
+	// §7 UI teardown FIRST: unregister the tab and drop the bridge's status sink so no marshalled status can
+	// touch the view-model after this, then release the view-model. Clear the sink before the bridge tears
+	// down so a reader-thread invoke cannot race the reset.
+	if (MainWindowTab.IsValid())
+	{
+		MainWindowTab->Unregister();
+		MainWindowTab.Reset();
+	}
+	if (BridgeServer.IsValid())
+		BridgeServer->SetStatusSink(nullptr);
+	ViewModel.Reset();
 
 	if (BridgeServer.IsValid())
 	{

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -104,10 +104,11 @@ void FUnrealMcpRuntime::Startup()
 		if (BridgeServerPtr)
 			BridgeServerPtr->SetEffectiveConfig(Cfg.BuildEffectiveConnectionConfig());
 	};
-	ViewModel->OnSendAuth = [BridgeServerPtr](const FString& AuthType)
+	ViewModel->OnSendAuth = [BridgeServerPtr](const FString& AuthType) -> bool
 	{
-		if (BridgeServerPtr)
-			BridgeServerPtr->SendAuthMessage(AuthType);
+		// Plumb the send result back so Authorize() does not enter a code-less Pending state when there is no
+		// connected sidecar to receive the auth-start frame.
+		return BridgeServerPtr ? BridgeServerPtr->SendAuthMessage(AuthType) : false;
 	};
 	ViewModel->OnOpenBrowser = [](const FString& Url)
 	{
@@ -187,11 +188,21 @@ void FUnrealMcpRuntime::Shutdown()
 	// down so a reader-thread invoke cannot race the reset.
 	if (MainWindowTab.IsValid())
 	{
-		MainWindowTab->Unregister();
+		MainWindowTab->Unregister(); // also closes a live tab so its widget (a strong view-model ref) is freed
 		MainWindowTab.Reset();
 	}
 	if (BridgeServer.IsValid())
 		BridgeServer->SetStatusSink(nullptr);
+	// Null the view-model's side-effect sinks before destroying the bridge/sidecar below: those sinks capture
+	// raw FUnrealMcpBridgeServer* pointers, so if anything still holds the view-model after the tab close
+	// (a deferred RequestCloseTab, a queued widget event) it cannot dereference the soon-to-be-freed bridge.
+	if (ViewModel.IsValid())
+	{
+		ViewModel->OnPersistConfig = nullptr;
+		ViewModel->OnPushConfig = nullptr;
+		ViewModel->OnSendAuth = nullptr;
+		ViewModel->OnOpenBrowser = nullptr;
+	}
 	ViewModel.Reset();
 
 	if (BridgeServer.IsValid())

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.h
@@ -10,6 +10,8 @@ class FUnrealMcpGameThreadDispatcher;
 class FUnrealMcpBridgeServer;
 class FUnrealMcpSidecarManager;
 class FUnrealMcpExtensionManager;
+class FUnrealMcpEditorViewModel;
+class FUnrealMcpMainWindowTab;
 
 /**
  * Plugin-lifetime coordinator (docs/ARCHITECTURE.md §0). Wires the four subsystems together: the tool
@@ -40,6 +42,10 @@ private:
 	TUniquePtr<FUnrealMcpBridgeServer> BridgeServer;
 	TUniquePtr<FUnrealMcpSidecarManager> SidecarManager;
 	TUniquePtr<FUnrealMcpExtensionManager> ExtensionManager;
+
+	// §7 UI: the main-window view-model (shared so the nomad tab's widget binds to it) and its tab spawner.
+	TSharedPtr<FUnrealMcpEditorViewModel> ViewModel;
+	TUniquePtr<FUnrealMcpMainWindowTab> MainWindowTab;
 
 	FDelegateHandle PreExitHandle;
 	bool bStarted = false;

--- a/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
+++ b/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
@@ -36,11 +36,10 @@ public class UnrealMcpEditor : ModuleRules
 			"EditorSubsystem",
 			"DeveloperSettings",
 			// Slate main window (docs/ARCHITECTURE.md §7): nomad-tab registration via FGlobalTabmanager
-			// needs WorkspaceMenuStructure (the "AI Game Developer" menu group) + ToolMenus (the
-			// Window-menu entry); the masked-token field reads keystrokes via InputCore; the copyable
-			// user code / token uses FPlatformApplicationMisc::ClipboardCopy (ApplicationCore).
+			// needs WorkspaceMenuStructure (the "AI Game Developer" Window-menu group, applied via
+			// RegisterNomadTabSpawner().SetGroup); the masked-token field reads keystrokes via InputCore;
+			// the copyable user code / token uses FPlatformApplicationMisc::ClipboardCopy (ApplicationCore).
 			"WorkspaceMenuStructure",
-			"ToolMenus",
 			"InputCore",
 			"ApplicationCore",
 			// Asset / Content-Browser tool family (docs/ARCHITECTURE.md §10, issue #10):

--- a/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
+++ b/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
@@ -35,6 +35,14 @@ public class UnrealMcpEditor : ModuleRules
 			"Projects",
 			"EditorSubsystem",
 			"DeveloperSettings",
+			// Slate main window (docs/ARCHITECTURE.md §7): nomad-tab registration via FGlobalTabmanager
+			// needs WorkspaceMenuStructure (the "AI Game Developer" menu group) + ToolMenus (the
+			// Window-menu entry); the masked-token field reads keystrokes via InputCore; the copyable
+			// user code / token uses FPlatformApplicationMisc::ClipboardCopy (ApplicationCore).
+			"WorkspaceMenuStructure",
+			"ToolMenus",
+			"InputCore",
+			"ApplicationCore",
 			// Asset / Content-Browser tool family (docs/ARCHITECTURE.md §10, issue #10):
 			//  - AssetRegistry            -> asset-find / asset-get-data / asset-refresh queries
 			//  - AssetTools               -> CreateAsset (material instance) + ImportAssetTasks

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
@@ -33,7 +33,7 @@ BEGIN_DEFINE_SPEC(FUnrealMcpEditorViewModelSpec, "UnrealMcp.EditorViewModel",
 		TSharedRef<FUnrealMcpEditorViewModel> VM = MakeShared<FUnrealMcpEditorViewModel>();
 		VM->OnPersistConfig = [Rec](const FUnrealMcpConfig&) { Rec->PersistCount++; };
 		VM->OnPushConfig = [Rec](const FUnrealMcpConfig& Cfg) { Rec->PushCount++; Rec->LastPushed = Cfg; };
-		VM->OnSendAuth = [Rec](const FString& Type) { Rec->AuthSent.Add(Type); };
+		VM->OnSendAuth = [Rec](const FString& Type) -> bool { Rec->AuthSent.Add(Type); return true; };
 		VM->OnOpenBrowser = [Rec](const FString& Url) { Rec->OpenedUrls.Add(Url); };
 		return VM;
 	}
@@ -173,12 +173,32 @@ void FUnrealMcpEditorViewModelSpec::Define()
 			VM->ApplyDeviceAuth(Pending);
 			TestEqual("browser not re-opened", Rec->OpenedUrls.Num(), 1);
 
+			const int32 PersistBeforeAuth = Rec->PersistCount;
+			const int32 PushBeforeAuth = Rec->PushCount;
 			TSharedPtr<FJsonObject> Authorized = MakeShared<FJsonObject>();
 			Authorized->SetStringField(TEXT("state"), TEXT("authorized"));
 			Authorized->SetStringField(TEXT("token"), TEXT("cloud-bearer-abc"));
 			VM->ApplyDeviceAuth(Authorized);
 			TestEqual("authorized state", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Authorized));
 			TestTrue("cloud token stored", VM->HasCloudToken());
+			// The authorized token MUST be persisted to the §8 store AND pushed into the bridge's effective
+			// config — otherwise it is lost on restart / a "Restart bridge" re-pushes a token-less config.
+			TestTrue("authorize persisted the token", Rec->PersistCount > PersistBeforeAuth);
+			TestTrue("authorize pushed the token", Rec->PushCount > PushBeforeAuth);
+			TestEqual("pushed config carries the cloud token", Rec->LastPushed.CloudToken, FString(TEXT("cloud-bearer-abc")));
+		});
+
+		It("Authorize stays out of Pending when the auth-start frame cannot be sent (no sidecar)", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			// A sink that reports the frame could not be delivered (no connected/handshaken sidecar).
+			VM->OnSendAuth = [Rec](const FString& Type) -> bool { Rec->AuthSent.Add(Type); return false; };
+
+			VM->Authorize();
+			TestTrue("auth-start attempted", Rec->AuthSent.Contains(TEXT("auth-start")));
+			// Must NOT wedge in a code-less Pending state — fall to Failed so the UI does not show an empty code.
+			TestEqual("not pending when send failed", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Failed));
 		});
 
 		It("Revoke clears the cloud token, sends auth-revoke and pushes the now-anonymous config", [this]()

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
@@ -199,6 +199,27 @@ void FUnrealMcpEditorViewModelSpec::Define()
 			TestTrue("auth-start attempted", Rec->AuthSent.Contains(TEXT("auth-start")));
 			// Must NOT wedge in a code-less Pending state — fall to Failed so the UI does not show an empty code.
 			TestEqual("not pending when send failed", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Failed));
+			// And surface a reason so the window shows feedback rather than silently collapsing.
+			TestEqual("no-sidecar reason surfaced", VM->GetDeviceAuthError(), FString(TEXT("No sidecar connected.")));
+		});
+
+		It("surfaces a failed device-auth message and clears it on a fresh Authorize", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			// A terminal failed device-auth carries the sidecar's human-readable reason (DeviceAuthMessage.Message)
+			// the UI must surface — without it the pending instructions collapse and the window shows nothing.
+			TSharedPtr<FJsonObject> Failed = MakeShared<FJsonObject>();
+			Failed->SetStringField(TEXT("state"), TEXT("failed"));
+			Failed->SetStringField(TEXT("message"), TEXT("Authorization was denied."));
+			VM->ApplyDeviceAuth(Failed);
+			TestEqual("failed state", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Failed));
+			TestEqual("failure reason surfaced", VM->GetDeviceAuthError(), FString(TEXT("Authorization was denied.")));
+
+			// A fresh Authorize clears the stale failure reason before starting the new flow.
+			VM->Authorize();
+			TestTrue("error cleared on re-authorize", VM->GetDeviceAuthError().IsEmpty());
 		});
 
 		It("Revoke clears the cloud token, sends auth-revoke and pushes the now-anonymous config", [this]()

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
@@ -1,0 +1,223 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Dom/JsonObject.h"
+#include "UI/UnrealMcpEditorViewModel.h"
+#include "Config/UnrealMcpConfig.h"
+
+/**
+ * View-model specs (docs/ARCHITECTURE.md §7): the connection-state machine, Custom-mode URL validation, the
+ * token-masking guard (§8), the Connect/Disconnect tri-state + the M9b "Disconnect genuinely halts reconnect"
+ * rule, the config-store round-trip the UI drives, and the `status` / `device-auth` IPC-feed application —
+ * all without a live bridge, editor world, or real files (the side-effect sinks are recording stubs).
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpEditorViewModelSpec, "UnrealMcp.EditorViewModel",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	// A view-model wired with recording sinks so a spec can assert what the UI persisted / pushed / sent.
+	struct FRecording
+	{
+		int32 PersistCount = 0;
+		int32 PushCount = 0;
+		TArray<FString> AuthSent;
+		TArray<FString> OpenedUrls;
+		FUnrealMcpConfig LastPushed;
+	};
+
+	static TSharedRef<FUnrealMcpEditorViewModel> MakeViewModel(TSharedRef<FRecording> Rec)
+	{
+		TSharedRef<FUnrealMcpEditorViewModel> VM = MakeShared<FUnrealMcpEditorViewModel>();
+		VM->OnPersistConfig = [Rec](const FUnrealMcpConfig&) { Rec->PersistCount++; };
+		VM->OnPushConfig = [Rec](const FUnrealMcpConfig& Cfg) { Rec->PushCount++; Rec->LastPushed = Cfg; };
+		VM->OnSendAuth = [Rec](const FString& Type) { Rec->AuthSent.Add(Type); };
+		VM->OnOpenBrowser = [Rec](const FString& Url) { Rec->OpenedUrls.Add(Url); };
+		return VM;
+	}
+
+END_DEFINE_SPEC(FUnrealMcpEditorViewModelSpec)
+
+void FUnrealMcpEditorViewModelSpec::Define()
+{
+	Describe("Server URL validation", [this]()
+	{
+		It("accepts well-formed http/https URLs and rejects malformed ones", [this]()
+		{
+			FString Error;
+			TestTrue("http localhost", FUnrealMcpEditorViewModel::ValidateServerUrl(TEXT("http://localhost:8080"), Error));
+			TestTrue("https host", FUnrealMcpEditorViewModel::ValidateServerUrl(TEXT("https://ai-game.dev"), Error));
+			TestTrue("http with path", FUnrealMcpEditorViewModel::ValidateServerUrl(TEXT("http://127.0.0.1:5244/mcp"), Error));
+
+			TestFalse("empty", FUnrealMcpEditorViewModel::ValidateServerUrl(TEXT(""), Error));
+			TestFalse("no scheme", FUnrealMcpEditorViewModel::ValidateServerUrl(TEXT("localhost:8080"), Error));
+			TestFalse("ftp scheme", FUnrealMcpEditorViewModel::ValidateServerUrl(TEXT("ftp://host"), Error));
+			TestFalse("scheme but no host", FUnrealMcpEditorViewModel::ValidateServerUrl(TEXT("http://"), Error));
+			TestFalse("scheme then slash", FUnrealMcpEditorViewModel::ValidateServerUrl(TEXT("http:///path"), Error));
+		});
+	});
+
+	Describe("Token masking (§8)", [this]()
+	{
+		It("never renders the raw token unless explicitly revealed, and never leaks length", [this]()
+		{
+			const FString Secret = TEXT("super-secret-bearer-1234567890");
+			const FString Masked = FUnrealMcpEditorViewModel::MaskTokenForDisplay(Secret, /*bReveal*/ false);
+			TestFalse("masked != raw", Masked.Equals(Secret));
+			TestFalse("masked contains no raw substring", Masked.Contains(TEXT("secret")));
+			// Fixed-width mask: length must NOT equal the secret length.
+			TestNotEqual("masked length is fixed, not secret length", Masked.Len(), Secret.Len());
+
+			TestEqual("reveal returns raw", FUnrealMcpEditorViewModel::MaskTokenForDisplay(Secret, true), Secret);
+			TestEqual("empty stays empty", FUnrealMcpEditorViewModel::MaskTokenForDisplay(FString(), false), FString());
+		});
+	});
+
+	Describe("Status tri-state presentation", [this]()
+	{
+		It("maps each connection state to a distinct button label, status label and colour", [this]()
+		{
+			TestEqual("Disconnected button", FUnrealMcpEditorViewModel::GetButtonText(EUnrealMcpConnectionState::Disconnected).ToString(), FString(TEXT("Connect")));
+			TestEqual("Connected button", FUnrealMcpEditorViewModel::GetButtonText(EUnrealMcpConnectionState::Connected).ToString(), FString(TEXT("Disconnect")));
+			TestEqual("Connecting button", FUnrealMcpEditorViewModel::GetButtonText(EUnrealMcpConnectionState::Connecting).ToString(), FString(TEXT("Stop")));
+
+			// Colours differ between connected (green) and disconnected (red).
+			const FLinearColor Connected = FUnrealMcpEditorViewModel::GetStatusColor(EUnrealMcpConnectionState::Connected);
+			const FLinearColor Disconnected = FUnrealMcpEditorViewModel::GetStatusColor(EUnrealMcpConnectionState::Disconnected);
+			TestFalse("connected colour != disconnected colour", Connected.Equals(Disconnected));
+		});
+
+		It("treats a reported Disconnected-while-armed as Degraded, not a true stop", [this]()
+		{
+			TestEqual("armed Disconnected -> Degraded",
+				static_cast<int32>(FUnrealMcpEditorViewModel::ParseConnectionState(TEXT("Disconnected"), /*keep*/ true)),
+				static_cast<int32>(EUnrealMcpConnectionState::Degraded));
+			TestEqual("unarmed Disconnected -> Disconnected",
+				static_cast<int32>(FUnrealMcpEditorViewModel::ParseConnectionState(TEXT("Disconnected"), /*keep*/ false)),
+				static_cast<int32>(EUnrealMcpConnectionState::Disconnected));
+			TestEqual("Connected -> Connected",
+				static_cast<int32>(FUnrealMcpEditorViewModel::ParseConnectionState(TEXT("Connected"), true)),
+				static_cast<int32>(EUnrealMcpConnectionState::Connected));
+		});
+	});
+
+	Describe("Connect / Disconnect (the M9b reconnect-halt rule)", [this]()
+	{
+		It("Connect arms keepConnected and pushes; Disconnect disarms it and pushes keepConnected=false", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			VM->Connect();
+			TestTrue("armed after Connect", VM->IsReconnectArmed());
+			TestEqual("Connecting state after Connect", static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connecting));
+			TestTrue("pushed at least once", Rec->PushCount >= 1);
+			TestTrue("last pushed keepConnected=true", Rec->LastPushed.bKeepConnected);
+
+			VM->Disconnect();
+			TestFalse("disarmed after Disconnect", VM->IsReconnectArmed());
+			TestEqual("Disconnected state after Disconnect", static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Disconnected));
+			TestFalse("last pushed keepConnected=false", Rec->LastPushed.bKeepConnected);
+		});
+	});
+
+	Describe("Config-store round-trip the UI drives", [this]()
+	{
+		It("mode / valid-host / auth / generated-token changes persist and push; invalid host does not push", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			const int32 PushAfterMode = Rec->PushCount;
+			TestTrue("mode change pushed", PushAfterMode >= 1);
+
+			// Invalid host: field updates but no push.
+			VM->SetCustomHost(TEXT("not-a-url"));
+			TestEqual("invalid host did not push", Rec->PushCount, PushAfterMode);
+			TestEqual("field still updated", VM->GetCustomHost(), FString(TEXT("not-a-url")));
+
+			// Valid host: pushes.
+			VM->SetCustomHost(TEXT("http://localhost:5244"));
+			TestTrue("valid host pushed", Rec->PushCount > PushAfterMode);
+
+			VM->GenerateCustomToken();
+			TestFalse("token generated", VM->GetCustomToken().IsEmpty());
+			TestEqual("generating flips auth to Required", static_cast<int32>(VM->GetAuthOption()), static_cast<int32>(EUnrealMcpAuthOption::Required));
+			TestTrue("persisted at least once", Rec->PersistCount >= 1);
+		});
+	});
+
+	Describe("Cloud device-code auth", [this]()
+	{
+		It("Authorize sends auth-start; device-auth feed opens the browser once and stores the token", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			VM->Authorize();
+			TestTrue("auth-start sent", Rec->AuthSent.Contains(TEXT("auth-start")));
+			TestEqual("pending state", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Pending));
+
+			TSharedPtr<FJsonObject> Pending = MakeShared<FJsonObject>();
+			Pending->SetStringField(TEXT("verificationUrl"), TEXT("https://ai-game.dev/device"));
+			Pending->SetStringField(TEXT("userCode"), TEXT("WXYZ-1234"));
+			Pending->SetStringField(TEXT("state"), TEXT("pending"));
+			VM->ApplyDeviceAuth(Pending);
+			TestEqual("user code surfaced", VM->GetDeviceUserCode(), FString(TEXT("WXYZ-1234")));
+			TestEqual("browser opened once", Rec->OpenedUrls.Num(), 1);
+
+			// A second pending update with the same URL must NOT re-open the browser.
+			VM->ApplyDeviceAuth(Pending);
+			TestEqual("browser not re-opened", Rec->OpenedUrls.Num(), 1);
+
+			TSharedPtr<FJsonObject> Authorized = MakeShared<FJsonObject>();
+			Authorized->SetStringField(TEXT("state"), TEXT("authorized"));
+			Authorized->SetStringField(TEXT("token"), TEXT("cloud-bearer-abc"));
+			VM->ApplyDeviceAuth(Authorized);
+			TestEqual("authorized state", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Authorized));
+			TestTrue("cloud token stored", VM->HasCloudToken());
+		});
+
+		It("Revoke clears the cloud token, sends auth-revoke and pushes the now-anonymous config", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			TSharedPtr<FJsonObject> Authorized = MakeShared<FJsonObject>();
+			Authorized->SetStringField(TEXT("state"), TEXT("authorized"));
+			Authorized->SetStringField(TEXT("token"), TEXT("cloud-bearer-abc"));
+			VM->ApplyDeviceAuth(Authorized);
+			TestTrue("token present before revoke", VM->HasCloudToken());
+
+			VM->Revoke();
+			TestFalse("token cleared after revoke", VM->HasCloudToken());
+			TestTrue("auth-revoke sent", Rec->AuthSent.Contains(TEXT("auth-revoke")));
+		});
+	});
+
+	Describe("Status feed application", [this]()
+	{
+		It("applies connectionState and aiAgents from a status message", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			TSharedPtr<FJsonObject> Status = MakeShared<FJsonObject>();
+			Status->SetStringField(TEXT("connectionState"), TEXT("Connected"));
+			Status->SetBoolField(TEXT("keepConnected"), true);
+			TArray<TSharedPtr<FJsonValue>> Agents;
+			Agents.Add(MakeShared<FJsonValueString>(TEXT("Claude Code")));
+			Agents.Add(MakeShared<FJsonValueString>(TEXT("Cursor")));
+			Status->SetArrayField(TEXT("aiAgents"), Agents);
+
+			VM->ApplyStatus(Status);
+			TestEqual("connected", static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connected));
+			TestEqual("two agents", VM->GetAiAgents().Num(), 2);
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
@@ -227,6 +227,10 @@ void FUnrealMcpEditorViewModelSpec::Define()
 			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
 			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
 
+			// Drive a realistic flow: Authorize (→ Pending) THEN the sidecar's authorized frame stores the token.
+			// (An authorized device-auth only ever arrives after auth-start; applying it straight to an Idle VM
+			// is now ignored by the cancel-race complement, so the spec mirrors the real ordering.)
+			VM->Authorize();
 			TSharedPtr<FJsonObject> Authorized = MakeShared<FJsonObject>();
 			Authorized->SetStringField(TEXT("state"), TEXT("authorized"));
 			Authorized->SetStringField(TEXT("token"), TEXT("cloud-bearer-abc"));
@@ -236,6 +240,69 @@ void FUnrealMcpEditorViewModelSpec::Define()
 			VM->Revoke();
 			TestFalse("token cleared after revoke", VM->HasCloudToken());
 			TestTrue("auth-revoke sent", Rec->AuthSent.Contains(TEXT("auth-revoke")));
+		});
+
+		It("ignores an authorized device-auth that races in after the user cancelled the flow", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			// First-time flow (no stored token yet): Authorize then cancel it before authorization completes.
+			VM->Authorize();
+			TestEqual("pending after Authorize", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Pending));
+			VM->CancelAuth();
+			TestEqual("idle after cancel (no stored token)", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Idle));
+
+			const int32 PushBefore = Rec->PushCount;
+			// The sidecar's authorized frame (emitted before its own cancel guard ran) races in AFTER the cancel.
+			TSharedPtr<FJsonObject> Authorized = MakeShared<FJsonObject>();
+			Authorized->SetStringField(TEXT("state"), TEXT("authorized"));
+			Authorized->SetStringField(TEXT("token"), TEXT("cloud-bearer-late"));
+			VM->ApplyDeviceAuth(Authorized);
+
+			// Cancel-race complement: a just-cancelled flow (Idle) ignores the late authorized — the dropped token
+			// is NOT resurrected, the indicator stays Idle, and nothing is persisted/pushed.
+			TestEqual("still idle, late authorized ignored", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Idle));
+			TestFalse("no token resurrected", VM->HasCloudToken());
+			TestEqual("nothing pushed for the ignored authorized", Rec->PushCount, PushBefore);
+		});
+
+		It("CancelAuth keeps the Authorized indicator when a cloud token is already stored", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			// Establish a stored cloud token (a completed prior authorization, via the realistic Authorize flow).
+			VM->Authorize();
+			TSharedPtr<FJsonObject> Authorized = MakeShared<FJsonObject>();
+			Authorized->SetStringField(TEXT("state"), TEXT("authorized"));
+			Authorized->SetStringField(TEXT("token"), TEXT("cloud-bearer-abc"));
+			VM->ApplyDeviceAuth(Authorized);
+			TestTrue("token stored", VM->HasCloudToken());
+
+			// The user starts a RE-authorize then cancels: the indicator must fall back to Authorized (a bearer is
+			// still stored), not Idle — otherwise the Authorized/Revoke affordance vanishes until restart.
+			VM->Authorize();
+			VM->CancelAuth();
+			TestEqual("authorized indicator preserved on cancel-with-token",
+				static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Authorized));
+			TestTrue("token still stored", VM->HasCloudToken());
+		});
+	});
+
+	Describe("Custom-mode host trimming (§7 validated field)", [this]()
+	{
+		It("trims surrounding whitespace before storing and pushing the dial target", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			// A padded-but-valid URL must validate AND be stored/pushed trimmed — the sidecar must not dial the
+			// untrimmed target.
+			VM->SetCustomHost(TEXT("  http://localhost:5244  "));
+			TestEqual("stored host is trimmed", VM->GetCustomHost(), FString(TEXT("http://localhost:5244")));
+			TestTrue("trimmed valid host pushed", Rec->PushCount >= 1);
+			TestEqual("pushed dial target is trimmed", Rec->LastPushed.CustomHost, FString(TEXT("http://localhost:5244")));
 		});
 	});
 

--- a/bridge/src/Auth/DeviceCodeAuthenticator.cs
+++ b/bridge/src/Auth/DeviceCodeAuthenticator.cs
@@ -44,15 +44,19 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Auth
         private readonly HttpClient _http;
         private readonly ILogger? _logger;
         private readonly Func<TimeSpan, CancellationToken, Task> _delay;
+        private readonly Func<DateTimeOffset> _now;
 
         public DeviceCodeAuthenticator(
             HttpClient http,
             ILogger? logger = null,
-            Func<TimeSpan, CancellationToken, Task>? delay = null)
+            Func<TimeSpan, CancellationToken, Task>? delay = null,
+            Func<DateTimeOffset>? now = null)
         {
             _http = http ?? throw new ArgumentNullException(nameof(http));
             _logger = logger;
             _delay = delay ?? ((d, ct) => Task.Delay(d, ct));
+            // Injectable like _delay so the xUnit suite can drive the expires_in deadline deterministically.
+            _now = now ?? (() => DateTimeOffset.UtcNow);
         }
 
         /// <summary>
@@ -104,8 +108,21 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Auth
             // Poll honouring the server interval (default 5 s per RFC 8628 §3.5), backing off on slow_down.
             var interval = TimeSpan.FromSeconds(Math.Max(1, authorize.Interval > 0 ? authorize.Interval : 5));
 
+            // Client-side deadline from expires_in (RFC 8628 §3.2). Without this the loop relies entirely on the
+            // server returning expired_token — and a misbehaving/unreachable token endpoint (whose transport
+            // errors are swallowed as transient below) would poll forever. On breach we emit a terminal expired
+            // failure and stop. Fall back to 15 min only if the server omits a sane expires_in.
+            var expiresInSeconds = authorize.ExpiresIn > 0 ? authorize.ExpiresIn : 900;
+            var deadline = _now() + TimeSpan.FromSeconds(expiresInSeconds);
+
             while (!ct.IsCancellationRequested)
             {
+                if (_now() >= deadline)
+                {
+                    await SafeEmit(emit, DeviceAuthResult.FailedMessage("The authorization request expired.")).ConfigureAwait(false);
+                    return DeviceAuthResult.Failed("expired_token");
+                }
+
                 try
                 {
                     await _delay(interval, ct).ConfigureAwait(false);

--- a/bridge/src/Auth/DeviceCodeAuthenticator.cs
+++ b/bridge/src/Auth/DeviceCodeAuthenticator.cs
@@ -1,0 +1,234 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Auth
+{
+    /// <summary>
+    /// The real Cloud device-code authorization flow (docs/ARCHITECTURE.md §7 item 4 / §1.3), replacing PR #8's
+    /// <c>auth-start</c> / <c>auth-cancel</c> / <c>auth-revoke</c> stubs for the happy path. It is the RFC 8628
+    /// device-authorization grant against the ai-game.dev cloud — the SAME contract Unity-MCP's
+    /// <c>DeviceAuthService</c> uses: <c>POST {cloudUrl}/api/auth/device/authorize</c> →
+    /// <c>POST {cloudUrl}/api/auth/device/token</c> polled until an <c>access_token</c> is issued, the flow is
+    /// denied/expired, or it is cancelled.
+    ///
+    /// As each step progresses it invokes the <c>emit</c> callback with a <see cref="DeviceAuthMessage"/> so the
+    /// sidecar can forward it to the plugin (which renders the verification URL + user code, §7). The HTTP layer
+    /// and the inter-poll delay are injectable so the xUnit suite drives the full flow against a fake handler
+    /// with no network and no real waiting. The issued token is returned to the caller and NEVER logged (§8).
+    /// </summary>
+    public sealed class DeviceCodeAuthenticator
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            PropertyNameCaseInsensitive = true,
+        };
+
+        private readonly HttpClient _http;
+        private readonly ILogger? _logger;
+        private readonly Func<TimeSpan, CancellationToken, Task> _delay;
+
+        public DeviceCodeAuthenticator(
+            HttpClient http,
+            ILogger? logger = null,
+            Func<TimeSpan, CancellationToken, Task>? delay = null)
+        {
+            _http = http ?? throw new ArgumentNullException(nameof(http));
+            _logger = logger;
+            _delay = delay ?? ((d, ct) => Task.Delay(d, ct));
+        }
+
+        /// <summary>
+        /// Run the full device-code flow against <paramref name="cloudUrl"/>. Emits a <c>pending</c>
+        /// device-auth (with the verification URL + user code) as soon as the authorize call returns, polls the
+        /// token endpoint honouring the server's <c>interval</c> (and <c>slow_down</c>), and returns the issued
+        /// bearer on success. On denial / expiry / cancellation it emits a terminal <c>failed</c> (or the flow's
+        /// own cancellation) and returns a non-success result. Never throws for an expected protocol outcome;
+        /// a transport exception bubbles as a failed result with the message.
+        /// </summary>
+        public async Task<DeviceAuthResult> AuthorizeAsync(
+            string cloudUrl,
+            string? clientLabel,
+            Func<DeviceAuthMessage, Task> emit,
+            CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(cloudUrl))
+                return DeviceAuthResult.Failed("No cloud URL configured.");
+
+            var baseUrl = cloudUrl.TrimEnd('/');
+
+            DeviceAuthorizeResponse authorize;
+            try
+            {
+                authorize = await InitiateAsync(baseUrl, clientLabel, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                return DeviceAuthResult.Cancelled();
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Device-code authorize request failed: {Message}", ex.Message);
+                await SafeEmit(emit, DeviceAuthResult.FailedMessage("Could not start authorization.")).ConfigureAwait(false);
+                return DeviceAuthResult.Failed(ex.Message);
+            }
+
+            var verificationUrl = !string.IsNullOrEmpty(authorize.VerificationUriComplete)
+                ? authorize.VerificationUriComplete
+                : authorize.VerificationUri;
+
+            await SafeEmit(emit, new DeviceAuthMessage
+            {
+                State = "pending",
+                VerificationUrl = verificationUrl,
+                UserCode = authorize.UserCode,
+            }).ConfigureAwait(false);
+
+            // Poll honouring the server interval (default 5 s per RFC 8628 §3.5), backing off on slow_down.
+            var interval = TimeSpan.FromSeconds(Math.Max(1, authorize.Interval > 0 ? authorize.Interval : 5));
+
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    await _delay(interval, ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return DeviceAuthResult.Cancelled();
+                }
+
+                DeviceTokenResponse token;
+                try
+                {
+                    token = await PollAsync(baseUrl, authorize.DeviceCode, ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    return DeviceAuthResult.Cancelled();
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogDebug("Device-code poll transient error: {Message}", ex.Message);
+                    continue; // transient — keep polling until the server gives a terminal answer or we cancel
+                }
+
+                if (!string.IsNullOrEmpty(token.AccessToken))
+                {
+                    await SafeEmit(emit, new DeviceAuthMessage
+                    {
+                        State = "authorized",
+                        Token = token.AccessToken,
+                    }).ConfigureAwait(false);
+                    _logger?.LogInformation("Device-code flow authorized; cloud token stored."); // token NEVER logged (§8)
+                    return DeviceAuthResult.Authorized(token.AccessToken!);
+                }
+
+                switch (token.Error)
+                {
+                    case "authorization_pending":
+                        continue; // user has not finished yet — keep polling at the current interval
+                    case "slow_down":
+                        interval += TimeSpan.FromSeconds(5); // RFC 8628 §3.5
+                        continue;
+                    case "access_denied":
+                        await SafeEmit(emit, DeviceAuthResult.FailedMessage("Authorization was denied.")).ConfigureAwait(false);
+                        return DeviceAuthResult.Failed("access_denied");
+                    case "expired_token":
+                        await SafeEmit(emit, DeviceAuthResult.FailedMessage("The authorization request expired.")).ConfigureAwait(false);
+                        return DeviceAuthResult.Failed("expired_token");
+                    default:
+                        // An unknown error string is terminal — do not spin forever.
+                        var reason = token.Error ?? "unknown error";
+                        await SafeEmit(emit, DeviceAuthResult.FailedMessage("Authorization failed.")).ConfigureAwait(false);
+                        return DeviceAuthResult.Failed(reason);
+                }
+            }
+
+            return DeviceAuthResult.Cancelled();
+        }
+
+        private async Task<DeviceAuthorizeResponse> InitiateAsync(string baseUrl, string? clientLabel, CancellationToken ct)
+        {
+            var body = clientLabel != null
+                ? JsonSerializer.Serialize(new { client_label = clientLabel }, JsonOptions)
+                : "{}";
+            using var content = new StringContent(body, Encoding.UTF8, "application/json");
+            using var response = await _http.PostAsync($"{baseUrl}/api/auth/device/authorize", content, ct).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            return JsonSerializer.Deserialize<DeviceAuthorizeResponse>(json, JsonOptions)
+                ?? throw new InvalidOperationException("Empty device authorize response.");
+        }
+
+        private async Task<DeviceTokenResponse> PollAsync(string baseUrl, string deviceCode, CancellationToken ct)
+        {
+            var body = JsonSerializer.Serialize(
+                new { device_code = deviceCode, grant_type = "urn:ietf:params:oauth:grant-type:device_code" },
+                JsonOptions);
+            using var content = new StringContent(body, Encoding.UTF8, "application/json");
+            using var response = await _http.PostAsync($"{baseUrl}/api/auth/device/token", content, ct).ConfigureAwait(false);
+            var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            return JsonSerializer.Deserialize<DeviceTokenResponse>(json, JsonOptions)
+                ?? throw new InvalidOperationException("Empty device token response.");
+        }
+
+        private static async Task SafeEmit(Func<DeviceAuthMessage, Task> emit, DeviceAuthMessage message)
+        {
+            try { await emit(message).ConfigureAwait(false); } catch { /* a UI feed hiccup never breaks the flow */ }
+        }
+
+        // --- DTOs (ai-game.dev contract; snake_case on the wire) --------------------------------------
+
+        public sealed class DeviceAuthorizeResponse
+        {
+            [JsonPropertyName("device_code")] public string DeviceCode { get; set; } = "";
+            [JsonPropertyName("user_code")] public string UserCode { get; set; } = "";
+            [JsonPropertyName("verification_uri")] public string VerificationUri { get; set; } = "";
+            [JsonPropertyName("verification_uri_complete")] public string VerificationUriComplete { get; set; } = "";
+            [JsonPropertyName("expires_in")] public int ExpiresIn { get; set; }
+            [JsonPropertyName("interval")] public int Interval { get; set; }
+        }
+
+        public sealed class DeviceTokenResponse
+        {
+            [JsonPropertyName("access_token")] public string? AccessToken { get; set; }
+            [JsonPropertyName("token_type")] public string? TokenType { get; set; }
+            [JsonPropertyName("error")] public string? Error { get; set; }
+            [JsonPropertyName("error_description")] public string? ErrorDescription { get; set; }
+        }
+    }
+
+    /// <summary>Terminal outcome of a device-code flow. The token is present only on <see cref="Success"/>.</summary>
+    public sealed class DeviceAuthResult
+    {
+        public bool Success { get; private init; }
+        public bool WasCancelled { get; private init; }
+        public string? Token { get; private init; }
+        public string? Error { get; private init; }
+
+        public static DeviceAuthResult Authorized(string token) => new() { Success = true, Token = token };
+        public static DeviceAuthResult Cancelled() => new() { WasCancelled = true, Error = "cancelled" };
+        public static DeviceAuthResult Failed(string error) => new() { Error = error };
+
+        // A device-auth failed message for the UI feed (never carries a secret).
+        public static DeviceAuthMessage FailedMessage(string message) => new() { State = "failed", Message = message };
+    }
+}

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -9,11 +9,14 @@
 */
 
 using System;
+using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Text.Json.Nodes;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.ReflectorNet;
+using com.IvanMurzak.Unreal.MCP.Bridge.Auth;
 using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
 using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
 using Microsoft.Extensions.Logging;
@@ -53,12 +56,20 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         private Reflector? _reflector;
         private int _signalRConnectStarted;
 
+        // §7 Cloud device-code flow (replaces PR #8's auth stubs). The authenticator is injectable so the xUnit
+        // suite drives the flow against a fake HTTP handler; _authCts cancels an in-progress flow (auth-cancel).
+        private readonly DeviceCodeAuthenticator _authenticator;
+        private readonly string _clientLabel;
+        private CancellationTokenSource? _authCts;
+
         public SidecarHost(
             IpcClient ipc,
             string sidecarVersion,
             ILoggerProvider? loggerProvider = null,
             string? fallbackHost = null,
-            string? fallbackToken = null)
+            string? fallbackToken = null,
+            DeviceCodeAuthenticator? authenticator = null,
+            string clientLabel = "Unreal-MCP-Bridge")
         {
             _ipc = ipc ?? throw new ArgumentNullException(nameof(ipc));
             _sidecarVersion = sidecarVersion;
@@ -66,6 +77,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _logger = loggerProvider?.CreateLogger(nameof(SidecarHost));
             _fallbackHost = fallbackHost;
             _fallbackToken = fallbackToken;
+            _clientLabel = clientLabel;
+            _authenticator = authenticator
+                ?? new DeviceCodeAuthenticator(new HttpClient(), loggerProvider?.CreateLogger(nameof(DeviceCodeAuthenticator)));
         }
 
         public IMcpPlugin? Plugin => _plugin;
@@ -139,11 +153,17 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
         private void OnConfigReceived(JsonObject config)
         {
-            // §8 "on change": the plugin re-pushed the effective connection config. Apply it. A live mode/host
-            // change that requires re-dialling SignalR is deferred to the UI task — for now KeepConnected
-            // covers transient reconnects and the next reconnect epoch picks up the applied values.
+            // §8 "on change": the plugin re-pushed the effective connection config. Apply it, then honour a
+            // keepConnected transition: false → genuinely tear down SignalR (the §7 / Godot M9b Disconnect
+            // lesson — not merely drop one link); false→true → (re)connect.
+            var wasKeepConnected = _config.KeepConnected;
             ApplyConnectionConfig(config);
             _logger?.LogInformation("Applied updated connection config (mode-aware host {Host}).", _config.Host);
+
+            if (wasKeepConnected && !_config.KeepConnected)
+                _ = HandleDisconnectAsync();
+            else if (!wasKeepConnected && _config.KeepConnected)
+                _ = ReconnectAsync();
         }
 
         /// <summary>
@@ -187,27 +207,106 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         }
 
         /// <summary>
-        /// Handle a §1.3 auth message (<c>auth-start</c> / <c>auth-cancel</c> / <c>auth-revoke</c>) as a
-        /// graceful stub pending the full device-code UI flow (§8). <c>auth-revoke</c> clears the stored
-        /// cloud bearer. Public so the bridge xUnit suite can assert the stub behavior directly.
+        /// Handle a §1.3 auth message (<c>auth-start</c> / <c>auth-cancel</c> / <c>auth-revoke</c>), driving the
+        /// REAL Cloud device-code flow (§7 item 4) — the PR #8 stubs are gone for the happy path.
+        /// <c>auth-start</c> launches <see cref="DeviceCodeAuthenticator"/> against the resolved cloud URL,
+        /// forwarding <c>device-auth</c> progress to the plugin; <c>auth-cancel</c> cancels an in-progress flow;
+        /// <c>auth-revoke</c> cancels any flow and clears the stored cloud bearer. Public so the bridge xUnit
+        /// suite can drive it directly. Never throws (the flow runs on a background task).
         /// </summary>
         public void HandleAuthMessage(string type)
         {
-            // §8 auth plumbing — graceful stubs until the device-code UI flow lands.
             switch (type)
             {
+                case IpcProtocol.Type.AuthStart:
+                    StartDeviceAuth();
+                    break;
+                case IpcProtocol.Type.AuthCancel:
+                    _authCts?.Cancel();
+                    _logger?.LogInformation("auth-cancel received; cancelling the in-progress device-code flow (if any).");
+                    break;
                 case IpcProtocol.Type.AuthRevoke:
+                    _authCts?.Cancel();
                     // Clear the stored cloud bearer so a subsequent (re)connect is anonymous until re-authorized.
                     _config.Token = null;
                     _logger?.LogInformation("Cloud token revoked (auth-revoke); cleared the in-memory bearer.");
                     break;
-                case IpcProtocol.Type.AuthStart:
-                    _logger?.LogInformation("auth-start received; the device-code flow is not implemented in the sidecar-bridge MVP (pending the UI task).");
-                    break;
-                case IpcProtocol.Type.AuthCancel:
-                    _logger?.LogInformation("auth-cancel received; no in-progress device-code flow to cancel (pending the UI task).");
-                    break;
             }
+        }
+
+        private void StartDeviceAuth()
+        {
+            _authCts?.Cancel();
+            var cts = new CancellationTokenSource();
+            _authCts = cts;
+            var cloudUrl = _config.Host; // Cloud mode resolved Host to cloudUrl (ApplyConnectionConfig).
+            _logger?.LogInformation("auth-start received; beginning device-code flow against {Host}.", cloudUrl);
+            _ = RunDeviceAuthAsync(cloudUrl, cts.Token);
+        }
+
+        private async Task RunDeviceAuthAsync(string cloudUrl, CancellationToken ct)
+        {
+            try
+            {
+                var result = await _authenticator.AuthorizeAsync(
+                    cloudUrl,
+                    _clientLabel,
+                    emit: msg => _ipc.SendToPluginAsync(msg, CancellationToken.None),
+                    ct).ConfigureAwait(false);
+
+                if (result.Success && result.Token != null)
+                {
+                    _config.Token = result.Token; // the issued cloud bearer is NEVER logged (§8)
+                    await ReconnectAsync().ConfigureAwait(false); // the authorized session takes effect
+                    await EmitStatusAsync("Connected", cloudAuthState: "Authorized").ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Device-code flow ended with an error: {Message}", ex.Message);
+            }
+        }
+
+        /// <summary>Fully disconnect SignalR (auth-revoke / Disconnect), then surface a Disconnected status.</summary>
+        private async Task HandleDisconnectAsync()
+        {
+            var plugin = _plugin;
+            if (plugin != null)
+            {
+                try { await plugin.Disconnect().ConfigureAwait(false); }
+                catch (Exception ex) { _logger?.LogDebug("SignalR disconnect failed: {Message}", ex.Message); }
+            }
+            await EmitStatusAsync("Disconnected").ConfigureAwait(false);
+        }
+
+        /// <summary>Disconnect then reconnect SignalR so a newly-applied token/host takes effect.</summary>
+        private async Task ReconnectAsync()
+        {
+            var plugin = _plugin;
+            if (plugin == null)
+                return;
+            try { await plugin.Disconnect().ConfigureAwait(false); } catch { /* may not be connected */ }
+            try
+            {
+                var ok = await plugin.Connect().ConfigureAwait(false);
+                _logger?.LogInformation(ok ? "SignalR reconnected." : "SignalR reconnect returned false; client keeps retrying.");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("SignalR reconnect failed: {Message}", ex.Message);
+            }
+        }
+
+        /// <summary>Push a §1.3 <c>status</c> message to the plugin (the §7 live connection indicator).</summary>
+        private Task EmitStatusAsync(string connectionState, string? cloudAuthState = null)
+        {
+            var status = new StatusMessage
+            {
+                ConnectionState = connectionState,
+                KeepConnected = _config.KeepConnected,
+                CloudAuthState = cloudAuthState,
+            };
+            return _ipc.SendToPluginAsync(status, CancellationToken.None);
         }
 
         private async System.Threading.Tasks.Task ConnectSignalRAsync()
@@ -219,6 +318,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             {
                 var ok = await plugin.Connect().ConfigureAwait(false);
                 _logger?.LogInformation(ok ? "SignalR connected." : "SignalR initial connect returned false; client will keep retrying.");
+                // §7 live status: surface the connection result to the plugin's view-model.
+                var cloudAuthState = string.IsNullOrEmpty(_config.Token) ? null : "Authorized";
+                await EmitStatusAsync(ok ? "Connected" : "Connecting", cloudAuthState).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -231,6 +333,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _ipc.HandshakeAccepted -= OnHandshakeAccepted;
             _ipc.ConfigReceived -= OnConfigReceived;
             _ipc.AuthMessageReceived -= HandleAuthMessage;
+            try { _authCts?.Cancel(); } catch { /* ignore */ }
             try { _plugin?.Dispose(); } catch { /* ignore */ }
             _plugin = null;
         }

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -62,6 +62,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         private readonly string _clientLabel;
         private CancellationTokenSource? _authCts;
 
+        // Serialize SignalR connect/disconnect transitions so rapid Connect/Disconnect toggles (or a device-auth
+        // reconnect racing a config-driven disconnect) apply in submission order — last-write-wins — instead of
+        // two in-flight plugin.Connect()/Disconnect() calls interleaving and landing in the wrong final state.
+        private readonly object _transitionLock = new();
+        private Task _connectionTransition = Task.CompletedTask;
+
         public SidecarHost(
             IpcClient ipc,
             string sidecarVersion,
@@ -161,9 +167,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _logger?.LogInformation("Applied updated connection config (mode-aware host {Host}).", _config.Host);
 
             if (wasKeepConnected && !_config.KeepConnected)
-                _ = HandleDisconnectAsync();
+                _ = RunConnectionTransition(HandleDisconnectAsync);
             else if (!wasKeepConnected && _config.KeepConnected)
-                _ = ReconnectAsync();
+                _ = RunConnectionTransition(() => ReconnectAsync());
         }
 
         /// <summary>
@@ -236,7 +242,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
         private void StartDeviceAuth()
         {
+            // Cancel AND dispose the previous flow's source before replacing it (cancel-before-dispose is safe:
+            // the in-flight flow observes an already-cancelled token, so no post-dispose registration throws).
             _authCts?.Cancel();
+            _authCts?.Dispose();
             var cts = new CancellationTokenSource();
             _authCts = cts;
             var cloudUrl = _config.Host; // Cloud mode resolved Host to cloudUrl (ApplyConnectionConfig).
@@ -257,8 +266,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 if (result.Success && result.Token != null)
                 {
                     _config.Token = result.Token; // the issued cloud bearer is NEVER logged (§8)
-                    await ReconnectAsync().ConfigureAwait(false); // the authorized session takes effect
-                    await EmitStatusAsync("Connected", cloudAuthState: "Authorized").ConfigureAwait(false);
+                    // Reconnect through the serialized transition queue and surface the ACTUAL connect outcome —
+                    // do not claim "Connected" if SignalR is still establishing (mirrors ConnectSignalRAsync).
+                    var connected = false;
+                    await RunConnectionTransition(async () => connected = await ReconnectAsync().ConfigureAwait(false)).ConfigureAwait(false);
+                    await EmitStatusAsync(connected ? "Connected" : "Connecting", cloudAuthState: "Authorized").ConfigureAwait(false);
                 }
             }
             catch (Exception ex)
@@ -279,21 +291,43 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             await EmitStatusAsync("Disconnected").ConfigureAwait(false);
         }
 
-        /// <summary>Disconnect then reconnect SignalR so a newly-applied token/host takes effect.</summary>
-        private async Task ReconnectAsync()
+        /// <summary>
+        /// Disconnect then reconnect SignalR so a newly-applied token/host takes effect. Returns whether the
+        /// connect attempt reported success, so a caller (the device-code flow) can surface the real state
+        /// instead of an unconditional "Connected".
+        /// </summary>
+        private async Task<bool> ReconnectAsync()
         {
             var plugin = _plugin;
             if (plugin == null)
-                return;
+                return false;
             try { await plugin.Disconnect().ConfigureAwait(false); } catch { /* may not be connected */ }
             try
             {
                 var ok = await plugin.Connect().ConfigureAwait(false);
                 _logger?.LogInformation(ok ? "SignalR reconnected." : "SignalR reconnect returned false; client keeps retrying.");
+                return ok;
             }
             catch (Exception ex)
             {
                 _logger?.LogWarning("SignalR reconnect failed: {Message}", ex.Message);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Run a SignalR connect/disconnect transition serialized after any previously-queued one (last-write-wins
+        /// in submission order). Prevents two in-flight transitions from interleaving their plugin.Connect()/
+        /// Disconnect() calls and leaving the client in a state that contradicts the user's last action.
+        /// </summary>
+        private Task RunConnectionTransition(Func<Task> transition)
+        {
+            lock (_transitionLock)
+            {
+                var queued = _connectionTransition.ContinueWith(
+                    _ => transition(), CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default).Unwrap();
+                _connectionTransition = queued;
+                return queued;
             }
         }
 
@@ -334,6 +368,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _ipc.ConfigReceived -= OnConfigReceived;
             _ipc.AuthMessageReceived -= HandleAuthMessage;
             try { _authCts?.Cancel(); } catch { /* ignore */ }
+            _authCts?.Dispose();
             try { _plugin?.Dispose(); } catch { /* ignore */ }
             _plugin = null;
         }

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -61,6 +61,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         private readonly DeviceCodeAuthenticator _authenticator;
         private readonly string _clientLabel;
         private CancellationTokenSource? _authCts;
+        // The HttpClient the default-path authenticator uses, owned here so Dispose() releases it (the
+        // injected-authenticator path supplies its own client and leaves this null).
+        private readonly HttpClient? _ownedHttpClient;
+        // Whether the last applied connection config selected Cloud mode. Gates the §7 cloud-auth indicator:
+        // a Custom-mode bearer is a LOCAL token, not a cloud authorization, so it must not light "Authorized".
+        private bool _isCloudMode;
 
         // Serialize SignalR connect/disconnect transitions so rapid Connect/Disconnect toggles (or a device-auth
         // reconnect racing a config-driven disconnect) apply in submission order — last-write-wins — instead of
@@ -84,8 +90,17 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _fallbackHost = fallbackHost;
             _fallbackToken = fallbackToken;
             _clientLabel = clientLabel;
-            _authenticator = authenticator
-                ?? new DeviceCodeAuthenticator(new HttpClient(), loggerProvider?.CreateLogger(nameof(DeviceCodeAuthenticator)));
+            if (authenticator != null)
+            {
+                _authenticator = authenticator;
+            }
+            else
+            {
+                // We OWN this HttpClient (the injected-authenticator path supplies its own); the authenticator
+                // never disposes it, so we track it here and release it in Dispose() for symmetry.
+                _ownedHttpClient = new HttpClient();
+                _authenticator = new DeviceCodeAuthenticator(_ownedHttpClient, loggerProvider?.CreateLogger(nameof(DeviceCodeAuthenticator)));
+            }
         }
 
         public IMcpPlugin? Plugin => _plugin;
@@ -179,7 +194,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                     _ = RunConnectionTransition(HandleDisconnectAsync);
                     break;
                 case ConfigTransition.Reconnect:
-                    _ = RunConnectionTransition(() => ReconnectAsync());
+                    // Re-dial AND surface the honest result — a bare RunConnectionTransition(ReconnectAsync) would
+                    // reconnect silently, leaving the UI stuck on the optimistic "Connecting…" after a successful
+                    // re-dial (and a stale "Connected" after a failed one). The §7 medium fix.
+                    _ = ReconnectAndEmitStatusAsync();
                     break;
             }
         }
@@ -231,6 +249,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             // Mode-aware host selection: Cloud connects to cloudUrl, Custom to host (§8). Fall back to the
             // other field only when the mode's own field is blank, so a partial message still resolves a host.
             var isCloud = string.Equals(mode, "Cloud", StringComparison.OrdinalIgnoreCase);
+            // Remember the mode so the §7 cloud-auth indicator does not treat a Custom-mode bearer as a cloud
+            // token. Only update when the message actually carried a mode — a partial config push (mode absent)
+            // must not silently flip us out of Cloud.
+            if (mode != null)
+                _isCloudMode = isCloud;
             var selected = isCloud ? cloudUrl : host;
             if (string.IsNullOrWhiteSpace(selected))
                 selected = isCloud ? host : cloudUrl;
@@ -318,11 +341,43 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             if (ct.IsCancellationRequested)
                 return;
             _config.Token = token; // the issued cloud bearer is NEVER logged (§8)
-            // Reconnect through the serialized transition queue and surface the ACTUAL connect outcome —
-            // do not claim "Connected" if SignalR is still establishing (mirrors ConnectSignalRAsync).
+            // Re-dial (only when still armed) and surface the HONEST status + the cloud-authorized indicator. When
+            // the user is DISARMED — they clicked Disconnect (keepConnected=false) before authorizing — store the
+            // bearer WITHOUT dialing: claiming Connected here would build a live link Disconnect could never tear
+            // down (DecideConfigTransition maps a false→false push to None), violating the §7 Disconnect AC.
+            await ReconnectAndEmitStatusAsync(cloudAuthState: "Authorized").ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Re-dial SignalR (only when still armed) and push the HONEST resulting status to the plugin, optionally
+        /// carrying a cloud-auth indicator. BOTH §7 re-dial paths route here — a config-driven host/token change
+        /// (<see cref="OnConfigReceived"/>) and the device-auth commit (<see cref="CommitAuthorizedSessionAsync"/>)
+        /// — so neither leaves the window stuck on the optimistic "Connecting…" after a successful connect nor
+        /// claims "Connected" after a failed re-dial. When DISARMED (keepConnected=false) it does NOT dial.
+        /// </summary>
+        private async Task ReconnectAndEmitStatusAsync(string? cloudAuthState = null)
+        {
+            if (!_config.KeepConnected)
+            {
+                await EmitStatusAsync(ResolveConnectionStatusAfterReconnect(keepConnected: false, connected: false), cloudAuthState).ConfigureAwait(false);
+                return;
+            }
+
             var connected = false;
             await RunConnectionTransition(async () => connected = await ReconnectAsync().ConfigureAwait(false)).ConfigureAwait(false);
-            await EmitStatusAsync(connected ? "Connected" : "Connecting", cloudAuthState: "Authorized").ConfigureAwait(false);
+            await EmitStatusAsync(ResolveConnectionStatusAfterReconnect(keepConnected: true, connected), cloudAuthState).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// The connection-state string to surface after a (possible) re-dial: a disarmed commit never claims a
+        /// live link ("Disconnected"); an armed re-dial reports the ACTUAL connect outcome instead of an
+        /// optimistic guess. Pure so the bridge xUnit suite locks the matrix without a live plugin or IPC link.
+        /// </summary>
+        internal static string ResolveConnectionStatusAfterReconnect(bool keepConnected, bool connected)
+        {
+            if (!keepConnected)
+                return "Disconnected";
+            return connected ? "Connected" : "Connecting";
         }
 
         /// <summary>Fully disconnect SignalR (auth-revoke / Disconnect), then surface a Disconnected status.</summary>
@@ -398,8 +453,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             {
                 var ok = await plugin.Connect().ConfigureAwait(false);
                 _logger?.LogInformation(ok ? "SignalR connected." : "SignalR initial connect returned false; client will keep retrying.");
-                // §7 live status: surface the connection result to the plugin's view-model.
-                var cloudAuthState = string.IsNullOrEmpty(_config.Token) ? null : "Authorized";
+                // §7 live status: surface the connection result to the plugin's view-model. Only a CLOUD-mode
+                // bearer is a cloud authorization — a Custom-mode token is a local bearer and must NOT light the
+                // "Authorized — cloud token stored" indicator (ApplyStatus latches it and never demotes).
+                var cloudAuthState = _isCloudMode && !string.IsNullOrEmpty(_config.Token) ? "Authorized" : null;
                 await EmitStatusAsync(ok ? "Connected" : "Connecting", cloudAuthState).ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -415,6 +472,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _ipc.AuthMessageReceived -= HandleAuthMessage;
             try { _authCts?.Cancel(); } catch { /* ignore */ }
             _authCts?.Dispose();
+            _ownedHttpClient?.Dispose(); // released here — the authenticator does not own it (default path)
             try { _plugin?.Dispose(); } catch { /* ignore */ }
             _plugin = null;
         }

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -161,15 +161,49 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         {
             // §8 "on change": the plugin re-pushed the effective connection config. Apply it, then honour a
             // keepConnected transition: false → genuinely tear down SignalR (the §7 / Godot M9b Disconnect
-            // lesson — not merely drop one link); false→true → (re)connect.
+            // lesson — not merely drop one link); false→true → (re)connect. A host/token change WHILE still
+            // armed must also re-dial (below) — otherwise SignalR stays bound to the stale endpoint.
             var wasKeepConnected = _config.KeepConnected;
+            var priorHost = _config.Host;
+            var priorToken = _config.Token;
             ApplyConnectionConfig(config);
             _logger?.LogInformation("Applied updated connection config (mode-aware host {Host}).", _config.Host);
 
-            if (wasKeepConnected && !_config.KeepConnected)
-                _ = RunConnectionTransition(HandleDisconnectAsync);
-            else if (!wasKeepConnected && _config.KeepConnected)
-                _ = RunConnectionTransition(() => ReconnectAsync());
+            var hostOrTokenChanged =
+                !string.Equals(priorHost, _config.Host, StringComparison.Ordinal) ||
+                !string.Equals(priorToken, _config.Token, StringComparison.Ordinal);
+
+            switch (DecideConfigTransition(wasKeepConnected, _config.KeepConnected, hostOrTokenChanged))
+            {
+                case ConfigTransition.Disconnect:
+                    _ = RunConnectionTransition(HandleDisconnectAsync);
+                    break;
+                case ConfigTransition.Reconnect:
+                    _ = RunConnectionTransition(() => ReconnectAsync());
+                    break;
+            }
+        }
+
+        internal enum ConfigTransition { None, Disconnect, Reconnect }
+
+        /// <summary>
+        /// Decide how a §8 config push affects the live SignalR link. A keepConnected edge drives a full
+        /// disconnect (true→false, the §7 / Godot M9b Disconnect lesson — not merely drop one link) or a
+        /// reconnect (false→true). A host/token change WHILE still armed ALSO forces a reconnect: otherwise the
+        /// user switching Cloud↔Custom, editing the Server URL, or changing/generating the token while connected
+        /// leaves SignalR bound to the stale endpoint while the UI still reports "Connected". Pure so the bridge
+        /// xUnit suite locks the matrix without a live plugin; the serialized-transition queue keeps the issued
+        /// reconnect last-write-wins safe.
+        /// </summary>
+        internal static ConfigTransition DecideConfigTransition(bool wasKeepConnected, bool nowKeepConnected, bool hostOrTokenChanged)
+        {
+            if (wasKeepConnected && !nowKeepConnected)
+                return ConfigTransition.Disconnect;
+            if (!wasKeepConnected && nowKeepConnected)
+                return ConfigTransition.Reconnect;
+            if (nowKeepConnected && hostOrTokenChanged)
+                return ConfigTransition.Reconnect;
+            return ConfigTransition.None;
         }
 
         /// <summary>
@@ -264,19 +298,31 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                     ct).ConfigureAwait(false);
 
                 if (result.Success && result.Token != null)
-                {
-                    _config.Token = result.Token; // the issued cloud bearer is NEVER logged (§8)
-                    // Reconnect through the serialized transition queue and surface the ACTUAL connect outcome —
-                    // do not claim "Connected" if SignalR is still establishing (mirrors ConnectSignalRAsync).
-                    var connected = false;
-                    await RunConnectionTransition(async () => connected = await ReconnectAsync().ConfigureAwait(false)).ConfigureAwait(false);
-                    await EmitStatusAsync(connected ? "Connected" : "Connecting", cloudAuthState: "Authorized").ConfigureAwait(false);
-                }
+                    await CommitAuthorizedSessionAsync(result.Token, ct).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 _logger?.LogWarning("Device-code flow ended with an error: {Message}", ex.Message);
             }
+        }
+
+        /// <summary>
+        /// Store the issued cloud bearer and reconnect SignalR so it takes effect. Guards the success-to-store
+        /// window: an auth-cancel/auth-revoke can land between the flow's final successful poll and here, and
+        /// (for revoke) already cleared the token — storing it now would resurrect a bearer the user just
+        /// cancelled/revoked. Bail before storing/reconnecting/emitting when the flow was cancelled. Internal so
+        /// the bridge xUnit suite can assert the guard without driving the whole HTTP flow.
+        /// </summary>
+        internal async Task CommitAuthorizedSessionAsync(string token, CancellationToken ct)
+        {
+            if (ct.IsCancellationRequested)
+                return;
+            _config.Token = token; // the issued cloud bearer is NEVER logged (§8)
+            // Reconnect through the serialized transition queue and surface the ACTUAL connect outcome —
+            // do not claim "Connected" if SignalR is still establishing (mirrors ConnectSignalRAsync).
+            var connected = false;
+            await RunConnectionTransition(async () => connected = await ReconnectAsync().ConfigureAwait(false)).ConfigureAwait(false);
+            await EmitStatusAsync(connected ? "Connected" : "Connecting", cloudAuthState: "Authorized").ConfigureAwait(false);
         }
 
         /// <summary>Fully disconnect SignalR (auth-revoke / Disconnect), then surface a Disconnected status.</summary>

--- a/bridge/src/Ipc/IpcClient.cs
+++ b/bridge/src/Ipc/IpcClient.cs
@@ -390,6 +390,28 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
             return await task.ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Send a sidecar→plugin message (the §7 <c>device-auth</c> / <c>status</c> feed) over the live IPC
+        /// link. No-op (returns false) when no connection is up — the plugin re-reads state on the next
+        /// handshake anyway. Never throws on a dropped link; the single mutex-guarded writer keeps the frame
+        /// from interleaving with tool traffic (§1.2). The host calls this off the reader thread.
+        /// </summary>
+        public async Task<bool> SendToPluginAsync<T>(T message, CancellationToken ct = default)
+        {
+            if (_stream == null || _tcp is not { Connected: true })
+                return false;
+            try
+            {
+                await SendAsync(message, ct).ConfigureAwait(false);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogDebug("SendToPluginAsync failed (link down?): {Message}", ex.Message);
+                return false;
+            }
+        }
+
         // --- writer (single mutex-guarded path, §1.2) -------------------------------------------------
 
         private async Task SendAsync<T>(T message, CancellationToken ct)

--- a/bridge/src/Ipc/IpcMessages.cs
+++ b/bridge/src/Ipc/IpcMessages.cs
@@ -107,4 +107,38 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         [JsonPropertyName("level")] public string? Level { get; set; }
         [JsonPropertyName("message")] public string? Message { get; set; }
     }
+
+    /// <summary>
+    /// sidecar → plugin: device-code authorization progress (§1.3 / §7 Cloud auth). Carries the verification
+    /// URL + user code (for the UI to display/open) and a coarse <c>state</c> the view-model maps to its
+    /// device-auth indicator. On success it carries the issued cloud bearer so the plugin can store it via the
+    /// §8 config store. The token is part of the success payload but is NEVER written to a log line (§8).
+    /// </summary>
+    public sealed class DeviceAuthMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.DeviceAuth;
+        /// <summary>One of <c>pending</c> / <c>authorized</c> / <c>failed</c> / <c>denied</c> / <c>expired</c>.</summary>
+        [JsonPropertyName("state")] public string State { get; set; } = "pending";
+        [JsonPropertyName("verificationUrl")] public string? VerificationUrl { get; set; }
+        [JsonPropertyName("userCode")] public string? UserCode { get; set; }
+        /// <summary>The issued cloud bearer — present only on the terminal <c>authorized</c> state.</summary>
+        [JsonPropertyName("token")] public string? Token { get; set; }
+        /// <summary>A short human-readable reason on a <c>failed</c> state (never a secret).</summary>
+        [JsonPropertyName("message")] public string? Message { get; set; }
+    }
+
+    /// <summary>
+    /// sidecar → plugin: live SignalR state for the §7 UI (§1.3 <c>status</c>). The plugin's view-model reads
+    /// <c>connectionState</c> / <c>keepConnected</c> / <c>cloudAuthState</c> / <c>aiAgents</c>.
+    /// </summary>
+    public sealed class StatusMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.Status;
+        /// <summary>One of <c>Connected</c> / <c>Connecting</c> / <c>Disconnected</c> / <c>Degraded</c>.</summary>
+        [JsonPropertyName("connectionState")] public string ConnectionState { get; set; } = "Disconnected";
+        [JsonPropertyName("keepConnected")] public bool KeepConnected { get; set; }
+        /// <summary>One of <c>Authorized</c> / <c>Unauthorized</c> (Cloud mode only; null in Custom).</summary>
+        [JsonPropertyName("cloudAuthState")] public string? CloudAuthState { get; set; }
+        [JsonPropertyName("aiAgents")] public List<string> AiAgents { get; set; } = new();
+    }
 }

--- a/bridge/tests/DeviceCodeAuthenticatorTests.cs
+++ b/bridge/tests/DeviceCodeAuthenticatorTests.cs
@@ -1,0 +1,158 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak)              │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Unreal.MCP.Bridge.Auth;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>
+    /// Device-code flow specs (docs/ARCHITECTURE.md §7 item 4 / §1.3) — the real RFC 8628 grant the sidecar
+    /// now runs in place of PR #8's stub. Drives <see cref="DeviceCodeAuthenticator"/> against a scripted HTTP
+    /// handler (no network, no real waiting): asserts it emits a pending device-auth with the verification URL
+    /// + user code, polls until an access token is issued, surfaces denial/expiry, and honours cancellation.
+    /// </summary>
+    public class DeviceCodeAuthenticatorTests
+    {
+        // A scripted handler: the /authorize call returns a fixed JSON; each /token call dequeues the next body.
+        private sealed class ScriptedHandler : HttpMessageHandler
+        {
+            private readonly string _authorizeJson;
+            private readonly Queue<string> _tokenJson;
+            public int AuthorizeCalls { get; private set; }
+            public int TokenCalls { get; private set; }
+
+            public ScriptedHandler(string authorizeJson, IEnumerable<string> tokenJson)
+            {
+                _authorizeJson = authorizeJson;
+                _tokenJson = new Queue<string>(tokenJson);
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var url = request.RequestUri!.AbsoluteUri;
+                string body;
+                if (url.EndsWith("/api/auth/device/authorize", StringComparison.Ordinal))
+                {
+                    AuthorizeCalls++;
+                    body = _authorizeJson;
+                }
+                else
+                {
+                    TokenCalls++;
+                    body = _tokenJson.Count > 0 ? _tokenJson.Dequeue() : "{\"error\":\"authorization_pending\"}";
+                }
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+                });
+            }
+        }
+
+        private static DeviceCodeAuthenticator MakeAuth(ScriptedHandler handler) =>
+            // Zero delay so polling does not wait real seconds.
+            new(new HttpClient(handler), logger: null, delay: (_, _) => Task.CompletedTask);
+
+        private const string AuthorizeJson =
+            "{\"device_code\":\"dev-123\",\"user_code\":\"WXYZ-1234\"," +
+            "\"verification_uri\":\"https://ai-game.dev/device\"," +
+            "\"verification_uri_complete\":\"https://ai-game.dev/device?code=WXYZ-1234\"," +
+            "\"expires_in\":900,\"interval\":1}";
+
+        [Fact]
+        public async Task HappyPath_EmitsPendingThenAuthorizesAndReturnsToken()
+        {
+            var handler = new ScriptedHandler(AuthorizeJson, new[]
+            {
+                "{\"error\":\"authorization_pending\"}",
+                "{\"error\":\"authorization_pending\"}",
+                "{\"access_token\":\"cloud-bearer-abc\",\"token_type\":\"Bearer\"}",
+            });
+            var auth = MakeAuth(handler);
+
+            var emitted = new List<DeviceAuthMessage>();
+            var result = await auth.AuthorizeAsync("https://ai-game.dev", "Unreal", m => { emitted.Add(m); return Task.CompletedTask; }, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Equal("cloud-bearer-abc", result.Token);
+
+            // First emit is the pending state with the verification URL + user code (what the UI renders, §7).
+            Assert.Contains(emitted, m => m.State == "pending" && m.UserCode == "WXYZ-1234"
+                && m.VerificationUrl == "https://ai-game.dev/device?code=WXYZ-1234");
+            // The authorized emit carries the issued token.
+            Assert.Contains(emitted, m => m.State == "authorized" && m.Token == "cloud-bearer-abc");
+            Assert.Equal(3, handler.TokenCalls); // pending, pending, success
+        }
+
+        [Fact]
+        public async Task SlowDown_IncreasesIntervalButStillSucceeds()
+        {
+            var handler = new ScriptedHandler(AuthorizeJson, new[]
+            {
+                "{\"error\":\"slow_down\"}",
+                "{\"access_token\":\"tok\"}",
+            });
+            var auth = MakeAuth(handler);
+
+            var result = await auth.AuthorizeAsync("https://ai-game.dev", null, _ => Task.CompletedTask, CancellationToken.None);
+            Assert.True(result.Success);
+            Assert.Equal("tok", result.Token);
+        }
+
+        [Fact]
+        public async Task AccessDenied_FailsAndEmitsFailed()
+        {
+            var handler = new ScriptedHandler(AuthorizeJson, new[] { "{\"error\":\"access_denied\"}" });
+            var auth = MakeAuth(handler);
+
+            var emitted = new List<DeviceAuthMessage>();
+            var result = await auth.AuthorizeAsync("https://ai-game.dev", null, m => { emitted.Add(m); return Task.CompletedTask; }, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Equal("access_denied", result.Error);
+            Assert.Contains(emitted, m => m.State == "failed");
+        }
+
+        [Fact]
+        public async Task Cancellation_StopsPollingWithCancelledResult()
+        {
+            // An endless stream of authorization_pending — only cancellation ends it.
+            var pending = new List<string>();
+            for (var i = 0; i < 100; i++) pending.Add("{\"error\":\"authorization_pending\"}");
+            var handler = new ScriptedHandler(AuthorizeJson, pending);
+
+            using var cts = new CancellationTokenSource();
+            // Cancel after the first poll by counting emits is racy; instead inject a delay that cancels.
+            var auth = new DeviceCodeAuthenticator(new HttpClient(handler), logger: null,
+                delay: (_, ct) => { cts.Cancel(); return Task.CompletedTask; });
+
+            var result = await auth.AuthorizeAsync("https://ai-game.dev", null, _ => Task.CompletedTask, cts.Token);
+            Assert.False(result.Success);
+            Assert.True(result.WasCancelled);
+        }
+
+        [Fact]
+        public async Task EmptyCloudUrl_FailsImmediately()
+        {
+            var handler = new ScriptedHandler(AuthorizeJson, Array.Empty<string>());
+            var auth = MakeAuth(handler);
+            var result = await auth.AuthorizeAsync("", null, _ => Task.CompletedTask, CancellationToken.None);
+            Assert.False(result.Success);
+            Assert.Equal(0, handler.AuthorizeCalls);
+        }
+    }
+}

--- a/bridge/tests/DeviceCodeAuthenticatorTests.cs
+++ b/bridge/tests/DeviceCodeAuthenticatorTests.cs
@@ -1,7 +1,7 @@
 /*
 ┌───────────────────────────────────────────────────────────────────┐
 │  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
-│  Repository: GitHub (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
 │  Copyright (c) 2026 Ivan Murzak                                   │
 │  Licensed under the Apache License, Version 2.0.                  │
 │  See the LICENSE file in the project root for more information.   │
@@ -143,6 +143,35 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             var result = await auth.AuthorizeAsync("https://ai-game.dev", null, _ => Task.CompletedTask, cts.Token);
             Assert.False(result.Success);
             Assert.True(result.WasCancelled);
+        }
+
+        [Fact]
+        public async Task ExpiresIn_StopsPollingWithExpiredFailure()
+        {
+            // A token endpoint that never resolves (endless authorization_pending) must NOT poll forever: once
+            // the client-side expires_in deadline is breached the flow terminates with expired_token. The clock
+            // is injected so the deadline is reached deterministically without real waiting.
+            const string authorizeJson =
+                "{\"device_code\":\"dev-123\",\"user_code\":\"WXYZ-1234\"," +
+                "\"verification_uri\":\"https://ai-game.dev/device\",\"expires_in\":10,\"interval\":1}";
+            var pending = new List<string>();
+            for (var i = 0; i < 100; i++) pending.Add("{\"error\":\"authorization_pending\"}");
+            var handler = new ScriptedHandler(authorizeJson, pending);
+
+            var start = DateTimeOffset.UtcNow;
+            var clockReads = 0;
+            // First read sets the deadline (start + 10 s); subsequent reads jump 20 s past it so the very first
+            // poll iteration sees the deadline breached.
+            var auth = new DeviceCodeAuthenticator(new HttpClient(handler), logger: null,
+                delay: (_, _) => Task.CompletedTask,
+                now: () => clockReads++ == 0 ? start : start.AddSeconds(20));
+
+            var emitted = new List<DeviceAuthMessage>();
+            var result = await auth.AuthorizeAsync("https://ai-game.dev", null, m => { emitted.Add(m); return Task.CompletedTask; }, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Equal("expired_token", result.Error);
+            Assert.Contains(emitted, m => m.State == "failed");
         }
 
         [Fact]

--- a/bridge/tests/DeviceCodeAuthenticatorTests.cs
+++ b/bridge/tests/DeviceCodeAuthenticatorTests.cs
@@ -15,6 +15,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.Unreal.MCP.Bridge.Auth;
+using com.IvanMurzak.Unreal.MCP.Bridge.Host;
 using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
 using Xunit;
 
@@ -182,6 +183,42 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             var result = await auth.AuthorizeAsync("", null, _ => Task.CompletedTask, CancellationToken.None);
             Assert.False(result.Success);
             Assert.Equal(0, handler.AuthorizeCalls);
+        }
+
+        [Fact]
+        public async Task CommitAuthorizedSession_CancelledFlow_DoesNotResurrectToken()
+        {
+            // The cancel race (docs/ARCHITECTURE.md §7 item 4): an auth-cancel/auth-revoke can land between the
+            // device-code flow's final successful poll and the commit. The commit MUST NOT resurrect a bearer the
+            // user just cancelled/revoked. (Port 39998 is never dialed — the guard returns before SignalR.)
+            var ipc = new IpcClient("127.0.0.1", 39998, token: "ipc-token", sidecarVersion: "0.1.0");
+            using var host = new SidecarHost(ipc, "0.1.0");
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await host.CommitAuthorizedSessionAsync("cloud-bearer-abc", cts.Token);
+            Assert.Null(host.Config.Token); // the guard bailed — the just-cancelled bearer is NOT stored
+
+            // Control: an uncancelled commit DOES store the bearer, proving the guard (not a no-op) blocks it.
+            await host.CommitAuthorizedSessionAsync("cloud-bearer-abc", CancellationToken.None);
+            Assert.Equal("cloud-bearer-abc", host.Config.Token);
+        }
+
+        [Theory]
+        // expected uses ConfigTransition's underlying values (None=0, Disconnect=1, Reconnect=2) — the internal
+        // enum cannot appear in this public xUnit signature, so it is cast to int inside the body.
+        // keepConnected edges: armed→disarmed tears down; disarmed→armed (re)connects.
+        [InlineData(true, false, false, (int)SidecarHost.ConfigTransition.Disconnect)]
+        [InlineData(false, true, false, (int)SidecarHost.ConfigTransition.Reconnect)]
+        // Still armed + host/token changed → re-dial so SignalR leaves the stale endpoint (the §7 medium fix).
+        [InlineData(true, true, true, (int)SidecarHost.ConfigTransition.Reconnect)]
+        // Still armed, nothing changed → no churn; not armed + host changed → no connect.
+        [InlineData(true, true, false, (int)SidecarHost.ConfigTransition.None)]
+        [InlineData(false, false, true, (int)SidecarHost.ConfigTransition.None)]
+        public void DecideConfigTransition_CoversTheKeepConnectedAndEndpointChangeMatrix(
+            bool wasKeepConnected, bool nowKeepConnected, bool hostOrTokenChanged, int expected)
+        {
+            Assert.Equal(expected, (int)SidecarHost.DecideConfigTransition(wasKeepConnected, nowKeepConnected, hostOrTokenChanged));
         }
     }
 }

--- a/bridge/tests/DeviceCodeAuthenticatorTests.cs
+++ b/bridge/tests/DeviceCodeAuthenticatorTests.cs
@@ -220,5 +220,39 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         {
             Assert.Equal(expected, (int)SidecarHost.DecideConfigTransition(wasKeepConnected, nowKeepConnected, hostOrTokenChanged));
         }
+
+        [Theory]
+        // Armed re-dial reports the ACTUAL connect outcome — never the optimistic "Connecting…" left stuck after
+        // a successful re-dial (the §7 medium fix for the OnConfigReceived Reconnect path + the device-auth commit).
+        [InlineData(true, true, "Connected")]
+        [InlineData(true, false, "Connecting")]
+        // Disarmed (the user clicked Disconnect before authorizing): the commit stores the bearer but NEVER claims
+        // a live link — "Disconnected" — so Disconnect stays genuine and no un-tearable link is built.
+        [InlineData(false, false, "Disconnected")]
+        [InlineData(false, true, "Disconnected")]
+        public void ResolveConnectionStatusAfterReconnect_HonestStatusAndDisarmedNeverConnected(
+            bool keepConnected, bool connected, string expected)
+        {
+            Assert.Equal(expected, SidecarHost.ResolveConnectionStatusAfterReconnect(keepConnected, connected));
+        }
+
+        [Fact]
+        public async Task CommitAuthorizedSession_WhileDisarmed_StoresTokenWithoutRearming()
+        {
+            // The disarmed-authorize path (docs/ARCHITECTURE.md §7): the user clicked Disconnect (keepConnected=
+            // false persisted) and then authorized. The commit MUST store the issued bearer but MUST NOT silently
+            // re-arm/claim Connected — otherwise it builds a SignalR link Disconnect (which maps a false→false
+            // config push to None) could never tear down. With no live plugin a dial is a no-op, so the no-dial
+            // status contract is locked by ResolveConnectionStatusAfterReconnect above; here we assert the disarmed
+            // commit still COMMITS the token and leaves keepConnected false. (Port 39998 is never dialed.)
+            var ipc = new IpcClient("127.0.0.1", 39998, token: "ipc-token", sidecarVersion: "0.1.0");
+            using var host = new SidecarHost(ipc, "0.1.0");
+            host.Config.KeepConnected = false;
+
+            await host.CommitAuthorizedSessionAsync("cloud-bearer-abc", CancellationToken.None);
+
+            Assert.Equal("cloud-bearer-abc", host.Config.Token); // the authorized bearer is stored even while disarmed
+            Assert.False(host.Config.KeepConnected); // and the disarmed intent is untouched — no silent re-arm
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Pure-Slate "AI Game Developer" main window (docs/ARCHITECTURE.md §7): a nomad dockable tab with a Window-menu entry, all five sections (header/settings, connection panel + status timeline, Cloud/Custom mode toggle, Cloud device-code auth, Custom server auth + masked token, bridge status, AI agents, footer).
- A game-thread-only `FUnrealMcpEditorViewModel` owns all UI state over the §8 config store; the live `status` / `device-auth` IPC feed is marshalled to the game thread before touching Slate (the Godot M9b rule). Disconnect genuinely halts the reconnect loop (`keepConnected=false` → sidecar fully tears down SignalR).
- The REAL Cloud device-code auth flow (RFC 8628 against ai-game.dev) implemented in the sidecar, replacing PR #8's `auth-start` / `auth-cancel` / `auth-revoke` stubs for the happy path; tokens are never rendered unmasked and never logged (§8).

## Test plan
- [x] Suite 1 — UBT `UnrealTestProjectEditor Win64 Development`: exit 0.
- [x] Suite 2 — headless boot smoke: `[Unreal-MCP] plugin loaded` (+ the new tab registered at boot).
- [x] Suite 3 — `Automation RunTests UnrealMcp`: 80 succeeded / 0 failed (9 new `UnrealMcp.EditorViewModel` specs: state machine, URL validation, masking, connect/disconnect-halt, config round-trip, device-code apply, status feed).
- [x] Suite 4 — bridge `dotnet build` + xUnit: 74/74 (5 new device-code specs).
- [ ] Windowed/visual (open the window, dock, drive connect→timeline→disconnect, device-code) — NOT verifiable headless; pending operator. Device-code flow against the real ai-game.dev cloud is also operator/online-pending (no local cloud auth endpoint).

Closes #20