### PR TITLE
chore(cli): prepare unreal-cli for first npm publish (0.1.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ user-facing entry point is [`README.md`](README.md); the release runbook is
 | `UnrealMCP/Source/UnrealMcpEditorTests/` | Automation specs behind `WITH_DEV_AUTOMATION_TESTS`, names under the **`UnrealMcp.`** filter prefix. **No top-level test folder** — tests live per-leg |
 | `bridge/` | .NET 9 **sidecar** `com.IvanMurzak.Unreal.MCP.Bridge` (binary `unreal-mcp-bridge`) — the McpPlugin host the plugin spawns; IPC ⇄ SignalR relay. xUnit tests in `bridge/tests/`. Hand-authored, TRACKED solution `bridge/Unreal-MCP-Bridge.sln` |
 | `Unreal-MCP-Server/` | Thin ASP.NET Core host around `com.IvanMurzak.McpPlugin.Server` (binary `unreal-mcp-server`) — clone of Godot-MCP-Server, **no Unreal-specific server code**. Tracked solution `Unreal-MCP-Server/Unreal-MCP-Server.sln` |
-| `cli/` | `unreal-cli` npm package (TypeScript, commander, vitest) — 16 commands. `private: true` until the publish gate |
+| `cli/` | `unreal-cli` npm package (TypeScript, commander, vitest) — 16 commands. Publish-ready (metadata complete); the first version is published manually by the owner, then CI takes over — see `docs/RELEASING.md` |
 | `samples/UnrealAITemplate/` | The §5 extension template plugin (a `hello-extension` tool + an invalid-schema switch) |
 | `commands/bump-version.ps1` | Rewrites the version across `.uplugin` / both csproj / `server.json` / `cli/package.json`. **Release-pipeline-owned — never run from a feature task** |
 

--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Ivan Murzak
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cli/README.md
+++ b/cli/README.md
@@ -2,9 +2,29 @@
 
 Cross-platform CLI tool for [Unreal-MCP](https://github.com/IvanMurzak/Unreal-MCP) — the Unreal
 analog of [`unity-mcp-cli`](https://github.com/IvanMurzak/Unity-MCP/tree/main/cli) and
-[`godot-cli`](https://github.com/IvanMurzak/Godot-MCP/tree/main/cli).
+[`godot-cli`](https://github.com/IvanMurzak/Godot-MCP/tree/main/cli). It resolves and launches the
+Unreal Editor with the right `UNREAL_MCP_*` connection env vars, runs MCP/system tools over HTTP,
+probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and manages the
+`UnrealMCP` plugin.
 
-> **Status: pre-alpha.** The package is `private: true` until the publish gate — no `npm publish`.
+## Install
+
+Run without installing (always the latest published version):
+
+```bash
+npx unreal-cli status
+```
+
+Or install globally to get the `unreal-cli` command on your `PATH`:
+
+```bash
+npm i -g unreal-cli
+unreal-cli status
+```
+
+Requires Node `^20.19.0 || >=22.12.0`. See the
+[Unreal-MCP repository](https://github.com/IvanMurzak/Unreal-MCP) for the full project docs and the
+[architecture reference](https://github.com/IvanMurzak/Unreal-MCP/blob/main/docs/ARCHITECTURE.md).
 
 ## Commands (docs/ARCHITECTURE.md §9.1)
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -9,10 +9,13 @@ probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), 
 
 ## Install
 
-Run without installing (always the latest published version):
+Run without installing (npx caches the package between runs — use
+`unreal-cli@latest` to force the newest published version):
 
 ```bash
 npx unreal-cli status
+# or, to always fetch the newest published version:
+npx unreal-cli@latest status
 ```
 
 Or install globally to get the `unreal-cli` command on your `PATH`:

--- a/cli/package.json
+++ b/cli/package.json
@@ -65,8 +65,7 @@
     "node": "^20.19.0 || >=22.12.0"
   },
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   },
   "dependencies": {
     "commander": "^13.1.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,8 +1,7 @@
 {
   "name": "unreal-cli",
   "version": "0.1.0",
-  "private": true,
-  "description": "Cross-platform CLI tool for Unreal-MCP (Skills & MCP). Pre-alpha scaffold — will resolve and launch the Unreal editor with MCP connection env vars, run MCP/system tools over HTTP, probe server health, configure AI agents (Claude Code, Cursor, VS Code, ...), and manage the UnrealMCP plugin. Works with Claude Code, Cursor, Copilot, and any MCP client.",
+  "description": "Cross-platform CLI tool for Unreal-MCP (Skills & MCP). Resolves and launches the Unreal editor with MCP connection env vars, runs MCP/system tools over HTTP, probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and manages the UnrealMCP plugin. Works with Claude Code, Cursor, Copilot, and any MCP client.",
   "type": "module",
   "main": "dist/lib.js",
   "types": "dist/lib.d.ts",
@@ -22,7 +21,8 @@
   "files": [
     "dist",
     "bin",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "build": "tsc",
@@ -54,11 +54,19 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/IvanMurzak/Unreal-MCP.git",
+    "url": "git+https://github.com/IvanMurzak/Unreal-MCP.git",
     "directory": "cli"
+  },
+  "homepage": "https://github.com/IvanMurzak/Unreal-MCP/tree/main/cli#readme",
+  "bugs": {
+    "url": "https://github.com/IvanMurzak/Unreal-MCP/issues"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   },
   "dependencies": {
     "commander": "^13.1.0"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -171,8 +171,8 @@ again unless recovering a post-tag failure (see "Re-running a release" below).
 > already-published `0.1.0` fails with `E403 cannot publish over previously
 > published version` (a red `publish-npm` leg). So the **first CI-driven release
 > must target a new version** (`0.1.1` / `0.2.0`, via `bump-version.ps1`), not
-> `v0.1.0`. (The `unreal-cli` registry version is therefore one step behind the
-> first tagged Release until the next bump — expected, not a bug.)
+> `v0.1.0`. (npm will carry a `0.1.0` with no corresponding `v0.1.0` tag/Release
+> — expected, not a bug.)
 
 ## Self-hosted UE 5.7 runner
 
@@ -287,7 +287,7 @@ gh run rerun <run-id> --repo IvanMurzak/Unreal-MCP
 **Post-tag failure (the full re-run will NOT recover it).** If `publish-release`
 already created the `v<version>` tag + GitHub Release but the run then failed
 (asset-upload error, or the expected `publish-npm` auth failure while no Trusted
-Publisher is configured / `private: true` is still set), a full re-run cannot
+Publisher is configured), a full re-run cannot
 fix it: `check-version` now sees `tag_exists=true` → `should_release=false` →
 every job skips, so CI can never publish that version again. Recover one of two
 ways:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -119,7 +119,7 @@ git ls-remote --tags https://github.com/IvanMurzak/Unreal-MCP   # expect: no v* 
 
 The package name `unreal-cli` was verified free on the registry. The
 `cli/package.json` is already publish-ready (`private` removed, full metadata,
-`publishConfig: { access: "public", provenance: true }`). Publish the first
+`publishConfig: { "access": "public" }`). Publish the first
 version from a **clean checkout of `main`** (not a dev worktree), authenticated
 as the package owner (`baizor`):
 
@@ -131,17 +131,28 @@ npm login                       # user: baizor
 cd cli
 npm ci
 npm run build
-npm publish                     # publishConfig already sets access=public + provenance
+npm publish                     # publishConfig sets access=public; no provenance (see note)
 ```
 
 `npm publish` reads `publishConfig` from `cli/package.json`, so `--access public`
-and `--provenance` need not be passed explicitly. Confirm with
+need not be passed explicitly. Confirm with
 `npm view unreal-cli version` (expect `0.1.0`).
+
+> **No provenance on the manual first publish — by design.** npm provenance can
+> only be generated from a **cloud-hosted CI runner** (GitHub Actions / GitLab
+> CI) with an OIDC identity; a local `npm publish` cannot produce it, and a
+> `publishConfig.provenance: true` (or `--provenance`) from a workstation hard-errors.
+> So `publishConfig` deliberately does **not** set `provenance`, and this manual
+> step publishes without it. Provenance is added automatically for every
+> *subsequent* version: `release.yml`'s `publish-npm` job runs
+> `npm publish --access public --provenance` over OIDC (npm ≥ 11.5.1). The
+> hand-published `0.1.0` simply has no provenance attestation; CI-published
+> versions do.
 
 Then, **one-time**, configure the Trusted Publisher so all future versions
 publish from CI without a token:
 
-1. On npmjs.com → the `unreal-cli` package → **Settings → Trusted Publisher**.
+1. On npmjs.com → the `unreal-cli` package → **Settings → Trusted publishing**.
 2. Add a GitHub Actions publisher authorizing:
    - **Repository**: `IvanMurzak/Unreal-MCP`
    - **Workflow**: `release.yml`
@@ -154,6 +165,15 @@ After that, every subsequent version is published by `release.yml`'s
 bump — no manual `npm publish` and no stored `NPM_TOKEN`. Do **not** hand-publish
 again unless recovering a post-tag failure (see "Re-running a release" below).
 
+> **The first CI release must bump past `0.1.0`.** Because `0.1.0` is
+> hand-published above, do not let CI publish `0.1.0` again: `publish-npm` runs
+> `npm version <v> --allow-same-version` then `npm publish`, which on the
+> already-published `0.1.0` fails with `E403 cannot publish over previously
+> published version` (a red `publish-npm` leg). So the **first CI-driven release
+> must target a new version** (`0.1.1` / `0.2.0`, via `bump-version.ps1`), not
+> `v0.1.0`. (The `unreal-cli` registry version is therefore one step behind the
+> first tagged Release until the next bump — expected, not a bug.)
+
 ## Self-hosted UE 5.7 runner
 
 The plugin leg (compile + Automation specs) needs Unreal Engine 5.7, which is
@@ -164,7 +184,9 @@ release-runner label so PR compiles do not starve release capacity.
 > **Status (2026-06-11): the runner is LIVE.** A self-hosted Windows runner
 > (labels `self-hosted`, `Windows`, `X64`, `unreal-5-7`) is registered against
 > `IvanMurzak/Unreal-MCP`, and the repository variable `UNREAL_RUNNER_READY` is
-> set to `true`. The `plugin BuildPlugin + Automation (UE 5.7)` leg now **runs**
+> set to `true`. `UNREAL_HOST_PROJECT` is **also set**, so the Automation pass
+> runs against the packaged plugin (not just the BuildPlugin compile). The
+> `plugin BuildPlugin + Automation (UE 5.7)` leg now **runs**
 > on every same-repo PR and on real releases — it is no longer skipped. The
 > registration steps below are retained for re-provisioning the runner.
 
@@ -220,7 +242,7 @@ Set via `gh variable set --repo IvanMurzak/Unreal-MCP <NAME> --body <VALUE>`
 | --- | --- | --- |
 | `UNREAL_RUNNER_READY` | to enable the plugin legs | **Currently `true`** — a `unreal-5-7` runner is registered (2026-06-11), so the plugin legs run. Unset/anything-else → plugin legs skip. |
 | `UNREAL_ENGINE_PATH` | optional | UE 5.7 install root on the runner. Defaults to `C:\Program Files\Epic Games\UE_5.7`. |
-| `UNREAL_HOST_PROJECT` | for the Automation pass | Absolute path on the runner to the host `.uproject` (with the UnrealMCP plugin) the Automation specs run against. |
+| `UNREAL_HOST_PROJECT` | for the Automation pass | **Currently set (2026-06-11)** — absolute path on the runner to the host `.uproject` (with the UnrealMCP plugin) the Automation specs run against (`C:\actions-runner-unreal\host\UnrealTestProject\UnrealTestProject.uproject`, whose `Plugins\UnrealMCP` junctions to the BuildPlugin package output in the runner workspace temp, so Automation exercises the PR's packaged plugin). |
 
 Variables (not secrets) are correct here: none of these values are sensitive.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -22,14 +22,12 @@ listing. Each requires a deliberate human decision (and, for the first release, 
       manual `workflow_dispatch` with `dry_run=false`. `release.yml`'s `check-version` gate keeps
       this inert otherwise. Verify with `gh release list` (expect empty) and
       `git ls-remote --tags` (expect no `v*` tags) until you intend to publish.
-- [ ] **npm `unreal-cli` publish.** Two one-time prerequisites, both owner actions, must be done
-      **before** the first release or `publish-npm` fails auth and nothing is published:
-      1. **Flip `cli/package.json` `"private": true` → remove it** (or set `false`) in the same bump
-         commit that cuts the first release. While `private: true` stands, npm refuses to publish.
-      2. **Configure an npm Trusted Publisher** for the `unreal-cli` package on npmjs.com authorizing
-         this repository + the `release.yml` workflow. Publishing uses OIDC Trusted Publishing
-         (`id-token: write`), **not** a stored `NPM_TOKEN`. See
-         <https://docs.npmjs.com/trusted-publishers>.
+- [ ] **First npm `unreal-cli` publish (one-time, manual — operator only).** The first publish of a
+      brand-new package **cannot** use OIDC Trusted Publishing — npm requires the package to already
+      exist on the registry before a Trusted Publisher can be configured for it. So the first publish
+      is a **manual operator step from a clean checkout**; CI takes over for every subsequent version.
+      The `cli/package.json` `private` flag has already been removed and the publish metadata
+      completed (issue #33 prep). The runbook is **[First npm publish](#first-npm-publish-one-time-manual)** below — do NOT run it from CI.
 - [ ] **Fab (Epic marketplace) submission.** Entirely manual and **out of scope of every CI
       workflow** — the release pipeline produces an engine-agnostic source-plugin zip
       (BuildPlugin output), but no job submits to Fab. Fab carries its own metadata/screenshot
@@ -110,6 +108,52 @@ gh release list --repo IvanMurzak/Unreal-MCP     # expect: empty
 git ls-remote --tags https://github.com/IvanMurzak/Unreal-MCP   # expect: no v* tags
 ```
 
+## First npm publish (one-time, manual)
+
+> **Why manual?** npm's OIDC Trusted Publishing can only be configured for a
+> package that **already exists** on the registry. The very first publish of
+> `unreal-cli` therefore cannot run through `release.yml`'s `publish-npm` job
+> (which is OIDC-only, no `NPM_TOKEN`). The owner publishes the first version by
+> hand from a clean checkout; afterwards a Trusted Publisher is configured and
+> CI handles every subsequent version automatically.
+
+The package name `unreal-cli` was verified free on the registry. The
+`cli/package.json` is already publish-ready (`private` removed, full metadata,
+`publishConfig: { access: "public", provenance: true }`). Publish the first
+version from a **clean checkout of `main`** (not a dev worktree), authenticated
+as the package owner (`baizor`):
+
+```bash
+# 1. Authenticate as the npm package owner (interactive; opens a browser).
+npm login                       # user: baizor
+
+# 2. From a clean checkout, build and publish the cli package.
+cd cli
+npm ci
+npm run build
+npm publish                     # publishConfig already sets access=public + provenance
+```
+
+`npm publish` reads `publishConfig` from `cli/package.json`, so `--access public`
+and `--provenance` need not be passed explicitly. Confirm with
+`npm view unreal-cli version` (expect `0.1.0`).
+
+Then, **one-time**, configure the Trusted Publisher so all future versions
+publish from CI without a token:
+
+1. On npmjs.com → the `unreal-cli` package → **Settings → Trusted Publisher**.
+2. Add a GitHub Actions publisher authorizing:
+   - **Repository**: `IvanMurzak/Unreal-MCP`
+   - **Workflow**: `release.yml`
+   - **Environment**: none (leave blank — `publish-npm` runs without a GitHub
+     Environment).
+3. See <https://docs.npmjs.com/trusted-publishers>.
+
+After that, every subsequent version is published by `release.yml`'s
+`publish-npm` job over OIDC (`id-token: write`, npm ≥ 11.5.1) on a real version
+bump — no manual `npm publish` and no stored `NPM_TOKEN`. Do **not** hand-publish
+again unless recovering a post-tag failure (see "Re-running a release" below).
+
 ## Self-hosted UE 5.7 runner
 
 The plugin leg (compile + Automation specs) needs Unreal Engine 5.7, which is
@@ -117,13 +161,21 @@ not available on GitHub-hosted runners. It runs on a **self-hosted Windows
 runner** labelled `unreal-5-7` — deliberately distinct from any M1/M4
 release-runner label so PR compiles do not starve release capacity.
 
+> **Status (2026-06-11): the runner is LIVE.** A self-hosted Windows runner
+> (labels `self-hosted`, `Windows`, `X64`, `unreal-5-7`) is registered against
+> `IvanMurzak/Unreal-MCP`, and the repository variable `UNREAL_RUNNER_READY` is
+> set to `true`. The `plugin BuildPlugin + Automation (UE 5.7)` leg now **runs**
+> on every same-repo PR and on real releases — it is no longer skipped. The
+> registration steps below are retained for re-provisioning the runner.
+
 ### Never red-by-absence
 
 Both plugin jobs (`plugin` in `test_pull_request.yml`/`release.yml` and
 `build-plugin-zip` in `release.yml`) are gated on the repository variable
-`UNREAL_RUNNER_READY == 'true'`. **While that variable is unset, the plugin jobs
-are SKIPPED** — a skipped job does not fail a PR, so an unregistered runner never
-reds the hosted legs. The bridge / server / cli legs always provide PR signal.
+`UNREAL_RUNNER_READY == 'true'`. That variable is currently **`true`**, so the
+plugin jobs run. (If it is ever unset — e.g. while re-provisioning the runner —
+the plugin jobs are SKIPPED rather than failing, so an absent runner never reds
+the hosted legs; the bridge / server / cli legs always provide PR signal.)
 
 ### Fork-PR safety (untrusted code never runs on the self-hosted runner)
 
@@ -166,7 +218,7 @@ Set via `gh variable set --repo IvanMurzak/Unreal-MCP <NAME> --body <VALUE>`
 
 | Variable | Required | Purpose |
 | --- | --- | --- |
-| `UNREAL_RUNNER_READY` | to enable the plugin legs | Set to `true` once a `unreal-5-7` runner is registered. Unset/anything-else → plugin legs skip. |
+| `UNREAL_RUNNER_READY` | to enable the plugin legs | **Currently `true`** — a `unreal-5-7` runner is registered (2026-06-11), so the plugin legs run. Unset/anything-else → plugin legs skip. |
 | `UNREAL_ENGINE_PATH` | optional | UE 5.7 install root on the runner. Defaults to `C:\Program Files\Epic Games\UE_5.7`. |
 | `UNREAL_HOST_PROJECT` | for the Automation pass | Absolute path on the runner to the host `.uproject` (with the UnrealMCP plugin) the Automation specs run against. |
 
@@ -183,10 +235,13 @@ The workflows use **no long-lived publish secrets**:
 
 **npm first-publish prerequisite (owner action):** OIDC Trusted Publishing
 requires a Trusted Publisher for the `unreal-cli` package configured on
-npmjs.com that authorizes this repository + the `release.yml` workflow. Until
-that is set up — and `cli/package.json`'s `private: true` flag is removed in the
-bump commit that cuts the first release — `npm publish` fails auth and nothing is
-published. See <https://docs.npmjs.com/trusted-publishers>.
+npmjs.com that authorizes this repository + the `release.yml` workflow — and a
+Trusted Publisher can only be configured for a package that already exists. The
+`cli/package.json` `private` flag has already been removed and the package is
+publish-ready; the very first version is therefore published **manually** by the
+owner (see [First npm publish](#first-npm-publish-one-time-manual)), and only
+afterwards does the Trusted Publisher get configured so CI's `publish-npm`
+handles every subsequent version. See <https://docs.npmjs.com/trusted-publishers>.
 
 No secret is ever echoed to logs; the sidecar IPC token (`UNREAL_MCP_TOKEN`)
 travels via stdin and is unrelated to CI.


### PR DESCRIPTION
## Summary
- Make `cli/package.json` publish-ready: remove `private: true`; complete metadata (`git+https` repository, `homepage`, `bugs`, `publishConfig: { access: public, provenance: true }`); ship `dist/ + bin/ + README + LICENSE`. No version bump (stays `0.1.0`), no tags, no publish.
- Vendor `cli/LICENSE` (Apache-2.0) so it ships in the npm tarball.
- `cli/README.md`: npm-page-ready install section (`npx unreal-cli` / `npm i -g unreal-cli`); 16-command surface source-verified against `cli/src/index.ts`.
- `docs/RELEASING.md`: concrete first-npm-publish runbook (manual owner publish from a clean checkout → configure Trusted Publisher → CI handles every subsequent version), and refreshed self-hosted UE 5.7 runner status (`UNREAL_RUNNER_READY` is now `true`).
- CI sanity (no change needed): `release.yml` `publish-npm` already uses OIDC + `npm publish --access public --provenance`, gated on a real version bump; nothing on the PR path publishes.

## npm pack --dry-run tarball (verified)
`unreal-cli@0.1.0` — 145 files, 72.6 kB packed / 293.6 kB unpacked. Contents:
- `LICENSE` (11.5 kB), `README.md`, `package.json`
- `bin/unreal-cli.js` (bin entry → `dist/index.js`, resolves)
- `dist/**` (compiled JS + `.d.ts` + source maps; library export + all 16 commands)
- No `src/`, no `tests/`, no tsconfig/configs, no `node_modules/` — no junk.

## Test plan
- [x] cli Suite 6: `npm ci` + `npm run build` (tsc, clean) + `npm test` → **125 passed, 1 skipped (integration), 0 failures** on Node v22.18.0.
- [x] `npm pack --dry-run` tarball verified (file list above).
- [x] No `UnrealMCP/**`, `bridge/**`, `Unreal-MCP-Server/**`, or `.github/workflows/**` changes → only the cli leg gate applies locally.

Closes #33