### PR TITLE
fix(sidecar): recover stale 'Unreal: Connected' after Cloud auth -> Custom switch (#35)

### DIFF
--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -450,6 +450,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         /// </summary>
         internal Task RunConnectionTransition(Func<CancellationToken, Task> transition)
         {
+            CancellationTokenSource? superseded;
+            Task queued;
             lock (_transitionLock)
             {
                 // Supersede the in-flight transition (the documented last-write-wins): cancel its token so a
@@ -458,23 +460,36 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 // the loop's whole duration, so a token-less plugin.Connect() can NEVER return on its own and
                 // can NEVER be interrupted — this is the #35 root cause: after the device-auth Cloud reconnect
                 // the user's switch-back-to-Custom re-dial was enqueued behind the still-running Cloud connect
-                // and never ran, so the bridge held no link and the UI kept a stale "Connected". Cancel-before-
-                // dispose is safe (the in-flight transition observes an already-cancelled token, so no post-
-                // dispose registration throws), mirroring StartDeviceAuth's CTS handling.
-                _transitionCts?.Cancel();
-                _transitionCts?.Dispose();
+                // and never ran, so the bridge held no link and the UI kept a stale "Connected". Capture the
+                // predecessor here but cancel/dispose it OUTSIDE the lock (below): CancellationTokenSource.Cancel()
+                // runs the loser's await-continuations SYNCHRONOUSLY, and running arbitrary continuation code under
+                // _transitionLock is fragile against future edits.
+                superseded = _transitionCts;
                 var cts = new CancellationTokenSource();
                 _transitionCts = cts;
+                // Capture the token STRUCT, not the source: the queued continuation reads it when it RUNS, which
+                // may be after a LATER submission Cancel()+Dispose()'d this source. CancellationTokenSource.Token's
+                // getter still throws ObjectDisposedException post-dispose (would fault the loser transition task),
+                // but a captured CancellationToken copy stays usable — and cancel-before-dispose guarantees it
+                // reads cancelled, so the body observes the supersede correctly.
+                var token = cts.Token;
 
                 // Still CHAIN off the previous transition so two transitions never interleave their Connect/
                 // Disconnect calls (the original serialization reason) — but because the predecessor was just
                 // cancelled it now completes promptly, so this freshly-submitted transition runs without waiting
                 // on a wedged connect. The continuation passes THIS transition's token to the body.
-                var queued = _connectionTransition.ContinueWith(
-                    _ => transition(cts.Token), CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default).Unwrap();
+                queued = _connectionTransition.ContinueWith(
+                    _ => transition(token), CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default).Unwrap();
                 _connectionTransition = queued;
-                return queued;
             }
+
+            // Cancel-before-dispose is safe (the in-flight transition observes an already-cancelled token, so no
+            // post-dispose registration throws), mirroring StartDeviceAuth's CTS handling. Done outside the lock so
+            // the loser's synchronous continuations do not run under _transitionLock. Guard against a concurrent
+            // Dispose() having already torn this source down.
+            try { superseded?.Cancel(); } catch (ObjectDisposedException) { /* Dispose() raced us */ }
+            superseded?.Dispose();
+            return queued;
         }
 
         /// <summary>Push a §1.3 <c>status</c> message to the plugin (the §7 live connection indicator).</summary>
@@ -489,7 +504,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             return _ipc.SendToPluginAsync(status, CancellationToken.None);
         }
 
-        private Task ConnectSignalRAsync()
+        // Internal (not private) so the bridge xUnit suite can assert the initial connect is routed through the
+        // serialized + supersedable transition queue (a bare plugin.Connect() would not be cancellable).
+        internal Task ConnectSignalRAsync()
         {
             // Route the initial connect through the SAME serialized + supersedable queue as every re-dial, so a
             // config push arriving right after the handshake-ack cannot run a second plugin.Connect() concurrently
@@ -529,8 +546,18 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _ipc.AuthMessageReceived -= HandleAuthMessage;
             try { _authCts?.Cancel(); } catch { /* ignore */ }
             _authCts?.Dispose();
-            try { _transitionCts?.Cancel(); } catch { /* ignore */ }
-            _transitionCts?.Dispose();
+            // Tear down the transition CTS under _transitionLock so a concurrent RunConnectionTransition cannot
+            // observe a half-disposed field (or have its captured predecessor disposed out from under it): take
+            // and null the field inside the lock, then cancel/dispose outside (cancel runs continuations
+            // synchronously — keep them off the lock). Cancel-after-dispose / double-dispose are guarded.
+            CancellationTokenSource? transitionCts;
+            lock (_transitionLock)
+            {
+                transitionCts = _transitionCts;
+                _transitionCts = null;
+            }
+            try { transitionCts?.Cancel(); } catch (ObjectDisposedException) { /* a racing submission disposed it */ }
+            transitionCts?.Dispose();
             _ownedHttpClient?.Dispose(); // released here — the authenticator does not own it (default path)
             try { _plugin?.Dispose(); } catch { /* ignore */ }
             _plugin = null;

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -71,8 +71,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         // Serialize SignalR connect/disconnect transitions so rapid Connect/Disconnect toggles (or a device-auth
         // reconnect racing a config-driven disconnect) apply in submission order — last-write-wins — instead of
         // two in-flight plugin.Connect()/Disconnect() calls interleaving and landing in the wrong final state.
+        // _transitionCts is the CURRENT transition's cancellation source: a newly-submitted transition cancels
+        // it so a wedged/slow connect cannot pin every later transition behind it (the #35 root cause).
         private readonly object _transitionLock = new();
         private Task _connectionTransition = Task.CompletedTask;
+        private CancellationTokenSource? _transitionCts;
 
         public SidecarHost(
             IpcClient ipc,
@@ -105,6 +108,14 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
         public IMcpPlugin? Plugin => _plugin;
         public ConnectionConfig Config => _config;
+
+        /// <summary>
+        /// Test seam: substitute a fake <see cref="IMcpPlugin"/> for the real one <see cref="Build"/> creates,
+        /// so the bridge xUnit suite can drive the connection-transition orchestration (re-dial / supersede /
+        /// status) against a controllable connect — including a connect that stalls until cancelled, the #35
+        /// repro — without standing up a live SignalR endpoint.
+        /// </summary>
+        internal void SetPluginForTest(IMcpPlugin plugin) => _plugin = plugin;
 
         /// <summary>
         /// Build the plugin (empty tool set) + reflector, wire the manifest registrar to the live
@@ -172,7 +183,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 _logger?.LogDebug("Handshake re-accepted; SignalR connect already initiated (KeepConnected handles reconnection).");
         }
 
-        private void OnConfigReceived(JsonObject config)
+        internal void OnConfigReceived(JsonObject config)
         {
             // §8 "on change": the plugin re-pushed the effective connection config. Apply it, then honour a
             // keepConnected transition: false → genuinely tear down SignalR (the §7 / Godot M9b Disconnect
@@ -363,9 +374,16 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 return;
             }
 
-            var connected = false;
-            await RunConnectionTransition(async () => connected = await ReconnectAsync().ConfigureAwait(false)).ConfigureAwait(false);
-            await EmitStatusAsync(ResolveConnectionStatusAfterReconnect(keepConnected: true, connected), cloudAuthState).ConfigureAwait(false);
+            // Emit INSIDE the transition so a supersede (the user's next action queued a newer re-dial) skips
+            // this now-stale status and lets the winning transition emit the authoritative one — otherwise a
+            // slow connect here could land "Connecting"/"Connected" AFTER the newer transition reported the truth.
+            await RunConnectionTransition(async ct =>
+            {
+                var connected = await ReconnectAsync(ct).ConfigureAwait(false);
+                if (ct.IsCancellationRequested)
+                    return; // superseded — the newer transition owns the authoritative status emit
+                await EmitStatusAsync(ResolveConnectionStatusAfterReconnect(keepConnected: true, connected), cloudAuthState).ConfigureAwait(false);
+            }).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -381,15 +399,18 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         }
 
         /// <summary>Fully disconnect SignalR (auth-revoke / Disconnect), then surface a Disconnected status.</summary>
-        private async Task HandleDisconnectAsync()
+        private async Task HandleDisconnectAsync(CancellationToken ct)
         {
             var plugin = _plugin;
             if (plugin != null)
             {
-                try { await plugin.Disconnect().ConfigureAwait(false); }
+                try { await plugin.Disconnect(ct).ConfigureAwait(false); }
                 catch (Exception ex) { _logger?.LogDebug("SignalR disconnect failed: {Message}", ex.Message); }
             }
-            await EmitStatusAsync("Disconnected").ConfigureAwait(false);
+            // A superseded disconnect must not emit its now-stale "Disconnected" after the winning transition's
+            // status — the newer transition owns the authoritative emit (last-write-wins).
+            if (!ct.IsCancellationRequested)
+                await EmitStatusAsync("Disconnected").ConfigureAwait(false);
         }
 
         /// <summary>
@@ -397,17 +418,23 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         /// connect attempt reported success, so a caller (the device-code flow) can surface the real state
         /// instead of an unconditional "Connected".
         /// </summary>
-        private async Task<bool> ReconnectAsync()
+        private async Task<bool> ReconnectAsync(CancellationToken ct)
         {
             var plugin = _plugin;
             if (plugin == null)
                 return false;
-            try { await plugin.Disconnect().ConfigureAwait(false); } catch { /* may not be connected */ }
+            try { await plugin.Disconnect(ct).ConfigureAwait(false); } catch { /* may not be connected / superseded */ }
             try
             {
-                var ok = await plugin.Connect().ConfigureAwait(false);
+                var ok = await plugin.Connect(ct).ConfigureAwait(false);
                 _logger?.LogInformation(ok ? "SignalR reconnected." : "SignalR reconnect returned false; client keeps retrying.");
                 return ok;
+            }
+            catch (OperationCanceledException)
+            {
+                // Superseded by a newer transition (the user's latest action wins); it owns the next dial + status.
+                _logger?.LogDebug("SignalR reconnect superseded before it completed.");
+                return false;
             }
             catch (Exception ex)
             {
@@ -421,12 +448,30 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         /// in submission order). Prevents two in-flight transitions from interleaving their plugin.Connect()/
         /// Disconnect() calls and leaving the client in a state that contradicts the user's last action.
         /// </summary>
-        private Task RunConnectionTransition(Func<Task> transition)
+        internal Task RunConnectionTransition(Func<CancellationToken, Task> transition)
         {
             lock (_transitionLock)
             {
+                // Supersede the in-flight transition (the documented last-write-wins): cancel its token so a
+                // connect that is slow or wedged cannot pin every later transition behind it. McpPlugin's
+                // StartConnectionLoop retries every 5 s while a transport keeps failing and holds its gate for
+                // the loop's whole duration, so a token-less plugin.Connect() can NEVER return on its own and
+                // can NEVER be interrupted — this is the #35 root cause: after the device-auth Cloud reconnect
+                // the user's switch-back-to-Custom re-dial was enqueued behind the still-running Cloud connect
+                // and never ran, so the bridge held no link and the UI kept a stale "Connected". Cancel-before-
+                // dispose is safe (the in-flight transition observes an already-cancelled token, so no post-
+                // dispose registration throws), mirroring StartDeviceAuth's CTS handling.
+                _transitionCts?.Cancel();
+                _transitionCts?.Dispose();
+                var cts = new CancellationTokenSource();
+                _transitionCts = cts;
+
+                // Still CHAIN off the previous transition so two transitions never interleave their Connect/
+                // Disconnect calls (the original serialization reason) — but because the predecessor was just
+                // cancelled it now completes promptly, so this freshly-submitted transition runs without waiting
+                // on a wedged connect. The continuation passes THIS transition's token to the body.
                 var queued = _connectionTransition.ContinueWith(
-                    _ => transition(), CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default).Unwrap();
+                    _ => transition(cts.Token), CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default).Unwrap();
                 _connectionTransition = queued;
                 return queued;
             }
@@ -444,25 +489,37 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             return _ipc.SendToPluginAsync(status, CancellationToken.None);
         }
 
-        private async System.Threading.Tasks.Task ConnectSignalRAsync()
+        private Task ConnectSignalRAsync()
         {
-            var plugin = _plugin;
-            if (plugin == null)
-                return;
-            try
+            // Route the initial connect through the SAME serialized + supersedable queue as every re-dial, so a
+            // config push arriving right after the handshake-ack cannot run a second plugin.Connect() concurrently
+            // (interleaving the two), and so a slow initial connect is superseded by — not a blocker of — that push.
+            return RunConnectionTransition(async ct =>
             {
-                var ok = await plugin.Connect().ConfigureAwait(false);
-                _logger?.LogInformation(ok ? "SignalR connected." : "SignalR initial connect returned false; client will keep retrying.");
-                // §7 live status: surface the connection result to the plugin's view-model. Only a CLOUD-mode
-                // bearer is a cloud authorization — a Custom-mode token is a local bearer and must NOT light the
-                // "Authorized — cloud token stored" indicator (ApplyStatus latches it and never demotes).
-                var cloudAuthState = _isCloudMode && !string.IsNullOrEmpty(_config.Token) ? "Authorized" : null;
-                await EmitStatusAsync(ok ? "Connected" : "Connecting", cloudAuthState).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning("SignalR connect failed: {Message}", ex.Message);
-            }
+                var plugin = _plugin;
+                if (plugin == null)
+                    return;
+                try
+                {
+                    var ok = await plugin.Connect(ct).ConfigureAwait(false);
+                    _logger?.LogInformation(ok ? "SignalR connected." : "SignalR initial connect returned false; client will keep retrying.");
+                    if (ct.IsCancellationRequested)
+                        return; // superseded — a newer transition owns the status emit
+                    // §7 live status: surface the connection result to the plugin's view-model. Only a CLOUD-mode
+                    // bearer is a cloud authorization — a Custom-mode token is a local bearer and must NOT light the
+                    // "Authorized — cloud token stored" indicator (ApplyStatus latches it and never demotes).
+                    var cloudAuthState = _isCloudMode && !string.IsNullOrEmpty(_config.Token) ? "Authorized" : null;
+                    await EmitStatusAsync(ok ? "Connected" : "Connecting", cloudAuthState).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger?.LogDebug("SignalR initial connect superseded before it completed.");
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning("SignalR connect failed: {Message}", ex.Message);
+                }
+            });
         }
 
         public void Dispose()
@@ -472,6 +529,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _ipc.AuthMessageReceived -= HandleAuthMessage;
             try { _authCts?.Cancel(); } catch { /* ignore */ }
             _authCts?.Dispose();
+            try { _transitionCts?.Cancel(); } catch { /* ignore */ }
+            _transitionCts?.Dispose();
             _ownedHttpClient?.Dispose(); // released here — the authenticator does not own it (default path)
             try { _plugin?.Dispose(); } catch { /* ignore */ }
             _plugin = null;

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -427,7 +427,14 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             try
             {
                 var ok = await plugin.Connect(ct).ConfigureAwait(false);
-                _logger?.LogInformation(ok ? "SignalR reconnected." : "SignalR reconnect returned false; client keeps retrying.");
+                // The real ConnectionManager returns false (not OCE) when its token is cancelled mid-dial —
+                // distinguish a superseded dial from a genuine retry-in-progress so the log stays truthful.
+                if (ok)
+                    _logger?.LogInformation("SignalR reconnected.");
+                else if (ct.IsCancellationRequested)
+                    _logger?.LogDebug("SignalR reconnect superseded before it completed.");
+                else
+                    _logger?.LogInformation("SignalR reconnect returned false; client keeps retrying.");
                 return ok;
             }
             catch (OperationCanceledException)
@@ -519,9 +526,14 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 try
                 {
                     var ok = await plugin.Connect(ct).ConfigureAwait(false);
-                    _logger?.LogInformation(ok ? "SignalR connected." : "SignalR initial connect returned false; client will keep retrying.");
                     if (ct.IsCancellationRequested)
-                        return; // superseded — a newer transition owns the status emit
+                    {
+                        // Superseded — a newer transition owns the next dial + status emit. (The real
+                        // ConnectionManager returns false rather than throwing OCE on a cancelled token.)
+                        _logger?.LogDebug("SignalR initial connect superseded before it completed.");
+                        return;
+                    }
+                    _logger?.LogInformation(ok ? "SignalR connected." : "SignalR initial connect returned false; client will keep retrying.");
                     // §7 live status: surface the connection result to the plugin's view-model. Only a CLOUD-mode
                     // bearer is a cloud authorization — a Custom-mode token is a local bearer and must NOT light the
                     // "Authorized — cloud token stored" indicator (ApplyStatus latches it and never demotes).

--- a/bridge/tests/Fakes.cs
+++ b/bridge/tests/Fakes.cs
@@ -13,11 +13,66 @@ using System.Collections.Generic;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
 using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging;
+using R3;
+using McpVersion = com.IvanMurzak.McpPlugin.Common.Version;
 
 namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
 {
+    /// <summary>
+    /// A controllable <see cref="IMcpPlugin"/> for driving <see cref="SidecarHost"/>'s connection-transition
+    /// orchestration (re-dial / supersede / status) without a live SignalR endpoint. Only <see cref="Connect"/>
+    /// / <see cref="Disconnect"/> are meaningful — the rest of the (large) interface surface is never touched by
+    /// the transition machinery and throws if accessed, surfacing any accidental new dependency loudly.
+    /// </summary>
+    internal sealed class FakeMcpPlugin : IMcpPlugin
+    {
+        private readonly Func<CancellationToken, Task<bool>> _onConnect;
+        private readonly Func<CancellationToken, Task>? _onDisconnect;
+        public int ConnectCalls;
+        public int DisconnectCalls;
+
+        public FakeMcpPlugin(Func<CancellationToken, Task<bool>> onConnect, Func<CancellationToken, Task>? onDisconnect = null)
+        {
+            _onConnect = onConnect;
+            _onDisconnect = onDisconnect;
+        }
+
+        public Task<bool> Connect(CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref ConnectCalls);
+            return _onConnect(cancellationToken);
+        }
+
+        public Task Disconnect(CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref DisconnectCalls);
+            return _onDisconnect?.Invoke(cancellationToken) ?? Task.CompletedTask;
+        }
+
+        public void DisconnectImmediate() { }
+        public void Dispose() { }
+
+        // Unused surface — the transition orchestration under test never reads these. Throwing keeps the fake
+        // honest: if a future change starts depending on one, the test fails loudly instead of silently.
+        public ReadOnlyReactiveProperty<bool> KeepConnected => throw new NotSupportedException();
+        public ReadOnlyReactiveProperty<HubConnectionState> ConnectionState => throw new NotSupportedException();
+        public Observable<Unit> OnAuthorizationRejected => throw new NotSupportedException();
+        public ILogger Logger => throw new NotSupportedException();
+        public IMcpManager McpManager => throw new NotSupportedException();
+        public IMcpManagerHub? McpManagerHub => throw new NotSupportedException();
+        public McpVersion Version => throw new NotSupportedException();
+        public VersionHandshakeResponse? VersionHandshakeStatus => throw new NotSupportedException();
+        public bool GenerateSkillFiles(string? path = null) => throw new NotSupportedException();
+        public bool GenerateSkillFilesIfNeeded(string? path = null) => throw new NotSupportedException();
+        public bool DeleteSkillFiles(string? path = null) => throw new NotSupportedException();
+    }
+
     /// <summary>A scripted <see cref="IToolCallChannel"/> for testing the proxy/registration path.</summary>
     public sealed class FakeToolCallChannel : IToolCallChannel
     {

--- a/bridge/tests/SidecarHostTransitionTests.cs
+++ b/bridge/tests/SidecarHostTransitionTests.cs
@@ -113,5 +113,77 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             // Post-fix: the supersede cancels the wedged connect → the localhost dial runs (green).
             await localDialed.Task.WaitAsync(TimeSpan.FromSeconds(10));
         }
+
+        [Fact]
+        public async Task SupersededDisconnect_CancelsTheTokenThreadedIntoPluginDisconnect()
+        {
+            using var host = NewHost(out _);
+
+            var disconnectStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var disconnectCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var laterRan = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // The disconnect wedges inside plugin.Disconnect until ITS token is cancelled — proving the
+            // per-transition token is actually threaded all the way into plugin.Disconnect(ct) (HandleDisconnectAsync).
+            var fake = new FakeMcpPlugin(
+                onConnect: _ => Task.FromResult(true),
+                onDisconnect: async ct =>
+                {
+                    disconnectStarted.TrySetResult();
+                    try { await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { disconnectCancelled.TrySetResult(); }
+                });
+            host.SetPluginForTest(fake);
+
+            // keepConnected defaults to true; a config push with keepConnected=false drives a Disconnect transition
+            // (DecideConfigTransition true→false), whose HandleDisconnectAsync threads the token into plugin.Disconnect.
+            var disconnectCfg = new JsonObject
+            {
+                ["type"] = "config",
+                ["mode"] = "Custom",
+                ["host"] = "http://localhost:8500",
+                ["keepConnected"] = false,
+            };
+            host.OnConfigReceived(disconnectCfg);
+            await disconnectStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // A newer transition supersedes the wedged disconnect — the token observed by plugin.Disconnect must cancel.
+            _ = host.RunConnectionTransition(_ => { laterRan.TrySetResult(); return Task.CompletedTask; });
+
+            await disconnectCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5)); // token threaded in AND cancelled on supersede
+            await laterRan.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        [Fact]
+        public async Task InitialConnect_RoutedThroughQueue_IsSupersedableByALaterTransition()
+        {
+            using var host = NewHost(out _);
+
+            var connectStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var connectCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var laterRan = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // The initial connect wedges until ITS token is cancelled. If ConnectSignalRAsync issued a bare
+            // plugin.Connect() (no per-transition token) instead of routing through the queue, the token would
+            // never cancel and connectCancelled would time out.
+            var fake = new FakeMcpPlugin(async ct =>
+            {
+                connectStarted.TrySetResult();
+                try { await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { connectCancelled.TrySetResult(); }
+                return false;
+            });
+            host.SetPluginForTest(fake);
+
+            // The first handshake-ack kicks the initial SignalR connect through the serialized queue.
+            _ = host.ConnectSignalRAsync();
+            await connectStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // A later transition supersedes the in-flight initial connect — only possible because it was queued.
+            _ = host.RunConnectionTransition(_ => { laterRan.TrySetResult(); return Task.CompletedTask; });
+
+            await connectCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5)); // initial connect WAS routed through the queue
+            await laterRan.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
     }
 }

--- a/bridge/tests/SidecarHostTransitionTests.cs
+++ b/bridge/tests/SidecarHostTransitionTests.cs
@@ -1,0 +1,117 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Unreal.MCP.Bridge.Host;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>
+    /// Regression specs for the connection-transition queue (docs/ARCHITECTURE.md §6/§7, issue #35): the
+    /// serialized queue must be genuinely LAST-WRITE-WINS. Before the fix it was strict FIFO with no way to
+    /// interrupt an in-flight transition, so a Cloud reconnect whose <c>plugin.Connect()</c> never returned
+    /// (McpPlugin's <c>StartConnectionLoop</c> retries forever while a transport keeps failing, holding its
+    /// gate) pinned every later transition behind it. The user's switch-back-to-Custom re-dial was therefore
+    /// enqueued and never ran — the bridge held no SignalR link while the UI kept a stale "Connected", and a
+    /// "Restart bridge" was the only recovery. The fix supersedes (cancels) the in-flight transition on each
+    /// new submission and threads the token into <c>plugin.Connect/Disconnect</c>.
+    /// </summary>
+    public class SidecarHostTransitionTests
+    {
+        private static JsonObject Cfg(string mode, string? host = null, string? cloudUrl = null, string? token = null)
+        {
+            var o = new JsonObject { ["type"] = "config", ["mode"] = mode };
+            if (host != null) o["host"] = host;
+            if (cloudUrl != null) o["cloudUrl"] = cloudUrl;
+            if (token != null) o["token"] = token;
+            return o;
+        }
+
+        private static SidecarHost NewHost(out IpcClient ipc)
+        {
+            // Port 39998 is never dialed — the fake plugin replaces the real SignalR client, so no socket opens.
+            ipc = new IpcClient("127.0.0.1", 39998, token: "ipc-token", sidecarVersion: "0.1.0");
+            return new SidecarHost(ipc, "0.1.0");
+        }
+
+        [Fact]
+        public async Task RunConnectionTransition_NewSubmissionSupersedesAStalledPredecessor()
+        {
+            using var host = NewHost(out _);
+
+            var aStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var aCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var bRan = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // Transition A models the wedged Cloud connect: it never completes on its own, only on cancellation.
+            _ = host.RunConnectionTransition(async ct =>
+            {
+                aStarted.TrySetResult();
+                try { await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { aCancelled.TrySetResult(); }
+            });
+
+            await aStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // Transition B is the user's latest action. It MUST run even though A is still "connecting".
+            _ = host.RunConnectionTransition(_ => { bRan.TrySetResult(); return Task.CompletedTask; });
+
+            await bRan.Task.WaitAsync(TimeSpan.FromSeconds(5));        // pre-fix: pinned behind A → times out
+            await aCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));  // A was superseded (cancelled), not abandoned
+        }
+
+        [Fact]
+        public async Task PostDeviceAuth_SwitchBackToCustom_ReDialsLocal_NotPinnedBehindTheStalledCloudConnect()
+        {
+            using var host = NewHost(out _);
+
+            var cloudStalling = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var localDialed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // The fake mirrors the live failure mode: a Cloud dial never returns on its own (stalls until its
+            // token is cancelled = superseded); a Custom (localhost) dial succeeds at once and proves the
+            // switch-back-to-Custom re-dial actually ran. It reads the live Host the bridge resolved, exactly
+            // as the real ConnectionManager reads Endpoint from the shared ConnectionConfig.
+            var fake = new FakeMcpPlugin(async ct =>
+            {
+                var target = host.Config.Host ?? "";
+                if (target.Contains("localhost", StringComparison.OrdinalIgnoreCase))
+                {
+                    localDialed.TrySetResult();
+                    return true;
+                }
+                cloudStalling.TrySetResult();
+                await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false); // wedged Cloud connect
+                return false;
+            });
+            host.SetPluginForTest(fake);
+
+            // In Cloud mode, armed (the state right after the user switched to Cloud and authorized).
+            host.ApplyConnectionConfig(Cfg("Cloud", cloudUrl: "https://ai-game.dev"));
+
+            // The device-auth commit re-dials Cloud with the bearer — and that dial wedges. Fire-and-forget:
+            // awaiting it would hang forever on the pre-fix code, which is precisely the bug.
+            _ = host.CommitAuthorizedSessionAsync("cloud-bearer", CancellationToken.None);
+            await cloudStalling.Task.WaitAsync(TimeSpan.FromSeconds(5)); // ensure the Cloud connect is in-flight
+
+            // The user switches back to Custom. This MUST supersede the wedged Cloud connect and dial localhost.
+            host.OnConfigReceived(Cfg("Custom", host: "http://localhost:8500", token: ""));
+
+            // Pre-fix: the localhost dial is pinned behind the never-completing Cloud connect → times out (red).
+            // Post-fix: the supersede cancels the wedged connect → the localhost dial runs (green).
+            await localDialed.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- The sidecar's connection-transition queue claimed *last-write-wins* but was strict FIFO with no way to interrupt an in-flight transition; `plugin.Connect()/Disconnect()` were called **token-less**, and McpPlugin's `StartConnectionLoop` retries forever (5s cadence) while a transport keeps failing, holding its gate the whole time — so a wedged Cloud connect could never return nor be interrupted.
- After a device-auth Cloud commit re-dialed Cloud and that dial wedged, the user's switch-back-to-Custom re-dial was enqueued **behind** it and never ran: the bridge held no SignalR link while the UI kept a stale "Unreal: Connected" (`ping` -> HTTP 500), recoverable only via "Restart bridge".
- Fix: `RunConnectionTransition` now **supersedes** (cancels) the in-flight transition on each new submission and threads that token into `plugin.Connect(ct)/Disconnect(ct)`; superseded transitions skip their now-stale status emit so the winning transition emits the authoritative one. The initial connect is routed through the same queue so a config push right after the handshake-ack can't run a second concurrent `Connect`.

## Test plan

- [x] Bridge build: 0 warnings / 0 errors (`dotnet build`, Debug, net9.0).
- [x] Bridge xUnit: **88/88 pass** (was 86; +2 regression specs).
- [x] **Red/green proof**: with the supersede temporarily disabled, both new specs time out — reproducing the exact #35 hang; restoring the supersede makes them green.
  - `PostDeviceAuth_SwitchBackToCustom_ReDialsLocal_NotPinnedBehindTheStalledCloudConnect` — drives the real config-push + device-auth-commit path against a `FakeMcpPlugin` whose Cloud dial wedges until superseded.
  - `RunConnectionTransition_NewSubmissionSupersedesAStalledPredecessor` — locks the supersede contract directly.
- Live windowed UI re-verification of the exact repro is an operator follow-up (not headless-verifiable).

Closes #35
