### PR TITLE
docs: finalize Unreal-MCP user-facing documentation for M10 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,86 +2,169 @@
 
 Unreal-MCP bridges LLMs (Claude, Cursor, Copilot, …) with the [Unreal Engine](https://www.unrealengine.com/)
 editor via the [Model Context Protocol](https://modelcontextprotocol.io/) — the Unreal-engine sibling of
-Unity-MCP and Godot-MCP. **Status: pre-alpha scaffold** — the skeleton compiles and the plugin loads, but
-tool families, the IPC bridge, and the UI are not implemented yet.
+Unity-MCP and Godot-MCP. **Status: beta** — the plugin, the .NET sidecar, the local server, the
+`unreal-cli`, the AI Game Developer editor UI, and **62 built-in tools across 8 families** have shipped
+and are covered by CI; nothing is published to a package registry yet.
 
-**The authoritative design is [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).** Read it before implementing
-anything non-trivial — it locks the IPC protocol (§1), dynamic tool registration (§2), schema generation
-(§3), the game-thread dispatcher (§4), extensions (§5), sidecar lifecycle (§6), UI (§7), config (§8),
-repo/versioning/CI (§9), and the tool-family roadmap (§10).
+**The authoritative design is [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).** Read the relevant
+section before implementing anything non-trivial — it locks the IPC protocol (§1), dynamic tool
+registration (§2), schema generation (§3), the game-thread dispatcher (§4), extensions (§5), sidecar
+lifecycle (§6), UI (§7), config (§8), repo/versioning/CI (§9), and the tool-family roadmap (§10). The
+user-facing entry point is [`README.md`](README.md); the release runbook is
+[`docs/RELEASING.md`](docs/RELEASING.md); the extension author guide is
+[`docs/EXTENSIONS.md`](docs/EXTENSIONS.md).
 
 ## Layout
 
 | Path | What it is |
 | --- | --- |
-| `UnrealMCP/` | The UE **editor plugin**. `.uplugin` `VersionName` is the version single-source. Modules: `UnrealMcpEditor` (Type Editor, LoadingPhase Default) + `UnrealMcpEditorTests` (Automation specs, filter prefix `UnrealMcp.`) |
-| `bridge/` | .NET 9 **sidecar** `com.IvanMurzak.Unreal.MCP.Bridge` (binary `unreal-mcp-bridge`) — the McpPlugin host the plugin spawns; IPC ⇄ SignalR relay. xUnit tests in `bridge/tests/` |
-| `Unreal-MCP-Server/` | Thin ASP.NET Core host around `com.IvanMurzak.McpPlugin.Server` (binary `unreal-mcp-server`) — clone of Godot-MCP-Server, **no Unreal-specific server code** |
-| `cli/` | `unreal-cli` npm package (TypeScript, commander, vitest). `private: true` until the publish gate |
-| `samples/UnrealAITemplate/` | Extension template plugin (placeholder — lands with the extensions task) |
-| `commands/bump-version.ps1` | Rewrites the version across .uplugin / bridge / server / cli (see Versioning) |
+| `UnrealMCP/` | The UE **editor plugin**. `UnrealMCP/UnrealMCP.uplugin` `VersionName` is the version single-source (currently `0.1.0`). **No `EngineVersion` pin** (UE treats it as exact-match, not a floor). Modules: `UnrealMcpEditor` + `UnrealMcpEditorTests` (both Type `Editor`, LoadingPhase `Default`) |
+| `UnrealMCP/Source/UnrealMcpEditor/Public/` | The extension contract (`IUnrealMcpToolProvider.h`), the tool registry (`UnrealMcpToolRegistry.h`), and the core-family `Register` entry points (`UnrealMcpCoreTools.h`) |
+| `UnrealMCP/Source/UnrealMcpEditor/Private/` | `Tools/` (the 8 families), `Config/`, `UI/`, plus Bridge/Schema/Dispatch/Sidecar code per ARCHITECTURE §9.1 |
+| `UnrealMCP/Source/UnrealMcpEditorTests/` | Automation specs behind `WITH_DEV_AUTOMATION_TESTS`, names under the **`UnrealMcp.`** filter prefix. **No top-level test folder** — tests live per-leg |
+| `bridge/` | .NET 9 **sidecar** `com.IvanMurzak.Unreal.MCP.Bridge` (binary `unreal-mcp-bridge`) — the McpPlugin host the plugin spawns; IPC ⇄ SignalR relay. xUnit tests in `bridge/tests/`. Hand-authored, TRACKED solution `bridge/Unreal-MCP-Bridge.sln` |
+| `Unreal-MCP-Server/` | Thin ASP.NET Core host around `com.IvanMurzak.McpPlugin.Server` (binary `unreal-mcp-server`) — clone of Godot-MCP-Server, **no Unreal-specific server code**. Tracked solution `Unreal-MCP-Server/Unreal-MCP-Server.sln` |
+| `cli/` | `unreal-cli` npm package (TypeScript, commander, vitest) — 16 commands. `private: true` until the publish gate |
+| `samples/UnrealAITemplate/` | The §5 extension template plugin (a `hello-extension` tool + an invalid-schema switch) |
+| `commands/bump-version.ps1` | Rewrites the version across `.uplugin` / both csproj / `server.json` / `cli/package.json`. **Release-pipeline-owned — never run from a feature task** |
 
 Unlike Unity/Godot, the editor is C++: the .NET `McpPlugin` host lives in the **sidecar process**, not
-in-process. The plugin LISTENS on a localhost TCP port; the sidecar DIALS, authenticating with a one-shot
-token delivered over **stdin** (never argv — see §1.4). Two child processes exist and must not be conflated:
+in-process. The plugin **listens** on a localhost TCP port; the sidecar **dials**, authenticating with a
+one-shot token delivered over **stdin** (never argv — §1.4). Two child processes must not be conflated:
 `unreal-mcp-bridge` (always required) and `unreal-mcp-server` (Custom/local mode only).
 
-## Build / test
+## Build / test (per leg)
+
+The repo is a four-leg mono-repo. Run only the legs your change touches.
+
+### UE plugin (`UnrealMCP/**`)
+
+Needs UE 5.7 and a host C++ project with the plugin available (the infra repo's `Unreal-Test-Project/`
+junctions `Plugins/UnrealMCP → <repo>/UnrealMCP`). Quote engine paths — they contain spaces.
 
 ```bash
-# UE plugin — needs an UE 5.7 install and a host project (the infra repo's Unreal-Test-Project
-# junctions Plugins/UnrealMCP -> this repo's UnrealMCP/):
-#   UnrealBuildTool.exe UnrealTestProjectEditor Win64 Development -project=<path>\UnrealTestProject.uproject -WaitMutex
-# Headless boot smoke (expect "[Unreal-MCP] plugin loaded" in the log):
-#   UnrealEditor-Cmd.exe <uproject> -nullrhi -nosplash -unattended -ExecCmds="QUIT_EDITOR" -log
-# Automation specs (filter prefix UnrealMcp.):
-#   UnrealEditor-Cmd.exe <uproject> -nullrhi -nosplash -unattended -ExecCmds="Automation RunTests UnrealMcp; Quit" -ReportExportPath=<dir> -log
+# 1. Build (UBT). First build in a fresh checkout can take 10+ minutes; incremental 1-3 min.
+"C:/Program Files/Epic Games/UE_5.7/Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.exe" \
+  UnrealTestProjectEditor Win64 Development \
+  -project="<host>/UnrealTestProject.uproject" -WaitMutex
 
-# bridge (.NET 9)
-dotnet build bridge/Unreal-MCP-Bridge.sln
-dotnet test  bridge/Unreal-MCP-Bridge.sln
+# 2. Headless boot smoke — expect "[Unreal-MCP] plugin loaded" in the log:
+"C:/Program Files/Epic Games/UE_5.7/Engine/Binaries/Win64/UnrealEditor-Cmd.exe" \
+  "<host>/UnrealTestProject.uproject" -nullrhi -nosplash -unattended -ExecCmds="QUIT_EDITOR" -log
 
-# server (.NET 8)
-dotnet build Unreal-MCP-Server/com.IvanMurzak.Unreal.MCP.Server.csproj
-
-# cli (Node 20.19+/22.12+)
-cd cli && npm install && npm run build && npm test
+# 3. Automation specs (filter prefix UnrealMcp.):
+"C:/Program Files/Epic Games/UE_5.7/Engine/Binaries/Win64/UnrealEditor-Cmd.exe" \
+  "<host>/UnrealTestProject.uproject" -nullrhi -nosplash -unattended \
+  -ExecCmds="Automation RunTests UnrealMcp; Quit" -ReportExportPath="<dir>" -log
 ```
+
+**The exported JSON report is authoritative, not the exit code** (UnrealEditor-Cmd's exit code is
+unreliable across versions for test failures). Parse `<ReportExportPath>/index.json` — **note it is
+written UTF-8 with a BOM (`utf-8-sig`)**, so decode accordingly. Pass = `"failed": 0` AND
+`"succeeded" >= 1`. A **missing** `index.json` after a run means a CRASH (assert/exception aborted the
+editor) — treat as FAILURE, not as the 0/0 "no specs" case; find the crash in the Saved log
+(`Fatal error` / `Unhandled Exception` / `[Callstack]`). Pixel-capture (screenshot) tools can't render
+under `-nullrhi`; their GPU-free branches are spec-covered, full capture is windowed-verified.
+
+### bridge (.NET 9) — `bridge/**`
+
+```bash
+dotnet restore bridge/Unreal-MCP-Bridge.sln
+dotnet build   bridge/Unreal-MCP-Bridge.sln --configuration Debug --no-restore
+dotnet test    bridge/Unreal-MCP-Bridge.sln --configuration Debug --no-build
+```
+
+### server (.NET 8) — `Unreal-MCP-Server/**`
+
+```bash
+dotnet restore Unreal-MCP-Server/Unreal-MCP-Server.sln
+dotnet build   Unreal-MCP-Server/Unreal-MCP-Server.sln --configuration Debug --no-restore
+```
+
+No server test project exists (thin host). **Never add Unreal-specific server code** — re-read
+ARCHITECTURE §0 if a task seems to require it.
+
+### cli (Node 20.19+/22.12+) — `cli/**`
+
+```bash
+cd cli && npm install && npm run build && npm test     # build = tsc; test = vitest run
+```
+
+### Live bridge e2e (any tool-family change)
+
+Stand up server ⇄ bridge ⇄ headless editor and exercise the tool over HTTP. Boot the editor with all
+three of `UNREAL_MCP_BRIDGE_PATH`, `UNREAL_MCP_HOST=http://localhost:<port>`, and
+**`UNREAL_MCP_CONNECTION_MODE=Custom`** (without the mode the sidecar dials Cloud and the local server
+returns HTTP 500 after `No connected clients`). Tool-set/manifest assertions need MCP `tools/list` over
+`POST /mcp`, not the `/api/tools/<name>` REST passthrough (which only invokes one named tool and drops
+the `content[]` image array). `/api/tools/<name>` calls **require** `-H "Content-Type: application/json"`.
 
 ## Versioning
 
-Single semver shared by plugin / bridge / server / cli, starting at **0.1.0**
-(design §9.2). Bump with:
+Single semver shared by plugin / bridge / server / cli, starting at **0.1.0**. The
+`UnrealMCP/UnrealMCP.uplugin` `VersionName` is the **single source of truth**. Bump with:
 
 ```powershell
 .\commands\bump-version.ps1 -NewVersion "0.2.0"        # add -WhatIf to preview
 ```
 
-It rewrites: `UnrealMCP/UnrealMCP.uplugin` `VersionName`, both csproj `<Version>`s,
-`Unreal-MCP-Server/server.json`, `cli/package.json` (+ lock). Never hand-edit one of them alone.
+It rewrites the `.uplugin` `VersionName`, both csproj `<Version>`s, `Unreal-MCP-Server/server.json`, and
+`cli/package.json` (+ lock). **Never hand-edit one of them alone, and never bump from a feature task** —
+the release pipeline owns version changes.
 
-**Frozen NuGet pins** (lockstep with Godot-MCP; owned by the upstream release pipelines — NEVER bump here):
-`com.IvanMurzak.ReflectorNet` **5.3.1**, `com.IvanMurzak.McpPlugin` **6.7.0** (bridge),
-`com.IvanMurzak.McpPlugin.Server` **6.7.0** (server). The §2.3 ProxyTool API will arrive as a minor
-upstream bump (6.8.0) through its own pipeline.
+**Frozen NuGet pins** (lockstep with Godot-MCP; owned by the upstream release pipelines — NEVER bump
+here): `com.IvanMurzak.ReflectorNet` **5.3.1**, `com.IvanMurzak.McpPlugin` **6.7.0** (bridge),
+`com.IvanMurzak.McpPlugin.Server` **6.7.0** (server). The §2.3 `ProxyTool` lives in `bridge/`
+(`bridge/src/Tools/ProxyTool.cs` + `ProxyToolFactory.cs`) — `IRunTool` + `ToolManager.AddTool` are
+already public, so no upstream API bump was required; a future upstream 6.8.0 ProxyTool can replace the
+local copy through its own pipeline.
 
 ## Conventions
 
-- **Naming (design §0):** plugin `UnrealMCP`, module `UnrealMcpEditor`; C++ prefixes `FUnrealMcp*` /
-  `UUnrealMcp*` / `SUnrealMcp*` (Slate) / `IUnrealMcp*` (interfaces). .NET root namespaces
-  `com.IvanMurzak.Unreal.MCP.Bridge` / `.Server`. Tool ids are kebab-case (`actor-create`,
-  `blueprint-compile`) matching Unity/Godot.
-- C++ follows Unreal style: tabs, braces on new lines, UE types (`FString`, `TArray`), log via the
-  dedicated `LogUnrealMcp` category.
-- Every `.cs` starts with the ASCII-art Apache-2.0 header (copy from a neighbouring file). C++ files use
-  the `// Copyright (c) 2026 Ivan Murzak ...` one-liner.
-- All Unreal API calls from tool handlers must run on the game thread via the dispatcher (§4); the IPC
-  reader thread never executes tool bodies. No modal UI and no synchronous waits on bridge state inside
-  tool bodies.
-- Tests live per design §9.1 — NO top-level test folder: `UnrealMCP/Source/UnrealMcpEditorTests/`
-  (Automation specs behind `WITH_DEV_AUTOMATION_TESTS`, names under the `UnrealMcp.` filter prefix),
-  `bridge/tests/` (xUnit), `cli/tests/` (vitest).
-- Secrets: `.env` is gitignored and must stay that way (it can hold `UNREAL_MCP_TOKEN`); the sidecar
+- **Naming:** plugin `UnrealMCP`, module `UnrealMcpEditor`; C++ prefixes `FUnrealMcp*` / `UUnrealMcp*` /
+  `SUnrealMcp*` (Slate) / `IUnrealMcp*` (interfaces). .NET root namespaces
+  `com.IvanMurzak.Unreal.MCP.Bridge` / `.Server`. **Tool ids are kebab-case** (`actor-create`,
+  `blueprint-compile`); the registry validates the pattern `^[a-z0-9]+(-[a-z0-9]+)*$`.
+- **C++ style:** Unreal — **tabs**, braces on new lines, UE types (`FString`, `TArray`, `TSharedPtr`).
+  Log via the dedicated `LogUnrealMcp` category. File header: the
+  `// Copyright (c) 2026 Ivan Murzak ...` one-liner (copy from a neighbour).
+- **Unity-build ODR rule (load-bearing):** the `UnrealMcpEditor` / `UnrealMcpEditorTests` modules are
+  unity-built — every `.cpp` is concatenated into one translation unit — so an `anonymous namespace`
+  does **not** make a helper file-private. Give every per-family local helper a **family-unique** name
+  (e.g. `LevelMakeStringArraySchema`, not `MakeStringArraySchema`) and every per-spec `Run`/helper a
+  **spec-unique** name (or make it a `BEGIN_DEFINE_SPEC` member). A same-name/same-signature collision
+  across families fails the build — sometimes with a misleading cascade error at the call site (e.g.
+  `C2661: 'FAutomationTestBase::TestFalse': no overloaded function takes 1 arguments`) rather than a
+  redefinition error (`C2084`).
+- **C# style:** every `.cs` starts with the ASCII-art Apache-2.0 header (copy from a neighbour).
+- **Game-thread / no-modal-UI tool-handler contract:** all Unreal API calls from tool handlers run on
+  the game thread via the dispatcher (§4); the IPC reader thread never executes tool bodies. **A tool
+  handler must not pump modal UI and must not synchronously wait on bridge state** — doing either can
+  wedge the editor (ARCHITECTURE §11 risk 2). Long-running work (`source-compile`, `blueprint-compile`)
+  returns a `TFuture` the dispatcher chains; the per-call timeout always completes the future.
+- **Disabled tools are gated at `Execute()`**, not merely excluded from the manifest — a disabled tool
+  is rejected even if a stale `tools/list` dispatches it (`UnrealMcpToolRegistry::Execute`).
+- **Secrets:** `.env` is gitignored and must stay that way (it can hold `UNREAL_MCP_TOKEN`); the sidecar
   IPC token travels via stdin, never argv, and is never logged.
-- Commits: `<type>(<scope>): <description>` conventional commits; reference issues with `Closes #N`.
-  Never `git add -A`; never commit `Binaries/`/`Intermediate/`/`bin/`/`obj/`/`node_modules/`/`dist/`.
+- **Commits:** `<type>(<scope>): <description>` conventional commits (scopes: plugin, bridge, server,
+  cli, ipc, tools, dispatcher, schema, ui, sidecar, config, samples, ci, docs). Reference issues with
+  `Closes #N`. Never `git add -A`. Never commit `Binaries/`/`Intermediate/`/`Saved/`/`bin/`/`obj/`/
+  `node_modules/`/`dist/`. The `.sln` at a `.uproject` root is generated — never commit it; the
+  hand-authored `bridge/` and `Unreal-MCP-Server/` `.sln`s are the un-ignored exception.
+
+## CI
+
+CI runs on every PR via **`test_pull_request.yml`** (workflow name `test-pull-request`):
+
+- bridge build + xUnit on `ubuntu-latest` **and** `windows-latest`
+- server build (.NET 8)
+- `test-cli / cli` on Node 20 **and** Node 22 (reusable `test_cli.yml`)
+- `plugin BuildPlugin + Automation (UE 5.7)` — runs on a **self-hosted Windows runner** labelled
+  `unreal-5-7`, and is **gated on the repository variable `UNREAL_RUNNER_READY == 'true'`**. While that
+  variable is unset the plugin job is **SKIPPED** (never red-by-absence), and fork PRs skip it too (it
+  also requires `head.repo.full_name == github.repository`). The hosted bridge/server/cli legs always
+  provide PR signal.
+
+`release.yml` is version-gated and **publishes nothing on a normal merge** — see
+[`docs/RELEASING.md`](docs/RELEASING.md). Keep this file, `docs/RELEASING.md`, and the infra
+`implement-task` profile `test.md` in lockstep with the actual workflow command surface.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,8 +140,12 @@ local copy through its own pipeline.
 - **Game-thread / no-modal-UI tool-handler contract:** all Unreal API calls from tool handlers run on
   the game thread via the dispatcher (§4); the IPC reader thread never executes tool bodies. **A tool
   handler must not pump modal UI and must not synchronously wait on bridge state** — doing either can
-  wedge the editor (ARCHITECTURE §11 risk 2). Long-running work (`source-compile`, `blueprint-compile`)
-  returns a `TFuture` the dispatcher chains; the per-call timeout always completes the future.
+  wedge the editor (ARCHITECTURE §11 risk 2). Tool handlers are **synchronous**
+  (`FUnrealMcpToolHandler = TFunction<FUnrealMcpToolResult(const FUnrealMcpToolCall&)>`): long-running
+  work (`source-compile`, `blueprint-compile`) runs inline on the game thread and blocks it for the
+  duration (ARCHITECTURE §4 envisions an async-chaining `TFuture` handler surface once the registry
+  grows one; until then a compile blocks). Only the dispatcher's `Dispatch()` returns a `TFuture` to
+  the bridge, and the per-call timeout always completes it.
 - **Disabled tools are gated at `Execute()`**, not merely excluded from the manifest — a disabled tool
   is rejected even if a stale `tools/list` dispatches it (`UnrealMcpToolRegistry::Execute`).
 - **Secrets:** `.env` is gitignored and must stay that way (it can hold `UNREAL_MCP_TOKEN`); the sidecar

--- a/README.md
+++ b/README.md
@@ -5,22 +5,358 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![test-pull-request](https://github.com/IvanMurzak/Unreal-MCP/actions/workflows/test_pull_request.yml/badge.svg)](https://github.com/IvanMurzak/Unreal-MCP/actions/workflows/test_pull_request.yml)
 
-> **Status: pre-alpha.** This repository is a scaffold under active development — the plugin
-> compiles and loads, but no MCP tools are implemented yet. Nothing here is released or
-> production-ready.
+> **Status: beta.** The plugin, the .NET sidecar, the local server, the `unreal-cli`, the AI Game
+> Developer editor UI, and **62 built-in tools across 8 families** have shipped and are exercised by
+> CI. Nothing is published to a package registry yet — install from source (below). Pixel-capture
+> (screenshot) tools need a GPU-backed editor; everything else runs headless.
 
 Unreal-MCP is the Unreal Engine counterpart of
 [Unity-MCP](https://github.com/IvanMurzak/Unity-MCP) and
 [Godot-MCP](https://github.com/IvanMurzak/Godot-MCP): a C++ editor plugin that exposes Unreal
-Editor operations as **AI Tools** and connects them to an MCP server, so an AI assistant can
-inspect and drive your Unreal project — spawn actors, edit levels, author Blueprints, manage
-assets, capture screenshots, and more — through the same cloud backend
-([ai-game.dev](https://ai-game.dev)) that powers Unity-MCP and Godot-MCP.
+Editor operations as **AI Tools** and connects them to an MCP server, so an AI assistant
+(Claude, Cursor, Copilot, …) can inspect and drive your Unreal project — spawn actors, edit levels,
+author Blueprints, manage assets, edit and compile C++, capture screenshots, and more — through the
+same cloud backend ([ai-game.dev](https://ai-game.dev)) that powers Unity-MCP and Godot-MCP, or
+through a local server you run yourself.
 
-Unlike Unity and Godot (C# engines that host the .NET `McpPlugin` in-process), Unreal's editor
-is C++ — so the .NET MCP host runs as an auto-managed **sidecar process** (`unreal-mcp-bridge`)
-that the plugin spawns and talks to over a localhost IPC channel. The full design lives in
+Unlike Unity and Godot (C# engines that host the .NET `McpPlugin` in-process), Unreal's editor is
+C++ — so the .NET MCP host runs as an auto-managed **sidecar process** (`unreal-mcp-bridge`) that
+the plugin spawns and talks to over a localhost IPC channel. The full design lives in
 [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) (see the §0 system-overview diagram).
+
+## Table of contents
+
+- [Requirements](#requirements)
+- [Install](#install)
+- [First run](#first-run)
+- [Tools](#tools) — all 8 families, 62 tools
+- [Per-tool enable / disable & Settings](#per-tool-enable--disable--settings)
+- [`unreal-cli`](#unreal-cli)
+- [Writing an extension](#writing-an-extension)
+- [Configuration & environment variables](#configuration--environment-variables)
+- [Troubleshooting](#troubleshooting)
+- [Repo layout](#repo-layout)
+- [Links](#links)
+- [License](#license)
+
+## Requirements
+
+- **Unreal Engine 5.5+** (developed and CI-tested against **5.7**). The plugin deliberately ships
+  **no `EngineVersion` pin** — UE treats that field as an exact-build match, not a floor, and would
+  refuse to load on newer engines.
+- **.NET 9 SDK** to build the bridge sidecar; **.NET 8 SDK** to build the local server. (End users
+  who download release binaries need neither — they ship self-contained.)
+- **Node.js** `^20.19.0 || >=22.12.0` for the optional `unreal-cli`.
+- A C++ Unreal project (the plugin builds an Editor module, so the host project must be able to
+  compile C++).
+
+## Install
+
+> No package-registry release exists yet. Until the first GitHub Release / Fab listing, install the
+> plugin from source.
+
+### Option A — `unreal-cli` (recommended)
+
+```bash
+# From a clone of this repo (see "unreal-cli" below for the npm story once published):
+cd cli && npm install && npm run build
+
+# Copy or junction the plugin into <YourProject>/Plugins/UnrealMCP, then build the editor target:
+node bin/unreal-cli.js install-plugin --project <YourProject> --junction
+```
+
+### Option B — manual
+
+1. Copy [`UnrealMCP/`](UnrealMCP/) into `<YourProject>/Plugins/UnrealMCP/` (or create a directory
+   junction / symlink to it for live development).
+2. Open the project; UE compiles the `UnrealMcpEditor` module on first launch.
+3. On editor boot the Output Log prints **`[Unreal-MCP] plugin loaded`** — that confirms the plugin
+   and its game-thread dispatcher started.
+
+The sidecar binary (`unreal-mcp-bridge`) is **not** bundled: on first connect the plugin downloads
+the matching release into `<YourProject>/Intermediate/UnrealMCP/` (gitignored), or — for local
+development — `unreal-cli bootstrap-local` builds it from source into the same location.
+
+## First run
+
+1. Open **Window → AI Game Developer** (or click the toolbar button) to open the main window.
+2. **Choose a connection mode:**
+   - **Cloud** (default) — connects to [ai-game.dev](https://ai-game.dev). Click **Authorize** to
+     start the OAuth **device-code flow**: the window shows a verification URL and a short user
+     code; open the URL, enter the code, approve, and the editor finishes authorizing. Use
+     **Revoke** to clear the stored cloud token.
+   - **Custom** — connects to a local `unreal-mcp-server` you run (or any compatible server). Enter
+     the server URL, optionally start the bundled local server from the **MCP server** section, and
+     point your AI client at it.
+3. Watch the **connection timeline** (Unreal → MCP server → AI agent) and the **Bridge status**
+   panel (sidecar state, PID, version, restart count) to confirm everything is live.
+4. Point your AI client (Claude Code, Cursor, the AI Game Developer app, …) at the server. The
+   **AI agents** section can auto-write client config for supported agents, or use
+   `unreal-cli setup-mcp`.
+
+Connection settings persist to `<Project>/Saved/Config/UnrealMcp/ai-game-developer-config.json`
+(`Saved/` is gitignored by every UE template, so tokens never land in VCS by default).
+
+## Tools
+
+Unreal-MCP ships **62 built-in ("core") tools** across **8 families**. Tool ids are kebab-case
+(`actor-create`, `blueprint-compile`), matching the Unity/Godot naming convention. Extensions can
+add more (see [Writing an extension](#writing-an-extension)).
+
+> This list is generated from the registration source
+> (`UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcp*Tools.cpp`). Counts: actor 13,
+> blueprint 11, asset 11, editor/reflection 9, level 7, source 6, screenshot 4, ping 1 = **62**.
+
+### Actor & component family (13)
+
+| Tool id | What it does |
+| --- | --- |
+| `actor-create` | Spawn an actor from a class path (native or Blueprint), with optional name/location/rotation/parent |
+| `actor-destroy` | Destroy an actor |
+| `actor-duplicate` | Duplicate an actor |
+| `actor-find` | Find actors, with scoped reads (`paths`/`viewQuery`) |
+| `actor-modify` | Write actor `FProperty` values (including transform) |
+| `actor-set-parent` | Attach an actor to a parent |
+| `actor-component-add` | Add a component to an actor |
+| `actor-component-destroy` | Destroy a component |
+| `actor-component-get` | Read a component's data |
+| `actor-component-modify` | Modify a component's properties |
+| `actor-component-list-all` | List available `UActorComponent` classes (paginated) |
+| `object-get-data` | Read any `UObject` by path |
+| `object-modify` | Modify any `UObject` by path |
+
+### Blueprint family (11) — Unreal's flagship surface
+
+| Tool id | What it does |
+| --- | --- |
+| `blueprint-create` | Create a new Blueprint class from a parent `UClass` path |
+| `blueprint-get` | Graph summary for LLM inspection (variables, components, functions/events, parent chain) |
+| `blueprint-add-component` | Add a component via the Simple Construction Script |
+| `blueprint-remove-component` | Remove an SCS component |
+| `blueprint-add-variable` | Add a typed member variable |
+| `blueprint-modify-variable` | Modify a member variable |
+| `blueprint-set-default` | Edit a CDO (class-default) property |
+| `blueprint-add-function` | Add a function stub (entry/result nodes wired) |
+| `blueprint-add-event` | Add/bind an event stub (BeginPlay, Tick, input, …) |
+| `blueprint-compile` | Compile the Blueprint and return a **structured error/warning list** (the AI feedback loop) |
+| `blueprint-spawn` | Instance the Blueprint into the current level |
+
+### Asset / Content-Browser family (11)
+
+| Tool id | What it does |
+| --- | --- |
+| `asset-find` | Search the AssetRegistry by name/class/path/tags |
+| `asset-get-data` | Read an asset's data (scoped reads supported) |
+| `asset-create-folder` | Create a Content folder |
+| `asset-copy` | Copy an asset |
+| `asset-move` | Move / rename an asset |
+| `asset-delete` | Delete an asset |
+| `asset-refresh` | Rescan asset paths |
+| `asset-material-create` | Create a Material Instance from a parent material |
+| `asset-material-modify` | Set scalar/vector/texture material-instance parameters |
+| `asset-material-get-data` | Read material graph/parameter info (the "shader" analog) |
+| `asset-import` | Import FBX/textures via `AssetImportTask` |
+
+### Editor / console / reflection family (9)
+
+| Tool id | What it does |
+| --- | --- |
+| `editor-application-get-state` | Read editor application state (PIE, etc.) |
+| `editor-application-set-state` | Start / stop / pause Play-In-Editor |
+| `editor-selection-get` | Read the current editor selection |
+| `editor-selection-set` | Set the editor selection |
+| `console-get-logs` | Read recent editor logs from the `LogCollector` ring buffer |
+| `console-clear-logs` | Clear the captured-log ring buffer |
+| `console-run-command` | Run a console command / CVar |
+| `reflection-method-find` | Discover callable `UFunction`s (returns invocation schemas) |
+| `reflection-method-call` | Invoke a `UFunction` (static or instance, incl. `CallInEditor`) |
+
+### Level / map family (7)
+
+| Tool id | What it does |
+| --- | --- |
+| `level-create` | Create a new level |
+| `level-open` | Open a level |
+| `level-save` | Save the level (save-as via optional path) |
+| `level-get-data` | Actor-tree snapshot of a level (scoped reads) |
+| `level-list-loaded` | List persistent + streaming sublevels (World-Partition aware, read-only) |
+| `level-set-current` | Set the current/active level |
+| `level-unload-sublevel` | Unload a streaming sublevel |
+
+### Source / C++ family (6)
+
+| Tool id | What it does |
+| --- | --- |
+| `source-read` | Read a project C++ source file (sliced) |
+| `source-create-class` | Scaffold a new C++ class (header + cpp from templates) |
+| `source-update` | Edit a source file |
+| `source-delete` | Delete a source file |
+| `source-list` | List module source files |
+| `source-compile` | Compile project C++ (Live Coding when active, else UBT) with a structured error report |
+
+All file operations are jailed to `<Project>/Source/`.
+
+### Screenshot / viewport-capture family (4)
+
+| Tool id | What it does |
+| --- | --- |
+| `screenshot-viewport` | Capture the active editor viewport |
+| `screenshot-game-view` | Capture the PIE / game view |
+| `screenshot-camera` | Render from a resolved camera actor via `USceneCaptureComponent2D` |
+| `screenshot-isolated` | Render an actor in isolation (transient SceneCapture2D + show-only list) |
+
+Captures return a base64 **PNG as MCP image content** so the LLM can inspect the render directly.
+Dimensions are clamped (default 1024, hard cap 2048 per side). Pixel capture needs a GPU-backed
+editor; under headless `-nullrhi` these tools return a structured error.
+
+### Ping family (1)
+
+| Tool id | What it does |
+| --- | --- |
+| `ping` | Liveness probe — round-trips the plugin ⇄ sidecar ⇄ server chain |
+
+## Per-tool enable / disable & Settings
+
+Every tool can be individually enabled or disabled from the **MCP Tools** window
+(**Window → AI Game Developer → Features → Tools**, or the aux **MCP Tools** tab), which also shows
+each tool's token-count estimate. Disabling a tool:
+
+- **removes it from the served manifest entirely** — it never appears in the MCP `tools/list`; and
+- is **enforced at the execution boundary too** — even if a stale `tools/list` is dispatched, a
+  disabled tool is rejected at `Execute()` rather than run.
+
+Two filters combine to decide whether a tool is served (see ARCHITECTURE §7/§8):
+
+- a **whitelist** (`enabledTools`, overridable via `UNREAL_MCP_TOOLS`) — when non-empty, only listed
+  tools are served; empty means "no filter"; **and**
+- a **blocklist** (`disabledTools`) — the per-tool toggles you flip in the UI.
+
+A tool is served **iff** it passes the whitelist **and** is not in the blocklist. Both sets are
+persisted across editor sessions and survive an extension hot-reload (a re-registered tool inherits
+the retained toggle, so a rebuild can never silently re-enable a tool you disabled).
+
+The **Settings** page is reachable both as an aux tab and via
+**Project Settings → Plugins → AI Game Developer** (`ISettingsModule`). The **MCP Prompts** and
+**MCP Resources** windows are wired but ship empty in this release (counts show 0).
+
+## `unreal-cli`
+
+A cross-platform Node CLI (`unreal-cli`) that scaffolds projects, installs the plugin, configures
+connection settings, drives the local server, and invokes tools over HTTP. It is a port of
+`unity-mcp-cli` / `godot-cli`. Full reference: [`cli/README.md`](cli/README.md).
+
+> The npm package is `private: true` until the first publish gate. Until then, build it from source
+> (`cd cli && npm install && npm run build`) and invoke `node bin/unreal-cli.js <command>`.
+
+The full 16-command surface:
+
+| Command | What it does |
+| --- | --- |
+| `create-project` | Scaffold a minimal Unreal Engine C++ project |
+| `open` | Launch the Unreal Editor for a project, wiring MCP connection env vars |
+| `close` | Terminate the Unreal Editor process running a project |
+| `install-plugin` | Install the UnrealMCP plugin into `<project>/Plugins` (copy or `--junction`) |
+| `remove-plugin` | Remove the UnrealMCP plugin from `<project>/Plugins` |
+| `configure` | Write `UNREAL_MCP_*` values into `<project>/.env` and gitignore `.env` |
+| `setup-mcp` | Write an MCP client config snippet for an agent |
+| `login` | Authorize against ai-game.dev via the OAuth device-code flow |
+| `status` | Report package, project, plugin, and live connection status |
+| `wait-for-ready` | Block until the project's MCP server responds to a ping |
+| `run-tool` | Invoke an MCP tool via the project's local MCP server (HTTP) |
+| `run-system-tool` | Invoke a system tool via the project's local MCP server (HTTP) |
+| `bootstrap-local` | Build the bridge + server from source into `<project>/Intermediate/UnrealMCP` |
+| `update` | Update the UnrealMCP plugin installed in a project from the repo source |
+| `install-engine` | Detect installed Unreal engines; for a missing version, link to the Epic launcher |
+| `setup-skills` | Write a Claude-Code skill stub that drives this project's Unreal MCP server |
+
+## Writing an extension
+
+Any third-party UE plugin can contribute its own MCP tools through a small, public,
+modular-feature-based contract — no fork, no link-time coupling, no load-order assumptions.
+Implement [`IUnrealMcpToolProvider`](UnrealMCP/Source/UnrealMcpEditor/Public/IUnrealMcpToolProvider.h)
+and register it as a modular feature:
+
+```cpp
+#include "IUnrealMcpToolProvider.h"
+#include "UnrealMcpToolRegistry.h"
+
+class FMyExtensionProvider : public IUnrealMcpToolProvider
+{
+public:
+    virtual FString GetExtensionId() const override      { return TEXT("com.foo.my-extension"); }
+    virtual FText   GetDisplayName() const override      { return NSLOCTEXT("Foo", "Name", "My Extension"); }
+    virtual FString GetExtensionVersion() const override { return TEXT("1.0.0"); }
+
+    virtual void RegisterTools(FUnrealMcpToolRegistry& Registry) override
+    {
+        Registry.Tool(TEXT("hello-extension"))
+            .Title(TEXT("Hello Extension"))
+            .Description(TEXT("Returns a friendly greeting."))
+            .ParamString(TEXT("name"), TEXT("Who to greet. Defaults to 'world'."))
+            .ReadOnlyHint(true).IdempotentHint(true)
+            .Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult { /* … */ });
+    }
+};
+
+// In StartupModule:
+IModularFeatures::Get().RegisterModularFeature(
+    IUnrealMcpToolProvider::GetModularFeatureName(), Provider.Get());
+```
+
+Unreal-MCP discovers every registered provider on boot (and on late-load / hot-unload), merges
+their tools in deterministic `ExtensionId` order, and surfaces the merged manifest to the sidecar.
+Invalid or duplicate tools are dropped/rejected per-extension without affecting others; each
+extension can be toggled in the **Extensions** UI section.
+
+- **Full author guide:** [`docs/EXTENSIONS.md`](docs/EXTENSIONS.md)
+- **Working sample:** [`samples/UnrealAITemplate/`](samples/UnrealAITemplate) — a complete,
+  buildable plugin with a `hello-extension` tool and a compile-time switch
+  (`UNREAL_AI_TEMPLATE_INVALID_SCHEMA=1`) that demonstrates the isolation behaviour.
+
+## Configuration & environment variables
+
+The plugin reads configuration with the precedence **process env → `<Project>/.env` → config file
+→ built-in defaults**. The recognized `UNREAL_MCP_*` variables (defined in
+`UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp`):
+
+| Variable | Purpose |
+| --- | --- |
+| `UNREAL_MCP_CONNECTION_MODE` | `Cloud` or `Custom`. **Defaults to `Cloud`.** |
+| `UNREAL_MCP_HOST` | Server URL (Custom mode), e.g. `http://localhost:<port>` |
+| `UNREAL_MCP_CLOUD_URL` | Cloud backend URL (defaults to ai-game.dev) |
+| `UNREAL_MCP_TOKEN` | Auth token (sidecar IPC token / server token). **Secret — never commit.** |
+| `UNREAL_MCP_AUTH_OPTION` | `none` or `required` (local server auth) |
+| `UNREAL_MCP_KEEP_CONNECTED` | Persist/restore the connected state |
+| `UNREAL_MCP_TOOLS` | Enabled-tools override (whitelist; empty = no filter) |
+| `UNREAL_MCP_START_SERVER` | Auto-start the local `unreal-mcp-server` (Custom mode) |
+| `UNREAL_MCP_TRANSPORT` | `stdio` or `http` |
+| `UNREAL_MCP_LOG_LEVEL` | Log verbosity |
+| `UNREAL_MCP_BRIDGE_PATH` | **Dev-only.** Path to a locally built sidecar (skips download + version check) |
+
+> **Never commit `.env`.** A project-root `.env` can hold `UNREAL_MCP_TOKEN`, and UE project
+> templates ship no `.gitignore`. `unreal-cli configure` appends `.env` to the target project's
+> `.gitignore`; this repo's own scaffold already gitignores it. The sidecar IPC token travels over
+> stdin (never argv) and is never logged.
+
+## Troubleshooting
+
+- **`No connected clients. Retrying [1..10]` then HTTP 500 from a local server.** The connection
+  mode defaulted to `Cloud`, so the sidecar dialed ai-game.dev instead of your local server. Set
+  `UNREAL_MCP_CONNECTION_MODE=Custom` (env, `.env`, or the UI toggle).
+- **No `[Unreal-MCP] plugin loaded` line at boot.** The editor module failed to load — check the
+  Output Log for a `StartupModule` error or a malformed `.uplugin`.
+- **A tool body returns `'x' is required.` when invoked over the REST passthrough.** Send
+  `-H "Content-Type: application/json"`; without it the server drops the JSON body.
+- **Screenshot tools return a structured error.** Pixel capture needs a GPU-backed editor — they
+  cannot render under headless `-nullrhi`.
+- **Sidecar keeps restarting / version mismatch.** Check the **Bridge status** panel; a
+  plugin↔sidecar version skew triggers a single auto-redownload, then a hard-fail alert. Use
+  `UNREAL_MCP_BRIDGE_PATH` or `unreal-cli bootstrap-local` to point at a from-source build.
+- **Ports.** IPC uses a deterministic per-project port in `30000–39999`; the local server uses
+  `20000–29999`. Both probe forward on a collision, so the exact number is a debugging nicety, not a
+  requirement.
+- **Logs.** Use the main window's **Open log file** action, the `console-get-logs` tool, or the
+  editor Output Log (`LogUnrealMcp` category).
 
 ## Repo layout
 
@@ -29,31 +365,11 @@ that the plugin spawns and talks to over a localhost IPC channel. The full desig
 | [`UnrealMCP/`](UnrealMCP/) | The UE editor plugin (C++, module `UnrealMcpEditor`, UE 5.5+ floor, developed against 5.7) |
 | [`bridge/`](bridge/) | The .NET 9 sidecar (`unreal-mcp-bridge`) — McpPlugin host, IPC ⇄ SignalR relay |
 | [`Unreal-MCP-Server/`](Unreal-MCP-Server/) | Thin local MCP server host (`unreal-mcp-server`), analog of Godot-MCP-Server |
-| [`cli/`](cli/) | `unreal-cli` npm package (TypeScript) |
-| [`samples/UnrealAITemplate/`](samples/UnrealAITemplate/) | Extension template plugin (placeholder) |
+| [`cli/`](cli/) | `unreal-cli` npm package (TypeScript) — 16 commands |
+| [`samples/UnrealAITemplate/`](samples/UnrealAITemplate/) | Extension template plugin (`hello-extension`) |
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | The authoritative architecture design |
-
-## Requirements
-
-- **Unreal Engine 5.5+** (developed and CI-tested against **5.7**)
-- **.NET 9 SDK** (bridge), **.NET 8 SDK** (server)
-- **Node.js** `^20.19.0 || >=22.12.0` (cli)
-
-## Build (current scaffold)
-
-```bash
-# UE plugin — put UnrealMCP/ under <YourProject>/Plugins/ (or junction it) and build the
-# editor target; on editor boot the Output Log prints: [Unreal-MCP] plugin loaded
-
-# bridge
-dotnet build bridge/Unreal-MCP-Bridge.sln && dotnet test bridge/Unreal-MCP-Bridge.sln
-
-# server
-dotnet build Unreal-MCP-Server/com.IvanMurzak.Unreal.MCP.Server.csproj
-
-# cli
-cd cli && npm install && npm run build && npm test
-```
+| [`docs/EXTENSIONS.md`](docs/EXTENSIONS.md) | Extension author guide |
+| [`docs/RELEASING.md`](docs/RELEASING.md) | CI/CD + operator release runbook |
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ the plugin spawns and talks to over a localhost IPC channel. The full design liv
 # From a clone of this repo (see "unreal-cli" below for the npm story once published):
 cd cli && npm install && npm run build
 
-# Copy or junction the plugin into <YourProject>/Plugins/UnrealMCP, then build the editor target:
-node bin/unreal-cli.js install-plugin --project <YourProject> --junction
+# Copy or junction the plugin into <YourProject>/Plugins/UnrealMCP, then build the editor target.
+# install-plugin takes the project directory as a positional argument:
+node bin/unreal-cli.js install-plugin <YourProject> --junction
 ```
 
 ### Option B — manual
@@ -73,25 +74,32 @@ node bin/unreal-cli.js install-plugin --project <YourProject> --junction
 3. On editor boot the Output Log prints **`[Unreal-MCP] plugin loaded`** — that confirms the plugin
    and its game-thread dispatcher started.
 
-The sidecar binary (`unreal-mcp-bridge`) is **not** bundled: on first connect the plugin downloads
-the matching release into `<YourProject>/Intermediate/UnrealMCP/` (gitignored), or — for local
-development — `unreal-cli bootstrap-local` builds it from source into the same location.
+The sidecar binary (`unreal-mcp-bridge`) is **not** bundled. Today the plugin resolves it from the
+`UNREAL_MCP_BRIDGE_PATH` environment variable: point that at a sidecar binary, or run
+`unreal-cli bootstrap-local` to build the bridge + server from source into
+`<YourProject>/Intermediate/UnrealMCP/` and set the var to the result. With no path resolved, the
+plugin's TCP listener still starts but logs `[Unreal-MCP] no sidecar binary resolved (set
+UNREAL_MCP_BRIDGE_PATH)` and spawns nothing — launch the sidecar manually for the live e2e.
+Automatic download-on-first-connect from GitHub Releases is **planned** (ARCHITECTURE §6) but **not
+yet shipped**.
 
 ## First run
 
-1. Open **Window → AI Game Developer** (or click the toolbar button) to open the main window.
+1. Open the **AI Game Developer** main window from the editor's **Tools** menu (the tab is
+   registered under the Tools menu category).
 2. **Choose a connection mode:**
    - **Cloud** (default) — connects to [ai-game.dev](https://ai-game.dev). Click **Authorize** to
      start the OAuth **device-code flow**: the window shows a verification URL and a short user
      code; open the URL, enter the code, approve, and the editor finishes authorizing. Use
      **Revoke** to clear the stored cloud token.
    - **Custom** — connects to a local `unreal-mcp-server` you run (or any compatible server). Enter
-     the server URL, optionally start the bundled local server from the **MCP server** section, and
-     point your AI client at it.
-3. Watch the **connection timeline** (Unreal → MCP server → AI agent) and the **Bridge status**
-   panel (sidecar state, PID, version, restart count) to confirm everything is live.
+     the server URL and point your AI client at it. (The plugin does not start the local server for
+     you — run `unreal-cli` or your own process; see Troubleshooting.)
+3. The **Connection** section shows a status dot, a status label, and a Connect / Disconnect / Stop
+   button; the bridge status reads `Running (restarts: N)` or `Stopped`. Use them to confirm the
+   sidecar is live.
 4. Point your AI client (Claude Code, Cursor, the AI Game Developer app, …) at the server. The
-   **AI agents** section can auto-write client config for supported agents, or use
+   **AI agents** section lists the agents currently connected; to write an MCP client config use
    `unreal-cli setup-mcp`.
 
 Connection settings persist to `<Project>/Saved/Config/UnrealMcp/ai-game-developer-config.json`
@@ -217,9 +225,9 @@ editor; under headless `-nullrhi` these tools return a structured error.
 
 ## Per-tool enable / disable & Settings
 
-Every tool can be individually enabled or disabled from the **MCP Tools** window
-(**Window → AI Game Developer → Features → Tools**, or the aux **MCP Tools** tab), which also shows
-each tool's token-count estimate. Disabling a tool:
+Every tool can be individually enabled or disabled from the **MCP Tools** window — the standalone
+**MCP Tools** tab (registered under the editor's **Tools** menu). The window shows each tool's
+title, family, and description, plus an "N / M tools enabled" summary line. Disabling a tool:
 
 - **removes it from the served manifest entirely** — it never appears in the MCP `tools/list`; and
 - is **enforced at the execution boundary too** — even if a stale `tools/list` is dispatched, a
@@ -237,7 +245,8 @@ the retained toggle, so a rebuild can never silently re-enable a tool you disabl
 
 The **Settings** page is reachable both as an aux tab and via
 **Project Settings → Plugins → AI Game Developer** (`ISettingsModule`). The **MCP Prompts** and
-**MCP Resources** windows are wired but ship empty in this release (counts show 0).
+**MCP Resources** windows are wired but ship empty in this release — each renders a subdued
+empty-state message (the "N / M enabled" summary is unique to the Tools window).
 
 ## `unreal-cli`
 
@@ -305,8 +314,9 @@ IModularFeatures::Get().RegisterModularFeature(
 
 Unreal-MCP discovers every registered provider on boot (and on late-load / hot-unload), merges
 their tools in deterministic `ExtensionId` order, and surfaces the merged manifest to the sidecar.
-Invalid or duplicate tools are dropped/rejected per-extension without affecting others; each
-extension can be toggled in the **Extensions** UI section.
+Invalid or duplicate tools are dropped/rejected per-extension without affecting others. Individual
+tools (including those contributed by extensions) are toggled in the **MCP Tools** window; there is
+no separate per-extension UI toggle in this release.
 
 - **Full author guide:** [`docs/EXTENSIONS.md`](docs/EXTENSIONS.md)
 - **Working sample:** [`samples/UnrealAITemplate/`](samples/UnrealAITemplate) — a complete,
@@ -328,10 +338,10 @@ The plugin reads configuration with the precedence **process env → `<Project>/
 | `UNREAL_MCP_AUTH_OPTION` | `none` or `required` (local server auth) |
 | `UNREAL_MCP_KEEP_CONNECTED` | Persist/restore the connected state |
 | `UNREAL_MCP_TOOLS` | Enabled-tools override (whitelist; empty = no filter) |
-| `UNREAL_MCP_START_SERVER` | Auto-start the local `unreal-mcp-server` (Custom mode) |
+| `UNREAL_MCP_START_SERVER` | Parsed and persisted as the `startServer` config flag (Custom mode); auto-spawning the local `unreal-mcp-server` is **planned, not yet wired** — no code consumes this flag today, so start the server yourself (e.g. `unreal-cli`). |
 | `UNREAL_MCP_TRANSPORT` | `stdio` or `http` |
 | `UNREAL_MCP_LOG_LEVEL` | Log verbosity |
-| `UNREAL_MCP_BRIDGE_PATH` | **Dev-only.** Path to a locally built sidecar (skips download + version check) |
+| `UNREAL_MCP_BRIDGE_PATH` | Path to a sidecar binary. **Currently the only way the plugin resolves a sidecar** (auto-download is planned §6, not yet shipped). |
 
 > **Never commit `.env`.** A project-root `.env` can hold `UNREAL_MCP_TOKEN`, and UE project
 > templates ship no `.gitignore`. `unreal-cli configure` appends `.env` to the target project's
@@ -349,9 +359,11 @@ The plugin reads configuration with the precedence **process env → `<Project>/
   `-H "Content-Type: application/json"`; without it the server drops the JSON body.
 - **Screenshot tools return a structured error.** Pixel capture needs a GPU-backed editor — they
   cannot render under headless `-nullrhi`.
-- **Sidecar keeps restarting / version mismatch.** Check the **Bridge status** panel; a
-  plugin↔sidecar version skew triggers a single auto-redownload, then a hard-fail alert. Use
-  `UNREAL_MCP_BRIDGE_PATH` or `unreal-cli bootstrap-local` to point at a from-source build.
+- **No sidecar / sidecar keeps restarting.** Check the bridge status in the **Connection** section
+  (`Running (restarts: N)` / `Stopped`). If the log shows `no sidecar binary resolved (set
+  UNREAL_MCP_BRIDGE_PATH)`, no sidecar path was resolved — set `UNREAL_MCP_BRIDGE_PATH` or run
+  `unreal-cli bootstrap-local` to build one from source. (Automatic download and the version-skew
+  redownload/alert are planned §6 behavior, not yet shipped.)
 - **Ports.** IPC uses a deterministic per-project port in `30000–39999`; the local server uses
   `20000–29999`. Both probe forward on a collision, so the exact number is a debugging nicety, not a
   requirement.

--- a/README.md
+++ b/README.md
@@ -364,9 +364,10 @@ The plugin reads configuration with the precedence **process env → `<Project>/
   UNREAL_MCP_BRIDGE_PATH)`, no sidecar path was resolved — set `UNREAL_MCP_BRIDGE_PATH` or run
   `unreal-cli bootstrap-local` to build one from source. (Automatic download and the version-skew
   redownload/alert are planned §6 behavior, not yet shipped.)
-- **Ports.** IPC uses a deterministic per-project port in `30000–39999`; the local server uses
-  `20000–29999`. Both probe forward on a collision, so the exact number is a debugging nicety, not a
-  requirement.
+- **Ports.** IPC uses a deterministic per-project port in `30000–39999` and probes forward (then an
+  ephemeral port) on a collision; the local server uses a deterministic hash port in `20000–29999`
+  with no probing — the CLI derives the same number without reading any config, and the server binds
+  the exact requested port. The exact number is a debugging nicety, not a requirement.
 - **Logs.** Use the main window's **Open log file** action, the `console-get-logs` tool, or the
   editor Output Log (`LogUnrealMcp` category).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,6 +69,15 @@ Prompts/Resources ship empty-but-wired (§10), as designed.
 - **Device-code auth (#24).** The cloud OAuth device-code flow shipped in the main window (Authorize
   → `auth-start` → `device-auth` events render the verification URL + user code; Cancel/Revoke wired),
   per §1.3 / §7 item 4.
+- **§7 UI — shipped with partial coverage.** The §7 Slate UI shipped (#24/#29), but three §7 design
+  affordances did **not** make this release: the **toolbar button** (design line 544) — the main
+  window is opened from its nomad tab only, registered under the editor's **Tools** menu category
+  (`WorkspaceMenu::GetMenuStructure().GetToolsCategory()`), not the **Window** menu (design line 571);
+  and the **connection timeline** (Unreal → MCP server → AI agent) — the Connection section ships a
+  single status dot / label / button instead. The bridge status string is `Running (restarts: N)` /
+  `Stopped` (no PID/version), the AI agents section lists connected agents only (no config writing),
+  and there is no in-UI start-local-server control. The status table marks §7 "implemented" for the
+  window + 4 aux windows; these affordances are deferred.
 - **§9.1 `.uplugin` `EngineVersion`.** The §9.1 tree comment reads "EngineVersion floor 5.5.0", but
   the shipped `UnrealMCP.uplugin` carries **no `EngineVersion` field at all** — UE treats it as an
   exact-build match (not a floor) and would refuse to load on newer engines. The 5.5+ floor is a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -80,7 +80,7 @@ Prompts/Resources ship empty-but-wired (§10), as designed.
   **not yet wired**: the §6 **download-on-first-run** from GitHub Releases and the **version-skew
   re-download/alert** flow are TODO stubs. The §6 download prose is retained as the plan of record,
   not the shipped state.
-- **§7 UI — shipped with partial coverage.** The §7 Slate UI shipped (#24/#29), but three §7 design
+- **§7 UI — shipped with partial coverage.** The §7 Slate UI shipped (#24/#29), but two §7 design
   affordances did **not** make this release: the **toolbar button** (§7's tab-registration paragraph,
   "under Window → AI Game Developer plus a toolbar button") — the main window is opened from its nomad
   tab only, registered under the editor's **Tools** menu category

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,9 +24,12 @@ delivered it. Identifiers below (tool ids, command names, env vars, paths) were 
 | §3 Schema generation | implemented | exercised by every tool family (#13–#25) |
 | §4 GameThread dispatcher | implemented | #4 (used by all 8 families) |
 | §5 Extensions mechanism | implemented | #7 (`IUnrealMcpToolProvider`, `samples/UnrealAITemplate`) |
+| §6 Sidecar lifecycle | **partial** | #4 (spawn / crash auto-restart / orphan-prevention / stdin-token); auto-download + version-skew re-download are TODO stubs (see drift below) |
 | §7 Slate UI | implemented | #24 (AI Game Developer main window) + #29 (MCP Tools/Prompts/Resources/Settings aux windows) |
 | §8 Config & env | implemented | #8 (`UNREAL_MCP_*`, `.env`, on-disk config) |
 | §9.1 cli (`unreal-cli`, 16 commands) | implemented | #3 |
+| §9.2 Versioning | implemented | `commands/bump-version.ps1` single-sources `VersionName` across plugin/bridge/server/cli (the "≥ 6.8.0 w/ ProxyTool" pin is forward-looking — see §2.3 drift below) |
+| §9.3 Test strategy | implemented | bridge xUnit + cli vitest + plugin Automation specs (#13–#25), CI wiring #28 |
 | §9.4 CI (`test_pull_request` / `release` / `test_cli`) | implemented | #28 |
 | §10 ping family (1) | implemented | #4 |
 | §10 actor & component family (13) | implemented | #14 |
@@ -69,12 +72,21 @@ Prompts/Resources ship empty-but-wired (§10), as designed.
 - **Device-code auth (#24).** The cloud OAuth device-code flow shipped in the main window (Authorize
   → `auth-start` → `device-auth` events render the verification URL + user code; Cancel/Revoke wired),
   per §1.3 / §7 item 4.
+- **§6 sidecar lifecycle — shipped with partial coverage.** What ships today: the plugin **spawns**
+  the sidecar, hands it the one-shot IPC token over **stdin** (§1.4), **crash auto-restarts** it (the
+  Connection section reports `Running (restarts: N)` / `Stopped`), and prevents orphans (the sidecar
+  self-exits when its parent editor vanishes). The sidecar binary is resolved **only** from
+  `UNREAL_MCP_BRIDGE_PATH` (env/`.env`); `unreal-cli bootstrap-local` builds one from source. What is
+  **not yet wired**: the §6 **download-on-first-run** from GitHub Releases and the **version-skew
+  re-download/alert** flow are TODO stubs. The §6 download prose is retained as the plan of record,
+  not the shipped state.
 - **§7 UI — shipped with partial coverage.** The §7 Slate UI shipped (#24/#29), but three §7 design
-  affordances did **not** make this release: the **toolbar button** (design line 544) — the main
-  window is opened from its nomad tab only, registered under the editor's **Tools** menu category
-  (`WorkspaceMenu::GetMenuStructure().GetToolsCategory()`), not the **Window** menu (design line 571);
-  and the **connection timeline** (Unreal → MCP server → AI agent) — the Connection section ships a
-  single status dot / label / button instead. The bridge status string is `Running (restarts: N)` /
+  affordances did **not** make this release: the **toolbar button** (§7's tab-registration paragraph,
+  "under Window → AI Game Developer plus a toolbar button") — the main window is opened from its nomad
+  tab only, registered under the editor's **Tools** menu category
+  (`WorkspaceMenu::GetMenuStructure().GetToolsCategory()`), not the **Window** menu; and the
+  **connection timeline** (Unreal → MCP server → AI agent — see §7's Connection section design) — the
+  Connection section ships a single status dot / label / button instead. The bridge status string is `Running (restarts: N)` /
   `Stopped` (no PID/version), the AI agents section lists connected agents only (no config writing),
   and there is no in-UI start-local-server control. The status table marks §7 "implemented" for the
   window + 4 aux windows; these affordances are deferred.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,6 +10,74 @@
 
 ---
 
+## Implementation status (M10 — shipped)
+
+This document is the authoritative **design**; the M10 feature set has now shipped and this block
+reconciles the design with the implementation. Each numbered section is marked with the PR(s) that
+delivered it. Identifiers below (tool ids, command names, env vars, paths) were verified against
+`main` source; the README carries the user-facing, source-generated tool list.
+
+| Section | Status | Shipped by |
+|---|---|---|
+| §1 IPC bridge protocol | implemented | #4 (sidecar bridge e2e + live `ping`) |
+| §2 Dynamic tool registration | implemented | #4; the §2.3 `ProxyTool` lives in `bridge/` (see correction below) |
+| §3 Schema generation | implemented | exercised by every tool family (#13–#25) |
+| §4 GameThread dispatcher | implemented | #4 (used by all 8 families) |
+| §5 Extensions mechanism | implemented | #7 (`IUnrealMcpToolProvider`, `samples/UnrealAITemplate`) |
+| §7 Slate UI | implemented | #24 (AI Game Developer main window) + #29 (MCP Tools/Prompts/Resources/Settings aux windows) |
+| §8 Config & env | implemented | #8 (`UNREAL_MCP_*`, `.env`, on-disk config) |
+| §9.1 cli (`unreal-cli`, 16 commands) | implemented | #3 |
+| §9.4 CI (`test_pull_request` / `release` / `test_cli`) | implemented | #28 |
+| §10 ping family (1) | implemented | #4 |
+| §10 actor & component family (13) | implemented | #14 |
+| §10 asset family (11) | implemented | #15 (issue #10) |
+| §10 blueprint family (11) | implemented | #13 |
+| §10 source family (6) | implemented | #23 |
+| §10 screenshot family (4) | implemented | #21 |
+| §10 editor/reflection family (9) | implemented | #22 |
+| §10 level family (7) | implemented | #25 |
+
+**Total shipped: 62 core tools across 8 families** (counts verified from the registration source).
+Prompts/Resources ship empty-but-wired (§10), as designed.
+
+### Drift corrected against the implementation
+
+- **§2.3 ProxyTool — shipped in `bridge/`, not via an upstream 6.8.0 bump.** The design proposed an
+  additive MCP-Plugin-dotnet PR (`com.IvanMurzak.McpPlugin` 6.8.0). In practice the documented
+  fallback was taken: `ProxyTool` + `ProxyToolFactory` live entirely under `bridge/src/Tools/`
+  (`IRunTool` + `ToolManager.AddTool` are already public), so the bridge/server pin **stays frozen at
+  `com.IvanMurzak.McpPlugin[.Server]` 6.7.0 / `com.IvanMurzak.ReflectorNet` 5.3.1** (no
+  `UseLocalMcpPlugin` switch is wired today). A future upstream 6.8.0 ProxyTool can replace the local
+  copy through its own pipeline; until then, §2.3/§9.2's "≥ 6.8.0" is forward-looking, not the
+  shipped state.
+- **§8 effective-served semantics.** The served tool set is computed as: served **iff** the tool
+  passes the `enabledTools` **whitelist** (empty whitelist = no filter; `UNREAL_MCP_TOOLS` overrides
+  it) **AND** is not in the `disabledTools` **blocklist** (the per-tool UI toggles). Both sets are
+  retained members, so a registration or an extension hot-reload re-applies them — a rebuilt tool
+  inherits the retained toggle and cannot silently re-enable. See
+  `FUnrealMcpToolRegistry::ShouldToolBeEnabled`.
+- **Execute()-level enable gate (#29).** A disabled tool is excluded from the served manifest **and**
+  rejected at the execution boundary (`FUnrealMcpToolRegistry::Execute` returns
+  `"Tool '<name>' is disabled."`), so a stale `tools/list` that still names it can never run it.
+- **Image-content channel (#21).** The screenshot family returns a base64 **PNG as MCP image
+  content** (`content[]` with an `image` entry), as anticipated by §1.2's "binary payloads travel as
+  base64 strings inside JSON". Dimensions clamp to default 1024 / hard cap 2048 per side; capture
+  needs a GPU-backed editor (headless `-nullrhi` returns a structured error).
+- **LogCollector (#22).** `console-get-logs` / `console-clear-logs` are backed by a module-startup
+  `FUnrealMcpLogCollector` — a `GLog` `FOutputDevice` ring buffer (the Godot `GodotLogCollector`
+  pattern), as §10 describes.
+- **Device-code auth (#24).** The cloud OAuth device-code flow shipped in the main window (Authorize
+  → `auth-start` → `device-auth` events render the verification URL + user code; Cancel/Revoke wired),
+  per §1.3 / §7 item 4.
+- **§9.1 `.uplugin` `EngineVersion`.** The §9.1 tree comment reads "EngineVersion floor 5.5.0", but
+  the shipped `UnrealMCP.uplugin` carries **no `EngineVersion` field at all** — UE treats it as an
+  exact-build match (not a floor) and would refuse to load on newer engines. The 5.5+ floor is a
+  documented/CI claim, not a descriptor pin. (Corrected inline in §9.1.)
+- **On-disk config path.** Confirmed shipped at
+  `<Project>/Saved/Config/UnrealMcp/ai-game-developer-config.json` (§8), matching the design.
+
+---
+
 ## 0. System overview
 
 Unity and Godot embed the .NET `McpPlugin` host **in-process** (C# engine). Unreal's editor is C++,
@@ -574,7 +642,7 @@ the connection-config task).
 ```
 Unreal-MCP/
 ├── UnrealMCP/                          # the UE plugin (in-tree, like addons/godot_mcp)
-│   ├── UnrealMCP.uplugin               # VersionName single-source; EngineVersion floor 5.5.0
+│   ├── UnrealMCP.uplugin               # VersionName single-source; NO EngineVersion pin (5.5+ floor is a CI/doc claim, not a descriptor field — see status block)
 │   ├── Source/UnrealMcpEditor/         # Type Editor, LoadingPhase Default
 │   │   ├── Public/   (IUnrealMcpToolProvider.h, UnrealMcpToolRegistry.h, …)
 │   │   └── Private/  (Bridge/ Tools/ Schema/ Dispatch/ UI/ Config/ Sidecar/)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -10,6 +10,35 @@ The authoritative design is [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) §9
 keep the two in lockstep, and keep the CI command surface 1:1 with the
 implement-task profile `test.md` (infra repo).
 
+## Release checklist — operator-gated leaves (NONE fired automatically)
+
+The following actions are **deliberately operator-gated** and are **not** performed by a normal
+merge, by CI on a feature/docs PR, or by any automated task. As of this writing **none of them has
+fired** — Unreal-MCP has no GitHub Release, no `v*` tag, no published npm package, and no Fab
+listing. Each requires a deliberate human decision (and, for the first release, one-time setup):
+
+- [ ] **First GitHub Release + `v<version>` tag.** Fires only when a deliberate `VersionName` bump
+      lands on `main` (run `commands/bump-version.ps1`, commit, merge) on an untagged version — or a
+      manual `workflow_dispatch` with `dry_run=false`. `release.yml`'s `check-version` gate keeps
+      this inert otherwise. Verify with `gh release list` (expect empty) and
+      `git ls-remote --tags` (expect no `v*` tags) until you intend to publish.
+- [ ] **npm `unreal-cli` publish.** Two one-time prerequisites, both owner actions, must be done
+      **before** the first release or `publish-npm` fails auth and nothing is published:
+      1. **Flip `cli/package.json` `"private": true` → remove it** (or set `false`) in the same bump
+         commit that cuts the first release. While `private: true` stands, npm refuses to publish.
+      2. **Configure an npm Trusted Publisher** for the `unreal-cli` package on npmjs.com authorizing
+         this repository + the `release.yml` workflow. Publishing uses OIDC Trusted Publishing
+         (`id-token: write`), **not** a stored `NPM_TOKEN`. See
+         <https://docs.npmjs.com/trusted-publishers>.
+- [ ] **Fab (Epic marketplace) submission.** Entirely manual and **out of scope of every CI
+      workflow** — the release pipeline produces an engine-agnostic source-plugin zip
+      (BuildPlugin output), but no job submits to Fab. Fab carries its own metadata/screenshot
+      requirements and an Epic review; do it by hand when the listing is ready.
+
+A normal merge to `main` publishes nothing; the version gate keeps `release.yml` inert. The safe
+rehearsal is a `dry_run=true` dispatch (below), which exercises the test + artifact jobs and
+hard-skips every tag/Release/npm-publish job.
+
 ## Workflows at a glance
 
 | Workflow | Trigger | What it does |


### PR DESCRIPTION
## Summary

- **README.md** — complete user-facing rewrite: what Unreal-MCP is, UE 5.5+ install, first-run (AI Game Developer window, Cloud vs Custom, device-code auth), the full **8-family / 62-tool** list generated and verified from the registry source, `unreal-cli` (all 16 commands), extensions quickstart, per-tool enable/disable + Settings, CI badges, and troubleshooting (`UNREAL_MCP_*`, ports, logs).
- **docs/ARCHITECTURE.md** — M10 implementation-status block (each section → shipping PR) and drift corrections: ProxyTool shipped in `bridge/` on McpPlugin 6.7.0 (not the forward-looking 6.8.0); `enabledTools`/`disabledTools` effective-served semantics; `Execute()`-level enable gate; image-content channel; `LogCollector`; device-code auth; no `.uplugin` `EngineVersion` pin.
- **CLAUDE.md** — agent guide: layout, per-leg build/test commands (UBT, headless Automation `index.json` utf-8-sig, dotnet, npm), unity-build ODR naming rule, frozen NuGet pins, version single-source, no-modal-UI tool-handler contract, CI overview + `UNREAL_RUNNER_READY` gate.
- **docs/RELEASING.md** — explicit operator-gated release checklist (first GitHub Release/tag, npm `unreal-cli` publish with `private:true` flip + Trusted Publisher, Fab submission) — none fired by this task.

No version bumps, no releases/tags/npm publishes, no code changes.

## Test plan

- [x] Docs-accuracy review pass: every tool id (62), family count (8), CLI command (16), env var (11), file path, NuGet pin, config path, and CI identifier verified against `main` source (584a722b+) — not reproduced from memory.
- [x] Markdown relative links resolve (LICENSE, docs/*, cli/README.md, source paths).
- [x] CI green on the PR (hosted legs).

Closes #30
