### PR TITLE
feat: add MCP Tools, Prompts, Resources, and Settings editor windows

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
@@ -43,6 +43,24 @@ namespace
 	const TCHAR* KeyTransport      = TEXT("transport");
 	const TCHAR* KeyStartServer    = TEXT("startServer");
 	const TCHAR* KeyEnabledTools   = TEXT("enabledTools");
+	const TCHAR* KeyDisabledTools  = TEXT("disabledTools");
+
+	// Read a JSON array field into a string array (skipping empty/non-string entries). Shared by the
+	// enabledTools / disabledTools list fields so their parsing stays identical.
+	void ReadStringArrayField(const TSharedPtr<FJsonObject>& Json, const TCHAR* Key, TArray<FString>& Out)
+	{
+		const TArray<TSharedPtr<FJsonValue>>* Values = nullptr;
+		if (Json->TryGetArrayField(Key, Values) && Values != nullptr)
+		{
+			Out.Reset();
+			for (const TSharedPtr<FJsonValue>& Value : *Values)
+			{
+				FString Item;
+				if (Value.IsValid() && Value->TryGetString(Item) && !Item.IsEmpty())
+					Out.Add(Item);
+			}
+		}
+	}
 
 	FString TrimSlash(const FString& In)
 	{
@@ -134,17 +152,8 @@ void FUnrealMcpConfig::LoadFromJson(const TSharedPtr<FJsonObject>& Json)
 		if (Json->TryGetStringField(KeyTransport, Str)) Transport = Str;
 		if (Json->TryGetBoolField(KeyStartServer, bFlag)) bStartServer = bFlag;
 
-		const TArray<TSharedPtr<FJsonValue>>* Tools = nullptr;
-		if (Json->TryGetArrayField(KeyEnabledTools, Tools) && Tools != nullptr)
-		{
-			EnabledTools.Reset();
-			for (const TSharedPtr<FJsonValue>& Value : *Tools)
-			{
-				FString Tool;
-				if (Value.IsValid() && Value->TryGetString(Tool) && !Tool.IsEmpty())
-					EnabledTools.Add(Tool);
-			}
-		}
+		ReadStringArrayField(Json, KeyEnabledTools, EnabledTools);
+		ReadStringArrayField(Json, KeyDisabledTools, DisabledTools);
 	}
 
 	// Snapshot the (defaults + disk) baseline AFTER loading — this is what Save() restores for any key an
@@ -316,6 +325,11 @@ TSharedPtr<FJsonObject> FUnrealMcpConfig::ToJson() const
 	for (const FString& Tool : EnabledTools)
 		Tools.Add(MakeShared<FJsonValueString>(Tool));
 	Obj->SetArrayField(KeyEnabledTools, Tools);
+
+	TArray<TSharedPtr<FJsonValue>> Disabled;
+	for (const FString& Tool : DisabledTools)
+		Disabled.Add(MakeShared<FJsonValueString>(Tool));
+	Obj->SetArrayField(KeyDisabledTools, Disabled);
 
 	return Obj;
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
@@ -81,6 +81,13 @@ public:
 	FString Transport;         // "transport"
 	bool bStartServer = false; // "startServer"
 	TArray<FString> EnabledTools; // "enabledTools" (UNREAL_MCP_TOOLS override; empty = no override)
+	// "disabledTools" — the per-tool enable-map persisted by the §7 MCP Tools window. Names listed here are
+	// hidden from the served manifest (excluded by the registry on boot + on every UI toggle). A blocklist,
+	// NOT a whitelist: default-empty means every tool is enabled, and a tool added by a later plugin update is
+	// enabled unless the user explicitly turns it off. Orthogonal to EnabledTools (the env power-user filter):
+	// a tool is served iff (EnabledTools empty OR it is in EnabledTools) AND it is NOT in DisabledTools. This
+	// field has no env override — it is pure UI persistence, so Save() always round-trips the live value.
+	TArray<FString> DisabledTools; // "disabledTools"
 
 	UNREALMCPEDITOR_API FUnrealMcpConfig();
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpToolRegistry.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpToolRegistry.cpp
@@ -414,10 +414,65 @@ TSharedPtr<FJsonObject> FUnrealMcpToolRegistry::BuildManifestJson() const
 	Tools.GetKeys(Names);
 	Names.Sort();
 	for (const FString& Name : Names)
-		ToolArray.Add(MakeShared<FJsonValueObject>(Tools[Name].ToDescriptorJson()));
+	{
+		// §7 per-tool enable-map: a disabled tool is EXCLUDED from the served manifest entirely (not merely
+		// flagged), so the sidecar mirrors no ProxyTool for it and it never appears in tools/list (§2.2).
+		const FUnrealMcpRegisteredTool& Tool = Tools[Name];
+		if (!Tool.bEnabled)
+			continue;
+		ToolArray.Add(MakeShared<FJsonValueObject>(Tool.ToDescriptorJson()));
+	}
 
 	Manifest->SetArrayField(TEXT("tools"), ToolArray);
 	return Manifest;
+}
+
+TArray<FString> FUnrealMcpToolRegistry::GetToolNamesSorted() const
+{
+	TArray<FString> Names;
+	Tools.GetKeys(Names);
+	Names.Sort();
+	return Names;
+}
+
+int32 FUnrealMcpToolRegistry::NumEnabled() const
+{
+	int32 Count = 0;
+	for (const TPair<FString, FUnrealMcpRegisteredTool>& Pair : Tools)
+	{
+		if (Pair.Value.bEnabled)
+			++Count;
+	}
+	return Count;
+}
+
+bool FUnrealMcpToolRegistry::SetToolEnabled(const FString& Name, bool bEnabled)
+{
+	FUnrealMcpRegisteredTool* Found = Tools.Find(Name);
+	if (Found == nullptr || Found->bEnabled == bEnabled)
+		return false;
+	Found->bEnabled = bEnabled;
+	++Revision;
+	UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] tool '%s' %s (revision %d)."),
+		*Name, bEnabled ? TEXT("enabled") : TEXT("disabled"), Revision);
+	return true;
+}
+
+void FUnrealMcpToolRegistry::ApplyDisabledTools(const TArray<FString>& DisabledNames)
+{
+	const TSet<FString> Disabled(DisabledNames);
+	bool bAnyChanged = false;
+	for (TPair<FString, FUnrealMcpRegisteredTool>& Pair : Tools)
+	{
+		const bool bShouldEnable = !Disabled.Contains(Pair.Key);
+		if (Pair.Value.bEnabled != bShouldEnable)
+		{
+			Pair.Value.bEnabled = bShouldEnable;
+			bAnyChanged = true;
+		}
+	}
+	if (bAnyChanged)
+		++Revision;
 }
 
 FUnrealMcpToolResult FUnrealMcpToolRegistry::Execute(const FString& Name, const FUnrealMcpToolCall& Call) const

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpToolRegistry.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpToolRegistry.cpp
@@ -470,8 +470,12 @@ bool FUnrealMcpToolRegistry::ShouldToolBeEnabled(const FString& Name) const
 	// name is NOT in the §7 blocklist. Both sets are retained members, so this is the single source of truth
 	// shared by Commit (per-registration) and RecomputeEnablement (per-filter-change) — neither can clobber the
 	// other's intent.
-	const bool bPassesWhitelist = EnabledToolsWhitelist.IsEmpty() || EnabledToolsWhitelist.Contains(Name);
-	return bPassesWhitelist && !DisabledToolNames.Contains(Name);
+	return PassesEnabledToolsWhitelist(Name) && !DisabledToolNames.Contains(Name);
+}
+
+bool FUnrealMcpToolRegistry::PassesEnabledToolsWhitelist(const FString& Name) const
+{
+	return EnabledToolsWhitelist.IsEmpty() || EnabledToolsWhitelist.Contains(Name);
 }
 
 void FUnrealMcpToolRegistry::RecomputeEnablement()
@@ -507,6 +511,13 @@ FUnrealMcpToolResult FUnrealMcpToolRegistry::Execute(const FString& Name, const 
 	const FUnrealMcpRegisteredTool* Found = Tools.Find(Name);
 	if (Found == nullptr || !Found->Handler)
 		return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Unknown tool '%s'."), *Name));
+
+	// The §7 blocklist / §8 whitelist are authoritative at the execution boundary, not merely advisory via
+	// manifest exclusion: a disabled tool is DROPPED from BuildManifestJson, but a sidecar that has not yet
+	// applied a re-pushed manifest (toggle → push race) — or any non-conforming caller — could still dispatch
+	// it by name. Gate here so a disabled tool can never run, even if it leaked into a stale tools/list.
+	if (!Found->bEnabled)
+		return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Tool '%s' is disabled."), *Name));
 
 	return Found->Handler(Call);
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpToolRegistry.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpToolRegistry.cpp
@@ -359,6 +359,12 @@ void FUnrealMcpToolRegistry::Commit(FUnrealMcpRegisteredTool&& InTool)
 
 	InTool.SchemaHash = ComputeSchemaHash(InTool);
 	const FString Name = InTool.Name;
+	// §7/§8 retention: a (re-)registered tool inherits the retained whitelist/blocklist immediately, so an
+	// extension hot-reload (RebuildFromProviders removes then re-registers every extension tool FRESH, with
+	// bEnabled defaulting true) cannot resurrect a tool the user disabled, and a non-empty §8 whitelist still
+	// hides a non-whitelisted tool a rebuild re-adds. The schema hash above excludes the enabled flag (§2.2),
+	// so flipping bEnabled here does not perturb it.
+	InTool.bEnabled = ShouldToolBeEnabled(Name);
 	Tools.Add(Name, MoveTemp(InTool));
 	++Revision;
 	UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] registered tool '%s' (revision %d)."), *Name, Revision);
@@ -458,13 +464,22 @@ bool FUnrealMcpToolRegistry::SetToolEnabled(const FString& Name, bool bEnabled)
 	return true;
 }
 
-void FUnrealMcpToolRegistry::ApplyDisabledTools(const TArray<FString>& DisabledNames)
+bool FUnrealMcpToolRegistry::ShouldToolBeEnabled(const FString& Name) const
 {
-	const TSet<FString> Disabled(DisabledNames);
+	// §8 effective-served rule: served iff (whitelist empty — no filter — OR the name is whitelisted) AND the
+	// name is NOT in the §7 blocklist. Both sets are retained members, so this is the single source of truth
+	// shared by Commit (per-registration) and RecomputeEnablement (per-filter-change) — neither can clobber the
+	// other's intent.
+	const bool bPassesWhitelist = EnabledToolsWhitelist.IsEmpty() || EnabledToolsWhitelist.Contains(Name);
+	return bPassesWhitelist && !DisabledToolNames.Contains(Name);
+}
+
+void FUnrealMcpToolRegistry::RecomputeEnablement()
+{
 	bool bAnyChanged = false;
 	for (TPair<FString, FUnrealMcpRegisteredTool>& Pair : Tools)
 	{
-		const bool bShouldEnable = !Disabled.Contains(Pair.Key);
+		const bool bShouldEnable = ShouldToolBeEnabled(Pair.Key);
 		if (Pair.Value.bEnabled != bShouldEnable)
 		{
 			Pair.Value.bEnabled = bShouldEnable;
@@ -473,6 +488,18 @@ void FUnrealMcpToolRegistry::ApplyDisabledTools(const TArray<FString>& DisabledN
 	}
 	if (bAnyChanged)
 		++Revision;
+}
+
+void FUnrealMcpToolRegistry::SetEnabledToolsFilter(const TArray<FString>& EnabledTools)
+{
+	EnabledToolsWhitelist = TSet<FString>(EnabledTools);
+	RecomputeEnablement();
+}
+
+void FUnrealMcpToolRegistry::ApplyDisabledTools(const TArray<FString>& DisabledNames)
+{
+	DisabledToolNames = TSet<FString>(DisabledNames);
+	RecomputeEnablement();
 }
 
 FUnrealMcpToolResult FUnrealMcpToolRegistry::Execute(const FString& Name, const FUnrealMcpToolCall& Call) const

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpFeatureListWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpFeatureListWindow.cpp
@@ -11,8 +11,6 @@
 #include "Widgets/Text/STextBlock.h"
 #include "Styling/AppStyle.h"
 
-#define LOCTEXT_NAMESPACE "UnrealMcp"
-
 void SUnrealMcpFeatureListWindow::Construct(const FArguments& InArgs)
 {
 	TArray<FUnrealMcpFeatureEntry> Entries;
@@ -76,5 +74,3 @@ TSharedRef<SWidget> SUnrealMcpFeatureListWindow::BuildEntryRow(const FUnrealMcpF
 			]
 		];
 }
-
-#undef LOCTEXT_NAMESPACE

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpFeatureListWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpFeatureListWindow.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UI/SUnrealMcpFeatureListWindow.h"
+
+#include "Widgets/SNullWidget.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SScrollBox.h"
+#include "Widgets/Layout/SSeparator.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Styling/AppStyle.h"
+
+#define LOCTEXT_NAMESPACE "UnrealMcp"
+
+void SUnrealMcpFeatureListWindow::Construct(const FArguments& InArgs)
+{
+	TArray<FUnrealMcpFeatureEntry> Entries;
+	if (InArgs._FeatureProvider)
+		Entries = InArgs._FeatureProvider();
+
+	TSharedRef<SWidget> Body = SNullWidget::NullWidget;
+	if (Entries.Num() == 0)
+	{
+		Body = SNew(SBorder)
+			.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+			.Padding(12.0f)
+			[
+				SNew(STextBlock)
+				.Text(InArgs._EmptyMessage)
+				.AutoWrapText(true)
+				.ColorAndOpacity(FSlateColor::UseSubduedForeground())
+			];
+	}
+	else
+	{
+		TSharedRef<SVerticalBox> List = SNew(SVerticalBox);
+		for (const FUnrealMcpFeatureEntry& Entry : Entries)
+			List->AddSlot().AutoHeight().Padding(0, 0, 0, 4)[ BuildEntryRow(Entry) ];
+		Body = List;
+	}
+
+	ChildSlot
+	[
+		SNew(SVerticalBox)
+		+ SVerticalBox::Slot().AutoHeight().Padding(8, 8, 8, 4)
+		[
+			SNew(STextBlock).Text(InArgs._Heading).Font(FCoreStyle::GetDefaultFontStyle("Bold", 11))
+		]
+		+ SVerticalBox::Slot().AutoHeight()[ SNew(SSeparator) ]
+		+ SVerticalBox::Slot().FillHeight(1.0f)
+		[
+			SNew(SScrollBox)
+			+ SScrollBox::Slot().Padding(8.0f)[ Body ]
+		]
+	];
+}
+
+TSharedRef<SWidget> SUnrealMcpFeatureListWindow::BuildEntryRow(const FUnrealMcpFeatureEntry& Entry)
+{
+	return SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+		.Padding(8.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight()
+			[
+				SNew(STextBlock).Text(FText::FromString(Entry.Name)).Font(FCoreStyle::GetDefaultFontStyle("Bold", 10))
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 2, 0, 0)
+			[
+				SNew(STextBlock)
+				.Text(FText::FromString(Entry.Description))
+				.AutoWrapText(true)
+				.ColorAndOpacity(FSlateColor::UseSubduedForeground())
+			]
+		];
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpFeatureListWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpFeatureListWindow.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+
+/** One MCP prompt / resource entry rendered by SUnrealMcpFeatureListWindow (name + one-line description). */
+struct FUnrealMcpFeatureEntry
+{
+	FString Name;
+	FString Description;
+};
+
+/**
+ * A read-only list window shared by the §7 "MCP Prompts" and "MCP Resources" windows (docs/ARCHITECTURE.md §7,
+ * Unity's McpPromptsWindow / McpResourcesWindow analogs), pure-Slate (NO UMG). The plugin (C++) side declares
+ * no prompts/resources of its own — those features live in the .NET sidecar's McpPlugin feature managers (§2),
+ * which §2 did not surface back to the plugin. Rather than invent a fake registry, this window renders whatever
+ * its provider returns and shows an honest empty state ("none registered yet") when the list is empty — the
+ * minimal read surface the aux-windows task mandates, ready to light up when a prompts/resources feed lands.
+ */
+class SUnrealMcpFeatureListWindow : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SUnrealMcpFeatureListWindow) {}
+		/** The message shown when the list is empty (e.g. "No MCP prompts are registered yet."). Required. */
+		SLATE_ARGUMENT(FText, EmptyMessage)
+		/** The bold one-line heading above the list (e.g. "MCP Prompts"). Required. */
+		SLATE_ARGUMENT(FText, Heading)
+		/** Snapshots the current feature set. Optional; an unset provider renders the empty state. */
+		SLATE_ARGUMENT(TFunction<TArray<FUnrealMcpFeatureEntry>()>, FeatureProvider)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	static TSharedRef<SWidget> BuildEntryRow(const FUnrealMcpFeatureEntry& Entry);
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSettingsWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSettingsWindow.cpp
@@ -1,0 +1,223 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UI/SUnrealMcpSettingsWindow.h"
+#include "UI/UnrealMcpEditorViewModel.h"
+
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SScrollBox.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SCheckBox.h"
+#include "Widgets/Input/SEditableTextBox.h"
+#include "Styling/AppStyle.h"
+
+#define LOCTEXT_NAMESPACE "UnrealMcp"
+
+void SUnrealMcpSettingsWindow::Construct(const FArguments& InArgs)
+{
+	ViewModel = InArgs._ViewModel;
+	PortStatusProvider = InArgs._PortStatusProvider;
+
+	ChildSlot
+	[
+		SNew(SScrollBox)
+		+ SScrollBox::Slot().Padding(8.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 6)
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("SettingsHeading", "AI Game Developer — Connection Settings"))
+				.Font(FCoreStyle::GetDefaultFontStyle("Bold", 12))
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildConnectionModeRow() ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildHostRow() ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildAuthRow() ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildPortsRow() ]
+		]
+	];
+}
+
+TSharedRef<SWidget> SUnrealMcpSettingsWindow::BuildConnectionModeRow()
+{
+	return SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+		.Padding(8.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight()
+			[
+				SNew(STextBlock).Text(LOCTEXT("ModeLabel", "Connection mode")).Font(FCoreStyle::GetDefaultFontStyle("Bold", 10))
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(SHorizontalBox)
+				+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 16, 0)
+				[
+					SNew(SCheckBox)
+					.Style(FAppStyle::Get(), "RadioButton")
+					.IsChecked_Lambda([this]()
+					{
+						return IsViewModelValid() && ViewModel->GetConnectionMode() == EUnrealMcpConnectionMode::Cloud
+							? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+					})
+					.OnCheckStateChanged_Lambda([this](ECheckBoxState NewState)
+					{
+						if (IsViewModelValid() && NewState == ECheckBoxState::Checked)
+							ViewModel->SetConnectionMode(EUnrealMcpConnectionMode::Cloud);
+					})
+					[ SNew(STextBlock).Text(LOCTEXT("ModeCloud", "Cloud (ai-game.dev)")) ]
+				]
+				+ SHorizontalBox::Slot().AutoWidth()
+				[
+					SNew(SCheckBox)
+					.Style(FAppStyle::Get(), "RadioButton")
+					.IsChecked_Lambda([this]()
+					{
+						return IsViewModelValid() && ViewModel->GetConnectionMode() == EUnrealMcpConnectionMode::Custom
+							? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+					})
+					.OnCheckStateChanged_Lambda([this](ECheckBoxState NewState)
+					{
+						if (IsViewModelValid() && NewState == ECheckBoxState::Checked)
+							ViewModel->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+					})
+					[ SNew(STextBlock).Text(LOCTEXT("ModeCustom", "Custom (self-hosted)")) ]
+				]
+			]
+		];
+}
+
+TSharedRef<SWidget> SUnrealMcpSettingsWindow::BuildHostRow()
+{
+	return SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+		.Padding(8.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight()
+			[
+				SNew(STextBlock).Text(LOCTEXT("HostLabel", "Custom server URL")).Font(FCoreStyle::GetDefaultFontStyle("Bold", 10))
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(SEditableTextBox)
+				.HintText(LOCTEXT("HostHint", "http://localhost:8080"))
+				.IsEnabled_Lambda([this]()
+				{
+					return IsViewModelValid() && ViewModel->GetConnectionMode() == EUnrealMcpConnectionMode::Custom;
+				})
+				.Text_Lambda([this]()
+				{
+					return IsViewModelValid() ? FText::FromString(ViewModel->GetCustomHost()) : FText::GetEmpty();
+				})
+				.OnTextCommitted_Lambda([this](const FText& NewText, ETextCommit::Type)
+				{
+					if (IsViewModelValid())
+						ViewModel->SetCustomHost(NewText.ToString());
+				})
+			]
+		];
+}
+
+TSharedRef<SWidget> SUnrealMcpSettingsWindow::BuildAuthRow()
+{
+	return SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+		.Padding(8.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight()
+			[
+				SNew(STextBlock).Text(LOCTEXT("AuthLabel", "Custom-mode authorization")).Font(FCoreStyle::GetDefaultFontStyle("Bold", 10))
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(SCheckBox)
+				.IsChecked_Lambda([this]()
+				{
+					return IsViewModelValid() && ViewModel->GetAuthOption() == EUnrealMcpAuthOption::Required
+						? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+				})
+				.OnCheckStateChanged_Lambda([this](ECheckBoxState NewState)
+				{
+					if (IsViewModelValid())
+						ViewModel->SetAuthOption(NewState == ECheckBoxState::Checked ? EUnrealMcpAuthOption::Required : EUnrealMcpAuthOption::None);
+				})
+				[ SNew(STextBlock).Text(LOCTEXT("AuthRequired", "Require a bearer token")) ]
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(SHorizontalBox)
+				+ SHorizontalBox::Slot().FillWidth(1.0f)
+				[
+					SNew(SEditableTextBox)
+					// Mask natively via IsPassword (revealed only while Reveal is held) — committing a fixed-width
+					// display mask back would overwrite the real token (the §8 masking contract, mirrored from the
+					// main window's Custom-token field).
+					.IsPassword_Lambda([this]() { return !bRevealToken; })
+					.IsEnabled_Lambda([this]()
+					{
+						return IsViewModelValid() && ViewModel->GetAuthOption() == EUnrealMcpAuthOption::Required;
+					})
+					.Text_Lambda([this]()
+					{
+						return IsViewModelValid() ? FText::FromString(ViewModel->GetCustomToken()) : FText::GetEmpty();
+					})
+					.OnTextCommitted_Lambda([this](const FText& NewText, ETextCommit::Type)
+					{
+						if (IsViewModelValid())
+							ViewModel->SetCustomToken(NewText.ToString());
+					})
+				]
+				+ SHorizontalBox::Slot().AutoWidth().Padding(6, 0, 0, 0)
+				[
+					SNew(SButton)
+					.Text(LOCTEXT("Reveal", "Reveal"))
+					.OnPressed_Lambda([this]() { bRevealToken = true; })
+					.OnReleased_Lambda([this]() { bRevealToken = false; })
+				]
+				+ SHorizontalBox::Slot().AutoWidth().Padding(6, 0, 0, 0)
+				[
+					SNew(SButton)
+					.Text(LOCTEXT("Generate", "Generate"))
+					.OnClicked_Lambda([this]()
+					{
+						if (IsViewModelValid())
+							ViewModel->GenerateCustomToken();
+						return FReply::Handled();
+					})
+				]
+			]
+		];
+}
+
+TSharedRef<SWidget> SUnrealMcpSettingsWindow::BuildPortsRow()
+{
+	return SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+		.Padding(8.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight()
+			[
+				SNew(STextBlock).Text(LOCTEXT("PortsLabel", "Ports")).Font(FCoreStyle::GetDefaultFontStyle("Bold", 10))
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+			[
+				SNew(STextBlock)
+				.Text_Lambda([this]()
+				{
+					const FString Line = PortStatusProvider ? PortStatusProvider() : FString();
+					return Line.IsEmpty()
+						? LOCTEXT("PortsUnknown", "IPC bridge port: not bound")
+						: FText::FromString(Line);
+				})
+				.ColorAndOpacity(FSlateColor::UseSubduedForeground())
+			]
+		];
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSettingsWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSettingsWindow.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+
+class FUnrealMcpEditorViewModel;
+
+/**
+ * The "Settings" page (docs/ARCHITECTURE.md §7, Unity's UnityMcpProjectSettingsProvider analog), a pure-Slate
+ * compound widget — NO UMG. Reads and writes the §8 config (connection mode, Custom-mode server host, auth
+ * option + masked token) through the shared FUnrealMcpEditorViewModel, which persists every edit to the §8
+ * store and pushes it over IPC. The bound IPC port is surfaced read-only via a provider (the port is
+ * deterministic per project / chosen at bind time — not a user-editable field). The SAME widget instance is
+ * hosted by both the nomad "Settings" tab AND the "Project → Plugins → AI Game Developer" ISettingsModule
+ * section, so UE users find it where they expect (§7).
+ */
+class SUnrealMcpSettingsWindow : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SUnrealMcpSettingsWindow) {}
+		/** The shared view-model (owned by the runtime). Required — drives reads + writes + persistence. */
+		SLATE_ARGUMENT(TSharedPtr<FUnrealMcpEditorViewModel>, ViewModel)
+		/** A read-only provider for the bound IPC port line (e.g. "IPC bridge port: 31234"). Optional. */
+		SLATE_ARGUMENT(TFunction<FString()>, PortStatusProvider)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	TSharedPtr<FUnrealMcpEditorViewModel> ViewModel;
+	TFunction<FString()> PortStatusProvider;
+
+	bool bRevealToken = false;
+
+	TSharedRef<SWidget> BuildConnectionModeRow();
+	TSharedRef<SWidget> BuildHostRow();
+	TSharedRef<SWidget> BuildAuthRow();
+	TSharedRef<SWidget> BuildPortsRow();
+
+	bool IsViewModelValid() const { return ViewModel.IsValid(); }
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSettingsWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSettingsWindow.h
@@ -14,9 +14,10 @@ class FUnrealMcpEditorViewModel;
  * compound widget — NO UMG. Reads and writes the §8 config (connection mode, Custom-mode server host, auth
  * option + masked token) through the shared FUnrealMcpEditorViewModel, which persists every edit to the §8
  * store and pushes it over IPC. The bound IPC port is surfaced read-only via a provider (the port is
- * deterministic per project / chosen at bind time — not a user-editable field). The SAME widget instance is
- * hosted by both the nomad "Settings" tab AND the "Project → Plugins → AI Game Developer" ISettingsModule
- * section, so UE users find it where they expect (§7).
+ * deterministic per project / chosen at bind time — not a user-editable field). TWO instances of this widget are
+ * hosted — one by the nomad "Settings" tab, one by the "Project → Plugins → AI Game Developer" ISettingsModule
+ * section — so UE users find it where they expect (§7). Both bind the SAME shared view-model, so the two views
+ * read and write identical state and stay consistent.
  */
 class SUnrealMcpSettingsWindow : public SCompoundWidget
 {

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpToolsWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpToolsWindow.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UI/SUnrealMcpToolsWindow.h"
+#include "UI/UnrealMcpEditorViewModel.h"
+
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SScrollBox.h"
+#include "Widgets/Layout/SSeparator.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Input/SCheckBox.h"
+#include "Styling/AppStyle.h"
+
+#define LOCTEXT_NAMESPACE "UnrealMcp"
+
+void SUnrealMcpToolsWindow::Construct(const FArguments& InArgs)
+{
+	ViewModel = InArgs._ViewModel;
+	// Snapshot the registered-tool set once — the set is static after boot (§2.2: core families register before
+	// the bridge accepts), so a re-snapshot would not change. The per-row checkbox binds LIVE to the view-model,
+	// so enable/disable edits render immediately without rebuilding the list.
+	if (InArgs._ToolListProvider)
+		Tools = InArgs._ToolListProvider();
+
+	TSharedRef<SVerticalBox> List = SNew(SVerticalBox);
+	if (Tools.Num() == 0)
+	{
+		List->AddSlot().AutoHeight().Padding(4.0f)
+		[
+			SNew(STextBlock).Text(LOCTEXT("ToolsEmpty", "No tools registered."))
+		];
+	}
+	else
+	{
+		for (const FUnrealMcpToolListEntry& Entry : Tools)
+		{
+			List->AddSlot().AutoHeight().Padding(0, 0, 0, 4)[ BuildToolRow(Entry) ];
+		}
+	}
+
+	ChildSlot
+	[
+		SNew(SVerticalBox)
+		// Summary line: "N / M tools enabled".
+		+ SVerticalBox::Slot().AutoHeight().Padding(8, 8, 8, 4)
+		[
+			SNew(STextBlock)
+			.Text(this, &SUnrealMcpToolsWindow::GetSummaryText)
+			.Font(FCoreStyle::GetDefaultFontStyle("Bold", 11))
+		]
+		+ SVerticalBox::Slot().AutoHeight()[ SNew(SSeparator) ]
+		+ SVerticalBox::Slot().FillHeight(1.0f)
+		[
+			SNew(SScrollBox)
+			+ SScrollBox::Slot().Padding(8.0f)[ List ]
+		]
+	];
+}
+
+FText SUnrealMcpToolsWindow::GetSummaryText() const
+{
+	int32 Enabled = 0;
+	if (ViewModel.IsValid())
+	{
+		for (const FUnrealMcpToolListEntry& Entry : Tools)
+		{
+			if (!ViewModel->IsToolDisabled(Entry.Name))
+				++Enabled;
+		}
+	}
+	return FText::Format(LOCTEXT("ToolsSummary", "{0} / {1} tools enabled"),
+		FText::AsNumber(Enabled), FText::AsNumber(Tools.Num()));
+}
+
+TSharedRef<SWidget> SUnrealMcpToolsWindow::BuildToolRow(const FUnrealMcpToolListEntry& Entry)
+{
+	const FString ToolName = Entry.Name;
+	const FString Family = Entry.ExtensionId.IsEmpty() ? TEXT("core") : Entry.ExtensionId;
+	const FText Heading = Entry.Title.IsEmpty()
+		? FText::FromString(Entry.Name)
+		: FText::Format(LOCTEXT("ToolHeading", "{0}  ({1})"), FText::FromString(Entry.Title), FText::FromString(Entry.Name));
+
+	return SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+		.Padding(8.0f)
+		[
+			SNew(SHorizontalBox)
+			// Per-tool enable/disable checkbox.
+			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Top).Padding(0, 0, 8, 0)
+			[
+				SNew(SCheckBox)
+				.IsChecked_Lambda([this, ToolName]()
+				{
+					const bool bEnabled = ViewModel.IsValid() ? !ViewModel->IsToolDisabled(ToolName) : true;
+					return bEnabled ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+				})
+				.OnCheckStateChanged_Lambda([this, ToolName](ECheckBoxState NewState)
+				{
+					if (ViewModel.IsValid())
+						ViewModel->SetToolEnabled(ToolName, NewState == ECheckBoxState::Checked);
+				})
+			]
+			+ SHorizontalBox::Slot().FillWidth(1.0f)
+			[
+				SNew(SVerticalBox)
+				+ SVerticalBox::Slot().AutoHeight()
+				[
+					SNew(SHorizontalBox)
+					+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
+					[
+						SNew(STextBlock).Text(Heading).Font(FCoreStyle::GetDefaultFontStyle("Bold", 10))
+					]
+					+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(8, 0, 0, 0)
+					[
+						SNew(STextBlock)
+						.Text(FText::FromString(Family))
+						.ColorAndOpacity(FSlateColor::UseSubduedForeground())
+					]
+				]
+				+ SVerticalBox::Slot().AutoHeight().Padding(0, 2, 0, 0)
+				[
+					SNew(STextBlock)
+					.Text(FText::FromString(Entry.Description))
+					.AutoWrapText(true)
+					.ColorAndOpacity(FSlateColor::UseSubduedForeground())
+				]
+			]
+		];
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpToolsWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpToolsWindow.cpp
@@ -66,7 +66,9 @@ FText SUnrealMcpToolsWindow::GetSummaryText() const
 	{
 		for (const FUnrealMcpToolListEntry& Entry : Tools)
 		{
-			if (!ViewModel->IsToolDisabled(Entry.Name))
+			// Count the EFFECTIVE served state (§8): served iff it passes the env whitelist gate AND the user has
+			// not blocklisted it — matching the registry's manifest, not the §7 blocklist alone.
+			if (Entry.bWhitelisted && !ViewModel->IsToolDisabled(Entry.Name))
 				++Enabled;
 		}
 	}
@@ -77,6 +79,7 @@ FText SUnrealMcpToolsWindow::GetSummaryText() const
 TSharedRef<SWidget> SUnrealMcpToolsWindow::BuildToolRow(const FUnrealMcpToolListEntry& Entry)
 {
 	const FString ToolName = Entry.Name;
+	const bool bWhitelisted = Entry.bWhitelisted;
 	const FString Family = Entry.ExtensionId.IsEmpty() ? TEXT("core") : Entry.ExtensionId;
 	const FText Heading = Entry.Title.IsEmpty()
 		? FText::FromString(Entry.Name)
@@ -87,12 +90,16 @@ TSharedRef<SWidget> SUnrealMcpToolsWindow::BuildToolRow(const FUnrealMcpToolList
 		.Padding(8.0f)
 		[
 			SNew(SHorizontalBox)
-			// Per-tool enable/disable checkbox.
+			// Per-tool enable/disable checkbox. A whitelist-gated tool (§8) is served-disabled regardless of the
+			// §7 blocklist, so its checkbox is forced unchecked + disabled — toggling it would have no wire effect.
 			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Top).Padding(0, 0, 8, 0)
 			[
 				SNew(SCheckBox)
-				.IsChecked_Lambda([this, ToolName]()
+				.IsEnabled(bWhitelisted)
+				.IsChecked_Lambda([this, ToolName, bWhitelisted]()
 				{
+					if (!bWhitelisted)
+						return ECheckBoxState::Unchecked; // never served — the §8 whitelist excludes it
 					const bool bEnabled = ViewModel.IsValid() ? !ViewModel->IsToolDisabled(ToolName) : true;
 					return bEnabled ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
 				})
@@ -116,6 +123,15 @@ TSharedRef<SWidget> SUnrealMcpToolsWindow::BuildToolRow(const FUnrealMcpToolList
 					[
 						SNew(STextBlock)
 						.Text(FText::FromString(Family))
+						.ColorAndOpacity(FSlateColor::UseSubduedForeground())
+					]
+					// Whitelist-gate annotation (§8): the tool is excluded by the EnabledTools filter and cannot be
+					// re-enabled from this window — make that explicit instead of showing an inert checked row.
+					+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(8, 0, 0, 0)
+					[
+						SNew(STextBlock)
+						.Visibility(bWhitelisted ? EVisibility::Collapsed : EVisibility::Visible)
+						.Text(LOCTEXT("ToolWhitelistGated", "disabled by the EnabledTools filter"))
 						.ColorAndOpacity(FSlateColor::UseSubduedForeground())
 					]
 				]

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpToolsWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpToolsWindow.cpp
@@ -17,9 +17,10 @@
 void SUnrealMcpToolsWindow::Construct(const FArguments& InArgs)
 {
 	ViewModel = InArgs._ViewModel;
-	// Snapshot the registered-tool set once — the set is static after boot (§2.2: core families register before
-	// the bridge accepts), so a re-snapshot would not change. The per-row checkbox binds LIVE to the view-model,
-	// so enable/disable edits render immediately without rebuilding the list.
+	// Snapshot the registered-tool set once at construction. Core families register before the bridge accepts
+	// (§2.2), but a §5 extension hot-reload CAN add/remove tools after boot — an already-open window keeps its
+	// construction snapshot, so a late-registered tool only appears on reopen. The per-row checkbox binds LIVE to
+	// the view-model, so enable/disable edits render immediately without rebuilding the list.
 	if (InArgs._ToolListProvider)
 		Tools = InArgs._ToolListProvider();
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpToolsWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpToolsWindow.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+
+class FUnrealMcpEditorViewModel;
+
+/** One row in the §7 MCP Tools window — a registry snapshot the widget renders (kept free of the registry type). */
+struct FUnrealMcpToolListEntry
+{
+	FString Name;
+	FString Title;
+	FString Description;
+	FString ExtensionId; // "core" or an extension id (§5) — surfaced as the family label.
+};
+
+/**
+ * The "MCP Tools" window (docs/ARCHITECTURE.md §7, Unity's McpToolsWindow analog), a pure-Slate compound widget
+ * — NO UMG / editor-utility dependency. Lists every registered tool (across all families, enabled or not) with a
+ * per-tool enable/disable checkbox. Toggling routes through the shared FUnrealMcpEditorViewModel, which persists
+ * the choice to the §8 config store and asks the runtime to exclude/restore the tool in the served manifest
+ * (so the sidecar's tools/list drops/restores it over the wire). The tool set is snapshotted at Construct (it is
+ * static after boot); each row's checkbox binds live to the view-model so the rendered state always reflects the
+ * persisted blocklist.
+ */
+class SUnrealMcpToolsWindow : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SUnrealMcpToolsWindow) {}
+		/** The shared view-model (owned by the runtime). Required — drives enable state + persistence. */
+		SLATE_ARGUMENT(TSharedPtr<FUnrealMcpEditorViewModel>, ViewModel)
+		/** Snapshots the full registered-tool set (sorted). Required — the runtime closes over the registry. */
+		SLATE_ARGUMENT(TFunction<TArray<FUnrealMcpToolListEntry>()>, ToolListProvider)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	TSharedPtr<FUnrealMcpEditorViewModel> ViewModel;
+	TArray<FUnrealMcpToolListEntry> Tools;
+
+	TSharedRef<SWidget> BuildToolRow(const FUnrealMcpToolListEntry& Entry);
+	FText GetSummaryText() const;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpToolsWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpToolsWindow.h
@@ -16,6 +16,10 @@ struct FUnrealMcpToolListEntry
 	FString Title;
 	FString Description;
 	FString ExtensionId; // "core" or an extension id (§5) — surfaced as the family label.
+	// Whether the tool passes the §8 EnabledTools whitelist gate (static, env-driven). A non-whitelisted tool is
+	// served-disabled regardless of the §7 blocklist toggle, so the window renders its row gated rather than
+	// pretending the per-tool checkbox controls it. Defaults true (the common "no whitelist" case).
+	bool bWhitelisted = true;
 };
 
 /**
@@ -23,9 +27,10 @@ struct FUnrealMcpToolListEntry
  * — NO UMG / editor-utility dependency. Lists every registered tool (across all families, enabled or not) with a
  * per-tool enable/disable checkbox. Toggling routes through the shared FUnrealMcpEditorViewModel, which persists
  * the choice to the §8 config store and asks the runtime to exclude/restore the tool in the served manifest
- * (so the sidecar's tools/list drops/restores it over the wire). The tool set is snapshotted at Construct (it is
- * static after boot); each row's checkbox binds live to the view-model so the rendered state always reflects the
- * persisted blocklist.
+ * (so the sidecar's tools/list drops/restores it over the wire). The tool set is snapshotted at Construct; each
+ * row's checkbox binds live to the view-model so a blocklist edit renders immediately. A tool that fails the §8
+ * EnabledTools whitelist gate is rendered gated (row disabled + annotated) and excluded from the "N / M enabled"
+ * count, so the window matches the registry's effective served manifest rather than the blocklist alone.
  */
 class SUnrealMcpToolsWindow : public SCompoundWidget
 {

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.cpp
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UI/UnrealMcpAuxWindows.h"
+#include "UI/SUnrealMcpSettingsWindow.h"
+#include "UI/UnrealMcpEditorViewModel.h"
+#include "UnrealMcpLog.h"
+
+#include "Framework/Docking/TabManager.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Widgets/Docking/SDockTab.h"
+#include "Styling/AppStyle.h"
+#include "Textures/SlateIcon.h"
+#include "WorkspaceMenuStructure.h"
+#include "WorkspaceMenuStructureModule.h"
+#include "ISettingsModule.h"
+#include "Modules/ModuleManager.h"
+
+#define LOCTEXT_NAMESPACE "UnrealMcp"
+
+const FName FUnrealMcpAuxWindows::ToolsTabId(TEXT("UnrealMcpToolsWindow"));
+const FName FUnrealMcpAuxWindows::PromptsTabId(TEXT("UnrealMcpPromptsWindow"));
+const FName FUnrealMcpAuxWindows::ResourcesTabId(TEXT("UnrealMcpResourcesWindow"));
+const FName FUnrealMcpAuxWindows::SettingsTabId(TEXT("UnrealMcpSettingsWindow"));
+
+namespace
+{
+	const FName SettingsContainer(TEXT("Project"));
+	const FName SettingsCategory(TEXT("Plugins"));
+	const FName SettingsSection(TEXT("AI Game Developer"));
+}
+
+void FUnrealMcpAuxWindows::Register(
+	const TSharedRef<FUnrealMcpEditorViewModel>& InViewModel,
+	TFunction<TArray<FUnrealMcpToolListEntry>()> InToolListProvider,
+	TFunction<FString()> InPortStatusProvider,
+	TFunction<TArray<FUnrealMcpFeatureEntry>()> InPromptProvider,
+	TFunction<TArray<FUnrealMcpFeatureEntry>()> InResourceProvider)
+{
+	if (bRegistered)
+		return;
+
+	ViewModel = InViewModel;
+	ToolListProvider = MoveTemp(InToolListProvider);
+	PortStatusProvider = MoveTemp(InPortStatusProvider);
+	PromptProvider = MoveTemp(InPromptProvider);
+	ResourceProvider = MoveTemp(InResourceProvider);
+
+	// Slate may be unavailable in a commandlet / -nullrhi headless run; guard so the Automation/smoke runs
+	// (which load the module) never crash on tab registration (mirrors the main-window tab).
+	if (!FSlateApplication::IsInitialized())
+	{
+		UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] Slate not initialized; skipping aux-window registration (headless)."));
+		return;
+	}
+
+	const TSharedRef<FWorkspaceItem> Group = WorkspaceMenu::GetMenuStructure().GetToolsCategory();
+	FGlobalTabmanager& TabManager = *FGlobalTabmanager::Get();
+
+	TabManager.RegisterNomadTabSpawner(ToolsTabId, FOnSpawnTab::CreateRaw(this, &FUnrealMcpAuxWindows::SpawnToolsTab))
+		.SetDisplayName(LOCTEXT("ToolsTabTitle", "MCP Tools"))
+		.SetTooltipText(LOCTEXT("ToolsTabTooltip", "List and enable/disable the registered MCP tools."))
+		.SetGroup(Group)
+		.SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "Icons.Settings"));
+
+	TabManager.RegisterNomadTabSpawner(PromptsTabId, FOnSpawnTab::CreateRaw(this, &FUnrealMcpAuxWindows::SpawnPromptsTab))
+		.SetDisplayName(LOCTEXT("PromptsTabTitle", "MCP Prompts"))
+		.SetTooltipText(LOCTEXT("PromptsTabTooltip", "List the registered MCP prompts."))
+		.SetGroup(Group)
+		.SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "Icons.Documentation"));
+
+	TabManager.RegisterNomadTabSpawner(ResourcesTabId, FOnSpawnTab::CreateRaw(this, &FUnrealMcpAuxWindows::SpawnResourcesTab))
+		.SetDisplayName(LOCTEXT("ResourcesTabTitle", "MCP Resources"))
+		.SetTooltipText(LOCTEXT("ResourcesTabTooltip", "List the registered MCP resources."))
+		.SetGroup(Group)
+		.SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "Icons.Box"));
+
+	TabManager.RegisterNomadTabSpawner(SettingsTabId, FOnSpawnTab::CreateRaw(this, &FUnrealMcpAuxWindows::SpawnSettingsTab))
+		.SetDisplayName(LOCTEXT("SettingsTabTitle", "AI Game Developer Settings"))
+		.SetTooltipText(LOCTEXT("SettingsTabTooltip", "Edit the AI Game Developer (Unreal-MCP) connection settings."))
+		.SetGroup(Group)
+		.SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "Icons.Toolbar.Settings"));
+
+	// Also register the Settings page as a Project Settings section rendering the SAME widget (§7) — UE users
+	// expect Project Settings discoverability. The nomad tab satisfies the 4-aux-windows mandate; this is the
+	// additional, conventional entry point. Both read/write the same view-model, so they stay consistent.
+	if (ISettingsModule* Settings = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
+	{
+		Settings->RegisterSettings(
+			SettingsContainer, SettingsCategory, SettingsSection,
+			LOCTEXT("SettingsSectionName", "AI Game Developer"),
+			LOCTEXT("SettingsSectionDesc", "Connection settings for the AI Game Developer (Unreal-MCP) plugin."),
+			SNew(SUnrealMcpSettingsWindow)
+				.ViewModel(ViewModel)
+				.PortStatusProvider(PortStatusProvider));
+		bSettingsRegistered = true;
+	}
+
+	bRegistered = true;
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] registered the MCP Tools/Prompts/Resources/Settings aux windows."));
+}
+
+void FUnrealMcpAuxWindows::Unregister()
+{
+	if (!bRegistered)
+		return;
+
+	if (FSlateApplication::IsInitialized())
+	{
+		FGlobalTabmanager& TabManager = *FGlobalTabmanager::Get();
+		// Close any live tab first so its hosted widget (a strong view-model ref) is torn down before the runtime
+		// frees the view-model — same use-after-free guard as the main-window tab.
+		for (const FName& TabId : { ToolsTabId, PromptsTabId, ResourcesTabId, SettingsTabId })
+		{
+			if (TSharedPtr<SDockTab> LiveTab = TabManager.FindExistingLiveTab(TabId))
+				LiveTab->RequestCloseTab();
+			TabManager.UnregisterNomadTabSpawner(TabId);
+		}
+	}
+
+	if (bSettingsRegistered)
+	{
+		if (ISettingsModule* Settings = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
+			Settings->UnregisterSettings(SettingsContainer, SettingsCategory, SettingsSection);
+		bSettingsRegistered = false;
+	}
+
+	bRegistered = false;
+}
+
+TSharedRef<SDockTab> FUnrealMcpAuxWindows::SpawnToolsTab(const FSpawnTabArgs& Args)
+{
+	TSharedRef<SDockTab> Tab = SNew(SDockTab).TabRole(ETabRole::NomadTab);
+	Tab->SetContent(
+		SNew(SUnrealMcpToolsWindow)
+		.ViewModel(ViewModel)
+		.ToolListProvider(ToolListProvider));
+	return Tab;
+}
+
+TSharedRef<SDockTab> FUnrealMcpAuxWindows::SpawnPromptsTab(const FSpawnTabArgs& Args)
+{
+	TSharedRef<SDockTab> Tab = SNew(SDockTab).TabRole(ETabRole::NomadTab);
+	Tab->SetContent(
+		SNew(SUnrealMcpFeatureListWindow)
+		.Heading(LOCTEXT("PromptsHeading", "MCP Prompts"))
+		.EmptyMessage(LOCTEXT("PromptsEmpty", "No MCP prompts are registered yet. Prompts are provided by the sidecar's McpPlugin feature managers; this window will list them once a prompts feed is surfaced to the plugin."))
+		.FeatureProvider(PromptProvider));
+	return Tab;
+}
+
+TSharedRef<SDockTab> FUnrealMcpAuxWindows::SpawnResourcesTab(const FSpawnTabArgs& Args)
+{
+	TSharedRef<SDockTab> Tab = SNew(SDockTab).TabRole(ETabRole::NomadTab);
+	Tab->SetContent(
+		SNew(SUnrealMcpFeatureListWindow)
+		.Heading(LOCTEXT("ResourcesHeading", "MCP Resources"))
+		.EmptyMessage(LOCTEXT("ResourcesEmpty", "No MCP resources are registered yet. Resources are provided by the sidecar's McpPlugin feature managers; this window will list them once a resources feed is surfaced to the plugin."))
+		.FeatureProvider(ResourceProvider));
+	return Tab;
+}
+
+TSharedRef<SDockTab> FUnrealMcpAuxWindows::SpawnSettingsTab(const FSpawnTabArgs& Args)
+{
+	TSharedRef<SDockTab> Tab = SNew(SDockTab).TabRole(ETabRole::NomadTab);
+	Tab->SetContent(
+		SNew(SUnrealMcpSettingsWindow)
+		.ViewModel(ViewModel)
+		.PortStatusProvider(PortStatusProvider));
+	return Tab;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.cpp
@@ -81,9 +81,10 @@ void FUnrealMcpAuxWindows::Register(
 		.SetGroup(Group)
 		.SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "Icons.Toolbar.Settings"));
 
-	// Also register the Settings page as a Project Settings section rendering the SAME widget (§7) — UE users
-	// expect Project Settings discoverability. The nomad tab satisfies the 4-aux-windows mandate; this is the
-	// additional, conventional entry point. Both read/write the same view-model, so they stay consistent.
+	// Also register the Settings page as a Project Settings section rendering a SECOND SUnrealMcpSettingsWindow
+	// instance (§7) — UE users expect Project Settings discoverability. The nomad tab satisfies the 4-aux-windows
+	// mandate; this is the additional, conventional entry point. Both instances bind the same view-model, so they
+	// read/write identical state and stay consistent.
 	if (ISettingsModule* Settings = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
 	{
 		Settings->RegisterSettings(

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.cpp
@@ -41,8 +41,23 @@ void FUnrealMcpAuxWindows::Register(
 		return;
 
 	ViewModel = InViewModel;
-	ToolListProvider = MoveTemp(InToolListProvider);
-	PortStatusProvider = MoveTemp(InPortStatusProvider);
+
+	// The Tools/Settings providers close over the runtime-owned registry/bridge (raw, non-owning). A widget can
+	// outlive Unregister() — a deferred RequestCloseTab still queued when the runtime frees those subsystems — and
+	// paint once more, dereferencing freed memory. Guard both providers with a shared alive-flag that
+	// NeutralizeProviders() (from Unregister(), ahead of the runtime's BridgeServer/Registry resets) flips off, so
+	// every surviving widget copy short-circuits to a safe empty result. Mirrors the runtime's view-model
+	// side-effect-sink nulling: same teardown race, same defense, for the widget-held providers.
+	ProvidersAlive = MakeShared<bool>(true);
+	TSharedPtr<bool> Alive = ProvidersAlive;
+	ToolListProvider = [Alive, Inner = MoveTemp(InToolListProvider)]() -> TArray<FUnrealMcpToolListEntry>
+	{
+		return (Alive.IsValid() && *Alive && Inner) ? Inner() : TArray<FUnrealMcpToolListEntry>();
+	};
+	PortStatusProvider = [Alive, Inner = MoveTemp(InPortStatusProvider)]() -> FString
+	{
+		return (Alive.IsValid() && *Alive && Inner) ? Inner() : FString();
+	};
 	PromptProvider = MoveTemp(InPromptProvider);
 	ResourceProvider = MoveTemp(InResourceProvider);
 
@@ -106,6 +121,12 @@ void FUnrealMcpAuxWindows::Unregister()
 	if (!bRegistered)
 		return;
 
+	// Neutralize the widget-held providers FIRST: a tab closed via the deferred RequestCloseTab below (or any
+	// queued widget event) could otherwise paint once more after the runtime frees the registry/bridge. Runtime
+	// Shutdown calls Unregister() ahead of the BridgeServer/Registry resets, so flipping the alive-flag here makes
+	// every surviving provider copy return a safe empty result.
+	NeutralizeProviders();
+
 	if (FSlateApplication::IsInitialized())
 	{
 		FGlobalTabmanager& TabManager = *FGlobalTabmanager::Get();
@@ -127,6 +148,12 @@ void FUnrealMcpAuxWindows::Unregister()
 	}
 
 	bRegistered = false;
+}
+
+void FUnrealMcpAuxWindows::NeutralizeProviders()
+{
+	if (ProvidersAlive.IsValid())
+		*ProvidersAlive = false;
 }
 
 TSharedRef<SDockTab> FUnrealMcpAuxWindows::SpawnToolsTab(const FSpawnTabArgs& Args)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.h
@@ -51,8 +51,16 @@ public:
 		TFunction<TArray<FUnrealMcpFeatureEntry>()> InPromptProvider,
 		TFunction<TArray<FUnrealMcpFeatureEntry>()> InResourceProvider);
 
-	/** Unregister the tab spawners + the settings section (Shutdown). Idempotent. */
+	/** Unregister the tab spawners + the settings section (Shutdown). Idempotent. Neutralizes the providers first. */
 	void Unregister();
+
+	/**
+	 * Flip the shared alive-flag the Tools/Settings providers close over, so any widget that outlives Unregister()
+	 * (a deferred RequestCloseTab still queued when the runtime frees the registry/bridge) short-circuits its
+	 * provider to a safe empty result instead of dereferencing freed memory. Called from Unregister(), which the
+	 * runtime invokes BEFORE the BridgeServer/Registry resets. Idempotent; safe before Register(). Game-thread only.
+	 */
+	void NeutralizeProviders();
 
 private:
 	TSharedRef<SDockTab> SpawnToolsTab(const FSpawnTabArgs& Args);
@@ -65,6 +73,9 @@ private:
 	TFunction<FString()> PortStatusProvider;
 	TFunction<TArray<FUnrealMcpFeatureEntry>()> PromptProvider;
 	TFunction<TArray<FUnrealMcpFeatureEntry>()> ResourceProvider;
+	// Shared with every widget-held copy of the registry/bridge-touching providers; NeutralizeProviders() flips it
+	// false during teardown so a surviving widget's next paint returns empty rather than dereferencing freed memory.
+	TSharedPtr<bool> ProvidersAlive;
 	bool bRegistered = false;
 	bool bSettingsRegistered = false;
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UI/SUnrealMcpToolsWindow.h"
+#include "UI/SUnrealMcpFeatureListWindow.h"
+
+class FUnrealMcpEditorViewModel;
+class SDockTab;
+class FSpawnTabArgs;
+
+/**
+ * Registers the four §7 auxiliary windows (docs/ARCHITECTURE.md §7) as nomad dockable tabs under the same
+ * "Window → Tools" group as the main window, plus the Settings page ALSO as a "Project → Plugins → AI Game
+ * Developer" ISettingsModule section (UE users expect Project Settings discoverability):
+ *
+ *   - UnrealMcpToolsWindow     — per-tool enable/disable (drives the §8 enable-map + manifest exclusion).
+ *   - UnrealMcpPromptsWindow   — MCP prompts (honest empty state until a prompts feed lands).
+ *   - UnrealMcpResourcesWindow — MCP resources (honest empty state).
+ *   - UnrealMcpSettingsWindow  — §8 connection settings (also the ISettingsModule section).
+ *
+ * Dedup/focus (the known Godot [low] fixed here): nomad tabs are owned by FGlobalTabmanager, which keeps a
+ * single live tab per id and FOCUSES the existing one when the menu entry is invoked again — invoking a
+ * window's menu entry twice never errors, it brings the open tab forward.
+ *
+ * Lifetime mirrors FUnrealMcpMainWindowTab: Register() runs in StartupModule (after the view-model + registry
+ * exist), Unregister() in Shutdown — and Unregister CLOSES any live tab first so the hosted widget (which holds
+ * a strong view-model ref) is torn down before the runtime frees the view-model/bridge.
+ */
+class FUnrealMcpAuxWindows
+{
+public:
+	static const FName ToolsTabId;
+	static const FName PromptsTabId;
+	static const FName ResourcesTabId;
+	static const FName SettingsTabId;
+
+	/**
+	 * Register the four nomad tabs + the ISettingsModule settings section. @p InViewModel is the shared state
+	 * model (must outlive the windows — the runtime owns it). @p InToolListProvider snapshots the registry's
+	 * tool set for the Tools window; @p InPortStatusProvider yields the read-only IPC-port line for Settings;
+	 * @p InPromptProvider / @p InResourceProvider feed the Prompts / Resources lists (may be unset → empty
+	 * state). Idempotent: a second call is a no-op.
+	 */
+	void Register(
+		const TSharedRef<FUnrealMcpEditorViewModel>& InViewModel,
+		TFunction<TArray<FUnrealMcpToolListEntry>()> InToolListProvider,
+		TFunction<FString()> InPortStatusProvider,
+		TFunction<TArray<FUnrealMcpFeatureEntry>()> InPromptProvider,
+		TFunction<TArray<FUnrealMcpFeatureEntry>()> InResourceProvider);
+
+	/** Unregister the tab spawners + the settings section (Shutdown). Idempotent. */
+	void Unregister();
+
+private:
+	TSharedRef<SDockTab> SpawnToolsTab(const FSpawnTabArgs& Args);
+	TSharedRef<SDockTab> SpawnPromptsTab(const FSpawnTabArgs& Args);
+	TSharedRef<SDockTab> SpawnResourcesTab(const FSpawnTabArgs& Args);
+	TSharedRef<SDockTab> SpawnSettingsTab(const FSpawnTabArgs& Args);
+
+	TSharedPtr<FUnrealMcpEditorViewModel> ViewModel;
+	TFunction<TArray<FUnrealMcpToolListEntry>()> ToolListProvider;
+	TFunction<FString()> PortStatusProvider;
+	TFunction<TArray<FUnrealMcpFeatureEntry>()> PromptProvider;
+	TFunction<TArray<FUnrealMcpFeatureEntry>()> ResourceProvider;
+	bool bRegistered = false;
+	bool bSettingsRegistered = false;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -238,6 +238,38 @@ void FUnrealMcpEditorViewModel::ApplyDeviceAuth(const TSharedPtr<FJsonObject>& D
 		OnOpenBrowser(DeviceVerificationUrl);
 }
 
+// --- §7 per-tool enable-map ------------------------------------------------------------------------
+
+bool FUnrealMcpEditorViewModel::IsToolDisabled(const FString& ToolName) const
+{
+	return Config.DisabledTools.Contains(ToolName);
+}
+
+void FUnrealMcpEditorViewModel::SetToolEnabled(const FString& ToolName, bool bEnabled)
+{
+	const bool bCurrentlyDisabled = Config.DisabledTools.Contains(ToolName);
+	const bool bWantDisabled = !bEnabled;
+	if (bCurrentlyDisabled == bWantDisabled)
+		return; // already in the requested state — no persist / no manifest churn.
+
+	if (bWantDisabled)
+		Config.DisabledTools.AddUnique(ToolName);
+	else
+		Config.DisabledTools.Remove(ToolName);
+
+	// Persist the blocklist to the §8 store FIRST (so the choice survives a restart even if the manifest push
+	// races a teardown), then ask the runtime to re-apply enablement to the registry + re-push the manifest.
+	// Note: this deliberately does NOT call OnPushConfig — tool enablement is a manifest (§2.2) concern, not a
+	// §1.3 `config` (connection) concern; pushing the connection config here would be a spurious sidecar re-dial.
+	if (OnPersistConfig)
+		OnPersistConfig(Config);
+	if (OnToolEnablementChanged)
+		OnToolEnablementChanged(Config.DisabledTools);
+
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] tool '%s' %s via the MCP Tools window."),
+		*ToolName, bEnabled ? TEXT("enabled") : TEXT("disabled"));
+}
+
 // --- Pure helpers ----------------------------------------------------------------------------------
 
 bool FUnrealMcpEditorViewModel::ValidateServerUrl(const FString& Url, FString& OutError)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
@@ -73,6 +73,13 @@ public:
 	TFunction<bool(const FString& /*AuthType*/)> OnSendAuth;
 	/** Open a verification URL in the system browser (device-code flow). */
 	TFunction<void(const FString& /*Url*/)> OnOpenBrowser;
+	/**
+	 * Apply the §7 per-tool enable-map change: the runtime re-applies the disabled set to the tool registry and
+	 * re-pushes the manifest so the sidecar's tools/list drops/restores the toggled tool over the wire. Invoked
+	 * with the CURRENT persisted disabled-tool name list. Optional; a spec may wire a recording stub. This is
+	 * distinct from OnPushConfig: tool enablement travels via the tool-manifest (§2.2), NOT the §1.3 `config`.
+	 */
+	TFunction<void(const TArray<FString>& /*DisabledTools*/)> OnToolEnablementChanged;
 
 	// --- Config accessors (the working §8 config the UI edits). ---
 
@@ -135,6 +142,20 @@ public:
 
 	/** Connected AI-agent labels surfaced in the §7 AI-agents section (from the last `status`). */
 	const TArray<FString>& GetAiAgents() const { return AiAgents; }
+
+	// --- §7 per-tool enable-map (the MCP Tools window). ---
+
+	/** The persisted §8 disabled-tool blocklist (names the user turned off; empty = all enabled). */
+	const TArray<FString>& GetDisabledTools() const { return Config.DisabledTools; }
+	/** Whether @p ToolName is currently disabled (present in the §8 disabled-tool blocklist). */
+	UNREALMCPEDITOR_API bool IsToolDisabled(const FString& ToolName) const;
+	/**
+	 * Toggle one tool's enabled state (the §7 MCP Tools window per-tool checkbox). Mutates the §8 disabled-tool
+	 * blocklist, persists the config (OnPersistConfig — so the choice survives an editor restart), then fires
+	 * OnToolEnablementChanged so the runtime excludes/restores the tool in the served manifest. A no-op change
+	 * (already in the requested state) does nothing. Game-thread only.
+	 */
+	UNREALMCPEDITOR_API void SetToolEnabled(const FString& ToolName, bool bEnabled);
 
 	// --- Pure helpers (no instance state; the spec-friendly heart of the view-model). ---
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -211,7 +211,8 @@ void FUnrealMcpRuntime::Startup()
 				for (const FString& Name : RegistryPtr->GetToolNamesSorted())
 				{
 					if (const FUnrealMcpRegisteredTool* Tool = RegistryPtr->Find(Name))
-						Entries.Add(FUnrealMcpToolListEntry{ Tool->Name, Tool->Title, Tool->Description, Tool->ExtensionId });
+						Entries.Add(FUnrealMcpToolListEntry{ Tool->Name, Tool->Title, Tool->Description, Tool->ExtensionId,
+							RegistryPtr->PassesEnabledToolsWhitelist(Name) });
 				}
 			}
 			return Entries;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -254,7 +254,7 @@ void FUnrealMcpRuntime::Shutdown()
 	// down so a reader-thread invoke cannot race the reset.
 	if (AuxWindows.IsValid())
 	{
-		AuxWindows->Unregister(); // closes live aux tabs + unregisters the ISettingsModule section before view-model teardown
+		AuxWindows->Unregister(); // neutralizes the widget-held providers + closes live aux tabs + unregisters the ISettingsModule section, all before the bridge/registry below are freed
 		AuxWindows.Reset();
 	}
 	if (MainWindowTab.IsValid())

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -78,9 +78,11 @@ void FUnrealMcpRuntime::Startup()
 
 	const FUnrealMcpConfig Config = FUnrealMcpConfig::LoadAndResolve(DotEnv);
 
-	// §7 per-tool enable-map: apply the persisted §8 `disabledTools` blocklist to the registry BEFORE the bridge
-	// starts accepting, so the FIRST manifest a sidecar reads on handshake already excludes the disabled tools
-	// (their ProxyTools are never created sidecar-side, so they never appear in tools/list).
+	// §7/§8 enable-map: apply the §8 `enabledTools` env whitelist and the persisted §7 `disabledTools` blocklist to
+	// the registry BEFORE the bridge starts accepting, so the FIRST manifest a sidecar reads on handshake already
+	// reflects them (excluded ProxyTools are never created sidecar-side, so they never appear in tools/list). The
+	// registry RETAINS both filters, so a later §5 extension hot-reload re-applies them to the rebuilt tools.
+	Registry->SetEnabledToolsFilter(Config.EnabledTools);
 	Registry->ApplyDisabledTools(Config.DisabledTools);
 	if (Config.DisabledTools.Num() > 0)
 	{
@@ -193,8 +195,9 @@ void FUnrealMcpRuntime::Startup()
 			return TEXT("Stopped");
 		});
 
-	// §7 auxiliary windows (MCP Tools / Prompts / Resources / Settings). The Tools window snapshots the registry
-	// (a stable set after boot) for its list; the Settings window surfaces the bound IPC port read-only. Prompts/
+	// §7 auxiliary windows (MCP Tools / Prompts / Resources / Settings). The Tools window snapshots the registry on
+	// open for its list — a §5 extension hot-reload can change the set after boot, so an already-open window shows its
+	// open-time snapshot and reopen refreshes it; the Settings window surfaces the bound IPC port read-only. Prompts/
 	// Resources have no plugin-side feed yet (the .NET sidecar owns those features, §2) — their providers return
 	// empty and the windows render an honest empty state rather than a fabricated registry.
 	AuxWindows = MakeUnique<FUnrealMcpAuxWindows>();

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -12,6 +12,9 @@
 #include "Extensions/UnrealMcpExtensionManager.h"
 #include "UI/UnrealMcpEditorViewModel.h"
 #include "UI/UnrealMcpMainWindowTab.h"
+#include "UI/UnrealMcpAuxWindows.h"
+#include "UI/SUnrealMcpToolsWindow.h"
+#include "UI/SUnrealMcpFeatureListWindow.h"
 #include "Tools/UnrealMcpLogCollector.h"
 
 #include "Misc/CoreDelegates.h"
@@ -75,6 +78,16 @@ void FUnrealMcpRuntime::Startup()
 
 	const FUnrealMcpConfig Config = FUnrealMcpConfig::LoadAndResolve(DotEnv);
 
+	// §7 per-tool enable-map: apply the persisted §8 `disabledTools` blocklist to the registry BEFORE the bridge
+	// starts accepting, so the FIRST manifest a sidecar reads on handshake already excludes the disabled tools
+	// (their ProxyTools are never created sidecar-side, so they never appear in tools/list).
+	Registry->ApplyDisabledTools(Config.DisabledTools);
+	if (Config.DisabledTools.Num() > 0)
+	{
+		UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] applied %d disabled tool(s) from the §8 enable-map (%d/%d tools enabled)."),
+			Config.DisabledTools.Num(), Registry->NumEnabled(), Registry->Num());
+	}
+
 	const TSharedPtr<FJsonObject> EffectiveConfig = Config.BuildEffectiveConnectionConfig();
 	// Token is NEVER logged at any level (§8) — log the shape with the bearer masked.
 	UE_LOG(LogUnrealMcp, Log,
@@ -124,6 +137,18 @@ void FUnrealMcpRuntime::Startup()
 		if (!Url.IsEmpty())
 			FPlatformProcess::LaunchURL(*Url, nullptr, nullptr);
 	};
+	// §7 per-tool enable-map: a Tools-window toggle re-applies the disabled set to the registry and re-pushes the
+	// manifest so the sidecar's tools/list drops/restores the toggled tool over the wire (§2.2). The view-model
+	// already persisted the choice to the §8 store before invoking this; here we only mutate the live registry +
+	// push. Runs on the game thread (the UI calls it there), matching the §2.2 dynamic-re-registration contract.
+	FUnrealMcpToolRegistry* RegistryPtr = Registry.Get();
+	ViewModel->OnToolEnablementChanged = [RegistryPtr, BridgeServerPtr](const TArray<FString>& DisabledTools)
+	{
+		if (RegistryPtr)
+			RegistryPtr->ApplyDisabledTools(DisabledTools);
+		if (BridgeServerPtr)
+			BridgeServerPtr->PushManifest();
+	};
 
 	// §7 live status feed: the bridge delivers `status` / `device-auth` on the IPC READER thread. Marshal onto
 	// the game thread before touching any view-model/Slate state (the Godot M9b main-thread-marshalled rule),
@@ -168,6 +193,34 @@ void FUnrealMcpRuntime::Startup()
 			return TEXT("Stopped");
 		});
 
+	// §7 auxiliary windows (MCP Tools / Prompts / Resources / Settings). The Tools window snapshots the registry
+	// (a stable set after boot) for its list; the Settings window surfaces the bound IPC port read-only. Prompts/
+	// Resources have no plugin-side feed yet (the .NET sidecar owns those features, §2) — their providers return
+	// empty and the windows render an honest empty state rather than a fabricated registry.
+	AuxWindows = MakeUnique<FUnrealMcpAuxWindows>();
+	AuxWindows->Register(
+		ViewModel.ToSharedRef(),
+		[RegistryPtr]() -> TArray<FUnrealMcpToolListEntry>
+		{
+			TArray<FUnrealMcpToolListEntry> Entries;
+			if (RegistryPtr)
+			{
+				for (const FString& Name : RegistryPtr->GetToolNamesSorted())
+				{
+					if (const FUnrealMcpRegisteredTool* Tool = RegistryPtr->Find(Name))
+						Entries.Add(FUnrealMcpToolListEntry{ Tool->Name, Tool->Title, Tool->Description, Tool->ExtensionId });
+				}
+			}
+			return Entries;
+		},
+		[BridgeServerPtr]() -> FString
+		{
+			const int32 Port = BridgeServerPtr ? BridgeServerPtr->GetBoundPort() : -1;
+			return Port > 0 ? FString::Printf(TEXT("IPC bridge port: %d"), Port) : FString();
+		},
+		[]() -> TArray<FUnrealMcpFeatureEntry> { return {}; },  // prompts (none surfaced to the plugin yet)
+		[]() -> TArray<FUnrealMcpFeatureEntry> { return {}; }); // resources (none surfaced to the plugin yet)
+
 	// §1.5: tear down on editor pre-exit so the sidecar never orphans (layer 1).
 	PreExitHandle = FCoreDelegates::OnEnginePreExit.AddLambda([this]() { Shutdown(); });
 }
@@ -195,6 +248,11 @@ void FUnrealMcpRuntime::Shutdown()
 	// §7 UI teardown FIRST: unregister the tab and drop the bridge's status sink so no marshalled status can
 	// touch the view-model after this, then release the view-model. Clear the sink before the bridge tears
 	// down so a reader-thread invoke cannot race the reset.
+	if (AuxWindows.IsValid())
+	{
+		AuxWindows->Unregister(); // closes live aux tabs + unregisters the ISettingsModule section before view-model teardown
+		AuxWindows.Reset();
+	}
 	if (MainWindowTab.IsValid())
 	{
 		MainWindowTab->Unregister(); // also closes a live tab so its widget (a strong view-model ref) is freed
@@ -211,6 +269,7 @@ void FUnrealMcpRuntime::Shutdown()
 		ViewModel->OnPushConfig = nullptr;
 		ViewModel->OnSendAuth = nullptr;
 		ViewModel->OnOpenBrowser = nullptr;
+		ViewModel->OnToolEnablementChanged = nullptr; // captures the raw registry/bridge pointers freed below
 	}
 	ViewModel.Reset();
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.h
@@ -12,6 +12,7 @@ class FUnrealMcpSidecarManager;
 class FUnrealMcpExtensionManager;
 class FUnrealMcpEditorViewModel;
 class FUnrealMcpMainWindowTab;
+class FUnrealMcpAuxWindows;
 
 /**
  * Plugin-lifetime coordinator (docs/ARCHITECTURE.md §0). Wires the four subsystems together: the tool
@@ -43,9 +44,11 @@ private:
 	TUniquePtr<FUnrealMcpSidecarManager> SidecarManager;
 	TUniquePtr<FUnrealMcpExtensionManager> ExtensionManager;
 
-	// §7 UI: the main-window view-model (shared so the nomad tab's widget binds to it) and its tab spawner.
+	// §7 UI: the main-window view-model (shared so the nomad tab's widget binds to it) and its tab spawner,
+	// plus the four §7 auxiliary windows (MCP Tools / Prompts / Resources / Settings) sharing the same view-model.
 	TSharedPtr<FUnrealMcpEditorViewModel> ViewModel;
 	TUniquePtr<FUnrealMcpMainWindowTab> MainWindowTab;
+	TUniquePtr<FUnrealMcpAuxWindows> AuxWindows;
 
 	FDelegateHandle PreExitHandle;
 	bool bStarted = false;

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
@@ -220,6 +220,28 @@ public:
 	int32 Num() const { return Tools.Num(); }
 	const FUnrealMcpRegisteredTool* Find(const FString& Name) const { return Tools.Find(Name); }
 
+	/** Every registered tool name, sorted (the §7 MCP Tools window enumerates the full set, enabled or not). */
+	TArray<FString> GetToolNamesSorted() const;
+
+	/** Count of tools whose bEnabled flag is set (the "N / M Tools" §7 Features line). */
+	int32 NumEnabled() const;
+
+	/**
+	 * Set one tool's enabled flag (the §7 per-tool toggle). Disabled tools are EXCLUDED from BuildManifestJson
+	 * so the sidecar never exposes them in tools/list (§2.2). Bumps the revision on a real change so the next
+	 * manifest push re-syncs the sidecar's diff. Unknown name / no-op change: returns false, no revision bump.
+	 * Game-thread only (same contract as any §2.2 dynamic re-registration — see the class comment).
+	 */
+	bool SetToolEnabled(const FString& Name, bool bEnabled);
+
+	/**
+	 * Apply the persisted §8 per-tool enable-map (the MCP Tools window's `disabledTools` blocklist): every tool
+	 * whose name is in @p DisabledNames is disabled, every other tool is enabled. Idempotent; bumps the revision
+	 * once if any flag changed. Called on boot (before the bridge accepts, so the first manifest already excludes
+	 * disabled tools) and on every UI toggle. Game-thread only.
+	 */
+	void ApplyDisabledTools(const TArray<FString>& DisabledNames);
+
 	/** Current manifest revision (bumps on every registry mutation). */
 	int32 GetRevision() const { return Revision; }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
@@ -227,6 +227,13 @@ public:
 	int32 NumEnabled() const;
 
 	/**
+	 * True iff @p Name passes the §8 EnabledTools whitelist gate (the whitelist is empty, or the name is listed) —
+	 * the STATIC env-driven dimension of the served predicate, independent of the §7 runtime blocklist. The §7
+	 * MCP Tools window reads this to surface whitelist-gated tools, which the per-tool UI toggle cannot re-enable.
+	 */
+	bool PassesEnabledToolsWhitelist(const FString& Name) const;
+
+	/**
 	 * Set one tool's enabled flag directly — a GRANULAR helper, NOT the production §7 toggle. The Tools-window
 	 * path is view-model → OnToolEnablementChanged → ApplyDisabledTools (a whole-blocklist re-apply); this method
 	 * is the single-name primitive used by tests and any future single-tool caller. It does NOT update the

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
@@ -227,18 +227,32 @@ public:
 	int32 NumEnabled() const;
 
 	/**
-	 * Set one tool's enabled flag (the §7 per-tool toggle). Disabled tools are EXCLUDED from BuildManifestJson
-	 * so the sidecar never exposes them in tools/list (§2.2). Bumps the revision on a real change so the next
-	 * manifest push re-syncs the sidecar's diff. Unknown name / no-op change: returns false, no revision bump.
-	 * Game-thread only (same contract as any §2.2 dynamic re-registration — see the class comment).
+	 * Set one tool's enabled flag directly — a GRANULAR helper, NOT the production §7 toggle. The Tools-window
+	 * path is view-model → OnToolEnablementChanged → ApplyDisabledTools (a whole-blocklist re-apply); this method
+	 * is the single-name primitive used by tests and any future single-tool caller. It does NOT update the
+	 * retained whitelist/blocklist, so a later SetEnabledToolsFilter / ApplyDisabledTools recompute can override
+	 * the flag it set. Disabled tools are EXCLUDED from BuildManifestJson so the sidecar never exposes them in
+	 * tools/list (§2.2). Bumps the revision on a real change. Unknown name / no-op change: returns false, no
+	 * revision bump. Game-thread only (same contract as any §2.2 dynamic re-registration — see the class comment).
 	 */
 	bool SetToolEnabled(const FString& Name, bool bEnabled);
 
 	/**
-	 * Apply the persisted §8 per-tool enable-map (the MCP Tools window's `disabledTools` blocklist): every tool
-	 * whose name is in @p DisabledNames is disabled, every other tool is enabled. Idempotent; bumps the revision
-	 * once if any flag changed. Called on boot (before the bridge accepts, so the first manifest already excludes
-	 * disabled tools) and on every UI toggle. Game-thread only.
+	 * Set the §8 env whitelist (UNREAL_MCP_TOOLS / Config.EnabledTools). A tool passes the whitelist gate iff the
+	 * whitelist is EMPTY (no filter — the common case) or the tool's name is listed. RETAINED, so a later
+	 * re-registration (extension hot-reload) and every ApplyDisabledTools re-apply re-evaluate it. Recomputes
+	 * enablement now and bumps the revision once if any flag changed. Combined effective rule (§8): a tool is
+	 * served iff (whitelist empty OR in whitelist) AND NOT in the blocklist. Game-thread only.
+	 */
+	void SetEnabledToolsFilter(const TArray<FString>& EnabledTools);
+
+	/**
+	 * Apply the persisted §7 per-tool enable-map (the MCP Tools window's `disabledTools` blocklist): every tool
+	 * whose name is in @p DisabledNames is disabled, the rest follow the §8 whitelist gate. RETAINED, so an
+	 * extension hot-reload that re-registers tools FRESH (RegisterExtension → Commit) re-applies the blocklist to
+	 * the rebuilt tools rather than resurrecting a disabled one. Recomputes against BOTH the retained whitelist and
+	 * this blocklist, so re-applying the blocklist never clobbers the whitelist. Idempotent; bumps the revision once
+	 * if any flag changed. Called on boot (before the bridge accepts) and on every UI toggle. Game-thread only.
 	 */
 	void ApplyDisabledTools(const TArray<FString>& DisabledNames);
 
@@ -260,6 +274,17 @@ public:
 private:
 	TMap<FString, FUnrealMcpRegisteredTool> Tools;
 	int32 Revision = 0;
+
+	// --- Retained §7/§8 enablement filters. Re-applied on every (re-)registration (Commit) so an extension
+	//     hot-reload cannot resurrect a disabled tool, and a blocklist re-apply never clobbers the whitelist. ---
+	TSet<FString> EnabledToolsWhitelist; // §8 UNREAL_MCP_TOOLS; empty = no filter (every tool passes the whitelist gate)
+	TSet<FString> DisabledToolNames;     // §7 persisted blocklist (the MCP Tools window's `disabledTools`)
+
+	/** The combined §8 effective-served predicate: enabled iff (whitelist empty OR member) AND NOT blocklisted. */
+	bool ShouldToolBeEnabled(const FString& Name) const;
+
+	/** Re-evaluate every registered tool's bEnabled against ShouldToolBeEnabled; bumps the revision once if any changed. */
+	void RecomputeEnablement();
 
 	// --- Extension-scope state (active only inside RegisterExtension; scopes never nest) ----------
 	bool bExtensionScope = false;

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpToolRegistry.h
@@ -223,7 +223,7 @@ public:
 	/** Every registered tool name, sorted (the §7 MCP Tools window enumerates the full set, enabled or not). */
 	TArray<FString> GetToolNamesSorted() const;
 
-	/** Count of tools whose bEnabled flag is set (the "N / M Tools" §7 Features line). */
+	/** Count of tools whose bEnabled flag is set (backs the boot-time enable-map log line). */
 	int32 NumEnabled() const;
 
 	/**

--- a/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
+++ b/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
@@ -42,6 +42,9 @@ public class UnrealMcpEditor : ModuleRules
 			"WorkspaceMenuStructure",
 			"InputCore",
 			"ApplicationCore",
+			// §7 Settings page: the "Project → Plugins → AI Game Developer" section is registered via
+			// ISettingsModule (the "Settings" developer module) rendering the same Slate widget as the nomad tab.
+			"Settings",
 			// Asset / Content-Browser tool family (docs/ARCHITECTURE.md §10, issue #10):
 			//  - AssetRegistry            -> asset-find / asset-get-data / asset-refresh queries
 			//  - AssetTools               -> CreateAsset (material instance) + ImportAssetTasks

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpToolsWindowSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpToolsWindowSpec.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/Paths.h"
+#include "Misc/Guid.h"
+#include "HAL/FileManager.h"
+#include "Dom/JsonObject.h"
+#include "UnrealMcpToolRegistry.h"
+#include "UI/UnrealMcpEditorViewModel.h"
+#include "Config/UnrealMcpConfig.h"
+
+/**
+ * MCP Tools window specs (docs/ARCHITECTURE.md §7, issue #26): the per-tool enable-map. Covers the three
+ * acceptance criteria that ARE headless-provable — (1) the §8 config-store round-trip of the `disabledTools`
+ * blocklist survives a save/reload (persistence across an editor restart), (2) a disabled tool is EXCLUDED
+ * from the registry's served manifest and re-enabling restores it (the manifest-exclusion the sidecar mirrors
+ * over the wire), and (3) the view-model toggle drives persistence + the manifest re-apply end to end, plus the
+ * boot path that re-applies the persisted blocklist to a fresh registry. All without Slate, a live bridge, or a
+ * real editor world. (The windowed open/dock + dedup/focus is operator-verified — not reachable headless.)
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpToolsWindowSpec, "UnrealMcp.ToolsWindow",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	// Register a handful of no-op tools so manifest/exclusion assertions have a stable, named set.
+	static void SeedTools(FUnrealMcpToolRegistry& Registry)
+	{
+		const TCHAR* Names[] = { TEXT("alpha"), TEXT("beta"), TEXT("gamma") };
+		for (const TCHAR* Name : Names)
+		{
+			Registry.Tool(Name)
+				.Title(FString(Name))
+				.Description(FString::Printf(TEXT("the %s tool"), Name))
+				.Handle([](const FUnrealMcpToolCall&) { return FUnrealMcpToolResult::Success(TEXT("ok")); });
+		}
+	}
+
+	// The set of tool names present in the registry's served manifest (the §2.2 tools[] array).
+	static TArray<FString> ManifestToolNames(const FUnrealMcpToolRegistry& Registry)
+	{
+		TArray<FString> Out;
+		const TSharedPtr<FJsonObject> Manifest = Registry.BuildManifestJson();
+		const TArray<TSharedPtr<FJsonValue>>* Tools = nullptr;
+		if (Manifest->TryGetArrayField(TEXT("tools"), Tools) && Tools)
+		{
+			for (const TSharedPtr<FJsonValue>& Value : *Tools)
+			{
+				const TSharedPtr<FJsonObject>* Obj = nullptr;
+				FString Name;
+				if (Value.IsValid() && Value->TryGetObject(Obj) && Obj && (*Obj)->TryGetStringField(TEXT("name"), Name))
+					Out.Add(Name);
+			}
+		}
+		return Out;
+	}
+
+END_DEFINE_SPEC(FUnrealMcpToolsWindowSpec)
+
+void FUnrealMcpToolsWindowSpec::Define()
+{
+	Describe("§8 disabledTools persistence", [this]()
+	{
+		It("round-trips the blocklist through ToJson/LoadFromJson", [this]()
+		{
+			FUnrealMcpConfig Config;
+			Config.DisabledTools = { TEXT("beta"), TEXT("gamma") };
+
+			FUnrealMcpConfig Reloaded;
+			Reloaded.LoadFromJson(Config.ToJson());
+
+			TestEqual("blocklist size preserved", Reloaded.DisabledTools.Num(), 2);
+			TestTrue("beta preserved", Reloaded.DisabledTools.Contains(TEXT("beta")));
+			TestTrue("gamma preserved", Reloaded.DisabledTools.Contains(TEXT("gamma")));
+		});
+
+		It("survives a real Save() / LoadFromFile() reload (editor-restart proof)", [this]()
+		{
+			const FString Path = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("UnrealMcpTests"),
+				FString::Printf(TEXT("tools-%s.json"), *FGuid::NewGuid().ToString(EGuidFormats::Digits)));
+
+			FUnrealMcpConfig Config;
+			Config.DisabledTools = { TEXT("alpha") };
+			TestTrue("save succeeds", Config.Save(Path));
+
+			FUnrealMcpConfig Reloaded;
+			Reloaded.LoadFromFile(Path);
+			TestTrue("alpha disabled after reload", Reloaded.DisabledTools.Contains(TEXT("alpha")));
+			TestFalse("beta not disabled after reload", Reloaded.DisabledTools.Contains(TEXT("beta")));
+
+			IFileManager::Get().Delete(*Path);
+		});
+	});
+
+	Describe("Registry manifest exclusion", [this]()
+	{
+		It("excludes a disabled tool from the served manifest and restores it on re-enable", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			SeedTools(Registry);
+			TestEqual("all three served initially", ManifestToolNames(Registry).Num(), 3);
+
+			TestTrue("disable bumps revision", Registry.SetToolEnabled(TEXT("beta"), false));
+			TArray<FString> AfterDisable = ManifestToolNames(Registry);
+			TestEqual("two served after disable", AfterDisable.Num(), 2);
+			TestFalse("beta excluded from manifest", AfterDisable.Contains(TEXT("beta")));
+			TestTrue("alpha still served", AfterDisable.Contains(TEXT("alpha")));
+			TestEqual("NumEnabled reflects exclusion", Registry.NumEnabled(), 2);
+
+			// A no-op toggle does not churn the revision.
+			TestFalse("re-disabling is a no-op", Registry.SetToolEnabled(TEXT("beta"), false));
+
+			TestTrue("re-enable bumps revision", Registry.SetToolEnabled(TEXT("beta"), true));
+			TArray<FString> AfterEnable = ManifestToolNames(Registry);
+			TestEqual("all three served after re-enable", AfterEnable.Num(), 3);
+			TestTrue("beta restored to manifest", AfterEnable.Contains(TEXT("beta")));
+		});
+
+		It("applies a whole disabled-name set at once (the boot path)", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			SeedTools(Registry);
+
+			Registry.ApplyDisabledTools({ TEXT("alpha"), TEXT("gamma") });
+			TArray<FString> Served = ManifestToolNames(Registry);
+			TestEqual("only beta served", Served.Num(), 1);
+			TestTrue("beta is the survivor", Served.Contains(TEXT("beta")));
+
+			// Re-applying an empty set re-enables everything.
+			Registry.ApplyDisabledTools({});
+			TestEqual("all re-enabled", ManifestToolNames(Registry).Num(), 3);
+		});
+	});
+
+	Describe("View-model toggle round-trip", [this]()
+	{
+		It("persists the choice and re-applies the manifest exclusion through the registry", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			SeedTools(Registry);
+
+			int32 PersistCount = 0;
+			FUnrealMcpEditorViewModel VM;
+			VM.OnPersistConfig = [&PersistCount](const FUnrealMcpConfig&) { ++PersistCount; };
+			// Wire the enablement sink exactly as the runtime does: re-apply the blocklist to the live registry.
+			VM.OnToolEnablementChanged = [&Registry](const TArray<FString>& Disabled) { Registry.ApplyDisabledTools(Disabled); };
+
+			// Disable "gamma" through the view-model (the §7 Tools-window checkbox path).
+			VM.SetToolEnabled(TEXT("gamma"), false);
+			TestEqual("persist fired once", PersistCount, 1);
+			TestTrue("view-model reports gamma disabled", VM.IsToolDisabled(TEXT("gamma")));
+			TestTrue("blocklist carries gamma", VM.GetDisabledTools().Contains(TEXT("gamma")));
+			TestFalse("gamma excluded from registry manifest", ManifestToolNames(Registry).Contains(TEXT("gamma")));
+
+			// A no-op toggle (already enabled) does nothing.
+			VM.SetToolEnabled(TEXT("alpha"), true);
+			TestEqual("no extra persist on no-op", PersistCount, 1);
+
+			// Re-enable restores the manifest + clears the blocklist.
+			VM.SetToolEnabled(TEXT("gamma"), true);
+			TestEqual("persist fired again on re-enable", PersistCount, 2);
+			TestFalse("view-model reports gamma enabled", VM.IsToolDisabled(TEXT("gamma")));
+			TestTrue("gamma restored to registry manifest", ManifestToolNames(Registry).Contains(TEXT("gamma")));
+		});
+
+		It("re-applies a persisted blocklist to a fresh registry on boot", [this]()
+		{
+			// Persist a blocklist via one view-model/config…
+			FUnrealMcpConfig Saved;
+			Saved.DisabledTools = { TEXT("beta") };
+			const TSharedPtr<FJsonObject> Json = Saved.ToJson();
+
+			// …then simulate a fresh editor boot: reload the config, seed a fresh registry, apply the blocklist.
+			FUnrealMcpConfig Booted;
+			Booted.LoadFromJson(Json);
+			FUnrealMcpToolRegistry Registry;
+			SeedTools(Registry);
+			Registry.ApplyDisabledTools(Booted.DisabledTools);
+
+			TArray<FString> Served = ManifestToolNames(Registry);
+			TestEqual("two served after boot-apply", Served.Num(), 2);
+			TestFalse("beta stays disabled across the restart", Served.Contains(TEXT("beta")));
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpToolsWindowSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpToolsWindowSpec.cpp
@@ -300,6 +300,60 @@ void FUnrealMcpToolsWindowSpec::Define()
 			RegisterExtensionTool(Registry, TEXT("com.example.ext"), TEXT("ext-tool"));
 			TestFalse("non-whitelisted ext-tool STILL excluded after rebuild", ManifestToolNames(Registry).Contains(TEXT("ext-tool")));
 		});
+
+		It("reports the whitelist gate independently of the blocklist (the §7 window's data source)", [this]()
+		{
+			// SUnrealMcpToolsWindow snapshots PassesEnabledToolsWhitelist() to render whitelist-gated rows; it is the
+			// STATIC env dimension, so it must NOT react to the §7 blocklist (which ApplyDisabledTools drives).
+			FUnrealMcpToolRegistry Registry;
+			SeedTools(Registry);
+			TestTrue("empty whitelist → every tool passes", Registry.PassesEnabledToolsWhitelist(TEXT("beta")));
+
+			Registry.SetEnabledToolsFilter({ TEXT("alpha") });
+			TestTrue("whitelisted name passes", Registry.PassesEnabledToolsWhitelist(TEXT("alpha")));
+			TestFalse("non-whitelisted name fails", Registry.PassesEnabledToolsWhitelist(TEXT("beta")));
+
+			// Blocklisting alpha must not change its whitelist verdict — the two dimensions are orthogonal.
+			Registry.ApplyDisabledTools({ TEXT("alpha") });
+			TestTrue("blocklist does not flip the whitelist verdict", Registry.PassesEnabledToolsWhitelist(TEXT("alpha")));
+		});
+	});
+
+	Describe("Execute enablement gate (§7/§8 execution boundary)", [this]()
+	{
+		It("refuses to dispatch a blocklisted tool and serves an enabled one", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			SeedTools(Registry);
+			Registry.ApplyDisabledTools({ TEXT("beta") }); // beta blocklisted (§7)
+
+			const FUnrealMcpToolResult Disabled = Registry.Execute(TEXT("beta"), FUnrealMcpToolCall{});
+			TestFalse("blocklisted tool does not execute", Disabled.bSuccess);
+			TestTrue("error names the disabled tool", Disabled.Message.Contains(TEXT("disabled")));
+
+			const FUnrealMcpToolResult Enabled = Registry.Execute(TEXT("alpha"), FUnrealMcpToolCall{});
+			TestTrue("enabled tool still executes", Enabled.bSuccess);
+
+			const FUnrealMcpToolResult Unknown = Registry.Execute(TEXT("does-not-exist"), FUnrealMcpToolCall{});
+			TestFalse("unknown tool still errors", Unknown.bSuccess);
+			TestTrue("unknown-tool error is distinct from the disabled error", Unknown.Message.Contains(TEXT("Unknown")));
+		});
+
+		It("refuses to dispatch a non-whitelisted tool (§8 stale-manifest race guard)", [this]()
+		{
+			// The gate is authoritative even when the manifest exclusion has not yet propagated to the sidecar: a
+			// tool the §8 whitelist excludes must never run, regardless of any stale tools/list the caller holds.
+			FUnrealMcpToolRegistry Registry;
+			SeedTools(Registry);
+			Registry.SetEnabledToolsFilter({ TEXT("alpha") }); // only alpha whitelisted; beta/gamma gated off
+
+			const FUnrealMcpToolResult Gated = Registry.Execute(TEXT("gamma"), FUnrealMcpToolCall{});
+			TestFalse("non-whitelisted tool does not execute", Gated.bSuccess);
+			TestTrue("error names the disabled tool", Gated.Message.Contains(TEXT("disabled")));
+
+			const FUnrealMcpToolResult Served = Registry.Execute(TEXT("alpha"), FUnrealMcpToolCall{});
+			TestTrue("whitelisted tool executes", Served.bSuccess);
+		});
 	});
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpToolsWindowSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpToolsWindowSpec.cpp
@@ -38,6 +38,19 @@ BEGIN_DEFINE_SPEC(FUnrealMcpToolsWindowSpec, "UnrealMcp.ToolsWindow",
 		}
 	}
 
+	// Register one extension-scoped tool under @p ExtensionId, mirroring the §5 RegisterExtension path the
+	// ExtensionManager drives on a hot-reload. Used to prove the blocklist survives a re-registration.
+	static void RegisterExtensionTool(FUnrealMcpToolRegistry& Registry, const FString& ExtensionId, const FString& ToolName)
+	{
+		Registry.RegisterExtension(ExtensionId, [&ToolName](FUnrealMcpToolRegistry& Reg)
+		{
+			Reg.Tool(ToolName)
+				.Title(ToolName)
+				.Description(TEXT("an extension tool"))
+				.Handle([](const FUnrealMcpToolCall&) { return FUnrealMcpToolResult::Success(TEXT("ok")); });
+		});
+	}
+
 	// The set of tool names present in the registry's served manifest (the §2.2 tools[] array).
 	static TArray<FString> ManifestToolNames(const FUnrealMcpToolRegistry& Registry)
 	{
@@ -182,6 +195,110 @@ void FUnrealMcpToolsWindowSpec::Define()
 			TArray<FString> Served = ManifestToolNames(Registry);
 			TestEqual("two served after boot-apply", Served.Num(), 2);
 			TestFalse("beta stays disabled across the restart", Served.Contains(TEXT("beta")));
+		});
+	});
+
+	Describe("Extension hot-reload retention (§5)", [this]()
+	{
+		It("keeps a blocklisted extension tool excluded across an extension rebuild", [this]()
+		{
+			// The §5 regression: ExtensionManager::RebuildFromProviders removes then re-registers every
+			// extension tool FRESH (bEnabled defaults true) and re-pushes the manifest. Before the registry
+			// retained the blocklist, a disabled extension tool sprang back enabled and leaked over the wire.
+			FUnrealMcpToolRegistry Registry;
+			SeedTools(Registry); // core: alpha/beta/gamma
+			RegisterExtensionTool(Registry, TEXT("com.example.ext"), TEXT("ext-tool"));
+			TestTrue("ext-tool served before disable", ManifestToolNames(Registry).Contains(TEXT("ext-tool")));
+
+			// User disables the extension tool through the §7 blocklist.
+			Registry.ApplyDisabledTools({ TEXT("ext-tool") });
+			TestFalse("ext-tool excluded after disable", ManifestToolNames(Registry).Contains(TEXT("ext-tool")));
+
+			// Simulate the hot-reload: remove the extension's tools, then re-register them fresh.
+			const int32 Removed = Registry.RemoveToolsForExtension(TEXT("com.example.ext"));
+			TestEqual("one extension tool removed on unload", Removed, 1);
+			RegisterExtensionTool(Registry, TEXT("com.example.ext"), TEXT("ext-tool"));
+
+			// Regression assertion: the rebuilt extension tool MUST still be excluded.
+			TArray<FString> AfterRebuild = ManifestToolNames(Registry);
+			TestFalse("ext-tool STILL excluded after the extension rebuild", AfterRebuild.Contains(TEXT("ext-tool")));
+			TestTrue("core alpha unaffected by the rebuild", AfterRebuild.Contains(TEXT("alpha")));
+		});
+	});
+
+	Describe("§8 enabledTools whitelist gating", [this]()
+	{
+		// served iff (whitelist empty OR member) AND NOT blocklisted — the full 3×2 matrix
+		// (whitelist empty / member / non-member) × (blocklisted / not).
+		It("gates the served manifest by the combined whitelist+blocklist rule", [this]()
+		{
+			// Row group 1 — EMPTY whitelist (no filter): blocklist alone decides.
+			{
+				FUnrealMcpToolRegistry Registry;
+				SeedTools(Registry);
+				Registry.SetEnabledToolsFilter({});             // empty → no whitelist filter
+				Registry.ApplyDisabledTools({ TEXT("beta") });  // beta blocklisted
+				TArray<FString> Served = ManifestToolNames(Registry);
+				TestTrue("empty whitelist + not blocklisted → served (alpha)", Served.Contains(TEXT("alpha")));
+				TestTrue("empty whitelist + not blocklisted → served (gamma)", Served.Contains(TEXT("gamma")));
+				TestFalse("empty whitelist + blocklisted → excluded (beta)", Served.Contains(TEXT("beta")));
+			}
+
+			// Row group 2 — whitelist {alpha,beta}, blocklist {beta}: covers member/not-blocklisted,
+			// member/blocklisted, and non-member/not-blocklisted in one shot.
+			{
+				FUnrealMcpToolRegistry Registry;
+				SeedTools(Registry);
+				Registry.SetEnabledToolsFilter({ TEXT("alpha"), TEXT("beta") });
+				Registry.ApplyDisabledTools({ TEXT("beta") });
+				TArray<FString> Served = ManifestToolNames(Registry);
+				TestTrue("member + not blocklisted → served (alpha)", Served.Contains(TEXT("alpha")));
+				TestFalse("member + blocklisted → excluded (beta)", Served.Contains(TEXT("beta")));
+				TestFalse("non-member + not blocklisted → excluded (gamma)", Served.Contains(TEXT("gamma")));
+				TestEqual("only alpha survives", Served.Num(), 1);
+			}
+
+			// Row group 3 — whitelist {alpha}, blocklist {gamma}: covers non-member/blocklisted.
+			{
+				FUnrealMcpToolRegistry Registry;
+				SeedTools(Registry);
+				Registry.SetEnabledToolsFilter({ TEXT("alpha") });
+				Registry.ApplyDisabledTools({ TEXT("gamma") });
+				TArray<FString> Served = ManifestToolNames(Registry);
+				TestTrue("member + not blocklisted → served (alpha)", Served.Contains(TEXT("alpha")));
+				TestFalse("non-member + blocklisted → excluded (gamma)", Served.Contains(TEXT("gamma")));
+				TestFalse("non-member + not blocklisted → excluded (beta)", Served.Contains(TEXT("beta")));
+			}
+		});
+
+		It("re-applying the blocklist does not clobber the retained whitelist", [this]()
+		{
+			// The §8 conflict the [medium] finding called out: ApplyDisabledTools used to set
+			// bEnabled = !blocklisted unconditionally. With both filters retained, a blocklist re-apply
+			// (even clearing it) must still honor the whitelist gate.
+			FUnrealMcpToolRegistry Registry;
+			SeedTools(Registry);
+			Registry.SetEnabledToolsFilter({ TEXT("alpha") }); // only alpha passes the whitelist
+			TestEqual("whitelist alone leaves only alpha", ManifestToolNames(Registry).Num(), 1);
+
+			Registry.ApplyDisabledTools({}); // clear the blocklist entirely
+			TArray<FString> Served = ManifestToolNames(Registry);
+			TestEqual("whitelist still enforced after a blocklist clear", Served.Num(), 1);
+			TestTrue("alpha remains the only served tool", Served.Contains(TEXT("alpha")));
+		});
+
+		It("registers extension tools honoring the retained whitelist on a rebuild", [this]()
+		{
+			// Closes the loop with §5: a non-whitelisted extension tool re-added by a hot-reload stays hidden.
+			FUnrealMcpToolRegistry Registry;
+			SeedTools(Registry);
+			Registry.SetEnabledToolsFilter({ TEXT("alpha") }); // ext-tool is NOT whitelisted
+			RegisterExtensionTool(Registry, TEXT("com.example.ext"), TEXT("ext-tool"));
+			TestFalse("non-whitelisted ext-tool excluded on first register", ManifestToolNames(Registry).Contains(TEXT("ext-tool")));
+
+			Registry.RemoveToolsForExtension(TEXT("com.example.ext"));
+			RegisterExtensionTool(Registry, TEXT("com.example.ext"), TEXT("ext-tool"));
+			TestFalse("non-whitelisted ext-tool STILL excluded after rebuild", ManifestToolNames(Registry).Contains(TEXT("ext-tool")));
 		});
 	});
 }


### PR DESCRIPTION
## Summary
- Add the four §7 auxiliary editor windows (docs/ARCHITECTURE.md §7): **MCP Tools** (per-tool enable/disable), **MCP Prompts**, **MCP Resources**, and a **Settings** page — pure Slate, additive only, no version bumps.
- Per-tool enablement is persisted to the §8 config store as a `disabledTools` blocklist, re-applied to the tool registry on boot, and excluded from the served manifest so disabled tools never appear in the sidecar's `tools/list`.
- Prompts/Resources windows render an honest empty state (no plugin-side feed yet — those features live in the .NET sidecar's McpPlugin managers); no fake registry is invented.
- Settings page reads/writes the §8 config (mode, host, auth, masked token, read-only IPC port), registered as a nomad tab **and** a `Project → Plugins → AI Game Developer` ISettingsModule section. Window dedup/focus comes free from FGlobalTabmanager (the known Godot `[low]`).

## Test plan
- [x] Suite 1 — UBT build (`UnrealMcpEditor` + `UnrealMcpEditorTests`), exit 0.
- [x] Suite 2 — headless boot smoke: `[Unreal-MCP] plugin loaded`, exit 0.
- [x] Suite 3 — Automation `UnrealMcp` filter: **157/157 Success, 0 failed, 0 notRun** (+6 new `UnrealMcp.ToolsWindow` specs: config round-trip, Save/reload persistence, manifest exclusion, view-model toggle, boot re-apply).
- [x] Suite 7 — live bridge e2e (server ⇄ bridge ⇄ headless editor): `tools/list` = **62** with `ping` enabled, **61** with `ping` disabled via the §8 config, restored to 62 on re-enable; clean no-orphan teardown.
- Windowed open/dock + dedup/focus: build/headless-verified; visual verification pending operator (Slate is not exercisable headless).

Closes #26
