### PR TITLE
feat(tools): add the level/map tool family (Unity Scene.* analog)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLevelTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLevelTools.cpp
@@ -1,0 +1,514 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpCoreTools.h"
+#include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpObjectRef.h"
+#include "UnrealMcpPropertyJson.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Editor.h"                  // GEditor->NewMap() — headless-safe in-memory world (AutomationEditorCommon uses it)
+#include "FileHelpers.h"            // UEditorLoadingAndSavingUtils — NewMapFromTemplate / LoadMap / SaveMap / SaveCurrentLevel (UnrealEd)
+#include "EditorLevelUtils.h"       // UEditorLevelUtils::MakeLevelCurrent / RemoveLevelFromWorld (UnrealEd)
+#include "EngineUtils.h"            // TActorIterator
+#include "Engine/World.h"
+#include "Engine/Level.h"
+#include "Engine/LevelStreaming.h"
+#include "GameFramework/Actor.h"
+#include "Misc/PackageName.h"
+#include "UObject/Package.h"
+
+/**
+ * The level / map tool family (docs/ARCHITECTURE.md §10 "level family", the Unity Scene.* analog),
+ * declared via §3.3. Seven native C++ tools over the world / map editor surface:
+ *   level-create, level-open, level-save, level-get-data, level-list-loaded, level-set-current,
+ *   level-unload-sublevel.
+ *
+ * Headless-safety (the binding lesson carried from the actor family, issue #16):
+ *   - UEditorActorSubsystem AND ULevelEditorSubsystem (LevelEditor module) are avoided. We touch the
+ *     editor UWorld directly (GEditor->NewMap, UEditorLoadingAndSavingUtils, UEditorLevelUtils — all
+ *     Engine/UnrealEd, already linked), so every body below is verified under -nullrhi automation.
+ *   - level-create's in-memory path uses GEditor->NewMap() (exactly what FAutomationEditorCommonUtils
+ *     does) so specs create worlds without writing a .umap to the testbed (working-tree stays clean).
+ *     Saving to disk happens only when the caller passes 'path' (save-as) and in the live bridge e2e.
+ *   - World-partition CREATION needs ULevelEditorSubsystem::NewLevel(path, true) from the LevelEditor
+ *     module; that module dependency (and its headless behaviour) is out of this family's MVP scope, so
+ *     level-create produces standard levels and World-Partition is surfaced READ-ONLY by
+ *     level-list-loaded per §10 ("World Partition read-only awareness").
+ *
+ * Every Handle() body runs ON the game thread (the dispatcher marshals Registry.Execute, §4), so the
+ * bodies touch the editor world / UObject graph directly. Reuses FUnrealMcpObjectRef (§3.2 path-or-name
+ * refs) and FUnrealMcpPropertyJson (scoped reads) from the actor family for level-get-data.
+ */
+namespace
+{
+	/** An `array` of strings — the §3.2 scoped-read `paths` filter (mirrors the actor family's local schema).
+	 *  Uniquely named (Level-prefixed): the UE unity build concatenates this TU with the other tool
+	 *  families' TUs, so a bare `MakeStringArraySchema` would ODR-collide with the actor family's copy. */
+	TSharedPtr<FJsonObject> LevelMakeStringArraySchema(const FString& Desc)
+	{
+		TSharedPtr<FJsonObject> Items = MakeShared<FJsonObject>();
+		Items->SetStringField(TEXT("type"), TEXT("string"));
+
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), TEXT("array"));
+		if (!Desc.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Desc);
+		Schema->SetObjectField(TEXT("items"), Items);
+		return Schema;
+	}
+
+	/**
+	 * Read a string array argument (the scoped-read `paths` filter); empty when absent or not an array.
+	 * A non-string entry is reported via OutError (and the array is left empty) rather than silently
+	 * dropped — a dropped entry would otherwise flip the scoped read to "identity only" (the opposite of
+	 * the requested scope) with no signal to the caller. Same contract as the actor family's helper.
+	 * Uniquely named (Level-prefixed) to avoid a unity-build ODR collision with the actor family's copy.
+	 */
+	TArray<FString> LevelGetStringArray(const FUnrealMcpToolCall& Call, const FString& Key, FString& OutError)
+	{
+		TArray<FString> Out;
+		const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
+		if (Call.Arguments->TryGetArrayField(Key, Arr) && Arr)
+		{
+			for (const TSharedPtr<FJsonValue>& V : *Arr)
+			{
+				FString S;
+				if (V.IsValid() && V->TryGetString(S))
+				{
+					Out.Add(S);
+				}
+				else
+				{
+					OutError = FString::Printf(TEXT("'%s' must be an array of strings; a non-string entry was provided."), *Key);
+					Out.Reset();
+					return Out;
+				}
+			}
+		}
+		return Out;
+	}
+
+	/** Long package name of a level's outermost package (e.g. /Game/Maps/Arena); empty when null. */
+	FString LevelPackageName(const ULevel* Level)
+	{
+		if (!Level)
+			return FString();
+		const UPackage* Package = Level->GetOutermost();
+		return Package ? Package->GetName() : FString();
+	}
+
+	/** Short, content-browser-style name of a level (e.g. "Arena"); empty when null. */
+	FString LevelShortName(const ULevel* Level)
+	{
+		const FString PackageName = LevelPackageName(Level);
+		return PackageName.IsEmpty() ? FString() : FPackageName::GetShortName(PackageName);
+	}
+
+	/** A `{ name, package, isPersistent, isCurrent }` identity block for a level loaded in @p World. */
+	TSharedPtr<FJsonObject> LevelIdentity(const ULevel* Level, const UWorld* World)
+	{
+		TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+		Out->SetStringField(TEXT("name"), LevelShortName(Level));
+		Out->SetStringField(TEXT("package"), LevelPackageName(Level));
+		const bool bPersistent = World && Level == World->PersistentLevel;
+		Out->SetBoolField(TEXT("isPersistent"), bPersistent);
+		Out->SetBoolField(TEXT("isCurrent"), World && Level == World->GetCurrentLevel());
+		return Out;
+	}
+
+	/** The editor world for level tools; null outside the editor (mirrors FUnrealMcpObjectRef::GetEditorWorld). */
+	UWorld* GetWorldOrNull()
+	{
+		return FUnrealMcpObjectRef::GetEditorWorld();
+	}
+
+	/**
+	 * Resolve a level asset path (object path like '/Game/Maps/Arena.Arena' or a plain package name like
+	 * '/Game/Maps/Arena') to the on-disk .umap filename, returning false + a reason when the path is
+	 * malformed or no package exists. Used to turn an expected-miss (typo'd path / template) into a clean
+	 * structured error BEFORE calling an engine API that would otherwise log an Error (an Automation
+	 * failure) or — for NewMapFromTemplate — silently fall back to a blank map.
+	 */
+	bool ResolveLevelFilename(const FString& AssetPath, FString& OutFilename, FString& OutError)
+	{
+		FString PackageName = AssetPath;
+		if (FPackageName::IsValidObjectPath(AssetPath))
+			PackageName = FPackageName::ObjectPathToPackageName(AssetPath);
+		if (!FPackageName::IsValidLongPackageName(PackageName))
+		{
+			OutError = FString::Printf(TEXT("'%s' is not a valid level asset path."), *AssetPath);
+			return false;
+		}
+		if (!FPackageName::DoesPackageExist(PackageName, &OutFilename))
+		{
+			OutError = FString::Printf(TEXT("No level package exists at '%s'."), *PackageName);
+			return false;
+		}
+		return true;
+	}
+}
+
+namespace UnrealMcpLevelTools
+{
+	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry)
+	{
+		// ----------------------------------------------------------------------------------------
+		// level-create — new (in-memory) level, optionally from a template, optionally saved to a path.
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("level-create"))
+			.Title(TEXT("Create Level"))
+			.Description(TEXT("Create a new, empty level and make it the active editor world. Optionally seed it "
+			                  "from an existing level via 'template' (asset path), and optionally persist it to "
+			                  "disk via 'path' (asset path, e.g. '/Game/Maps/Arena') — omit 'path' to leave the "
+			                  "new level transient/in-memory. Replaces the current editor world (its undo buffer "
+			                  "is reset, as with any New/Open Level)."))
+			.ParamString(TEXT("path"), TEXT("Asset path to save the new level to (e.g. '/Game/Maps/Arena'). Omit to leave it transient/in-memory."))
+			.ParamString(TEXT("template"), TEXT("Asset path of an existing level to seed the new one from. Omit for a blank level."))
+			.DestructiveHint(false)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				if (!GEditor)
+					return FUnrealMcpToolResult::Error(TEXT("No editor available (not running in the editor)."));
+
+				const FString Template = Call.GetString(TEXT("template"));
+				const FString SavePath = Call.GetString(TEXT("path"));
+
+				UWorld* NewWorld = nullptr;
+				if (!Template.IsEmpty())
+				{
+					// Validate the template package exists FIRST: NewMapFromTemplate silently falls back to
+					// a blank map when the template is missing (it does NOT return null), so a typo'd template
+					// would otherwise produce a misleading "success" with an empty world. Probe up front and
+					// fail with a structured error instead.
+					FString TemplateFilename, TemplateError;
+					if (!ResolveLevelFilename(Template, TemplateFilename, TemplateError))
+						return FUnrealMcpToolResult::Error(FString::Printf(
+							TEXT("Could not create a level from template '%s': %s"), *Template, *TemplateError));
+
+					NewWorld = UEditorLoadingAndSavingUtils::NewMapFromTemplate(Template, /*bSaveExistingMap*/ false);
+					if (!NewWorld)
+						return FUnrealMcpToolResult::Error(FString::Printf(
+							TEXT("Could not create a level from template '%s' (template found but invalid)."), *Template));
+				}
+				else
+				{
+					// GEditor->NewMap() is the headless-safe in-memory world creation the engine's own
+					// automation harness uses (FAutomationEditorCommonUtils::CreateNewMap); no disk write.
+					NewWorld = GEditor->NewMap();
+					if (!NewWorld)
+						return FUnrealMcpToolResult::Error(TEXT("Failed to create a new level (GEditor->NewMap returned null)."));
+				}
+
+				bool bSaved = false;
+				if (!SavePath.IsEmpty())
+				{
+					// Save-as the freshly created transient world to the requested asset path.
+					bSaved = UEditorLoadingAndSavingUtils::SaveMap(NewWorld, SavePath);
+					if (!bSaved)
+						return FUnrealMcpToolResult::Error(FString::Printf(
+							TEXT("Created the level but failed to save it to '%s' (invalid path or save was declined)."), *SavePath));
+				}
+
+				ULevel* Persistent = NewWorld->PersistentLevel;
+				TSharedPtr<FJsonObject> Structured = LevelIdentity(Persistent, NewWorld);
+				Structured->SetBoolField(TEXT("saved"), bSaved);
+				if (bSaved)
+					Structured->SetStringField(TEXT("savedPath"), SavePath);
+
+				const FString What = Template.IsEmpty() ? TEXT("blank level") : FString::Printf(TEXT("level from template '%s'"), *Template);
+				const FString Where = bSaved ? FString::Printf(TEXT(" and saved to '%s'"), *SavePath) : TEXT(" (transient — pass 'path' to save)");
+				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Created a %s%s."), *What, *Where), Structured);
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// level-open — open an existing level by asset path.
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("level-open"))
+			.Title(TEXT("Open Level"))
+			.Description(TEXT("Open an existing level as the active editor world, replacing the current one. "
+			                  "Identify it by asset path (e.g. '/Game/Maps/Arena')."))
+			.ParamString(TEXT("path"), TEXT("Asset path of the level to open (e.g. '/Game/Maps/Arena')."), EUnrealMcpParamRequirement::Required)
+			.DestructiveHint(false)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const FString Path = Call.GetString(TEXT("path"));
+				if (Path.IsEmpty())
+					return FUnrealMcpToolResult::Error(TEXT("Missing required 'path' (asset path of the level to open)."));
+
+				// Normalise to a long package name and resolve the .umap on disk. Probing existence up
+				// front turns an expected-miss into a clean structured error instead of an engine Error
+				// (which Automation would count as a failure) or a load of the wrong file.
+				FString Filename, ResolveError;
+				if (!ResolveLevelFilename(Path, Filename, ResolveError))
+					return FUnrealMcpToolResult::Error(ResolveError);
+
+				UWorld* Opened = UEditorLoadingAndSavingUtils::LoadMap(Filename);
+				if (!Opened)
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to open level '%s'."), *Path));
+
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Opened level '%s'."), *LevelShortName(Opened->PersistentLevel)),
+					LevelIdentity(Opened->PersistentLevel, Opened));
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// level-save — save the current level; save-as via optional 'path'.
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("level-save"))
+			.Title(TEXT("Save Level"))
+			.Description(TEXT("Save the current editor level. Pass 'path' (asset path) to save-as a copy to a new "
+			                  "location; omit it to save the current level in place. A transient/never-saved level "
+			                  "with no 'path' returns an error (provide 'path' to give it a location)."))
+			.ParamString(TEXT("path"), TEXT("Asset path to save-as to (e.g. '/Game/Maps/Arena'). Omit to save the current level in place."))
+			.DestructiveHint(false)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				UWorld* World = GetWorldOrNull();
+				if (!World)
+					return FUnrealMcpToolResult::Error(TEXT("No editor world available (not running in the editor)."));
+
+				const FString SavePath = Call.GetString(TEXT("path"));
+				if (!SavePath.IsEmpty())
+				{
+					if (!UEditorLoadingAndSavingUtils::SaveMap(World, SavePath))
+						return FUnrealMcpToolResult::Error(FString::Printf(
+							TEXT("Failed to save the level to '%s' (invalid path or save was declined)."), *SavePath));
+					return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Saved the current level to '%s'."), *SavePath));
+				}
+
+				// Save-in-place. SaveCurrentLevel returns false for a transient/never-saved world (no path
+				// yet) — surface that as a structured error rather than silently no-op'ing.
+				if (!UEditorLoadingAndSavingUtils::SaveCurrentLevel())
+					return FUnrealMcpToolResult::Error(
+						TEXT("The current level could not be saved in place (it is transient / has never been saved). "
+						     "Pass 'path' to save it to a location."));
+
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Saved the current level '%s'."), *LevelShortName(World->GetCurrentLevel())));
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// level-get-data — actor-tree snapshot of the loaded world; scoped reads via 'paths' (§3.2).
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("level-get-data"))
+			.Title(TEXT("Get Level Data"))
+			.Description(TEXT("Read an actor-tree snapshot of the loaded editor world. Returns each actor's "
+			                  "identity, optionally including reflected data scoped to the dotted 'paths' filter "
+			                  "(§3.2) to save tokens. Pass 'actor' to scope the read to a single actor instead of "
+			                  "the whole world."))
+			.ParamString(TEXT("actor"), TEXT("Label / name / path of a single actor to read. Omit to snapshot the whole world."))
+			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include per actor (scoped read). Identity only when omitted."), EUnrealMcpParamRequirement::Optional, LevelMakeStringArraySchema(TEXT("Dotted property paths to include per actor (scoped read).")))
+			.ParamInt(TEXT("limit"), TEXT("Maximum number of actors to return for a world snapshot. Defaults to 200."))
+			.ReadOnlyHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				UWorld* World = GetWorldOrNull();
+				if (!World)
+					return FUnrealMcpToolResult::Error(TEXT("No editor world available."));
+
+				FString PathsError;
+				const TArray<FString> Paths = LevelGetStringArray(Call, TEXT("paths"), PathsError);
+				if (!PathsError.IsEmpty())
+					return FUnrealMcpToolResult::Error(PathsError);
+
+				// Single-actor scope.
+				const FString ActorRef = Call.GetString(TEXT("actor"));
+				if (!ActorRef.IsEmpty())
+				{
+					AActor* Actor = FUnrealMcpObjectRef::ResolveActor(ActorRef, World);
+					if (!Actor)
+						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No actor matched '%s' (by label/name/path)."), *ActorRef));
+
+					TSharedPtr<FJsonObject> Entry = FUnrealMcpObjectRef::ActorIdentity(Actor);
+					Entry->SetObjectField(TEXT("data"), FUnrealMcpPropertyJson::SerializeObject(Actor, Paths));
+					return FUnrealMcpToolResult::Success(
+						FString::Printf(TEXT("Read actor '%s'."), *Actor->GetActorLabel()), Entry);
+				}
+
+				// Whole-world snapshot.
+				const int32 Limit = static_cast<int32>(Call.GetInt(TEXT("limit"), 200));
+				TArray<TSharedPtr<FJsonValue>> Actors;
+				int32 Total = 0;
+				for (TActorIterator<AActor> It(World); It; ++It)
+				{
+					AActor* Actor = *It;
+					if (!Actor)
+						continue;
+					++Total;
+					if (Limit > 0 && Actors.Num() >= Limit)
+						continue; // keep counting the total, stop materializing entries
+
+					TSharedPtr<FJsonObject> Entry = FUnrealMcpObjectRef::ActorIdentity(Actor);
+					if (Paths.Num() > 0)
+						Entry->SetObjectField(TEXT("data"), FUnrealMcpPropertyJson::SerializeObject(Actor, Paths));
+					Actors.Add(MakeShared<FJsonValueObject>(Entry));
+				}
+
+				TSharedPtr<FJsonObject> Structured = LevelIdentity(World->GetCurrentLevel(), World);
+				Structured->SetStringField(TEXT("world"), World->GetName());
+				Structured->SetBoolField(TEXT("isPartitionedWorld"), World->IsPartitionedWorld());
+				Structured->SetNumberField(TEXT("levelCount"), World->GetLevels().Num());
+				Structured->SetNumberField(TEXT("count"), Actors.Num());
+				Structured->SetNumberField(TEXT("total"), Total);
+				Structured->SetArrayField(TEXT("actors"), Actors);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Snapshot of world '%s': %d actor(s) (returned %d)."), *World->GetName(), Total, Actors.Num()),
+					Structured);
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// level-list-loaded — persistent + streaming sublevels, World-Partition aware (read-only).
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("level-list-loaded"))
+			.Title(TEXT("List Loaded Levels"))
+			.Description(TEXT("List the levels loaded in the current editor world — the persistent level plus any "
+			                  "streaming sublevels — with their load/visibility/current state, and whether the "
+			                  "world is a World-Partition world. Read-only."))
+			.ReadOnlyHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				UWorld* World = GetWorldOrNull();
+				if (!World)
+					return FUnrealMcpToolResult::Error(TEXT("No editor world available."));
+
+				TArray<TSharedPtr<FJsonValue>> Levels;
+
+				// Persistent level first.
+				if (World->PersistentLevel)
+				{
+					TSharedPtr<FJsonObject> Entry = LevelIdentity(World->PersistentLevel, World);
+					Entry->SetBoolField(TEXT("isLoaded"), true);
+					Entry->SetBoolField(TEXT("isVisible"), true);
+					Levels.Add(MakeShared<FJsonValueObject>(Entry));
+				}
+
+				// Streaming sublevels (the §10 "sublevels" awareness). A sublevel that is not currently
+				// loaded has a null loaded-level pointer; report its requested/visible flags regardless.
+				for (ULevelStreaming* Streaming : World->GetStreamingLevels())
+				{
+					if (!Streaming)
+						continue;
+					ULevel* Loaded = Streaming->GetLoadedLevel();
+					TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+					Entry->SetStringField(TEXT("name"), FPackageName::GetShortName(Streaming->GetWorldAssetPackageName()));
+					Entry->SetStringField(TEXT("package"), Streaming->GetWorldAssetPackageName());
+					Entry->SetBoolField(TEXT("isPersistent"), false);
+					Entry->SetBoolField(TEXT("isCurrent"), Loaded && Loaded == World->GetCurrentLevel());
+					Entry->SetBoolField(TEXT("isLoaded"), Loaded != nullptr);
+					Entry->SetBoolField(TEXT("isVisible"), Streaming->GetShouldBeVisibleInEditor());
+					Levels.Add(MakeShared<FJsonValueObject>(Entry));
+				}
+
+				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+				Structured->SetStringField(TEXT("world"), World->GetName());
+				Structured->SetBoolField(TEXT("isPartitionedWorld"), World->IsPartitionedWorld());
+				Structured->SetNumberField(TEXT("count"), Levels.Num());
+				Structured->SetArrayField(TEXT("levels"), Levels);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("World '%s' has %d loaded level(s)%s."), *World->GetName(), Levels.Num(),
+						World->IsPartitionedWorld() ? TEXT(" (World-Partition)") : TEXT("")),
+					Structured);
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// level-set-current — set the active editing level among the loaded levels.
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("level-set-current"))
+			.Title(TEXT("Set Current Level"))
+			.Description(TEXT("Set the current editing level (the one new actors are added to) by name — the "
+			                  "content-browser short name of a loaded level (persistent or streaming sublevel). "
+			                  "Use level-list-loaded to discover the available names."))
+			.ParamString(TEXT("name"), TEXT("Short name of the loaded level to make current."), EUnrealMcpParamRequirement::Required)
+			.DestructiveHint(false)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				UWorld* World = GetWorldOrNull();
+				if (!World)
+					return FUnrealMcpToolResult::Error(TEXT("No editor world available."));
+
+				const FString Name = Call.GetString(TEXT("name"));
+				if (Name.IsEmpty())
+					return FUnrealMcpToolResult::Error(TEXT("Missing required 'name' (short name of a loaded level)."));
+
+				ULevel* Target = nullptr;
+				for (ULevel* Level : World->GetLevels())
+				{
+					if (Level && LevelShortName(Level).Equals(Name, ESearchCase::IgnoreCase))
+					{
+						Target = Level;
+						break;
+					}
+				}
+				if (!Target)
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("No loaded level named '%s' (use level-list-loaded to see the available names)."), *Name));
+
+				if (World->GetCurrentLevel() == Target)
+					return FUnrealMcpToolResult::Success(
+						FString::Printf(TEXT("Level '%s' is already the current level."), *LevelShortName(Target)),
+						LevelIdentity(Target, World));
+
+				// MakeLevelCurrent updates the editor's current-level state (and the actor-editor context);
+				// it is a no-op for a locked level unless forced — we do not force here.
+				UEditorLevelUtils::MakeLevelCurrent(Target, /*bEvenIfLocked*/ false);
+				if (World->GetCurrentLevel() != Target)
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("Could not make '%s' the current level (it may be locked)."), *LevelShortName(Target)));
+
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Made '%s' the current level."), *LevelShortName(Target)),
+					LevelIdentity(Target, World));
+			});
+
+		// ----------------------------------------------------------------------------------------
+		// level-unload-sublevel — remove a loaded streaming sublevel from the world.
+		// ----------------------------------------------------------------------------------------
+		Registry.Tool(TEXT("level-unload-sublevel"))
+			.Title(TEXT("Unload Sublevel"))
+			.Description(TEXT("Unload (remove from the world) a loaded streaming sublevel by its short name. The "
+			                  "persistent level cannot be unloaded. Use level-list-loaded to discover the sublevel "
+			                  "names."))
+			.ParamString(TEXT("name"), TEXT("Short name of the streaming sublevel to unload."), EUnrealMcpParamRequirement::Required)
+			.DestructiveHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				UWorld* World = GetWorldOrNull();
+				if (!World)
+					return FUnrealMcpToolResult::Error(TEXT("No editor world available."));
+
+				const FString Name = Call.GetString(TEXT("name"));
+				if (Name.IsEmpty())
+					return FUnrealMcpToolResult::Error(TEXT("Missing required 'name' (short name of a streaming sublevel)."));
+
+				// Reject the persistent level explicitly — it is not a sublevel and cannot be unloaded.
+				if (World->PersistentLevel && LevelShortName(World->PersistentLevel).Equals(Name, ESearchCase::IgnoreCase))
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("'%s' is the persistent level and cannot be unloaded."), *Name));
+
+				ULevelStreaming* Match = nullptr;
+				for (ULevelStreaming* Streaming : World->GetStreamingLevels())
+				{
+					if (Streaming && FPackageName::GetShortName(Streaming->GetWorldAssetPackageName()).Equals(Name, ESearchCase::IgnoreCase))
+					{
+						Match = Streaming;
+						break;
+					}
+				}
+				if (!Match)
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("No streaming sublevel named '%s' (use level-list-loaded to see the available names)."), *Name));
+
+				ULevel* Loaded = Match->GetLoadedLevel();
+				if (!Loaded)
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("Sublevel '%s' is not currently loaded; nothing to unload."), *Name));
+
+				if (!UEditorLevelUtils::RemoveLevelFromWorld(Loaded))
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to unload sublevel '%s'."), *Name));
+
+				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Unloaded sublevel '%s'."), *Name));
+			});
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLevelTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLevelTools.cpp
@@ -278,8 +278,25 @@ namespace UnrealMcpLevelTools
 				{
 					bSaved = UEditorLoadingAndSavingUtils::SaveMap(NewWorld, SavedPackage);
 					if (!bSaved)
+					{
+						// The world was already replaced (and the previous world's unsaved edits discarded) before this
+						// save attempt; an Error result carries no structured payload, so name the discarded packages in
+						// the message text rather than dropping that signal silently.
+						FString DiscardedSuffix;
+						if (DiscardedDirty.Num() > 0)
+						{
+							TArray<FString> DiscardedNames;
+							for (const TSharedPtr<FJsonValue>& V : DiscardedDirty)
+								if (V.IsValid())
+									DiscardedNames.Add(V->AsString());
+							DiscardedSuffix = FString::Printf(
+								TEXT(" Unsaved edits from the previous world were already discarded: %s."),
+								*FString::Join(DiscardedNames, TEXT(", ")));
+						}
 						return FUnrealMcpToolResult::Error(FString::Printf(
-							TEXT("Created the level but failed to save it to '%s' (invalid path or save was declined)."), *SavedPackage));
+							TEXT("Created the level but failed to save it to '%s' (invalid path or save was declined).%s"),
+							*SavedPackage, *DiscardedSuffix));
+					}
 				}
 
 				ULevel* Persistent = NewWorld->PersistentLevel;
@@ -313,6 +330,12 @@ namespace UnrealMcpLevelTools
 			.DestructiveHint(true)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
+				// UEditorLoadingAndSavingUtils::LoadMap dereferences GEditor internally; guard it the same way
+				// level-create guards GEditor->NewMap. The other tools reach the editor via GetWorldOrNull, but
+				// level-open REPLACES the world, so there is no current world to probe — check GEditor directly.
+				if (!GEditor)
+					return FUnrealMcpToolResult::Error(TEXT("No editor available (not running in the editor)."));
+
 				const FString Path = Call.GetString(TEXT("path"));
 				if (Path.IsEmpty())
 					return FUnrealMcpToolResult::Error(TEXT("Missing required 'path' (asset path of the level to open)."));
@@ -636,7 +659,9 @@ namespace UnrealMcpLevelTools
 				if (!Match)
 				{
 					// Not a sublevel: explain the persistent-level case specifically, else a plain not-found.
-					if (World->PersistentLevel && LevelShortName(World->PersistentLevel).Equals(Name, ESearchCase::IgnoreCase))
+					if (World->PersistentLevel &&
+						(LevelShortName(World->PersistentLevel).Equals(Name, ESearchCase::IgnoreCase) ||
+						 LevelPackageName(World->PersistentLevel).Equals(Name, ESearchCase::IgnoreCase)))
 						return FUnrealMcpToolResult::Error(FString::Printf(
 							TEXT("'%s' is the persistent level and cannot be unloaded."), *Name));
 					return FUnrealMcpToolResult::Error(FString::Printf(
@@ -648,10 +673,21 @@ namespace UnrealMcpLevelTools
 					return FUnrealMcpToolResult::Error(FString::Printf(
 						TEXT("Sublevel '%s' is not currently loaded; nothing to unload."), *Name));
 
+				// Capture the sublevel's unsaved state BEFORE removing it: RemoveLevelFromWorld discards a dirty
+				// sublevel's edits with no prompt under -unattended, so surface `wasDirty` to complete the family's
+				// discarded-edits convention (mirrors `discardedDirtyLevels` on level-create / level-open).
+				const UPackage* LoadedPackage = Loaded->GetOutermost();
+				const bool bWasDirty = LoadedPackage && LoadedPackage->IsDirty();
+
 				if (!UEditorLevelUtils::RemoveLevelFromWorld(Loaded))
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to unload sublevel '%s'."), *Name));
 
-				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Unloaded sublevel '%s'."), *Name));
+				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+				Structured->SetBoolField(TEXT("wasDirty"), bWasDirty);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Unloaded sublevel '%s'%s."), *Name,
+						bWasDirty ? TEXT(" (discarded its unsaved edits)") : TEXT("")),
+					Structured);
 			});
 	}
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLevelTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLevelTools.cpp
@@ -146,6 +146,46 @@ namespace
 			OutError = FString::Printf(TEXT("No level package exists at '%s'."), *PackageName);
 			return false;
 		}
+		// DoesPackageExist is content-agnostic: a non-level asset (material, blueprint, …) also passes. Without
+		// this guard NewMapFromTemplate -> LoadMap would silently fall back to a blank map (and level-open would
+		// log an engine Error). Require the resolved package to be a .umap.
+		if (!OutFilename.EndsWith(FPackageName::GetMapPackageExtension(), ESearchCase::IgnoreCase))
+		{
+			OutError = FString::Printf(TEXT("'%s' is not a level/map asset."), *PackageName);
+			OutFilename.Reset();
+			return false;
+		}
+		return true;
+	}
+
+	/** Names of dirty (unsaved) map packages that a New/Open Level would silently discard — empty when none.
+	 *  Surfaced as a structured `discardedDirtyLevels` note so an unattended/headless caller (where the engine's
+	 *  own save-prompt is suppressed) still learns that unsaved level edits were dropped. */
+	TArray<TSharedPtr<FJsonValue>> DirtyMapPackageNames()
+	{
+		TArray<UPackage*> DirtyPackages;
+		UEditorLoadingAndSavingUtils::GetDirtyMapPackages(DirtyPackages);
+		TArray<TSharedPtr<FJsonValue>> Out;
+		for (const UPackage* Package : DirtyPackages)
+			if (Package)
+				Out.Add(MakeShared<FJsonValueString>(Package->GetName()));
+		return Out;
+	}
+
+	/** Normalise a save-as asset path (object-path or package-name form) to a long package name, validating it;
+	 *  returns false + a reason when malformed. Sets bOutExists when a package already exists at the target, so
+	 *  the caller can surface an overwrite (SaveMap force-overwrites silently otherwise). */
+	bool ResolveSaveTargetPackage(const FString& AssetPath, FString& OutPackageName, bool& bOutExists, FString& OutError)
+	{
+		OutPackageName = AssetPath;
+		if (FPackageName::IsValidObjectPath(AssetPath))
+			OutPackageName = FPackageName::ObjectPathToPackageName(AssetPath);
+		if (!FPackageName::IsValidLongPackageName(OutPackageName))
+		{
+			OutError = FString::Printf(TEXT("'%s' is not a valid level asset path (expected e.g. '/Game/Maps/Arena')."), *AssetPath);
+			return false;
+		}
+		bOutExists = FPackageName::DoesPackageExist(OutPackageName);
 		return true;
 	}
 }
@@ -175,6 +215,10 @@ namespace UnrealMcpLevelTools
 				const FString Template = Call.GetString(TEXT("template"));
 				const FString SavePath = Call.GetString(TEXT("path"));
 
+				// Capture unsaved map edits BEFORE replacing the world — New/Open Level discards them and the
+				// engine's confirm dialog is suppressed under -unattended, so this note is the only signal.
+				TArray<TSharedPtr<FJsonValue>> DiscardedDirty = DirtyMapPackageNames();
+
 				UWorld* NewWorld = nullptr;
 				if (!Template.IsEmpty())
 				{
@@ -187,7 +231,9 @@ namespace UnrealMcpLevelTools
 						return FUnrealMcpToolResult::Error(FString::Printf(
 							TEXT("Could not create a level from template '%s': %s"), *Template, *TemplateError));
 
-					NewWorld = UEditorLoadingAndSavingUtils::NewMapFromTemplate(Template, /*bSaveExistingMap*/ false);
+					// Pass the resolved on-disk filename (not the raw asset path): NewMapFromTemplate forwards it
+					// to FEditorFileUtils::LoadMap, exactly as level-open does with its resolved filename.
+					NewWorld = UEditorLoadingAndSavingUtils::NewMapFromTemplate(TemplateFilename, /*bSaveExistingMap*/ false);
 					if (!NewWorld)
 						return FUnrealMcpToolResult::Error(FString::Printf(
 							TEXT("Could not create a level from template '%s' (template found but invalid)."), *Template));
@@ -202,23 +248,36 @@ namespace UnrealMcpLevelTools
 				}
 
 				bool bSaved = false;
+				bool bOverwrote = false;
+				FString SavedPackage;
 				if (!SavePath.IsEmpty())
 				{
-					// Save-as the freshly created transient world to the requested asset path.
-					bSaved = UEditorLoadingAndSavingUtils::SaveMap(NewWorld, SavePath);
+					// Normalise + validate the target and probe for a pre-existing level: SaveMap force-overwrites
+					// an existing .umap silently, so detect the collision and surface it via `overwrote`.
+					FString SaveError;
+					if (!ResolveSaveTargetPackage(SavePath, SavedPackage, bOverwrote, SaveError))
+						return FUnrealMcpToolResult::Error(SaveError);
+					bSaved = UEditorLoadingAndSavingUtils::SaveMap(NewWorld, SavedPackage);
 					if (!bSaved)
 						return FUnrealMcpToolResult::Error(FString::Printf(
-							TEXT("Created the level but failed to save it to '%s' (invalid path or save was declined)."), *SavePath));
+							TEXT("Created the level but failed to save it to '%s' (invalid path or save was declined)."), *SavedPackage));
 				}
 
 				ULevel* Persistent = NewWorld->PersistentLevel;
 				TSharedPtr<FJsonObject> Structured = LevelIdentity(Persistent, NewWorld);
 				Structured->SetBoolField(TEXT("saved"), bSaved);
 				if (bSaved)
-					Structured->SetStringField(TEXT("savedPath"), SavePath);
+				{
+					Structured->SetStringField(TEXT("savedPath"), SavedPackage);
+					Structured->SetBoolField(TEXT("overwrote"), bOverwrote);
+				}
+				if (DiscardedDirty.Num() > 0)
+					Structured->SetArrayField(TEXT("discardedDirtyLevels"), DiscardedDirty);
 
 				const FString What = Template.IsEmpty() ? TEXT("blank level") : FString::Printf(TEXT("level from template '%s'"), *Template);
-				const FString Where = bSaved ? FString::Printf(TEXT(" and saved to '%s'"), *SavePath) : TEXT(" (transient — pass 'path' to save)");
+				const FString Where = bSaved
+					? FString::Printf(TEXT(" and saved to '%s'%s"), *SavedPackage, bOverwrote ? TEXT(" (overwrote an existing level)") : TEXT(""))
+					: TEXT(" (transient — pass 'path' to save)");
 				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Created a %s%s."), *What, *Where), Structured);
 			});
 
@@ -244,13 +303,19 @@ namespace UnrealMcpLevelTools
 				if (!ResolveLevelFilename(Path, Filename, ResolveError))
 					return FUnrealMcpToolResult::Error(ResolveError);
 
+				// Capture unsaved map edits BEFORE the load replaces the world (see level-create).
+				TArray<TSharedPtr<FJsonValue>> DiscardedDirty = DirtyMapPackageNames();
+
 				UWorld* Opened = UEditorLoadingAndSavingUtils::LoadMap(Filename);
 				if (!Opened)
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to open level '%s'."), *Path));
 
+				TSharedPtr<FJsonObject> Structured = LevelIdentity(Opened->PersistentLevel, Opened);
+				if (DiscardedDirty.Num() > 0)
+					Structured->SetArrayField(TEXT("discardedDirtyLevels"), DiscardedDirty);
 				return FUnrealMcpToolResult::Success(
 					FString::Printf(TEXT("Opened level '%s'."), *LevelShortName(Opened->PersistentLevel)),
-					LevelIdentity(Opened->PersistentLevel, Opened));
+					Structured);
 			});
 
 		// ----------------------------------------------------------------------------------------
@@ -272,18 +337,29 @@ namespace UnrealMcpLevelTools
 				const FString SavePath = Call.GetString(TEXT("path"));
 				if (!SavePath.IsEmpty())
 				{
-					if (!UEditorLoadingAndSavingUtils::SaveMap(World, SavePath))
+					// Normalise + validate the target and probe for a pre-existing level: SaveMap force-
+					// overwrites an existing .umap silently, so detect the collision and surface `overwrote`.
+					FString SavedPackage, SaveError;
+					bool bOverwrote = false;
+					if (!ResolveSaveTargetPackage(SavePath, SavedPackage, bOverwrote, SaveError))
+						return FUnrealMcpToolResult::Error(SaveError);
+					if (!UEditorLoadingAndSavingUtils::SaveMap(World, SavedPackage))
 						return FUnrealMcpToolResult::Error(FString::Printf(
-							TEXT("Failed to save the level to '%s' (invalid path or save was declined)."), *SavePath));
-					return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Saved the current level to '%s'."), *SavePath));
+							TEXT("Failed to save the level to '%s' (invalid path or save was declined)."), *SavedPackage));
+					TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+					Structured->SetStringField(TEXT("savedPath"), SavedPackage);
+					Structured->SetBoolField(TEXT("overwrote"), bOverwrote);
+					return FUnrealMcpToolResult::Success(
+						FString::Printf(TEXT("Saved the current level to '%s'%s."), *SavedPackage,
+							bOverwrote ? TEXT(" (overwrote an existing level)") : TEXT("")), Structured);
 				}
 
 				// Save-in-place. SaveCurrentLevel returns false for a transient/never-saved world (no path
 				// yet) — surface that as a structured error rather than silently no-op'ing.
 				if (!UEditorLoadingAndSavingUtils::SaveCurrentLevel())
 					return FUnrealMcpToolResult::Error(
-						TEXT("The current level could not be saved in place (it is transient / has never been saved). "
-						     "Pass 'path' to save it to a location."));
+						TEXT("The current level could not be saved in place. This happens for a transient / never-saved "
+						     "level (pass 'path' to give it a location), and can also indicate a checkout or write failure."));
 
 				return FUnrealMcpToolResult::Success(
 					FString::Printf(TEXT("Saved the current level '%s'."), *LevelShortName(World->GetCurrentLevel())));
@@ -300,7 +376,7 @@ namespace UnrealMcpLevelTools
 			                  "the whole world."))
 			.ParamString(TEXT("actor"), TEXT("Label / name / path of a single actor to read. Omit to snapshot the whole world."))
 			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include per actor (scoped read). Identity only when omitted."), EUnrealMcpParamRequirement::Optional, LevelMakeStringArraySchema(TEXT("Dotted property paths to include per actor (scoped read).")))
-			.ParamInt(TEXT("limit"), TEXT("Maximum number of actors to return for a world snapshot. Defaults to 200."))
+			.ParamInt(TEXT("limit"), TEXT("Maximum number of actors to return for a world snapshot. Defaults to 200; pass 0 or a negative value for no limit."))
 			.ReadOnlyHint(true)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
@@ -322,7 +398,10 @@ namespace UnrealMcpLevelTools
 						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No actor matched '%s' (by label/name/path)."), *ActorRef));
 
 					TSharedPtr<FJsonObject> Entry = FUnrealMcpObjectRef::ActorIdentity(Actor);
-					Entry->SetObjectField(TEXT("data"), FUnrealMcpPropertyJson::SerializeObject(Actor, Paths));
+					// Attach reflected data only when a scoped 'paths' filter is given — matching the whole-world
+					// branch and the "Identity only when omitted" contract (an empty Paths returns the full dump).
+					if (Paths.Num() > 0)
+						Entry->SetObjectField(TEXT("data"), FUnrealMcpPropertyJson::SerializeObject(Actor, Paths));
 					return FUnrealMcpToolResult::Success(
 						FString::Printf(TEXT("Read actor '%s'."), *Actor->GetActorLabel()), Entry);
 				}
@@ -420,7 +499,7 @@ namespace UnrealMcpLevelTools
 			.Description(TEXT("Set the current editing level (the one new actors are added to) by name — the "
 			                  "content-browser short name of a loaded level (persistent or streaming sublevel). "
 			                  "Use level-list-loaded to discover the available names."))
-			.ParamString(TEXT("name"), TEXT("Short name of the loaded level to make current."), EUnrealMcpParamRequirement::Required)
+			.ParamString(TEXT("name"), TEXT("Short name — or full package path, to disambiguate — of the loaded level to make current."), EUnrealMcpParamRequirement::Required)
 			.DestructiveHint(false)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
@@ -432,15 +511,29 @@ namespace UnrealMcpLevelTools
 				if (Name.IsEmpty())
 					return FUnrealMcpToolResult::Error(TEXT("Missing required 'name' (short name of a loaded level)."));
 
+				// Match by short name OR full package path. The package path is unambiguous; a short name that
+				// matches more than one loaded level is an error (the caller must pass the package path instead).
 				ULevel* Target = nullptr;
+				int32 ShortNameMatches = 0;
 				for (ULevel* Level : World->GetLevels())
 				{
-					if (Level && LevelShortName(Level).Equals(Name, ESearchCase::IgnoreCase))
+					if (!Level)
+						continue;
+					if (LevelPackageName(Level).Equals(Name, ESearchCase::IgnoreCase))
 					{
 						Target = Level;
+						ShortNameMatches = 1; // an exact package-path hit is decisive
 						break;
 					}
+					if (LevelShortName(Level).Equals(Name, ESearchCase::IgnoreCase))
+					{
+						Target = Level;
+						++ShortNameMatches;
+					}
 				}
+				if (ShortNameMatches > 1)
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("'%s' matches multiple loaded levels; pass the full package path (e.g. '/Game/Maps/Arena') to disambiguate."), *Name));
 				if (!Target)
 					return FUnrealMcpToolResult::Error(FString::Printf(
 						TEXT("No loaded level named '%s' (use level-list-loaded to see the available names)."), *Name));
@@ -470,7 +563,7 @@ namespace UnrealMcpLevelTools
 			.Description(TEXT("Unload (remove from the world) a loaded streaming sublevel by its short name. The "
 			                  "persistent level cannot be unloaded. Use level-list-loaded to discover the sublevel "
 			                  "names."))
-			.ParamString(TEXT("name"), TEXT("Short name of the streaming sublevel to unload."), EUnrealMcpParamRequirement::Required)
+			.ParamString(TEXT("name"), TEXT("Short name — or full package path, to disambiguate — of the streaming sublevel to unload."), EUnrealMcpParamRequirement::Required)
 			.DestructiveHint(true)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
@@ -482,23 +575,40 @@ namespace UnrealMcpLevelTools
 				if (Name.IsEmpty())
 					return FUnrealMcpToolResult::Error(TEXT("Missing required 'name' (short name of a streaming sublevel)."));
 
-				// Reject the persistent level explicitly — it is not a sublevel and cannot be unloaded.
-				if (World->PersistentLevel && LevelShortName(World->PersistentLevel).Equals(Name, ESearchCase::IgnoreCase))
-					return FUnrealMcpToolResult::Error(FString::Printf(
-						TEXT("'%s' is the persistent level and cannot be unloaded."), *Name));
-
+				// Search the streaming sublevels FIRST (by short name OR full package path). Doing this before
+				// the persistent-level guard keeps a sublevel that happens to share the persistent level's short
+				// name reachable via its package path. A short name matching multiple sublevels is an error.
 				ULevelStreaming* Match = nullptr;
+				int32 ShortNameMatches = 0;
 				for (ULevelStreaming* Streaming : World->GetStreamingLevels())
 				{
-					if (Streaming && FPackageName::GetShortName(Streaming->GetWorldAssetPackageName()).Equals(Name, ESearchCase::IgnoreCase))
+					if (!Streaming)
+						continue;
+					const FString Package = Streaming->GetWorldAssetPackageName();
+					if (Package.Equals(Name, ESearchCase::IgnoreCase))
 					{
 						Match = Streaming;
+						ShortNameMatches = 1; // an exact package-path hit is decisive
 						break;
 					}
+					if (FPackageName::GetShortName(Package).Equals(Name, ESearchCase::IgnoreCase))
+					{
+						Match = Streaming;
+						++ShortNameMatches;
+					}
 				}
+				if (ShortNameMatches > 1)
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("'%s' matches multiple streaming sublevels; pass the full package path to disambiguate."), *Name));
 				if (!Match)
+				{
+					// Not a sublevel: explain the persistent-level case specifically, else a plain not-found.
+					if (World->PersistentLevel && LevelShortName(World->PersistentLevel).Equals(Name, ESearchCase::IgnoreCase))
+						return FUnrealMcpToolResult::Error(FString::Printf(
+							TEXT("'%s' is the persistent level and cannot be unloaded."), *Name));
 					return FUnrealMcpToolResult::Error(FString::Printf(
 						TEXT("No streaming sublevel named '%s' (use level-list-loaded to see the available names)."), *Name));
+				}
 
 				ULevel* Loaded = Match->GetLoadedLevel();
 				if (!Loaded)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLevelTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLevelTools.cpp
@@ -185,7 +185,17 @@ namespace
 			OutError = FString::Printf(TEXT("'%s' is not a valid level asset path (expected e.g. '/Game/Maps/Arena')."), *AssetPath);
 			return false;
 		}
-		bOutExists = FPackageName::DoesPackageExist(OutPackageName);
+		// Probe for a pre-existing package AND verify it is a .umap (content-aware, like ResolveLevelFilename).
+		// SaveMap writes <name>.umap; if a NON-map asset (material, blueprint, …) already claims this long
+		// package name, saving would leave two on-disk files (Arena.umap + Arena.uasset) under one package name
+		// — an asset-registry/cooker ambiguity — while we'd wrongly report overwrote:true. Reject that collision.
+		FString ExistingFilename;
+		bOutExists = FPackageName::DoesPackageExist(OutPackageName, &ExistingFilename);
+		if (bOutExists && !ExistingFilename.EndsWith(FPackageName::GetMapPackageExtension(), ESearchCase::IgnoreCase))
+		{
+			OutError = FString::Printf(TEXT("'%s' already exists and is not a level/map asset; choose a different path."), *OutPackageName);
+			return false;
+		}
 		return true;
 	}
 }
@@ -206,7 +216,9 @@ namespace UnrealMcpLevelTools
 			                  "is reset, as with any New/Open Level)."))
 			.ParamString(TEXT("path"), TEXT("Asset path to save the new level to (e.g. '/Game/Maps/Arena'). Omit to leave it transient/in-memory."))
 			.ParamString(TEXT("template"), TEXT("Asset path of an existing level to seed the new one from. Omit for a blank level."))
-			.DestructiveHint(false)
+			// Destructive: replacing the editor world discards the current world's unsaved edits, and a
+			// create-with-path silently overwrites an existing .umap (hence `discardedDirtyLevels`/`overwrote`).
+			.DestructiveHint(true)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
 				if (!GEditor)
@@ -218,6 +230,18 @@ namespace UnrealMcpLevelTools
 				// Capture unsaved map edits BEFORE replacing the world — New/Open Level discards them and the
 				// engine's confirm dialog is suppressed under -unattended, so this note is the only signal.
 				TArray<TSharedPtr<FJsonValue>> DiscardedDirty = DirtyMapPackageNames();
+
+				// Validate the save-as target BEFORE replacing the world. ResolveSaveTargetPackage is pure
+				// validation (no side effects); doing it up front means a malformed 'path' fails fast instead of
+				// destroying the caller's open world (and its unsaved edits) only to then reject the bad path.
+				bool bOverwrote = false;
+				FString SavedPackage;
+				if (!SavePath.IsEmpty())
+				{
+					FString SaveError;
+					if (!ResolveSaveTargetPackage(SavePath, SavedPackage, bOverwrote, SaveError))
+						return FUnrealMcpToolResult::Error(SaveError);
+				}
 
 				UWorld* NewWorld = nullptr;
 				if (!Template.IsEmpty())
@@ -247,16 +271,11 @@ namespace UnrealMcpLevelTools
 						return FUnrealMcpToolResult::Error(TEXT("Failed to create a new level (GEditor->NewMap returned null)."));
 				}
 
+				// Save target was validated above; now that the world exists, write it to disk. SaveMap force-
+				// overwrites an existing .umap silently — the collision was already detected into `bOverwrote`.
 				bool bSaved = false;
-				bool bOverwrote = false;
-				FString SavedPackage;
 				if (!SavePath.IsEmpty())
 				{
-					// Normalise + validate the target and probe for a pre-existing level: SaveMap force-overwrites
-					// an existing .umap silently, so detect the collision and surface it via `overwrote`.
-					FString SaveError;
-					if (!ResolveSaveTargetPackage(SavePath, SavedPackage, bOverwrote, SaveError))
-						return FUnrealMcpToolResult::Error(SaveError);
 					bSaved = UEditorLoadingAndSavingUtils::SaveMap(NewWorld, SavedPackage);
 					if (!bSaved)
 						return FUnrealMcpToolResult::Error(FString::Printf(
@@ -289,7 +308,9 @@ namespace UnrealMcpLevelTools
 			.Description(TEXT("Open an existing level as the active editor world, replacing the current one. "
 			                  "Identify it by asset path (e.g. '/Game/Maps/Arena')."))
 			.ParamString(TEXT("path"), TEXT("Asset path of the level to open (e.g. '/Game/Maps/Arena')."), EUnrealMcpParamRequirement::Required)
-			.DestructiveHint(false)
+			// Destructive: opening a level replaces the editor world and discards the current world's
+			// unsaved edits (hence `discardedDirtyLevels`).
+			.DestructiveHint(true)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
 				const FString Path = Call.GetString(TEXT("path"));
@@ -323,11 +344,13 @@ namespace UnrealMcpLevelTools
 		// ----------------------------------------------------------------------------------------
 		Registry.Tool(TEXT("level-save"))
 			.Title(TEXT("Save Level"))
-			.Description(TEXT("Save the current editor level. Pass 'path' (asset path) to save-as a copy to a new "
-			                  "location; omit it to save the current level in place. A transient/never-saved level "
-			                  "with no 'path' returns an error (provide 'path' to give it a location)."))
-			.ParamString(TEXT("path"), TEXT("Asset path to save-as to (e.g. '/Game/Maps/Arena'). Omit to save the current level in place."))
-			.DestructiveHint(false)
+			.Description(TEXT("Save the current editor level. Pass 'path' (asset path) to save-as a copy of the "
+			                  "PERSISTENT level to a new location; omit it to save the current level (which may be a "
+			                  "streaming sublevel) in place. A transient/never-saved level with no 'path' returns an "
+			                  "error (provide 'path' to give it a location)."))
+			.ParamString(TEXT("path"), TEXT("Asset path to save-as the PERSISTENT level to (e.g. '/Game/Maps/Arena'). Omit to save the current level in place."))
+			// Destructive: save-as silently overwrites an existing .umap at the target (hence `overwrote`).
+			.DestructiveHint(true)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
 				UWorld* World = GetWorldOrNull();
@@ -354,12 +377,22 @@ namespace UnrealMcpLevelTools
 							bOverwrote ? TEXT(" (overwrote an existing level)") : TEXT("")), Structured);
 				}
 
-				// Save-in-place. SaveCurrentLevel returns false for a transient/never-saved world (no path
-				// yet) — surface that as a structured error rather than silently no-op'ing.
+				// Save-in-place. Guard the transient/never-saved case BEFORE calling SaveCurrentLevel: for a level
+				// with no on-disk package, FEditorFileUtils::SaveLevel falls into the interactive Save-As FILE
+				// DIALOG (and PromptToCheckoutLevels can raise a checkout dialog) — modal UI that would block the
+				// game thread / bridge, violating the handler contract (no modal UI in tool bodies). Probing the
+				// current level's package existence keeps this headless-safe in an interactive editor too.
+				const FString CurrentPackage = LevelPackageName(World->GetCurrentLevel());
+				if (CurrentPackage.IsEmpty() || !FPackageName::DoesPackageExist(CurrentPackage))
+					return FUnrealMcpToolResult::Error(
+						TEXT("The current level has never been saved (it has no on-disk location yet). "
+						     "Pass 'path' to save it to a new location."));
+
+				// The level has a real package on disk; an in-place save will not prompt for a location. A false
+				// return now indicates a checkout or write failure rather than the transient case.
 				if (!UEditorLoadingAndSavingUtils::SaveCurrentLevel())
 					return FUnrealMcpToolResult::Error(
-						TEXT("The current level could not be saved in place. This happens for a transient / never-saved "
-						     "level (pass 'path' to give it a location), and can also indicate a checkout or write failure."));
+						TEXT("The current level could not be saved in place (a checkout or write failure)."));
 
 				return FUnrealMcpToolResult::Success(
 					FString::Printf(TEXT("Saved the current level '%s'."), *LevelShortName(World->GetCurrentLevel())));

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -32,6 +32,7 @@ void FUnrealMcpRuntime::Startup()
 	UnrealMcpActorTools::Register(*Registry);
 	UnrealMcpBlueprintTools::Register(*Registry); // §10 flagship Blueprint family (CORE)
 	UnrealMcpAssetTools::Register(*Registry); // §10 asset / Content-Browser family (issue #10)
+	UnrealMcpLevelTools::Register(*Registry); // §10 level / map family (issue #16, Unity Scene.* analog)
 
 	Dispatcher = MakeUnique<FUnrealMcpGameThreadDispatcher>();
 	BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(*Registry, *Dispatcher);

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpCoreTools.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpCoreTools.h
@@ -50,3 +50,17 @@ namespace UnrealMcpAssetTools
 {
 	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry);
 }
+
+/**
+ * The level / map tool family (docs/ARCHITECTURE.md §10 "level family", issue #16 — the Unity Scene.*
+ * analog): level-create / level-open / level-save (save-as via optional path) / level-get-data (scoped
+ * actor-tree reads) / level-list-loaded (persistent + streaming sublevels, World-Partition aware,
+ * read-only) / level-set-current / level-unload-sublevel. 7 native C++ tools over the editor UWorld +
+ * UEditorLoadingAndSavingUtils + UEditorLevelUtils (Engine/UnrealEd only — no LevelEditor module, no
+ * UEditorActorSubsystem, so every body is headless-safe under -nullrhi). Registered in the boot path
+ * alongside the other core families; also exercised in isolation by Automation specs.
+ */
+namespace UnrealMcpLevelTools
+{
+	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry);
+}

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpLevelToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpLevelToolsSpec.cpp
@@ -65,9 +65,18 @@ void FUnrealMcpLevelToolsSpec::Define()
 		{
 			FUnrealMcpToolRegistry Registry;
 			UnrealMcpLevelTools::Register(Registry);
-			TestTrue(TEXT("get-data read-only"), Registry.Find(TEXT("level-get-data"))->bReadOnlyHint);
-			TestTrue(TEXT("list-loaded read-only"), Registry.Find(TEXT("level-list-loaded"))->bReadOnlyHint);
-			TestTrue(TEXT("unload-sublevel destructive"), Registry.Find(TEXT("level-unload-sublevel"))->bDestructiveHint);
+			// Find() returns nullptr for an unregistered id; null-check before dereferencing so a registration
+			// regression fails this assertion cleanly instead of crashing the whole automation run.
+			const FUnrealMcpRegisteredTool* GetData = Registry.Find(TEXT("level-get-data"));
+			const FUnrealMcpRegisteredTool* ListLoaded = Registry.Find(TEXT("level-list-loaded"));
+			const FUnrealMcpRegisteredTool* Unload = Registry.Find(TEXT("level-unload-sublevel"));
+			if (!TestNotNull(TEXT("level-get-data registered"), GetData) ||
+				!TestNotNull(TEXT("level-list-loaded registered"), ListLoaded) ||
+				!TestNotNull(TEXT("level-unload-sublevel registered"), Unload))
+				return;
+			TestTrue(TEXT("get-data read-only"), GetData->bReadOnlyHint);
+			TestTrue(TEXT("list-loaded read-only"), ListLoaded->bReadOnlyHint);
+			TestTrue(TEXT("unload-sublevel destructive"), Unload->bDestructiveHint);
 		});
 	});
 

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpLevelToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpLevelToolsSpec.cpp
@@ -145,6 +145,7 @@ void FUnrealMcpLevelToolsSpec::Define()
 
 			// level-create with no 'path' -> GEditor->NewMap(): a fresh in-memory world, nothing saved.
 			FString LevelName;
+			FString PersistentPackage;
 			{
 				const FUnrealMcpToolResult R = RunLevel(Registry, TEXT("level-create"), Args());
 				if (!R.bSuccess)
@@ -160,6 +161,7 @@ void FUnrealMcpLevelToolsSpec::Define()
 				TestTrue(TEXT("create reports not-saved"), !R.Structured->GetBoolField(TEXT("saved")));
 				TestTrue(TEXT("create reports a persistent level"), R.Structured->GetBoolField(TEXT("isPersistent")));
 				LevelName = R.Structured->GetStringField(TEXT("name"));
+				PersistentPackage = R.Structured->GetStringField(TEXT("package"));
 				TestTrue(TEXT("create returns a level name"), !LevelName.IsEmpty());
 			}
 
@@ -223,6 +225,28 @@ void FUnrealMcpLevelToolsSpec::Define()
 				TSharedPtr<FJsonObject> A = Args();
 				A->SetStringField(TEXT("name"), TEXT("__NoSuchSublevel__"));
 				TestFalse(TEXT("unload missing sublevel -> error"), RunLevel(Registry, TEXT("level-unload-sublevel"), A).bSuccess);
+			}
+
+			// level-unload-sublevel on the PERSISTENT level: rejected with the persistent-level explanation
+			// both by its short name AND by its full package path (the disambiguation form the param doc
+			// recommends — the package-path branch is the simplify finding under test).
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("name"), LevelName);
+				const FUnrealMcpToolResult R = RunLevel(Registry, TEXT("level-unload-sublevel"), A);
+				TestFalse(TEXT("unload persistent by short name -> error"), R.bSuccess);
+				TestTrue(TEXT("short-name error explains persistent level"), R.Message.Contains(TEXT("persistent level")));
+
+				// Guard the package-path assertion on a non-empty package (an in-memory NewMap world's persistent
+				// level normally has a transient package name, but skip rather than assert vacuously if it is empty).
+				if (!PersistentPackage.IsEmpty())
+				{
+					TSharedPtr<FJsonObject> B = Args();
+					B->SetStringField(TEXT("name"), PersistentPackage);
+					const FUnrealMcpToolResult RP = RunLevel(Registry, TEXT("level-unload-sublevel"), B);
+					TestFalse(TEXT("unload persistent by package path -> error"), RP.bSuccess);
+					TestTrue(TEXT("package-path error explains persistent level"), RP.Message.Contains(TEXT("persistent level")));
+				}
 			}
 
 			// level-save in place on the transient world -> error (never saved; no path).

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpLevelToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpLevelToolsSpec.cpp
@@ -143,7 +143,12 @@ void FUnrealMcpLevelToolsSpec::Define()
 					AddError(FString::Printf(TEXT("level-create failed: %s"), *R.Message));
 					return;
 				}
-				TestTrue(TEXT("create reports not-saved"), R.Structured.IsValid() && !R.Structured->GetBoolField(TEXT("saved")));
+				if (!R.Structured.IsValid())
+				{
+					AddError(TEXT("level-create returned no structured payload"));
+					return;
+				}
+				TestTrue(TEXT("create reports not-saved"), !R.Structured->GetBoolField(TEXT("saved")));
 				TestTrue(TEXT("create reports a persistent level"), R.Structured->GetBoolField(TEXT("isPersistent")));
 				LevelName = R.Structured->GetStringField(TEXT("name"));
 				TestTrue(TEXT("create returns a level name"), !LevelName.IsEmpty());
@@ -153,8 +158,13 @@ void FUnrealMcpLevelToolsSpec::Define()
 			{
 				const FUnrealMcpToolResult R = RunLevel(Registry, TEXT("level-list-loaded"), Args());
 				TestTrue(TEXT("list-loaded ok"), R.bSuccess);
+				if (!R.Structured.IsValid())
+				{
+					AddError(TEXT("level-list-loaded returned no structured payload"));
+					return;
+				}
 				double Count = 0;
-				TestTrue(TEXT("list-loaded has count"), R.Structured.IsValid() && R.Structured->TryGetNumberField(TEXT("count"), Count));
+				TestTrue(TEXT("list-loaded has count"), R.Structured->TryGetNumberField(TEXT("count"), Count));
 				TestTrue(TEXT("at least one level loaded"), Count >= 1.0);
 				TestFalse(TEXT("blank world is not partitioned"), R.Structured->GetBoolField(TEXT("isPartitionedWorld")));
 
@@ -172,8 +182,13 @@ void FUnrealMcpLevelToolsSpec::Define()
 			{
 				const FUnrealMcpToolResult R = RunLevel(Registry, TEXT("level-get-data"), Args());
 				TestTrue(TEXT("get-data ok"), R.bSuccess);
+				if (!R.Structured.IsValid())
+				{
+					AddError(TEXT("level-get-data returned no structured payload"));
+					return;
+				}
 				const TArray<TSharedPtr<FJsonValue>>* Actors = nullptr;
-				TestTrue(TEXT("get-data has actors array"), R.Structured.IsValid() && R.Structured->TryGetArrayField(TEXT("actors"), Actors) && Actors);
+				TestTrue(TEXT("get-data has actors array"), R.Structured->TryGetArrayField(TEXT("actors"), Actors) && Actors);
 				double Total = -1;
 				TestTrue(TEXT("get-data has total"), R.Structured->TryGetNumberField(TEXT("total"), Total) && Total >= 0.0);
 			}

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpLevelToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpLevelToolsSpec.cpp
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "UnrealMcpCoreTools.h"
+#include "UnrealMcpToolRegistry.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+
+/**
+ * Level / map tool family specs (docs/ARCHITECTURE.md §10, issue #16 — Unity Scene.* analog).
+ *
+ * Three groups:
+ *  - registration   — every declared tool is present with a kebab-case id + correct hints (no live editor).
+ *  - error paths     — each tool's required-arg / not-found guard returns an error result.
+ *  - live round-trip — a real in-editor lifecycle (create -> list-loaded -> get-data -> set-current),
+ *    driven entirely through GEditor->NewMap() (the level-create no-'path' branch), so NOTHING is
+ *    written to disk and the testbed working tree stays clean. Disk save / open is proven separately by
+ *    the live bridge e2e (which saves under a temp content path and cleans up).
+ *
+ * Headless note: every body uses the editor UWorld + UEditorLoadingAndSavingUtils + UEditorLevelUtils
+ * (no ULevelEditorSubsystem / UEditorActorSubsystem), so these specs run under -nullrhi without crashing.
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpLevelToolsSpec, "UnrealMcp.Tools.Level",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+	TSharedPtr<FJsonObject> Args() const { return MakeShared<FJsonObject>(); }
+END_DEFINE_SPEC(FUnrealMcpLevelToolsSpec)
+
+namespace
+{
+	// Uniquely named (not a bare `Run`): the tests module UNITY-builds every *Spec.cpp into one TU, so an
+	// anonymous-namespace `Run` with the same signature as another spec's (e.g. the asset spec's) ODR-collides.
+	FUnrealMcpToolResult RunLevel(FUnrealMcpToolRegistry& Registry, const FString& Name, const TSharedPtr<FJsonObject>& Args)
+	{
+		return Registry.Execute(Name, FUnrealMcpToolCall(Args));
+	}
+}
+
+void FUnrealMcpLevelToolsSpec::Define()
+{
+	Describe("registration", [this]()
+	{
+		It("registers all seven level tools with kebab-case ids", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpLevelTools::Register(Registry);
+
+			const TArray<FString> Expected = {
+				TEXT("level-create"), TEXT("level-open"), TEXT("level-save"),
+				TEXT("level-get-data"), TEXT("level-list-loaded"), TEXT("level-set-current"),
+				TEXT("level-unload-sublevel")
+			};
+			for (const FString& Name : Expected)
+			{
+				TestTrue(FString::Printf(TEXT("has %s"), *Name), Registry.HasTool(Name));
+				TestTrue(FString::Printf(TEXT("%s is valid kebab id"), *Name), FUnrealMcpToolRegistry::IsValidToolName(Name));
+			}
+			TestEqual(TEXT("exactly seven tools"), Registry.Num(), Expected.Num());
+		});
+
+		It("marks read-only and destructive tools correctly", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpLevelTools::Register(Registry);
+			TestTrue(TEXT("get-data read-only"), Registry.Find(TEXT("level-get-data"))->bReadOnlyHint);
+			TestTrue(TEXT("list-loaded read-only"), Registry.Find(TEXT("level-list-loaded"))->bReadOnlyHint);
+			TestTrue(TEXT("unload-sublevel destructive"), Registry.Find(TEXT("level-unload-sublevel"))->bDestructiveHint);
+		});
+	});
+
+	Describe("error paths", [this]()
+	{
+		It("level-open errors when path is missing", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpLevelTools::Register(Registry);
+			TestFalse(TEXT("not success"), RunLevel(Registry, TEXT("level-open"), Args()).bSuccess);
+		});
+
+		It("level-open errors for a non-existent level package", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpLevelTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("path"), TEXT("/Game/__definitely_missing__/Nope"));
+			TestFalse(TEXT("not success"), RunLevel(Registry, TEXT("level-open"), A).bSuccess);
+		});
+
+		It("level-open errors on a malformed asset path", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpLevelTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("path"), TEXT("not a valid path"));
+			TestFalse(TEXT("not success"), RunLevel(Registry, TEXT("level-open"), A).bSuccess);
+		});
+
+		It("level-create errors for a missing template", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpLevelTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("template"), TEXT("/Game/__definitely_missing__/NoTemplate"));
+			TestFalse(TEXT("not success"), RunLevel(Registry, TEXT("level-create"), A).bSuccess);
+		});
+
+		It("level-set-current errors when name is missing", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpLevelTools::Register(Registry);
+			TestFalse(TEXT("not success"), RunLevel(Registry, TEXT("level-set-current"), Args()).bSuccess);
+		});
+
+		It("level-unload-sublevel errors when name is missing", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpLevelTools::Register(Registry);
+			TestFalse(TEXT("not success"), RunLevel(Registry, TEXT("level-unload-sublevel"), Args()).bSuccess);
+		});
+
+		It("level-get-data errors on a non-string paths entry", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpLevelTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			// An object entry is genuinely non-stringable — unlike a JSON number, which UE's
+			// FJsonValue::TryGetString coerces to its text form ("42") and would NOT trip the guard.
+			TArray<TSharedPtr<FJsonValue>> Paths; Paths.Add(MakeShared<FJsonValueObject>(MakeShared<FJsonObject>()));
+			A->SetArrayField(TEXT("paths"), Paths);
+			TestFalse(TEXT("not success"), RunLevel(Registry, TEXT("level-get-data"), A).bSuccess);
+		});
+	});
+
+	Describe("live round-trip (in-memory, no disk writes)", [this]()
+	{
+		It("creates a blank level, lists it, snapshots it, and sets it current", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpLevelTools::Register(Registry);
+
+			// level-create with no 'path' -> GEditor->NewMap(): a fresh in-memory world, nothing saved.
+			FString LevelName;
+			{
+				const FUnrealMcpToolResult R = RunLevel(Registry, TEXT("level-create"), Args());
+				if (!R.bSuccess)
+				{
+					AddError(FString::Printf(TEXT("level-create failed: %s"), *R.Message));
+					return;
+				}
+				TestTrue(TEXT("create reports not-saved"), R.Structured.IsValid() && !R.Structured->GetBoolField(TEXT("saved")));
+				TestTrue(TEXT("create reports a persistent level"), R.Structured->GetBoolField(TEXT("isPersistent")));
+				LevelName = R.Structured->GetStringField(TEXT("name"));
+				TestTrue(TEXT("create returns a level name"), !LevelName.IsEmpty());
+			}
+
+			// level-list-loaded: at least the persistent level, not partitioned, persistent flagged.
+			{
+				const FUnrealMcpToolResult R = RunLevel(Registry, TEXT("level-list-loaded"), Args());
+				TestTrue(TEXT("list-loaded ok"), R.bSuccess);
+				double Count = 0;
+				TestTrue(TEXT("list-loaded has count"), R.Structured.IsValid() && R.Structured->TryGetNumberField(TEXT("count"), Count));
+				TestTrue(TEXT("at least one level loaded"), Count >= 1.0);
+				TestFalse(TEXT("blank world is not partitioned"), R.Structured->GetBoolField(TEXT("isPartitionedWorld")));
+
+				const TArray<TSharedPtr<FJsonValue>>* Levels = nullptr;
+				TestTrue(TEXT("has levels array"), R.Structured->TryGetArrayField(TEXT("levels"), Levels) && Levels);
+				bool bSawPersistent = false;
+				if (Levels)
+					for (const TSharedPtr<FJsonValue>& V : *Levels)
+						if (V.IsValid() && V->AsObject().IsValid() && V->AsObject()->GetBoolField(TEXT("isPersistent")))
+							bSawPersistent = true;
+				TestTrue(TEXT("persistent level present in list"), bSawPersistent);
+			}
+
+			// level-get-data whole-world snapshot: an actors array + numeric total.
+			{
+				const FUnrealMcpToolResult R = RunLevel(Registry, TEXT("level-get-data"), Args());
+				TestTrue(TEXT("get-data ok"), R.bSuccess);
+				const TArray<TSharedPtr<FJsonValue>>* Actors = nullptr;
+				TestTrue(TEXT("get-data has actors array"), R.Structured.IsValid() && R.Structured->TryGetArrayField(TEXT("actors"), Actors) && Actors);
+				double Total = -1;
+				TestTrue(TEXT("get-data has total"), R.Structured->TryGetNumberField(TEXT("total"), Total) && Total >= 0.0);
+			}
+
+			// level-set-current on the persistent level: already current -> success (idempotent).
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("name"), LevelName);
+				const FUnrealMcpToolResult R = RunLevel(Registry, TEXT("level-set-current"), A);
+				TestTrue(TEXT("set-current on persistent ok"), R.bSuccess);
+				TestTrue(TEXT("set-current reports it current"), R.Structured.IsValid() && R.Structured->GetBoolField(TEXT("isCurrent")));
+			}
+
+			// level-set-current on an unknown name -> error.
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("name"), TEXT("__NoSuchLevel__"));
+				TestFalse(TEXT("set-current unknown -> error"), RunLevel(Registry, TEXT("level-set-current"), A).bSuccess);
+			}
+
+			// level-unload-sublevel with no sublevels present -> error (nothing matches).
+			{
+				TSharedPtr<FJsonObject> A = Args();
+				A->SetStringField(TEXT("name"), TEXT("__NoSuchSublevel__"));
+				TestFalse(TEXT("unload missing sublevel -> error"), RunLevel(Registry, TEXT("level-unload-sublevel"), A).bSuccess);
+			}
+
+			// level-save in place on the transient world -> error (never saved; no path).
+			{
+				TestFalse(TEXT("save transient in-place -> error"), RunLevel(Registry, TEXT("level-save"), Args()).bSuccess);
+			}
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS


### PR DESCRIPTION
## Summary
- Adds the §10 **level family** (issue #16, the Unity `Scene.*` analog): 7 native C++ CORE tools — `level-create`, `level-open`, `level-save` (save-as via optional `path`), `level-get-data` (scoped actor-tree reads via `paths`), `level-list-loaded` (persistent + streaming sublevels, World-Partition aware, read-only), `level-set-current`, `level-unload-sublevel` — declared via the §3.3 builder and dispatched on the GameThread.
- Bodies use the editor `UWorld` + `UEditorLoadingAndSavingUtils` + `UEditorLevelUtils` (Engine/UnrealEd only — no `ULevelEditorSubsystem`/`UEditorActorSubsystem`), so every tool is verified headless under `-nullrhi`. `level-create`'s no-`path` branch uses `GEditor->NewMap()` (in-memory, no disk write); a typo'd `template` is rejected up front. Reuses the actor family's `FUnrealMcpObjectRef`/`FUnrealMcpPropertyJson` helpers for `get-data`.
- Wires the family into the boot path and adds 10 Automation specs (`UnrealMcp.Tools.Level`). Additive only — no version bumps.

## Test plan
- [x] Suite 1 (UBT `UnrealTestProjectEditor`) — exit 0
- [x] Suite 2 (headless boot smoke) — `[Unreal-MCP] plugin loaded`
- [x] Suite 3 (Automation `UnrealMcp.`) — 91 tests, **0 failed / 0 notRun** (81 prior + 10 new level specs)
- [x] Suite 7 (live bridge e2e) — full `create → open → get-data → save` round-trip + error paths + scoped read over HTTP, clean no-orphan teardown

Closes #16