### PR TITLE
chore(release): bump version 0.1.0 -> 0.2.0

### DIFF
--- a/UnrealMCP/UnrealMCP.uplugin
+++ b/UnrealMCP/UnrealMCP.uplugin
@@ -1,7 +1,7 @@
 {
   "FileVersion": 3,
   "Version": 1,
-  "VersionName": "0.1.0",
+  "VersionName": "0.2.0",
   "FriendlyName": "Unreal MCP (AI Game Developer)",
   "Description": "Model Context Protocol (MCP) integration for the Unreal Editor. Exposes editor operations as AI Tools so MCP-aware AI assistants (Claude, Cursor, Copilot, ...) can inspect and drive your Unreal project. Requires Unreal Engine 5.5+ (no EngineVersion pin: UE treats that field as an exact-build match, not a floor, and would refuse to load on newer engines).",
   "Category": "AI",

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>com.IvanMurzak.Unreal.MCP.Bridge</RootNamespace>
     <AssemblyName>unreal-mcp-bridge</AssemblyName>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2026 Ivan Murzak</Copyright>

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unreal-mcp-cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^13.1.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Cross-platform CLI tool for Unreal-MCP (Skills & MCP). Resolves and launches the Unreal editor with MCP connection env vars, runs MCP/system tools over HTTP, probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and manages the UnrealMCP plugin. Works with Claude Code, Cursor, Copilot, and any MCP client.",
   "type": "module",
   "main": "dist/lib.js",


### PR DESCRIPTION
Operator-approved release bump (Ivan approved 0.2.0 explicitly). First CI-driven release; cuts the first GitHub Release + `v0.2.0` tag and publishes `unreal-mcp-cli@0.2.0` to npm via OIDC Trusted Publishing on merge.

## What this release ships

The shared-server repoint (#41): the CLI downloads the shared **GameDev-MCP-Server v8.0.0** (binary `gamedev-mcp-server`) from [IvanMurzak/GameDev-MCP-Server](https://github.com/IvanMurzak/GameDev-MCP-Server) on `setup-mcp` into `<project>/Intermediate/UnrealMCP/server/<rid>/` (`UNREAL_MCP_SERVER_PATH` overrides for dev). No `unreal-mcp-server-<rid>.zip` assets are published from this repo anymore.

## Bump mechanics

- Bumped via `commands/bump-version.ps1 -NewVersion "0.2.0"` (rewrites `.uplugin` `VersionName`, bridge csproj `<Version>`, `cli/package.json` + lockfile — exactly the documented set).
- `cli/src/lib/server-version.ts` `SERVER_VERSION` untouched (already `8.0.0`); the `v8.0.0` GameDev-MCP-Server release with all 7 RID zips exists (release-order rule satisfied).
- Local `cd cli && npm ci && npm run build && npm test`: 144 passed, 1 skipped.
- Pre-merge ground truth: no releases / no `v*` tags on this repo; npm `unreal-mcp-cli` is at hand-published `0.1.0` — per docs/RELEASING.md the first CI release must bump past `0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)