### PR TITLE
ci: PR test pipeline + gated dry-run release

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+# actionlint configuration (https://github.com/rhysd/actionlint).
+# Declare the custom self-hosted runner label used by the UE 5.7 plugin legs so
+# actionlint does not flag it as unknown. The runner is registered by the owner
+# (see docs/RELEASING.md) and is gated on vars.UNREAL_RUNNER_READY so its absence
+# never reds a PR.
+self-hosted-runner:
+  labels:
+    - unreal-5-7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,434 @@
+# ┌──────────────────────────────────────────────────────────────────┐
+# │  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+# │  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)   │
+# │  Copyright (c) 2026 Ivan Murzak                                  │
+# │  Licensed under the Apache License, Version 2.0.                 │
+# │  See the LICENSE file in the project root for more information.  │
+# └──────────────────────────────────────────────────────────────────┘
+#
+# Release pipeline (Godot-MCP release.yml skeleton, adapted for the UE four-leg
+# mono-repo — docs/ARCHITECTURE.md §9.4). Shape:
+#   check-version (read VersionName, compute gate) -> test fan-out -> artifact
+#   build -> GATED publish (tag + GitHub Release + npm).
+#
+# ── Gating (read docs/RELEASING.md for the full contract) ──────────────────
+# `UnrealMCP/UnrealMCP.uplugin` VersionName is the SINGLE source of truth for the
+# release version (commands/bump-version.ps1 keeps the other four files in sync).
+#
+#   should_release = (no `v<version>` tag exists yet) AND (this push bumped the
+#                     VersionName line)
+#   dry_run        = workflow_dispatch was invoked with dry_run=true
+#   run_tests      = should_release OR dry_run
+#
+# Outcomes:
+#   * Plain merge to main that does NOT bump VersionName  -> should_release=false,
+#     dry_run=false -> run_tests=false -> EVERY job skips. Merging a workflow-only
+#     or feature PR is therefore a guaranteed no-op (no tests, no artifacts, no
+#     publish) — this is what keeps THIS PR's own merge inert.
+#   * workflow_dispatch with dry_run=true -> run_tests=true (rehearse tests +
+#     artifact builds, uploaded for inspection) while the tag/Release/npm jobs
+#     are HARD-SKIPPED. This is the only way this pipeline is exercised during
+#     the ci-workflows task — nothing is ever published.
+#   * Merge that bumps VersionName to a new (untagged) version -> should_release
+#     =true, dry_run=false -> the real release fires (operator action).
+#   * workflow_dispatch with dry_run=false on an untagged version -> real release
+#     escape hatch (re-run a release when the bump already landed).
+#
+# SAFETY: publish jobs are gated on `should_release == 'true' && dry_run !=
+# 'true'`. The npm publish uses OIDC Trusted Publishing (no NPM_TOKEN secret);
+# until the owner configures a Trusted Publisher for `unreal-cli`, that step
+# fails auth and nothing is published. The self-hosted plugin artifact leg is
+# gated on UNREAL_RUNNER_READY exactly like test_pull_request.yml.
+
+name: release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Rehearse the release (run tests + build artifacts) WITHOUT tagging, creating a GitHub Release, or publishing to npm."
+        required: false
+        default: true
+        type: boolean
+
+# Least-privilege default for the whole workflow; the publish jobs elevate
+# their own permissions (contents: write for the Release, id-token: write for
+# npm OIDC) in their job blocks.
+permissions:
+  contents: read
+
+jobs:
+  # Read the release version from the .uplugin and decide whether THIS event
+  # should cut a release, only rehearse (dry-run), or do nothing.
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      tag: ${{ steps.get_version.outputs.tag }}
+      tag_exists: ${{ steps.tag_exists.outputs.exists }}
+      version_changed: ${{ steps.version_changed.outputs.changed }}
+      should_release: ${{ steps.gate.outputs.should_release }}
+      dry_run: ${{ steps.gate.outputs.dry_run }}
+      run_tests: ${{ steps.gate.outputs.run_tests }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Get version from .uplugin VersionName
+        id: get_version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(grep -oE '"VersionName"[[:space:]]*:[[:space:]]*"[^"]+"' UnrealMCP/UnrealMCP.uplugin \
+            | head -n1 | sed -E 's/.*"VersionName"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+          if [ -z "${version}" ]; then
+            echo "::error::Could not read VersionName from UnrealMCP/UnrealMCP.uplugin"
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
+          echo "Release version: ${version} (tag v${version})"
+
+      - name: Check if tag exists
+        id: tag_exists
+        uses: mukunku/tag-exists-action@v1.7.0
+        with:
+          tag: ${{ steps.get_version.outputs.tag }}
+
+      # Did THIS push bump the VersionName line? On push we diff before..after;
+      # a plain feature/workflow merge that does not touch that line yields
+      # changed=false (keeping the release inert). On workflow_dispatch there is
+      # no push diff, so report changed=true and rely on tag_exists + dry_run.
+      - name: Detect VersionName bump
+        id: version_changed
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" != "push" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Non-push event (${EVENT_NAME}): bump check skipped (relying on tag_exists + dry_run)."
+            exit 0
+          fi
+          if [ -z "${BEFORE_SHA}" ] || [ "${BEFORE_SHA}" = "0000000000000000000000000000000000000000" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "No usable 'before' SHA — treating as changed."
+            exit 0
+          fi
+          if git diff "${BEFORE_SHA}" "${AFTER_SHA}" -- UnrealMCP/UnrealMCP.uplugin \
+               | grep -qE '^\+[[:space:]]*"VersionName"'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "VersionName changed in ${BEFORE_SHA}..${AFTER_SHA}."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "VersionName unchanged in ${BEFORE_SHA}..${AFTER_SHA} — release is a no-op."
+          fi
+
+      - name: Compute gate
+        id: gate
+        env:
+          TAG_EXISTS: ${{ steps.tag_exists.outputs.exists }}
+          VERSION_CHANGED: ${{ steps.version_changed.outputs.changed }}
+          EVENT_NAME: ${{ github.event_name }}
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          dry_run=false
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ] && [ "${DRY_RUN_INPUT}" = "true" ]; then
+            dry_run=true
+          fi
+          should_release=false
+          if [ "${TAG_EXISTS}" = "false" ] && [ "${VERSION_CHANGED}" = "true" ]; then
+            should_release=true
+          fi
+          run_tests=false
+          if [ "${should_release}" = "true" ] || [ "${dry_run}" = "true" ]; then
+            run_tests=true
+          fi
+          echo "dry_run=${dry_run}" >> "$GITHUB_OUTPUT"
+          echo "should_release=${should_release}" >> "$GITHUB_OUTPUT"
+          echo "run_tests=${run_tests}" >> "$GITHUB_OUTPUT"
+          echo "Gate: tag_exists=${TAG_EXISTS} version_changed=${VERSION_CHANGED} dry_run=${dry_run} -> should_release=${should_release}, run_tests=${run_tests}"
+
+  # ── TEST GATE (runs on a real release OR a dry-run rehearsal) ──────────────
+
+  bridge:
+    name: bridge build + xUnit (${{ matrix.os }})
+    needs: [check-version]
+    if: needs.check-version.outputs.run_tests == 'true'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+      - name: Restore
+        run: dotnet restore bridge/Unreal-MCP-Bridge.sln
+      - name: Build
+        run: dotnet build bridge/Unreal-MCP-Bridge.sln --configuration Debug --no-restore
+      - name: Test
+        run: dotnet test bridge/Unreal-MCP-Bridge.sln --configuration Debug --no-build --verbosity normal
+
+  test-cli:
+    needs: [check-version]
+    if: needs.check-version.outputs.run_tests == 'true'
+    uses: ./.github/workflows/test_cli.yml
+
+  # Plugin Automation gate — self-hosted, never red-by-absence (same
+  # UNREAL_RUNNER_READY gate as test_pull_request.yml). For a REAL release the
+  # runner MUST be registered (UNREAL_RUNNER_READY=true) so this job runs;
+  # otherwise it is skipped and the publish jobs below (which `need` it) are
+  # skipped too — a safe default. For a dry-run the publish jobs are skipped
+  # regardless. See docs/RELEASING.md.
+  plugin:
+    name: plugin BuildPlugin + Automation (UE 5.7)
+    needs: [check-version]
+    if: needs.check-version.outputs.run_tests == 'true' && vars.UNREAL_RUNNER_READY == 'true'
+    runs-on: [self-hosted, windows, unreal-5-7]
+    env:
+      UE_ROOT: ${{ vars.UNREAL_ENGINE_PATH || 'C:\Program Files\Epic Games\UE_5.7' }}
+      HOST_UPROJECT: ${{ vars.UNREAL_HOST_PROJECT }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: BuildPlugin (compile + marketplace packaging validation)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $runUAT = Join-Path $env:UE_ROOT 'Engine\Build\BatchFiles\RunUAT.bat'
+          if (-not (Test-Path $runUAT)) { throw "RunUAT.bat not found at $runUAT — set the UNREAL_ENGINE_PATH repo variable." }
+          $uplugin = Join-Path $env:GITHUB_WORKSPACE 'UnrealMCP\UnrealMCP.uplugin'
+          $package = Join-Path $env:RUNNER_TEMP 'UnrealMCP-Package'
+          & $runUAT BuildPlugin -Plugin="$uplugin" -Package="$package" -TargetPlatforms=Win64 -Rocket
+          if ($LASTEXITCODE -ne 0) { throw "BuildPlugin failed with exit code $LASTEXITCODE" }
+      - name: Run Automation specs (UnrealMcp. filter)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ([string]::IsNullOrWhiteSpace($env:HOST_UPROJECT)) {
+            throw "UNREAL_HOST_PROJECT repo variable is not set — the Automation pass needs a host .uproject with the UnrealMCP plugin enabled (see docs/RELEASING.md)."
+          }
+          $editorCmd = Join-Path $env:UE_ROOT 'Engine\Binaries\Win64\UnrealEditor-Cmd.exe'
+          $reportDir = Join-Path $env:RUNNER_TEMP 'AutomationReport'
+          if (Test-Path $reportDir) { Remove-Item $reportDir -Recurse -Force }
+          & $editorCmd "$env:HOST_UPROJECT" -nullrhi -nosplash -unattended `
+            -ExecCmds="Automation RunTests UnrealMcp; Quit" `
+            -ReportExportPath="$reportDir" -log
+          echo "REPORT_DIR=$reportDir" >> $env:GITHUB_ENV
+      - name: Parse Automation report (index.json is authoritative)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $index = Join-Path $env:REPORT_DIR 'index.json'
+          if (-not (Test-Path $index)) { throw "Automation index.json is MISSING at $index — treat as FAILURE." }
+          $report = Get-Content $index -Raw | ConvertFrom-Json
+          $failed = [int]$report.failed
+          $succeeded = [int]$report.succeeded
+          Write-Host "Automation results: succeeded=$succeeded failed=$failed"
+          if ($failed -gt 0) { throw "$failed Automation test(s) failed." }
+          if ($succeeded -lt 1) { throw "No Automation tests succeeded — expected at least one UnrealMcp. spec." }
+
+  # ── ARTIFACT BUILD (runs on a real release OR a dry-run rehearsal) ─────────
+
+  # bridge self-contained single-file binaries -> unreal-mcp-bridge-<rid>.zip ×4
+  # (§6). Cross-compiled from a single ubuntu host (no per-RID native toolchain).
+  build-bridge-zips:
+    name: build bridge zips
+    needs: [check-version]
+    if: needs.check-version.outputs.run_tests == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+      - name: Make publish script executable
+        run: chmod +x ./bridge/publish.sh
+      - name: Build self-contained bridge binaries for all RIDs
+        shell: bash
+        run: cd bridge && ./publish.sh Release
+      - name: Upload bridge zips
+        uses: actions/upload-artifact@v4
+        with:
+          name: unreal-mcp-bridge-zips
+          path: ./bridge/publish/*.zip
+          if-no-files-found: error
+          retention-days: 7
+
+  # server self-contained single-file binaries -> unreal-mcp-server-<rid>.zip
+  # (build-all.sh emits all 7 RIDs). Cross-compiled from a single ubuntu host.
+  build-server-zips:
+    name: build server zips
+    needs: [check-version]
+    if: needs.check-version.outputs.run_tests == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+      - name: Make build script executable
+        run: chmod +x ./Unreal-MCP-Server/build-all.sh
+      - name: Build self-contained server binaries for all RIDs
+        shell: bash
+        run: cd Unreal-MCP-Server && ./build-all.sh Release
+      - name: Upload server zips
+        uses: actions/upload-artifact@v4
+        with:
+          name: unreal-mcp-server-zips
+          path: ./Unreal-MCP-Server/publish/*.zip
+          if-no-files-found: error
+          retention-days: 7
+
+  # Engine-agnostic source plugin zip (BuildPlugin output). Self-hosted, gated
+  # like the plugin test job. Skipped when no runner is registered; for a real
+  # release the runner must be ready (publish-release `needs` this job).
+  build-plugin-zip:
+    name: build plugin zip (UE 5.7)
+    needs: [check-version]
+    if: needs.check-version.outputs.run_tests == 'true' && vars.UNREAL_RUNNER_READY == 'true'
+    runs-on: [self-hosted, windows, unreal-5-7]
+    env:
+      UE_ROOT: ${{ vars.UNREAL_ENGINE_PATH || 'C:\Program Files\Epic Games\UE_5.7' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: BuildPlugin + zip
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $runUAT = Join-Path $env:UE_ROOT 'Engine\Build\BatchFiles\RunUAT.bat'
+          if (-not (Test-Path $runUAT)) { throw "RunUAT.bat not found at $runUAT — set the UNREAL_ENGINE_PATH repo variable." }
+          $uplugin = Join-Path $env:GITHUB_WORKSPACE 'UnrealMCP\UnrealMCP.uplugin'
+          $package = Join-Path $env:RUNNER_TEMP 'UnrealMCP-Package'
+          if (Test-Path $package) { Remove-Item $package -Recurse -Force }
+          & $runUAT BuildPlugin -Plugin="$uplugin" -Package="$package" -TargetPlatforms=Win64 -Rocket
+          if ($LASTEXITCODE -ne 0) { throw "BuildPlugin failed with exit code $LASTEXITCODE" }
+          $version = '${{ needs.check-version.outputs.version }}'
+          $out = Join-Path $env:GITHUB_WORKSPACE 'dist'
+          New-Item -ItemType Directory -Force -Path $out | Out-Null
+          Compress-Archive -Path (Join-Path $package '*') -DestinationPath (Join-Path $out "unreal-mcp-plugin-$version.zip") -Force
+      - name: Upload plugin zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: unreal-mcp-plugin-zip
+          path: ./dist/*.zip
+          if-no-files-found: error
+          retention-days: 7
+
+  # ── PUBLISH (gated on a REAL release: tag absent + version bumped, NOT a
+  #    dry-run). Every job here is hard-skipped during the ci-workflows dry-run. ─
+
+  # Create the GitHub Release + `v<version>` tag with the bridge/server/plugin
+  # zips attached and auto-generated notes.
+  publish-release:
+    name: publish GitHub Release
+    needs:
+      [
+        check-version,
+        bridge,
+        test-cli,
+        plugin,
+        build-bridge-zips,
+        build-server-zips,
+        build-plugin-zip,
+      ]
+    if: needs.check-version.outputs.should_release == 'true' && needs.check-version.outputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      published: ${{ steps.mark.outputs.published }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Download bridge zips
+        uses: actions/download-artifact@v4
+        with:
+          name: unreal-mcp-bridge-zips
+          path: ./assets
+      - name: Download server zips
+        uses: actions/download-artifact@v4
+        with:
+          name: unreal-mcp-server-zips
+          path: ./assets
+      - name: Download plugin zip
+        uses: actions/download-artifact@v4
+        with:
+          name: unreal-mcp-plugin-zip
+          path: ./assets
+      - name: List assembled release assets
+        run: ls -la ./assets
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ needs.check-version.outputs.tag }}
+          tag_name: ${{ needs.check-version.outputs.tag }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            ./assets/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Mark publish success
+        id: mark
+        run: echo "published=true" >> "$GITHUB_OUTPUT"
+
+  # Publish unreal-cli to npm via OIDC Trusted Publishing (no NPM_TOKEN secret).
+  # Gated on the GitHub Release having been created (i.e. a real, non-dry-run
+  # release). The cli version is aligned to the release version at publish time.
+  publish-npm:
+    name: publish unreal-cli to npm
+    needs: [check-version, publish-release]
+    if: needs.publish-release.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC Trusted Publishing — no NPM_TOKEN needed.
+    defaults:
+      run:
+        working-directory: ./cli
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+      # npm OIDC Trusted Publishing requires npm >= 11.5.1; the bundled npm is
+      # older and would fail the token exchange with a masked E404.
+      - name: Upgrade npm (OIDC Trusted Publishing requires npm >= 11.5.1)
+        run: npm install -g npm@latest
+      - name: Align package version to the release version
+        run: npm version "${{ needs.check-version.outputs.version }}" --no-git-tag-version --allow-same-version
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: npm test
+      # NOTE: cli/package.json is `private: true` until the publish gate opens
+      # (conventions.md). The owner removes that flag in the version-bump commit
+      # that cuts the first real release; this step publishes the public package.
+      - name: Publish to npm with provenance
+        run: npm publish --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,12 @@ on:
 permissions:
   contents: read
 
+# Serialize release runs so the tag-existence check and the publish that follows
+# cannot race two concurrent runs into a double publish (tag_exists TOCTOU).
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   # Read the release version from the .uplugin and decide whether THIS event
   # should cut a release, only rehearse (dry-run), or do nothing.
@@ -90,15 +96,33 @@ jobs:
             echo "::error::Could not read VersionName from UnrealMCP/UnrealMCP.uplugin"
             exit 1
           fi
+          # Strict semver gate: this value is interpolated into downstream pwsh
+          # and npm run-scripts, so reject anything that is not a clean
+          # MAJOR.MINOR.PATCH(+prerelease/build) before it can leak shell/JS.
+          if ! printf '%s' "${version}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)*$'; then
+            echo "::error::VersionName '${version}' is not strict semver — refusing to release."
+            exit 1
+          fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tag=v${version}" >> "$GITHUB_OUTPUT"
           echo "Release version: ${version} (tag v${version})"
 
       - name: Check if tag exists
         id: tag_exists
-        uses: mukunku/tag-exists-action@v1.7.0
-        with:
-          tag: ${{ steps.get_version.outputs.tag }}
+        env:
+          TAG: ${{ steps.get_version.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The checkout above ran with fetch-tags: true, so local tags are
+          # complete — no third-party action needed (avoids an unpinned tag ref).
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG} already exists."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG} does not exist yet."
+          fi
 
       # Did THIS push bump the VersionName line? On push we diff before..after;
       # a plain feature/workflow merge that does not touch that line yields
@@ -118,18 +142,32 @@ jobs:
             echo "Non-push event (${EVENT_NAME}): bump check skipped (relying on tag_exists + dry_run)."
             exit 0
           fi
+          # Fail CLOSED: without a usable 'before' SHA we cannot prove a bump
+          # happened, so treat it as unchanged rather than firing a release.
           if [ -z "${BEFORE_SHA}" ] || [ "${BEFORE_SHA}" = "0000000000000000000000000000000000000000" ]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "No usable 'before' SHA — treating as changed."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No usable 'before' SHA — cannot confirm a bump; treating as unchanged (fail closed)."
             exit 0
           fi
-          if git diff "${BEFORE_SHA}" "${AFTER_SHA}" -- UnrealMCP/UnrealMCP.uplugin \
-               | grep -qE '^\+[[:space:]]*"VersionName"'; then
+          # Compare the VersionName VALUE at the before/after SHAs (not merely
+          # whether the line was touched) — a whitespace/comment-only edit to the
+          # line must not count as a release-worthy bump.
+          read_version() {
+            git show "$1:UnrealMCP/UnrealMCP.uplugin" 2>/dev/null \
+              | grep -oE '"VersionName"[[:space:]]*:[[:space:]]*"[^"]+"' \
+              | head -n1 | sed -E 's/.*"VersionName"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
+          }
+          before_version="$(read_version "${BEFORE_SHA}")"
+          after_version="$(read_version "${AFTER_SHA}")"
+          if [ -z "${after_version}" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Could not read VersionName at ${AFTER_SHA} — treating as unchanged (fail closed)."
+          elif [ "${before_version}" != "${after_version}" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "VersionName changed in ${BEFORE_SHA}..${AFTER_SHA}."
+            echo "VersionName changed: '${before_version}' -> '${after_version}'."
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "VersionName unchanged in ${BEFORE_SHA}..${AFTER_SHA} — release is a no-op."
+            echo "VersionName unchanged ('${after_version}') in ${BEFORE_SHA}..${AFTER_SHA} — release is a no-op."
           fi
 
       - name: Compute gate
@@ -138,13 +176,22 @@ jobs:
           TAG_EXISTS: ${{ steps.tag_exists.outputs.exists }}
           VERSION_CHANGED: ${{ steps.version_changed.outputs.changed }}
           EVENT_NAME: ${{ github.event_name }}
-          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
+          # Use the typed `inputs` context (default-applied) rather than the raw
+          # `github.event.inputs`, which is empty when the input is omitted via
+          # API/gh and would otherwise fail OPEN (dry_run=false -> real publish).
+          DRY_RUN_INPUT: ${{ inputs.dry_run }}
         shell: bash
         run: |
           set -euo pipefail
           dry_run=false
-          if [ "${EVENT_NAME}" = "workflow_dispatch" ] && [ "${DRY_RUN_INPUT}" = "true" ]; then
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            # Fail CLOSED: a manual dispatch is a dry-run UNLESS the input is
+            # explicitly the string "false". A missing/garbled input can never
+            # fire a real publish this way.
             dry_run=true
+            if [ "${DRY_RUN_INPUT}" = "false" ]; then
+              dry_run=false
+            fi
           fi
           should_release=false
           if [ "${TAG_EXISTS}" = "false" ] && [ "${VERSION_CHANGED}" = "true" ]; then
@@ -229,6 +276,11 @@ jobs:
           & $editorCmd "$env:HOST_UPROJECT" -nullrhi -nosplash -unattended `
             -ExecCmds="Automation RunTests UnrealMcp; Quit" `
             -ReportExportPath="$reportDir" -log
+          # The editor's exit code is unreliable for test verdicts (test.md
+          # Suite 3); the parsed index.json below is authoritative. Clear the
+          # exit code so pwsh's auto-appended `exit $LASTEXITCODE` does not red
+          # the step on a nonzero editor exit unrelated to a test failure.
+          $global:LASTEXITCODE = 0
           echo "REPORT_DIR=$reportDir" >> $env:GITHUB_ENV
       - name: Parse Automation report (index.json is authoritative)
         shell: pwsh
@@ -242,6 +294,15 @@ jobs:
           Write-Host "Automation results: succeeded=$succeeded failed=$failed"
           if ($failed -gt 0) { throw "$failed Automation test(s) failed." }
           if ($succeeded -lt 1) { throw "No Automation tests succeeded — expected at least one UnrealMcp. spec." }
+
+      - name: Upload Automation report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: automation-report
+          path: ${{ env.REPORT_DIR }}
+          if-no-files-found: ignore
+          retention-days: 7
 
   # ── ARTIFACT BUILD (runs on a real release OR a dry-run rehearsal) ─────────
 
@@ -314,6 +375,8 @@ jobs:
         uses: actions/checkout@v4
       - name: BuildPlugin + zip
         shell: pwsh
+        env:
+          PLUGIN_VERSION: ${{ needs.check-version.outputs.version }}
         run: |
           $ErrorActionPreference = 'Stop'
           $runUAT = Join-Path $env:UE_ROOT 'Engine\Build\BatchFiles\RunUAT.bat'
@@ -323,7 +386,7 @@ jobs:
           if (Test-Path $package) { Remove-Item $package -Recurse -Force }
           & $runUAT BuildPlugin -Plugin="$uplugin" -Package="$package" -TargetPlatforms=Win64 -Rocket
           if ($LASTEXITCODE -ne 0) { throw "BuildPlugin failed with exit code $LASTEXITCODE" }
-          $version = '${{ needs.check-version.outputs.version }}'
+          $version = $env:PLUGIN_VERSION
           $out = Join-Path $env:GITHUB_WORKSPACE 'dist'
           New-Item -ItemType Directory -Force -Path $out | Out-Null
           Compress-Archive -Path (Join-Path $package '*') -DestinationPath (Join-Path $out "unreal-mcp-plugin-$version.zip") -Force
@@ -352,7 +415,7 @@ jobs:
         build-server-zips,
         build-plugin-zip,
       ]
-    if: needs.check-version.outputs.should_release == 'true' && needs.check-version.outputs.dry_run != 'true'
+    if: needs.check-version.outputs.should_release == 'true' && needs.check-version.outputs.dry_run != 'true' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -379,7 +442,7 @@ jobs:
       - name: List assembled release assets
         run: ls -la ./assets
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           name: ${{ needs.check-version.outputs.tag }}
           tag_name: ${{ needs.check-version.outputs.tag }}
@@ -418,9 +481,11 @@ jobs:
       # npm OIDC Trusted Publishing requires npm >= 11.5.1; the bundled npm is
       # older and would fail the token exchange with a masked E404.
       - name: Upgrade npm (OIDC Trusted Publishing requires npm >= 11.5.1)
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - name: Align package version to the release version
-        run: npm version "${{ needs.check-version.outputs.version }}" --no-git-tag-version --allow-same-version
+        env:
+          RELEASE_VERSION: ${{ needs.check-version.outputs.version }}
+        run: npm version "$RELEASE_VERSION" --no-git-tag-version --allow-same-version
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,8 +157,11 @@ jobs:
               | grep -oE '"VersionName"[[:space:]]*:[[:space:]]*"[^"]+"' \
               | head -n1 | sed -E 's/.*"VersionName"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
           }
-          before_version="$(read_version "${BEFORE_SHA}")"
-          after_version="$(read_version "${AFTER_SHA}")"
+          # `|| true` keeps a read failure (unfetchable SHA, .uplugin absent at
+          # that SHA, or no VersionName match) from tripping `set -e` via the
+          # command substitution before the fail-closed branches below can run.
+          before_version="$(read_version "${BEFORE_SHA}" || true)"
+          after_version="$(read_version "${AFTER_SHA}" || true)"
           if [ -z "${after_version}" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "Could not read VersionName at ${AFTER_SHA} — treating as unchanged (fail closed)."
@@ -253,6 +256,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Self-hosted runner persists between jobs; don't leave this job's
+          # GITHUB_TOKEN in the worktree's .git config after checkout.
+          persist-credentials: false
       - name: BuildPlugin (compile + marketplace packaging validation)
         shell: pwsh
         run: |
@@ -261,6 +268,7 @@ jobs:
           if (-not (Test-Path $runUAT)) { throw "RunUAT.bat not found at $runUAT — set the UNREAL_ENGINE_PATH repo variable." }
           $uplugin = Join-Path $env:GITHUB_WORKSPACE 'UnrealMCP\UnrealMCP.uplugin'
           $package = Join-Path $env:RUNNER_TEMP 'UnrealMCP-Package'
+          if (Test-Path $package) { Remove-Item $package -Recurse -Force }
           & $runUAT BuildPlugin -Plugin="$uplugin" -Package="$package" -TargetPlatforms=Win64 -Rocket
           if ($LASTEXITCODE -ne 0) { throw "BuildPlugin failed with exit code $LASTEXITCODE" }
       - name: Run Automation specs (UnrealMcp. filter)
@@ -291,12 +299,20 @@ jobs:
           $report = Get-Content $index -Raw | ConvertFrom-Json
           $failed = [int]$report.failed
           $succeeded = [int]$report.succeeded
-          Write-Host "Automation results: succeeded=$succeeded failed=$failed"
+          # UE counts specs that pass while emitting a warning under a SEPARATE
+          # succeededWithWarnings field; fold it into the pass tally so a
+          # clean-but-warned suite is not misread as the 0-specs case below.
+          $succeededWithWarnings = [int]$report.succeededWithWarnings
+          $passed = $succeeded + $succeededWithWarnings
+          Write-Host "Automation results: succeeded=$succeeded succeededWithWarnings=$succeededWithWarnings failed=$failed"
           if ($failed -gt 0) { throw "$failed Automation test(s) failed." }
-          if ($succeeded -lt 1) { throw "No Automation tests succeeded — expected at least one UnrealMcp. spec." }
+          if ($passed -lt 1) { throw "No Automation tests succeeded — expected at least one UnrealMcp. spec." }
 
       - name: Upload Automation report on failure
-        if: failure()
+        # REPORT_DIR is exported only at the END of the Automation step; an
+        # earlier failure (BuildPlugin, missing editor) leaves it unset, so guard
+        # the upload to avoid a second confusing failure on an empty path.
+        if: ${{ failure() && env.REPORT_DIR != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: automation-report
@@ -373,6 +389,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Self-hosted runner persists between jobs; don't leave this job's
+          # GITHUB_TOKEN in the worktree's .git config after checkout.
+          persist-credentials: false
       - name: BuildPlugin + zip
         shell: pwsh
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,9 +162,18 @@ jobs:
           # command substitution before the fail-closed branches below can run.
           before_version="$(read_version "${BEFORE_SHA}" || true)"
           after_version="$(read_version "${AFTER_SHA}" || true)"
-          if [ -z "${after_version}" ]; then
+          # Fail CLOSED when EITHER side is unreadable. An empty after_version is
+          # the obvious "can't read the current version" case. An empty
+          # before_version is subtler but just as dangerous: read_version can fail
+          # on the BEFORE side when a force-push to main makes github.event.before
+          # unfetchable, or the .uplugin did not yet exist at that SHA. Comparing
+          # empty != non-empty would score that as a bump and fire a REAL tag +
+          # Release with no deliberate version change. The legitimate "VersionName
+          # first introduced" case is intentionally NOT auto-released here — cut it
+          # via workflow_dispatch with dry_run=false (the documented escape hatch).
+          if [ -z "${after_version}" ] || [ -z "${before_version}" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "Could not read VersionName at ${AFTER_SHA} — treating as unchanged (fail closed)."
+            echo "Could not read VersionName at before=${BEFORE_SHA} / after=${AFTER_SHA} — treating as unchanged (fail closed)."
           elif [ "${before_version}" != "${after_version}" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "VersionName changed: '${before_version}' -> '${after_version}'."
@@ -282,7 +291,7 @@ jobs:
           $reportDir = Join-Path $env:RUNNER_TEMP 'AutomationReport'
           if (Test-Path $reportDir) { Remove-Item $reportDir -Recurse -Force }
           & $editorCmd "$env:HOST_UPROJECT" -nullrhi -nosplash -unattended `
-            -ExecCmds="Automation RunTests UnrealMcp; Quit" `
+            -ExecCmds="Automation RunTests UnrealMcp.; Quit" `
             -ReportExportPath="$reportDir" -log
           # The editor's exit code is unreliable for test verdicts (test.md
           # Suite 3); the parsed index.json below is authoritative. Clear the

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -1,0 +1,48 @@
+# ┌──────────────────────────────────────────────────────────────────┐
+# │  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+# │  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)   │
+# │  Copyright (c) 2026 Ivan Murzak                                  │
+# │  Licensed under the Apache License, Version 2.0.                 │
+# │  See the LICENSE file in the project root for more information.  │
+# └──────────────────────────────────────────────────────────────────┘
+
+# Reusable workflow: build + test the unreal-cli npm package (cli/) on a
+# Node 20 & 22 matrix. Mirrors Unity-MCP / Godot-MCP test_cli.yml. Called by
+# both test_pull_request.yml (PR signal) and release.yml (pre-publish gate).
+name: test-cli
+
+on:
+  workflow_call:
+
+# Least-privilege: this workflow only reads the checked-out source.
+permissions:
+  contents: read
+
+jobs:
+  test-cli:
+    name: cli (node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20", "22"]
+    defaults:
+      run:
+        working-directory: ./cli
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build TypeScript
+        run: npm run build
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -118,6 +118,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Self-hosted runner persists between jobs; don't leave this job's
+          # GITHUB_TOKEN in the worktree's .git config after checkout.
+          persist-credentials: false
 
       - name: BuildPlugin (compile + marketplace packaging validation)
         shell: pwsh
@@ -127,6 +131,7 @@ jobs:
           if (-not (Test-Path $runUAT)) { throw "RunUAT.bat not found at $runUAT — set the UNREAL_ENGINE_PATH repo variable." }
           $uplugin = Join-Path $env:GITHUB_WORKSPACE 'UnrealMCP\UnrealMCP.uplugin'
           $package = Join-Path $env:RUNNER_TEMP 'UnrealMCP-Package'
+          if (Test-Path $package) { Remove-Item $package -Recurse -Force }
           & $runUAT BuildPlugin -Plugin="$uplugin" -Package="$package" -TargetPlatforms=Win64 -Rocket
           if ($LASTEXITCODE -ne 0) { throw "BuildPlugin failed with exit code $LASTEXITCODE" }
 
@@ -162,13 +167,21 @@ jobs:
           $report = Get-Content $index -Raw | ConvertFrom-Json
           $failed = [int]$report.failed
           $succeeded = [int]$report.succeeded
-          Write-Host "Automation results: succeeded=$succeeded failed=$failed"
+          # UE counts specs that pass while emitting a warning under a SEPARATE
+          # succeededWithWarnings field; fold it into the pass tally so a
+          # clean-but-warned suite is not misread as the 0-specs case below.
+          $succeededWithWarnings = [int]$report.succeededWithWarnings
+          $passed = $succeeded + $succeededWithWarnings
+          Write-Host "Automation results: succeeded=$succeeded succeededWithWarnings=$succeededWithWarnings failed=$failed"
           if ($failed -gt 0) { throw "$failed Automation test(s) failed." }
-          if ($succeeded -lt 1) { throw "No Automation tests succeeded (succeeded=$succeeded) — expected at least one UnrealMcp. spec." }
+          if ($passed -lt 1) { throw "No Automation tests succeeded (succeeded=$succeeded succeededWithWarnings=$succeededWithWarnings) — expected at least one UnrealMcp. spec." }
           Write-Host "Plugin Automation: all specs passed."
 
       - name: Upload Automation report on failure
-        if: failure()
+        # REPORT_DIR is exported only at the END of the Automation step; an
+        # earlier failure (BuildPlugin, missing editor) leaves it unset, so guard
+        # the upload to avoid a second confusing failure on an empty path.
+        if: ${{ failure() && env.REPORT_DIR != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: automation-report

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -102,7 +102,11 @@ jobs:
   # test or a missing report.
   plugin:
     name: plugin BuildPlugin + Automation (UE 5.7)
-    if: ${{ vars.UNREAL_RUNNER_READY == 'true' }}
+    # Gated on the runner being registered AND — for pull_request events — the PR
+    # originating from THIS repo, never a fork. A fork PR must never execute its
+    # checked-out code on the self-hosted runner (see docs/RELEASING.md). Manual
+    # dispatches (trusted) are unaffected by the fork clause.
+    if: ${{ vars.UNREAL_RUNNER_READY == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: [self-hosted, windows, unreal-5-7]
     env:
       # Overridable per-runner via repository variables (docs/RELEASING.md).
@@ -139,6 +143,11 @@ jobs:
           & $editorCmd "$env:HOST_UPROJECT" -nullrhi -nosplash -unattended `
             -ExecCmds="Automation RunTests UnrealMcp; Quit" `
             -ReportExportPath="$reportDir" -log
+          # The editor's exit code is unreliable for test verdicts (test.md
+          # Suite 3); the parsed index.json below is authoritative. Clear the
+          # exit code so pwsh's auto-appended `exit $LASTEXITCODE` does not red
+          # the step on a nonzero editor exit unrelated to a test failure.
+          $global:LASTEXITCODE = 0
           echo "REPORT_DIR=$reportDir" >> $env:GITHUB_ENV
 
       - name: Parse Automation report (index.json is authoritative)

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -146,7 +146,7 @@ jobs:
           $reportDir = Join-Path $env:RUNNER_TEMP 'AutomationReport'
           if (Test-Path $reportDir) { Remove-Item $reportDir -Recurse -Force }
           & $editorCmd "$env:HOST_UPROJECT" -nullrhi -nosplash -unattended `
-            -ExecCmds="Automation RunTests UnrealMcp; Quit" `
+            -ExecCmds="Automation RunTests UnrealMcp.; Quit" `
             -ReportExportPath="$reportDir" -log
           # The editor's exit code is unreliable for test verdicts (test.md
           # Suite 3); the parsed index.json below is authoritative. Clear the

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -1,0 +1,168 @@
+# ┌──────────────────────────────────────────────────────────────────┐
+# │  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+# │  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)   │
+# │  Copyright (c) 2026 Ivan Murzak                                  │
+# │  Licensed under the Apache License, Version 2.0.                 │
+# │  See the LICENSE file in the project root for more information.  │
+# └──────────────────────────────────────────────────────────────────┘
+
+# Pull-request CI aggregator (Unity-MCP / Godot-MCP parity, adapted for the UE
+# four-leg mono-repo — docs/ARCHITECTURE.md §9.3/§9.4). Fans out with fail-fast
+# disabled so every leg reports independently:
+#   (a) bridge  — dotnet build + xUnit on hosted ubuntu-latest + windows-latest
+#   (b) server  — dotnet build on hosted ubuntu-latest (thin host, no tests yet)
+#   (c) cli     — unreal-cli node 20/22 tests via the reusable test_cli.yml
+#   (d) plugin  — UE 5.7 BuildPlugin + Automation specs (UnrealMcp. filter) on a
+#                 SELF-HOSTED windows runner labelled `unreal-5-7`
+#
+# Self-hosted runner is NEVER red-by-absence: job (d) is gated on the repository
+# variable `vars.UNREAL_RUNNER_READY == 'true'`. While that variable is unset
+# (no runner registered), job (d) is SKIPPED — a skipped job does not fail the
+# PR, and the hosted legs (a)/(b)/(c) still give full PR signal. Once the owner
+# registers the runner they set the variable to `true` (see docs/RELEASING.md)
+# and the plugin leg becomes a live required-when-available check. The label
+# `unreal-5-7` is deliberately distinct from any M1/M4 release-runner label so
+# PR compiles do not starve release capacity (§9.4 constraint).
+name: test-pull-request
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+# Least-privilege: PR test jobs only read the checked-out source.
+permissions:
+  contents: read
+
+# Auto-cancel superseded runs when a new commit is pushed to the same PR so
+# intermediate pushes don't pile up runner time (§03-implement push-early note).
+concurrency:
+  group: test-pr-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # (a) bridge — .NET 9 sidecar build + xUnit on BOTH hosted OSes (the sidecar
+  # ships per-RID binaries, so cross-OS test coverage matters). 0 errors / 0
+  # failures required.
+  bridge:
+    name: bridge build + xUnit (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Restore
+        run: dotnet restore bridge/Unreal-MCP-Bridge.sln
+
+      - name: Build
+        run: dotnet build bridge/Unreal-MCP-Bridge.sln --configuration Debug --no-restore
+
+      - name: Test
+        run: dotnet test bridge/Unreal-MCP-Bridge.sln --configuration Debug --no-build --verbosity normal
+
+  # (b) server — .NET 8 thin host build (clone of Godot-MCP-Server, no
+  # Unreal-specific code, no test project today). 0 errors required.
+  server:
+    name: server build (.NET 8)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore
+        run: dotnet restore Unreal-MCP-Server/Unreal-MCP-Server.sln
+
+      - name: Build
+        run: dotnet build Unreal-MCP-Server/Unreal-MCP-Server.sln --configuration Debug --no-restore
+
+  # (c) cli — unreal-cli node tests (Node 20 & 22) via the reusable workflow.
+  test-cli:
+    uses: ./.github/workflows/test_cli.yml
+
+  # (d) plugin — UE 5.7 BuildPlugin (also validates marketplace packaging) +
+  # Automation specs on the self-hosted runner. Gated on UNREAL_RUNNER_READY so
+  # it never reds a PR by runner absence (see header). The job parses the
+  # exported Automation index.json (NOT the editor exit code, which is
+  # unreliable for test failures — test.md Suite 3) and fails on any failed
+  # test or a missing report.
+  plugin:
+    name: plugin BuildPlugin + Automation (UE 5.7)
+    if: ${{ vars.UNREAL_RUNNER_READY == 'true' }}
+    runs-on: [self-hosted, windows, unreal-5-7]
+    env:
+      # Overridable per-runner via repository variables (docs/RELEASING.md).
+      UE_ROOT: ${{ vars.UNREAL_ENGINE_PATH || 'C:\Program Files\Epic Games\UE_5.7' }}
+      # Absolute path on the runner to a host .uproject with the UnrealMCP plugin
+      # available (the runner's local Unreal-Test-Project analog). Required for
+      # the Automation pass; BuildPlugin alone does not need it.
+      HOST_UPROJECT: ${{ vars.UNREAL_HOST_PROJECT }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: BuildPlugin (compile + marketplace packaging validation)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $runUAT = Join-Path $env:UE_ROOT 'Engine\Build\BatchFiles\RunUAT.bat'
+          if (-not (Test-Path $runUAT)) { throw "RunUAT.bat not found at $runUAT — set the UNREAL_ENGINE_PATH repo variable." }
+          $uplugin = Join-Path $env:GITHUB_WORKSPACE 'UnrealMCP\UnrealMCP.uplugin'
+          $package = Join-Path $env:RUNNER_TEMP 'UnrealMCP-Package'
+          & $runUAT BuildPlugin -Plugin="$uplugin" -Package="$package" -TargetPlatforms=Win64 -Rocket
+          if ($LASTEXITCODE -ne 0) { throw "BuildPlugin failed with exit code $LASTEXITCODE" }
+
+      - name: Run Automation specs (UnrealMcp. filter)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ([string]::IsNullOrWhiteSpace($env:HOST_UPROJECT)) {
+            throw "UNREAL_HOST_PROJECT repo variable is not set — the Automation pass needs a host .uproject with the UnrealMCP plugin enabled (see docs/RELEASING.md)."
+          }
+          $editorCmd = Join-Path $env:UE_ROOT 'Engine\Binaries\Win64\UnrealEditor-Cmd.exe'
+          $reportDir = Join-Path $env:RUNNER_TEMP 'AutomationReport'
+          if (Test-Path $reportDir) { Remove-Item $reportDir -Recurse -Force }
+          & $editorCmd "$env:HOST_UPROJECT" -nullrhi -nosplash -unattended `
+            -ExecCmds="Automation RunTests UnrealMcp; Quit" `
+            -ReportExportPath="$reportDir" -log
+          echo "REPORT_DIR=$reportDir" >> $env:GITHUB_ENV
+
+      - name: Parse Automation report (index.json is authoritative)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $index = Join-Path $env:REPORT_DIR 'index.json'
+          if (-not (Test-Path $index)) {
+            throw "Automation index.json is MISSING at $index — the run crashed or produced no report (treat as FAILURE, not the 0/0 no-specs case)."
+          }
+          # The report is UTF-8 with BOM (utf-8-sig); ConvertFrom-Json handles the BOM.
+          $report = Get-Content $index -Raw | ConvertFrom-Json
+          $failed = [int]$report.failed
+          $succeeded = [int]$report.succeeded
+          Write-Host "Automation results: succeeded=$succeeded failed=$failed"
+          if ($failed -gt 0) { throw "$failed Automation test(s) failed." }
+          if ($succeeded -lt 1) { throw "No Automation tests succeeded (succeeded=$succeeded) — expected at least one UnrealMcp. spec." }
+          Write-Host "Plugin Automation: all specs passed."
+
+      - name: Upload Automation report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: automation-report
+          path: ${{ env.REPORT_DIR }}
+          if-no-files-found: ignore
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **Model Context Protocol (MCP) integration for [Unreal Engine](https://www.unrealengine.com/).**
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![test-pull-request](https://github.com/IvanMurzak/Unreal-MCP/actions/workflows/test_pull_request.yml/badge.svg)](https://github.com/IvanMurzak/Unreal-MCP/actions/workflows/test_pull_request.yml)
 
 > **Status: pre-alpha.** This repository is a scaffold under active development — the plugin
 > compiles and loads, but no MCP tools are implemented yet. Nothing here is released or

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -96,6 +96,25 @@ Both plugin jobs (`plugin` in `test_pull_request.yml`/`release.yml` and
 are SKIPPED** — a skipped job does not fail a PR, so an unregistered runner never
 reds the hosted legs. The bridge / server / cli legs always provide PR signal.
 
+### Fork-PR safety (untrusted code never runs on the self-hosted runner)
+
+The self-hosted runner executes the checked-out code, so a pull request from a
+**fork** must never reach it. The `plugin` leg's `if` condition adds
+`github.event.pull_request.head.repo.full_name == github.repository`, so the
+self-hosted job runs ONLY for same-repo (branch) PRs and manual dispatches —
+fork PRs skip it (the hosted bridge / server / cli legs still give them full
+signal).
+
+Defense in depth at the repository-settings level (operator):
+
+- *Settings → Actions → General → Fork pull request workflows*: require approval
+  for **all outside collaborators** (or all fork PRs) so no fork workflow runs
+  without a maintainer's explicit click.
+- Prefer an **ephemeral / just-in-time** self-hosted runner (re-provisioned per
+  job, e.g. registered with `--ephemeral`) so one job can never leave persistent
+  state on disk for a later job to read. Never register the `unreal-5-7` runner
+  on a machine holding secrets you would not hand to an untrusted PR author.
+
 ### Registration steps (operator)
 
 1. On a Windows machine with UE 5.7 installed at `C:\Program Files\Epic Games\UE_5.7`

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -178,6 +178,23 @@ gh run rerun <run-id> --repo IvanMurzak/Unreal-MCP
 # gh run rerun <run-id> --failed
 ```
 
+**Post-tag failure (the full re-run will NOT recover it).** If `publish-release`
+already created the `v<version>` tag + GitHub Release but the run then failed
+(asset-upload error, or the expected `publish-npm` auth failure while no Trusted
+Publisher is configured / `private: true` is still set), a full re-run cannot
+fix it: `check-version` now sees `tag_exists=true` → `should_release=false` →
+every job skips, so CI can never publish that version again. Recover one of two
+ways:
+
+```bash
+# Option A — delete the tag + Release, then full re-run (CI republishes cleanly):
+gh release delete v<version> --repo IvanMurzak/Unreal-MCP --cleanup-tag --yes
+gh run rerun <run-id> --repo IvanMurzak/Unreal-MCP
+
+# Option B — keep the tag/Release and publish npm by hand from a clean checkout:
+cd cli && npm ci && npm run build && npm publish --access public
+```
+
 ## Operator gate summary
 
 - A normal merge to `main` publishes **nothing** (the version gate keeps it inert).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,169 @@
+# Releasing Unreal-MCP
+
+This document is the operator runbook for the CI/CD workflows under
+`.github/workflows/`. It covers the PR test pipeline, the gated release pipeline,
+the self-hosted UE 5.7 runner, the dry-run rehearsal procedure, and the required
+secrets / repository variables.
+
+The authoritative design is [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) §9
+(repo / versioning / tests / CI). This file is the operational complement —
+keep the two in lockstep, and keep the CI command surface 1:1 with the
+implement-task profile `test.md` (infra repo).
+
+## Workflows at a glance
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| `test_pull_request.yml` | `pull_request` to `main` (+ manual) | Fans out the PR test legs: bridge build+xUnit (ubuntu + windows), server build (ubuntu), cli node 20/22, and — when a runner is registered — the UE 5.7 plugin BuildPlugin + Automation leg. |
+| `test_cli.yml` | `workflow_call` (reusable) | Builds + tests `unreal-cli` on Node 20 & 22. Called by both `test_pull_request.yml` and `release.yml`. |
+| `release.yml` | `push` to `main` (+ manual `workflow_dispatch`) | Version-gated release: builds bridge/server/plugin artifacts and (only on a real version bump) cuts the GitHub Release + tag and publishes `unreal-cli` to npm. Exposes a `dry_run` input to rehearse everything without publishing. |
+
+## Versioning — the single source of truth
+
+`UnrealMCP/UnrealMCP.uplugin` `VersionName` is the **single source of truth** for
+the release version. `release.yml`'s `check-version` job reads it.
+`commands/bump-version.ps1` rewrites the version across all five version-bearing
+files in one shot (the `.uplugin`, both csproj `<Version>`s, `server.json`, and
+`cli/package.json` + lockfile):
+
+```powershell
+.\commands\bump-version.ps1 -NewVersion "0.2.0"     # add -WhatIf to preview
+```
+
+**Never hand-edit one of the five alone.** The NuGet pins
+(`com.IvanMurzak.ReflectorNet`, `com.IvanMurzak.McpPlugin[.Server]`) are owned by
+the upstream release pipelines — never bump them here.
+
+## The release gate (why a normal merge never publishes)
+
+`release.yml` runs on every push to `main`, but is **inert unless a deliberate
+version bump landed**. The gate, computed in `check-version`:
+
+- `should_release` = **no `v<version>` tag exists yet** AND **this push bumped the
+  `VersionName` line** in `UnrealMCP/UnrealMCP.uplugin`.
+- `dry_run` = the run is a manual `workflow_dispatch` with `dry_run=true`.
+- `run_tests` = `should_release` OR `dry_run`.
+
+Outcomes:
+
+| Event | `run_tests` | Publish (tag / Release / npm) |
+| --- | --- | --- |
+| Merge that does **not** bump `VersionName` (e.g. a feature or workflow-only PR) | ❌ skip | ❌ skip — **guaranteed no-op** |
+| `workflow_dispatch` with `dry_run=true` | ✅ run (rehearsal) | ❌ hard-skipped |
+| Merge that **bumps** `VersionName` to a new untagged version | ✅ run | ✅ **real release** |
+| `workflow_dispatch` with `dry_run=false` on an untagged version | ✅ run | ✅ real release (escape hatch) |
+
+Publish jobs are gated on `should_release == 'true' && dry_run != 'true'`, so a
+dry-run can never publish even though it shares the test/artifact jobs.
+
+## Dry-run procedure (rehearse the release without publishing)
+
+> ⚠️ `workflow_dispatch` requires the workflow to exist **on the default branch**.
+> Until this PR merges, `release.yml` is not yet dispatchable. Run the dry-run
+> **after** the PR lands on `main`.
+
+```bash
+# Rehearse: runs the test fan-out + artifact builds, uploads the zips for
+# inspection, and HARD-SKIPS every tag/Release/npm-publish job.
+gh workflow run release.yml --repo IvanMurzak/Unreal-MCP -f dry_run=true
+
+# Watch it:
+gh run watch --repo IvanMurzak/Unreal-MCP "$(gh run list --repo IvanMurzak/Unreal-MCP --workflow release.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+```
+
+Expected: `bridge`, `test-cli`, `build-bridge-zips`, `build-server-zips` succeed;
+the `plugin` / `build-plugin-zip` legs run only if the self-hosted runner is
+registered (otherwise skipped); `publish-release` and `publish-npm` are
+**skipped**. Verify nothing was published:
+
+```bash
+gh release list --repo IvanMurzak/Unreal-MCP     # expect: empty
+git ls-remote --tags https://github.com/IvanMurzak/Unreal-MCP   # expect: no v* tags
+```
+
+## Self-hosted UE 5.7 runner
+
+The plugin leg (compile + Automation specs) needs Unreal Engine 5.7, which is
+not available on GitHub-hosted runners. It runs on a **self-hosted Windows
+runner** labelled `unreal-5-7` — deliberately distinct from any M1/M4
+release-runner label so PR compiles do not starve release capacity.
+
+### Never red-by-absence
+
+Both plugin jobs (`plugin` in `test_pull_request.yml`/`release.yml` and
+`build-plugin-zip` in `release.yml`) are gated on the repository variable
+`UNREAL_RUNNER_READY == 'true'`. **While that variable is unset, the plugin jobs
+are SKIPPED** — a skipped job does not fail a PR, so an unregistered runner never
+reds the hosted legs. The bridge / server / cli legs always provide PR signal.
+
+### Registration steps (operator)
+
+1. On a Windows machine with UE 5.7 installed at `C:\Program Files\Epic Games\UE_5.7`
+   (or elsewhere — see the `UNREAL_ENGINE_PATH` variable below), register a
+   self-hosted runner against `IvanMurzak/Unreal-MCP`:
+   *Settings → Actions → Runners → New self-hosted runner* (Windows x64). Follow
+   the `./config.cmd` steps GitHub shows.
+2. Give the runner the labels `self-hosted`, `windows`, and **`unreal-5-7`**.
+3. Prepare a host `.uproject` on the runner that has the `UnrealMCP` plugin
+   available (the analog of the infra `Unreal-Test-Project/`, plugin junctioned
+   or copied into its `Plugins/`). Note its absolute path.
+4. Set the repository variables (below).
+5. Open a throwaway PR (or re-run an existing one) and confirm the `plugin` leg
+   now runs and is green.
+
+### Repository variables
+
+Set via `gh variable set --repo IvanMurzak/Unreal-MCP <NAME> --body <VALUE>`
+(or *Settings → Secrets and variables → Actions → Variables*):
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `UNREAL_RUNNER_READY` | to enable the plugin legs | Set to `true` once a `unreal-5-7` runner is registered. Unset/anything-else → plugin legs skip. |
+| `UNREAL_ENGINE_PATH` | optional | UE 5.7 install root on the runner. Defaults to `C:\Program Files\Epic Games\UE_5.7`. |
+| `UNREAL_HOST_PROJECT` | for the Automation pass | Absolute path on the runner to the host `.uproject` (with the UnrealMCP plugin) the Automation specs run against. |
+
+Variables (not secrets) are correct here: none of these values are sensitive.
+
+## Secrets (least-privilege)
+
+The workflows use **no long-lived publish secrets**:
+
+| Secret | Used by | Notes |
+| --- | --- | --- |
+| `GITHUB_TOKEN` | `publish-release` | Auto-provided by GitHub Actions. Scoped per-job: the whole workflow defaults to `permissions: contents: read`; only `publish-release` elevates to `contents: write` to create the Release. |
+| *(none)* — npm | `publish-npm` | npm publish uses **OIDC Trusted Publishing** (`id-token: write`), not a stored `NPM_TOKEN`. |
+
+**npm first-publish prerequisite (owner action):** OIDC Trusted Publishing
+requires a Trusted Publisher for the `unreal-cli` package configured on
+npmjs.com that authorizes this repository + the `release.yml` workflow. Until
+that is set up — and `cli/package.json`'s `private: true` flag is removed in the
+bump commit that cuts the first release — `npm publish` fails auth and nothing is
+published. See <https://docs.npmjs.com/trusted-publishers>.
+
+No secret is ever echoed to logs; the sidecar IPC token (`UNREAL_MCP_TOKEN`)
+travels via stdin and is unrelated to CI.
+
+## Re-running a release — full rerun only
+
+If a release run fails partway, **always use a full re-run, never "re-run failed
+jobs"**. The artifact-build jobs (`build-bridge-zips`, `build-server-zips`,
+`build-plugin-zip`) upload artifacts that the `publish-release` job downloads; a
+partial re-run does not re-run the succeeded build jobs, so their artifacts are
+absent on the new attempt and `publish-release` fails with `Artifact not found`.
+
+```bash
+# Correct: full re-run (re-runs every job, regenerating all artifacts)
+gh run rerun <run-id> --repo IvanMurzak/Unreal-MCP
+
+# WRONG for this pipeline — leaves artifact-producing jobs un-run:
+# gh run rerun <run-id> --failed
+```
+
+## Operator gate summary
+
+- A normal merge to `main` publishes **nothing** (the version gate keeps it inert).
+- A real release is a **deliberate, operator-driven version bump** (run
+  `bump-version.ps1`, commit, merge) — or a manual `workflow_dispatch` with
+  `dry_run=false` on an untagged version.
+- The dry-run (`dry_run=true`) is the safe rehearsal and the only way the release
+  pipeline is exercised before the owner intends to publish.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/` CI to Unreal-MCP (docs/ARCHITECTURE.md §9.4), modeled on Unity-MCP / Godot-MCP and adapted for the four-leg UE mono-repo.
- `test_pull_request.yml`: bridge build+xUnit (ubuntu + windows), server build (ubuntu), `unreal-cli` node 20/22 (reusable `test_cli.yml`), and a self-hosted UE 5.7 BuildPlugin + Automation leg gated on `vars.UNREAL_RUNNER_READY` so it never reds a PR by runner absence.
- `release.yml`: Godot-skeleton version-gated release with a `workflow_dispatch` `dry_run` input; tag / GitHub Release / npm-OIDC publish jobs are hard-skipped on a dry-run and on any non-bump merge. Least-privilege `permissions` throughout; no long-lived publish secrets.
- `docs/RELEASING.md`: runner registration, repo variables, dry-run procedure, secrets, version single-source, full-rerun-only policy.

No version bump; no tag, GitHub Release, or npm publish is fired by this change.

## Test plan

- [x] `actionlint` clean on all workflows (custom `unreal-5-7` label declared in `.github/actionlint.yaml`).
- [x] Hosted-leg commands validated locally exactly as the workflows run them: bridge `dotnet build`+`dotnet test` 86/86, server `dotnet build` clean, `unreal-cli` `npm ci`+`npm run build`+`npm test` 125 pass.
- [x] The hosted PR legs (bridge xUnit on windows+ubuntu, cli npm) run on this PR itself — that is the core verification.
- [ ] `release.yml` dry-run: post-merge operator step (workflow_dispatch requires the workflow on the default branch first) — documented in `docs/RELEASING.md`.

Closes #27
