### PR TITLE
feat(server): default streamable-http idle timeout to 6h for local server

### DIFF
--- a/Unreal-MCP-Server/src/Program.cs
+++ b/Unreal-MCP-Server/src/Program.cs
@@ -31,6 +31,14 @@ namespace com.IvanMurzak.Unreal.MCP.Server
             // Configure NLog
             LogManager.Setup().LoadConfigurationFromFile("NLog.config");
 
+            // Default the streamableHttp idle-session window to 6 hours for this local server.
+            // The plugin's built-in default is 600s (10 min), which is too aggressive for a
+            // single-user local editor session and drops the MCP session mid-work. We only seed
+            // the env var when it is unset, and DataArguments parses CLI args after env vars, so an
+            // explicit MCP_PLUGIN_IDLE_TIMEOUT_SECONDS or --idle-timeout-seconds still overrides this.
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.IdleTimeoutSeconds)))
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.IdleTimeoutSeconds, "21600"); // 6 hours
+
             var dataArguments = new DataArguments(args);
 
             // In STDIO mode, redirect console logs to stderr to avoid polluting stdout with non-JSON content


### PR DESCRIPTION
## Problem
The plugin's built-in default idle-session window is **600s (10 min)**, which is too aggressive for a single-user local editor session and drops the MCP session mid-work.

## Fix
In `Unreal-MCP-Server/src/Program.cs`, seed the env var `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS=21600` (6h) **only when it is unset**, immediately before constructing `DataArguments`. `DataArguments` reads env vars first and CLI args second (CLI wins), so an explicit `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS` or `--idle-timeout-seconds` still overrides this default.

## Scope
Local `Unreal-MCP-Server` only. No behavior change when an override is supplied.

## Verification
`dotnet build Unreal-MCP-Server/com.IvanMurzak.Unreal.MCP.Server.csproj` → **0 errors, 0 warnings**. (This repo has no CI yet; local build is the gate.)