### PR TITLE
feat(ui): AI agent configurators (Phase A) — foundation + Slate panel + 2 reference agents

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfig.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfig.h
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+
+/**
+ * How two JSON scalar values are compared when deciding whether a config entry already matches the desired
+ * state (Unity's ValueComparisonMode). Exact = byte-equal JSON; Url = scheme/host case-insensitive + trailing
+ * slash trimmed (so "http://localhost:8080/mcp" matches "http://localhost:8080/mcp/").
+ */
+enum class EUnrealMcpValueComparison : uint8
+{
+	Exact,
+	Url
+};
+
+/**
+ * Abstract base for an AI-agent MCP-client config file writer (docs/ARCHITECTURE.md §8; the C++/Unreal analog
+ * of Unity's AiAgentConfig and Godot's AgentConfigJson). One instance describes the desired server entry for a
+ * single transport (STDIO or HTTP) of a single agent, plus the on-disk file it lives in and the body path the
+ * server map nests under (e.g. "mcpServers"). Subclasses implement the format-specific read-merge-write
+ * (FJsonAiAgentConfig for JSON; a TOML subclass would slot in here if a Phase-A agent ever needs it).
+ *
+ * The read-merge-write contract every subclass MUST honour (the robustness lessons carried from Unity + Godot):
+ *  - Configure() preserves SIBLING server entries and unrelated top-level keys in the file; it only touches
+ *    THIS server's identity entry under the body path.
+ *  - It tolerates a missing / empty / invalid file by writing a fresh expected-content file (never throws).
+ *  - It creates parent directories as needed.
+ *  - It removes duplicate sibling entries that represent the SAME server under a different name (identity-key
+ *    match) and migrates away deprecated server names.
+ *
+ * Token discipline (§8): a config object holds the REAL bearer token (it must — it writes it to the file). It is
+ * NEVER logged. The on-screen masking lives one layer up in the Slate panel / view-model; this class is the
+ * file-writer and deals in real values only.
+ */
+class FAiAgentConfig
+{
+public:
+	/** The canonical server identity key written under the body path (shared with the cli's SERVER_KEY). */
+	static UNREALMCPEDITOR_API const TCHAR* DefaultMcpServerName;
+	/** The default body path a JSON agent nests its server map under. */
+	static UNREALMCPEDITOR_API const TCHAR* DefaultBodyPath;
+	/** Server names from earlier plugin generations that Configure()/Remove() clean up on sight. */
+	static UNREALMCPEDITOR_API const TArray<FString>& DeprecatedMcpServerNames();
+
+	FAiAgentConfig(const FString& InName, const FString& InConfigPath, const FString& InBodyPath = TEXT("mcpServers"))
+		: Name(InName)
+		, ConfigPath(InConfigPath)
+		, BodyPath(InBodyPath)
+	{
+	}
+
+	virtual ~FAiAgentConfig() = default;
+
+	/** Display label for the agent (diagnostics / UI). */
+	const FString& GetName() const { return Name; }
+	/** Absolute path to the config file this entry is written into (empty = snippet-only, e.g. Custom). */
+	const FString& GetConfigPath() const { return ConfigPath; }
+	/** The body path the server map nests under (e.g. "mcpServers"; "servers" for VS Code). */
+	const FString& GetBodyPath() const { return BodyPath; }
+
+	/** The full file content the entry would produce when written into an otherwise-empty file (UI preview). */
+	virtual FString GetExpectedFileContent() const = 0;
+
+	/** Write/merge this server entry into the file, preserving siblings + unrelated keys. Returns IsConfigured(). */
+	virtual bool Configure() = 0;
+	/** Remove this server entry (and any deprecated/duplicate aliases) from the file. Returns true if it changed. */
+	virtual bool Remove() = 0;
+	/** Whether an entry for this server (or a deprecated/duplicate alias) is present in the file at all. */
+	virtual bool IsDetected() const = 0;
+	/** Whether the present entry matches every required property of the desired config (no reconfigure needed). */
+	virtual bool IsConfigured() const = 0;
+
+protected:
+	FString Name;
+	FString ConfigPath;
+	FString BodyPath;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "Agents/AiAgentConfigurator.h"
+#include "Agents/JsonAiAgentConfig.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+
+FAiAgentConnectionInfo FAiAgentConnectionInfo::FromPluginConfig(const FUnrealMcpConfig& Config, const FString& InServerPath, int32 InPort)
+{
+	FAiAgentConnectionInfo Info;
+	Info.ServerPath = InServerPath;
+	Info.Port = InPort;
+
+	const bool bCloud = Config.ConnectionMode == EUnrealMcpConnectionMode::Cloud;
+
+	// The MCP-client URL is the effective host + "/mcp" (mirrors the cli's `${url}/mcp`). Cloud uses the cloud
+	// base URL; Custom uses the user's host. ResolveCloudBaseUrl/ResolveCustomHost already trim a trailing slash.
+	const FString BaseUrl = bCloud ? Config.ResolveCloudBaseUrl() : Config.ResolveCustomHost();
+	Info.HttpUrl = BaseUrl + TEXT("/mcp");
+
+	// Auth: Cloud always requires it (the cloud enforces it); Custom follows AuthOption. The token is the
+	// mode-resolved effective bearer (Cloud→cloudToken, Custom+Required→token, else empty).
+	Info.bAuthRequired = bCloud || Config.AuthOption == EUnrealMcpAuthOption::Required;
+	Info.Token = Config.ResolveEffectiveToken();
+
+	return Info;
+}
+
+void FAiAgentConfigurator::Initialize(const FAiAgentConnectionInfo& InConnection, const FString& InProjectRoot)
+{
+	Connection = InConnection;
+	ProjectRoot = InProjectRoot;
+	Invalidate();
+}
+
+void FAiAgentConfigurator::Invalidate()
+{
+	ConfigStdio.Reset();
+	ConfigHttp.Reset();
+}
+
+FJsonAiAgentConfig& FAiAgentConfigurator::GetConfigStdio()
+{
+	if (!ConfigStdio.IsValid())
+		ConfigStdio = BuildStdio();
+	return *ConfigStdio;
+}
+
+FJsonAiAgentConfig& FAiAgentConfigurator::GetConfigHttp()
+{
+	if (!ConfigHttp.IsValid())
+		ConfigHttp = BuildHttp();
+	return *ConfigHttp;
+}
+
+TSharedRef<FJsonAiAgentConfig> FAiAgentConfigurator::BuildStdio() const
+{
+	// STDIO form (the shared GameDev-MCP-Server CLI contract, identical to the cli's buildServerEntry):
+	//   { "type": "stdio", "command": <serverPath>, "args": ["port=N", "client-transport=stdio",
+	//     "authorization=required|none", "token=<token>"] }
+	// command is an identity key (ValueComparison::Path-equivalent → Exact is fine since we always emit the
+	// same normalized path). The HTTP-only keys (type=http url headers) are explicitly removed so a transport
+	// switch in the same file leaves no stale HTTP entry.
+	const FString Command = Connection.ServerPath.Replace(TEXT("\\"), TEXT("/"));
+
+	TArray<TSharedPtr<FJsonValue>> Args;
+	Args.Add(MakeShared<FJsonValueString>(FString::Printf(TEXT("port=%d"), Connection.Port)));
+	Args.Add(MakeShared<FJsonValueString>(TEXT("client-transport=stdio")));
+	Args.Add(MakeShared<FJsonValueString>(FString::Printf(TEXT("authorization=%s"), Connection.bAuthRequired ? TEXT("required") : TEXT("none"))));
+	Args.Add(MakeShared<FJsonValueString>(FString::Printf(TEXT("token=%s"), Connection.bAuthRequired ? *Connection.Token : TEXT(""))));
+
+	TSharedRef<FJsonAiAgentConfig> Config = MakeShared<FJsonAiAgentConfig>(
+		GetAgentName(),
+		GetConfigFilePath(ProjectRoot),
+		GetBodyPath());
+
+	Config->SetStringProperty(TEXT("type"), TEXT("stdio"), /*bRequired*/ true);
+	Config->SetStringProperty(TEXT("command"), Command, /*bRequired*/ true);
+	Config->SetProperty(TEXT("args"), MakeShared<FJsonValueArray>(Args), /*bRequired*/ true);
+	// Drop the HTTP-only keys so a stdio write over a prior http entry is clean.
+	Config->SetPropertyToRemove(TEXT("url"));
+	Config->SetPropertyToRemove(TEXT("headers"));
+
+	return Config;
+}
+
+TSharedRef<FJsonAiAgentConfig> FAiAgentConfigurator::BuildHttp() const
+{
+	// HTTP form (identical to the cli's buildServerEntry):
+	//   { "type": "http", "url": "<host>/mcp", "headers": { "Authorization": "Bearer <token>" }? }
+	// url is compared with URL semantics (trailing-slash / case tolerant). The header is added ONLY when auth is
+	// required AND a token exists; otherwise it is explicitly removed so toggling auth off scrubs a stale header.
+	TSharedRef<FJsonAiAgentConfig> Config = MakeShared<FJsonAiAgentConfig>(
+		GetAgentName(),
+		GetConfigFilePath(ProjectRoot),
+		GetBodyPath());
+
+	Config->SetStringProperty(TEXT("type"), TEXT("http"), /*bRequired*/ true);
+	Config->SetStringProperty(TEXT("url"), Connection.HttpUrl, /*bRequired*/ true, EUnrealMcpValueComparison::Url);
+
+	if (Connection.bAuthRequired && !Connection.Token.IsEmpty())
+	{
+		TSharedPtr<FJsonObject> Headers = MakeShared<FJsonObject>();
+		Headers->SetStringField(TEXT("Authorization"), FString::Printf(TEXT("Bearer %s"), *Connection.Token));
+		Config->SetProperty(TEXT("headers"), MakeShared<FJsonValueObject>(Headers), /*bRequired*/ true);
+	}
+	else
+	{
+		Config->SetPropertyToRemove(TEXT("headers"));
+	}
+
+	// Drop the STDIO-only keys so an http write over a prior stdio entry is clean.
+	Config->SetPropertyToRemove(TEXT("command"));
+	Config->SetPropertyToRemove(TEXT("args"));
+
+	return Config;
+}
+
+bool FAiAgentConfigurator::IsAnyDetected()
+{
+	return GetConfigStdio().IsDetected() || GetConfigHttp().IsDetected();
+}
+
+bool FAiAgentConfigurator::IsConfigured(bool bStdio)
+{
+	return bStdio ? GetConfigStdio().IsConfigured() : GetConfigHttp().IsConfigured();
+}
+
+bool FAiAgentConfigurator::Configure(bool bStdio)
+{
+	const bool bResult = bStdio ? GetConfigStdio().Configure() : GetConfigHttp().Configure();
+	// A write changes IsConfigured/IsDetected for BOTH cached configs (same file); rebuild on next access.
+	Invalidate();
+	return bResult;
+}
+
+bool FAiAgentConfigurator::RemoveAll()
+{
+	// Remove via either transport's config — both share the same file/body/identity, and Remove() clears the
+	// canonical entry + deprecated + duplicate aliases regardless of which transport object calls it.
+	const bool bResult = GetConfigStdio().Remove();
+	Invalidate();
+	return bResult;
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.h
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Config/UnrealMcpConfig.h"
+
+class FAiAgentConfig;
+class FJsonAiAgentConfig;
+
+/**
+ * The resolved connection facts an FAiAgentConfigurator needs to assemble its STDIO + HTTP MCP-client entries
+ * (docs/ARCHITECTURE.md §8). Sourced from the live plugin config — NOT from any Unity/Godot path:
+ *
+ *  - ServerPath  — absolute path to the local `gamedev-mcp-server` binary the STDIO form launches (§6). May be
+ *                  empty in the editor before the cli has downloaded it; the STDIO snippet is still useful as a
+ *                  template and the file write still succeeds (the path is just not yet present).
+ *  - Port        — the deterministic IPC port for this project (§1.1, FUnrealMcpBridgeServer::ComputeDeterministicPort).
+ *  - HttpUrl     — the resolved MCP-client URL the HTTP form points at: <effective host>/mcp (Custom host or the
+ *                  Cloud base URL), mirroring the cli's `${url}/mcp` contract.
+ *  - bAuthRequired / Token — whether a bearer is sent and its real value. In Cloud mode auth is always required
+ *                  (the cloud enforces it); in Custom mode it follows AuthOption. The Token is the REAL bearer —
+ *                  the on-screen masking happens in the Slate panel, never here.
+ *
+ * Built by FromPluginConfig() from an FUnrealMcpConfig so the whole class is unit-testable with a hand-built
+ * config and an injected ServerPath/Port (no live editor, bridge, or agent).
+ */
+struct FAiAgentConnectionInfo
+{
+	FString ServerPath;
+	int32 Port = 0;
+	FString HttpUrl;
+	bool bAuthRequired = false;
+	FString Token;
+
+	/**
+	 * Resolve the connection facts from the live plugin config. @p InServerPath is the §6 server binary path
+	 * (resolved by the caller from the cli/install layout; may be empty). @p InPort is the deterministic IPC port.
+	 */
+	static UNREALMCPEDITOR_API FAiAgentConnectionInfo FromPluginConfig(const FUnrealMcpConfig& Config, const FString& InServerPath, int32 InPort);
+};
+
+/**
+ * Abstract base for an AI-agent configurator (docs/ARCHITECTURE.md §7/§8) — the C++/Slate analog of Unity's
+ * AiAgentConfigurator and Godot's GodotAgentConfigurator. Unlike Godot (HTTP-only, no server shipped), Unreal
+ * ships a server, so — like Unity — every configurator emits BOTH a STDIO (launch-the-server) and an HTTP
+ * (connect-to-URL) client config. A subclass supplies identity (name/id/download/tutorial) and the per-agent
+ * config-file path + body path; this base assembles the two FJsonAiAgentConfig objects, injecting the bearer
+ * token into the STDIO args and the HTTP Authorization header per the resolved auth state.
+ *
+ * Lifetime / threading: a configurator is a lightweight value object created on the game thread by the registry
+ * and the Slate panel. It caches its two configs lazily and rebuilds them when the connection info changes
+ * (Invalidate). All symbols are UNREALMCPEDITOR_API-exported so the specs drive them directly.
+ */
+class FAiAgentConfigurator
+{
+public:
+	virtual ~FAiAgentConfigurator() = default;
+
+	// --- Identity (subclass-supplied). ---
+	virtual FString GetAgentName() const = 0;
+	virtual FString GetAgentId() const = 0;
+	virtual FString GetDownloadUrl() const = 0;
+	virtual FString GetTutorialUrl() const { return FString(); }
+	virtual FString GetIconFileName() const { return FString(); }
+
+	/**
+	 * Absolute path to this agent's MCP config file (project-relative resolved to absolute). Empty for a
+	 * snippet-only configurator (e.g. a future Custom entry). @p ProjectRoot is the live project root.
+	 */
+	virtual FString GetConfigFilePath(const FString& ProjectRoot) const = 0;
+	/** The JSON body path this agent nests its server map under (Claude Code / Cursor: "mcpServers"). */
+	virtual FString GetBodyPath() const { return TEXT("mcpServers"); }
+
+	// --- Config assembly. ---
+
+	/** (Re)bind the configurator to the resolved connection info + project root; invalidates the cached configs. */
+	UNREALMCPEDITOR_API void Initialize(const FAiAgentConnectionInfo& InConnection, const FString& InProjectRoot);
+	/** Drop the cached configs so the next Get* call rebuilds them (after a connection/token change). */
+	UNREALMCPEDITOR_API void Invalidate();
+
+	/** The STDIO (launch-the-server) MCP-client config for this agent. Lazily built; never null after Initialize. */
+	UNREALMCPEDITOR_API FJsonAiAgentConfig& GetConfigStdio();
+	/** The HTTP (connect-to-URL) MCP-client config for this agent. Lazily built; never null after Initialize. */
+	UNREALMCPEDITOR_API FJsonAiAgentConfig& GetConfigHttp();
+
+	// --- Status helpers (across both transports, like Unity's RefreshConfigurationUI). ---
+
+	/** Whether EITHER transport's entry is present in the file (drives the Remove-button enabled state). */
+	UNREALMCPEDITOR_API bool IsAnyDetected();
+	/** Whether the entry matching @p bStdio is fully configured (no reconfigure needed). */
+	UNREALMCPEDITOR_API bool IsConfigured(bool bStdio);
+	/** Configure the entry for the chosen transport (writes/merges the file). Returns success. */
+	UNREALMCPEDITOR_API bool Configure(bool bStdio);
+	/** Remove BOTH transports' entries from the file (a single Remove clears the agent regardless of transport). */
+	UNREALMCPEDITOR_API bool RemoveAll();
+
+protected:
+	FAiAgentConnectionInfo Connection;
+	FString ProjectRoot;
+
+private:
+	TSharedPtr<FJsonAiAgentConfig> ConfigStdio;
+	TSharedPtr<FJsonAiAgentConfig> ConfigHttp;
+
+	TSharedRef<FJsonAiAgentConfig> BuildStdio() const;
+	TSharedRef<FJsonAiAgentConfig> BuildHttp() const;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfiguratorRegistry.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfiguratorRegistry.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "Agents/AiAgentConfiguratorRegistry.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Agents/Impl/ClaudeCodeConfigurator.h"
+#include "Agents/Impl/CursorConfigurator.h"
+
+TArray<TSharedRef<FAiAgentConfigurator>> FAiAgentConfiguratorRegistry::MakeDefault()
+{
+	// Phase A: the two reference agents. Sorted alphabetically by display name (matches Unity/Godot), which keeps
+	// the dropdown stable as Phase B adds agents. A future Custom configurator is appended AFTER the sort so it
+	// always stays last regardless of its name.
+	TArray<TSharedRef<FAiAgentConfigurator>> Configurators;
+	Configurators.Add(MakeShared<FClaudeCodeConfigurator>());
+	Configurators.Add(MakeShared<FCursorConfigurator>());
+
+	Configurators.Sort([](const TSharedRef<FAiAgentConfigurator>& A, const TSharedRef<FAiAgentConfigurator>& B)
+	{
+		return A->GetAgentName() < B->GetAgentName();
+	});
+
+	// (Phase B) append the Custom configurator here, after the sort, to preserve the Custom-last invariant.
+
+	return Configurators;
+}
+
+FAiAgentConfiguratorRegistry::FAiAgentConfiguratorRegistry(TArray<TSharedRef<FAiAgentConfigurator>> InConfigurators)
+	: Configurators(MoveTemp(InConfigurators))
+{
+}
+
+FAiAgentConfiguratorRegistry::FAiAgentConfiguratorRegistry()
+	: Configurators(MakeDefault())
+{
+}
+
+int32 FAiAgentConfiguratorRegistry::Num() const
+{
+	return Configurators.Num();
+}
+
+TArray<FString> FAiAgentConfiguratorRegistry::GetAgentNames() const
+{
+	TArray<FString> Names;
+	Names.Reserve(Configurators.Num());
+	for (const TSharedRef<FAiAgentConfigurator>& Configurator : Configurators)
+		Names.Add(Configurator->GetAgentName());
+	return Names;
+}
+
+TArray<FString> FAiAgentConfiguratorRegistry::GetAgentIds() const
+{
+	TArray<FString> Ids;
+	Ids.Reserve(Configurators.Num());
+	for (const TSharedRef<FAiAgentConfigurator>& Configurator : Configurators)
+		Ids.Add(Configurator->GetAgentId());
+	return Ids;
+}
+
+TSharedPtr<FAiAgentConfigurator> FAiAgentConfiguratorRegistry::GetByAgentId(const FString& AgentId) const
+{
+	for (const TSharedRef<FAiAgentConfigurator>& Configurator : Configurators)
+		if (Configurator->GetAgentId() == AgentId)
+			return Configurator;
+	return nullptr;
+}
+
+TSharedPtr<FAiAgentConfigurator> FAiAgentConfiguratorRegistry::GetByIndex(int32 Index) const
+{
+	return Configurators.IsValidIndex(Index) ? TSharedPtr<FAiAgentConfigurator>(Configurators[Index]) : nullptr;
+}
+
+int32 FAiAgentConfiguratorRegistry::GetIndexByAgentId(const FString& AgentId) const
+{
+	for (int32 i = 0; i < Configurators.Num(); ++i)
+		if (Configurators[i]->GetAgentId() == AgentId)
+			return i;
+	return INDEX_NONE;
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfiguratorRegistry.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfiguratorRegistry.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FAiAgentConfigurator;
+
+/**
+ * Ordered registry of the available AI-agent configurators (docs/ARCHITECTURE.md §7) — the C++ analog of Unity's
+ * AiAgentConfiguratorRegistry and Godot's GodotAgentConfiguratorRegistry. Phase A registers the two reference
+ * agents (Claude Code, Cursor); Phase B fills in the rest and a Custom entry that is kept LAST (the Custom-last
+ * invariant the registry guarantees regardless of insertion order, mirroring the siblings).
+ *
+ * Each call to MakeDefault() returns a fresh, independent set of configurator instances (they cache per-binding
+ * config state, so the Slate panel and a spec each want their own). Lookups by id / index / name are provided for
+ * the dropdown (index) and persistence (id).
+ */
+class FAiAgentConfiguratorRegistry
+{
+public:
+	/** Build the default ordered configurator set (alphabetical by name; a Custom entry, when present, stays last). */
+	static UNREALMCPEDITOR_API TArray<TSharedRef<FAiAgentConfigurator>> MakeDefault();
+
+	/** Construct around a supplied set (the production set or a spec's set). The registry does not own creation. */
+	UNREALMCPEDITOR_API explicit FAiAgentConfiguratorRegistry(TArray<TSharedRef<FAiAgentConfigurator>> InConfigurators);
+	/** Convenience: construct around MakeDefault(). */
+	UNREALMCPEDITOR_API FAiAgentConfiguratorRegistry();
+
+	const TArray<TSharedRef<FAiAgentConfigurator>>& All() const { return Configurators; }
+	UNREALMCPEDITOR_API int32 Num() const;
+
+	/** All display names in registry order (for the dropdown). */
+	UNREALMCPEDITOR_API TArray<FString> GetAgentNames() const;
+	/** All agent ids in registry order. */
+	UNREALMCPEDITOR_API TArray<FString> GetAgentIds() const;
+
+	/** The configurator with @p AgentId, or null. */
+	UNREALMCPEDITOR_API TSharedPtr<FAiAgentConfigurator> GetByAgentId(const FString& AgentId) const;
+	/** The configurator at @p Index, or null when out of range. */
+	UNREALMCPEDITOR_API TSharedPtr<FAiAgentConfigurator> GetByIndex(int32 Index) const;
+	/** The registry index of @p AgentId, or INDEX_NONE. */
+	UNREALMCPEDITOR_API int32 GetIndexByAgentId(const FString& AgentId) const;
+
+private:
+	TArray<TSharedRef<FAiAgentConfigurator>> Configurators;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ClaudeCodeConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ClaudeCodeConfigurator.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Misc/Paths.h"
+
+/**
+ * Claude Code configurator (docs/ARCHITECTURE.md §7). Writes the project-level `.mcp.json` at the project root,
+ * nesting under "mcpServers" — exactly the cli's claude-code agent def (cli/src/lib/setup-mcp.ts) and Unity's
+ * ClaudeCodeConfigurator. Phase-A reference agent #1.
+ */
+class FClaudeCodeConfigurator : public FAiAgentConfigurator
+{
+public:
+	virtual FString GetAgentName() const override { return TEXT("Claude Code"); }
+	virtual FString GetAgentId() const override { return TEXT("claude-code"); }
+	virtual FString GetDownloadUrl() const override { return TEXT("https://docs.anthropic.com/en/docs/claude-code/overview"); }
+	virtual FString GetIconFileName() const override { return TEXT("claude-64.png"); }
+
+	virtual FString GetConfigFilePath(const FString& InProjectRoot) const override
+	{
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".mcp.json")));
+	}
+	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/CursorConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/CursorConfigurator.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Misc/Paths.h"
+
+/**
+ * Cursor configurator (docs/ARCHITECTURE.md §7). Writes `.cursor/mcp.json` under the project root, nesting under
+ * "mcpServers" — exactly the cli's cursor agent def (cli/src/lib/setup-mcp.ts) and Unity's CursorConfigurator.
+ * Phase-A reference agent #2.
+ */
+class FCursorConfigurator : public FAiAgentConfigurator
+{
+public:
+	virtual FString GetAgentName() const override { return TEXT("Cursor"); }
+	virtual FString GetAgentId() const override { return TEXT("cursor"); }
+	virtual FString GetDownloadUrl() const override { return TEXT("https://cursor.com/download"); }
+	virtual FString GetIconFileName() const override { return TEXT("cursor-64.png"); }
+
+	virtual FString GetConfigFilePath(const FString& InProjectRoot) const override
+	{
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".cursor"), TEXT("mcp.json")));
+	}
+	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/JsonAiAgentConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/JsonAiAgentConfig.cpp
@@ -145,7 +145,9 @@ bool FJsonAiAgentConfig::WriteRoot(const TSharedPtr<FJsonObject>& Root) const
 	if (!Dir.IsEmpty())
 		IFileManager::Get().MakeDirectory(*Dir, /*Tree*/ true);
 
-	return FFileHelper::SaveStringToFile(Serialized, *ConfigPath);
+	// Force UTF-8 without a BOM: .mcp.json / .cursor/mcp.json are consumed by Node-based agents and the cli,
+	// and the default AutoDetect encoding can emit a UTF-8 BOM / UTF-16 that those JSON parsers choke on.
+	return FFileHelper::SaveStringToFile(Serialized, *ConfigPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
 }
 
 TSharedPtr<FJsonObject> FJsonAiAgentConfig::NavigateToBody(const TSharedPtr<FJsonObject>& Root, const TArray<FString>& Segments)
@@ -237,7 +239,8 @@ bool FJsonAiAgentConfig::Configure()
 		const FString Dir = FPaths::GetPath(ConfigPath);
 		if (!Dir.IsEmpty())
 			IFileManager::Get().MakeDirectory(*Dir, /*Tree*/ true);
-		if (!FFileHelper::SaveStringToFile(GetExpectedFileContent(), *ConfigPath))
+		// Force UTF-8 without a BOM (see WriteRoot): Node/cli JSON parsers must not see a BOM.
+		if (!FFileHelper::SaveStringToFile(GetExpectedFileContent(), *ConfigPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
 			return false;
 		return IsConfigured();
 	}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/JsonAiAgentConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/JsonAiAgentConfig.cpp
@@ -1,0 +1,437 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "Agents/JsonAiAgentConfig.h"
+
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "HAL/FileManager.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+// --- FAiAgentConfig statics (defined here, the only TU that needs them outside headers). ---
+const TCHAR* FAiAgentConfig::DefaultMcpServerName = TEXT("unreal-mcp");
+const TCHAR* FAiAgentConfig::DefaultBodyPath = TEXT("mcpServers");
+
+const TArray<FString>& FAiAgentConfig::DeprecatedMcpServerNames()
+{
+	// Earlier generations / sibling engines wrote the server under these names; clean them up on sight so a
+	// project migrated from a pre-release plugin (or hand-edited) ends up with exactly one canonical entry.
+	static const TArray<FString> Names = { TEXT("Unreal-MCP"), TEXT("ai-game-developer") };
+	return Names;
+}
+
+FJsonAiAgentConfig::FJsonAiAgentConfig(const FString& InName, const FString& InConfigPath, const FString& InBodyPath)
+	: FAiAgentConfig(InName, InConfigPath, InBodyPath)
+{
+	// Default identity keys mirror Unity's: a sibling entry sharing our command or url is the same server.
+	IdentityKeys = { TEXT("command"), TEXT("url") };
+}
+
+FJsonAiAgentConfig& FJsonAiAgentConfig::SetProperty(const FString& Key, const TSharedPtr<FJsonValue>& Value, bool bRequired, EUnrealMcpValueComparison Comparison)
+{
+	if (!Properties.Contains(Key))
+		PropertyOrder.Add(Key);
+	Properties.Add(Key, FDesiredProperty{ Value, bRequired, Comparison });
+	// A property that is being SET cannot also be in the to-remove list (the last call wins).
+	PropertiesToRemove.Remove(Key);
+	return *this;
+}
+
+FJsonAiAgentConfig& FJsonAiAgentConfig::SetStringProperty(const FString& Key, const FString& Value, bool bRequired, EUnrealMcpValueComparison Comparison)
+{
+	return SetProperty(Key, MakeShared<FJsonValueString>(Value), bRequired, Comparison);
+}
+
+FJsonAiAgentConfig& FJsonAiAgentConfig::SetPropertyToRemove(const FString& Key)
+{
+	if (Properties.Contains(Key))
+	{
+		Properties.Remove(Key);
+		PropertyOrder.Remove(Key);
+	}
+	PropertiesToRemove.AddUnique(Key);
+	return *this;
+}
+
+FJsonAiAgentConfig& FJsonAiAgentConfig::AddIdentityKey(const FString& Key)
+{
+	IdentityKeys.AddUnique(Key);
+	return *this;
+}
+
+TArray<FString> FJsonAiAgentConfig::BodyPathSegments(const FString& InBodyPath)
+{
+	TArray<FString> Segments;
+	FString Trimmed = InBodyPath;
+	Trimmed.TrimStartAndEndInline();
+	if (Trimmed.IsEmpty())
+		return Segments;
+	Trimmed.ParseIntoArray(Segments, TEXT("/"), /*CullEmpty*/ true);
+	return Segments;
+}
+
+TSharedPtr<FJsonObject> FJsonAiAgentConfig::BuildServerEntry() const
+{
+	TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+	// Deterministic output: alphabetical key order (matches Unity's OrderBy(Ordinal)).
+	TArray<FString> SortedKeys = PropertyOrder;
+	SortedKeys.Sort();
+	for (const FString& Key : SortedKeys)
+	{
+		const FDesiredProperty& Prop = Properties[Key];
+		Entry->SetField(Key, Prop.Value);
+	}
+	return Entry;
+}
+
+FString FJsonAiAgentConfig::GetExpectedFileContent() const
+{
+	const TArray<FString> Segments = BodyPathSegments(BodyPath);
+
+	TSharedPtr<FJsonObject> Inner = MakeShared<FJsonObject>();
+	Inner->SetObjectField(DefaultMcpServerName, BuildServerEntry());
+
+	// Wrap from innermost to outermost so the body path nests correctly.
+	TSharedPtr<FJsonObject> Result = Inner;
+	for (int32 i = Segments.Num() - 1; i >= 0; --i)
+	{
+		TSharedPtr<FJsonObject> Wrapper = MakeShared<FJsonObject>();
+		Wrapper->SetObjectField(Segments[i], Result);
+		Result = Wrapper;
+	}
+
+	FString Serialized;
+	const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> Writer =
+		TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Serialized);
+	FJsonSerializer::Serialize(Result.ToSharedRef(), Writer);
+	return Serialized;
+}
+
+bool FJsonAiAgentConfig::TryReadRoot(TSharedPtr<FJsonObject>& OutRoot) const
+{
+	OutRoot.Reset();
+	if (ConfigPath.IsEmpty() || !FPaths::FileExists(ConfigPath))
+		return false;
+
+	FString Json;
+	if (!FFileHelper::LoadFileToString(Json, *ConfigPath))
+		return false;
+	if (Json.TrimStartAndEnd().IsEmpty())
+		return false;
+
+	const TSharedRef<TJsonReader<TCHAR>> Reader = TJsonReaderFactory<TCHAR>::Create(Json);
+	TSharedPtr<FJsonObject> Parsed;
+	if (!FJsonSerializer::Deserialize(Reader, Parsed) || !Parsed.IsValid())
+		return false; // invalid / non-object → treated as "no config" by the caller
+
+	OutRoot = Parsed;
+	return true;
+}
+
+bool FJsonAiAgentConfig::WriteRoot(const TSharedPtr<FJsonObject>& Root) const
+{
+	if (ConfigPath.IsEmpty() || !Root.IsValid())
+		return false;
+
+	FString Serialized;
+	const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> Writer =
+		TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Serialized);
+	if (!FJsonSerializer::Serialize(Root.ToSharedRef(), Writer))
+		return false;
+
+	const FString Dir = FPaths::GetPath(ConfigPath);
+	if (!Dir.IsEmpty())
+		IFileManager::Get().MakeDirectory(*Dir, /*Tree*/ true);
+
+	return FFileHelper::SaveStringToFile(Serialized, *ConfigPath);
+}
+
+TSharedPtr<FJsonObject> FJsonAiAgentConfig::NavigateToBody(const TSharedPtr<FJsonObject>& Root, const TArray<FString>& Segments)
+{
+	TSharedPtr<FJsonObject> Current = Root;
+	for (const FString& Segment : Segments)
+	{
+		if (!Current.IsValid())
+			return nullptr;
+		const TSharedPtr<FJsonObject>* Child = nullptr;
+		if (!Current->TryGetObjectField(Segment, Child) || Child == nullptr)
+			return nullptr;
+		Current = *Child;
+	}
+	return Current;
+}
+
+TSharedPtr<FJsonObject> FJsonAiAgentConfig::EnsureBody(const TSharedPtr<FJsonObject>& Root, const TArray<FString>& Segments)
+{
+	TSharedPtr<FJsonObject> Current = Root;
+	for (const FString& Segment : Segments)
+	{
+		const TSharedPtr<FJsonObject>* Child = nullptr;
+		if (Current->TryGetObjectField(Segment, Child) && Child != nullptr)
+		{
+			Current = *Child;
+		}
+		else
+		{
+			// Missing OR present-but-not-an-object: overwrite with a fresh object (Unity's EnsureJsonPathExists).
+			TSharedPtr<FJsonObject> NewObj = MakeShared<FJsonObject>();
+			Current->SetObjectField(Segment, NewObj);
+			Current = NewObj;
+		}
+	}
+	return Current;
+}
+
+TArray<FString> FJsonAiAgentConfig::FindDuplicateServerEntryKeys(const TSharedPtr<FJsonObject>& Body) const
+{
+	TArray<FString> Result;
+	if (!Body.IsValid())
+		return Result;
+
+	// Our identity values (only those we actually set as desired properties).
+	TArray<TPair<FString, FDesiredProperty>> OurIdentities;
+	for (const FString& IdKey : IdentityKeys)
+	{
+		if (const FDesiredProperty* Prop = Properties.Find(IdKey))
+			OurIdentities.Add(TPair<FString, FDesiredProperty>(IdKey, *Prop));
+	}
+	if (OurIdentities.Num() == 0)
+		return Result;
+
+	for (const auto& Pair : Body->Values)
+	{
+		if (Pair.Key == DefaultMcpServerName)
+			continue;
+		if (!Pair.Value.IsValid() || Pair.Value->Type != EJson::Object)
+			continue;
+		const TSharedPtr<FJsonObject> Entry = Pair.Value->AsObject();
+		if (!Entry.IsValid())
+			continue;
+
+		for (const auto& Identity : OurIdentities)
+		{
+			const TSharedPtr<FJsonValue> ExistingValue = Entry->TryGetField(Identity.Key);
+			if (ExistingValue.IsValid() && AreValuesEquivalent(Identity.Value.Comparison, Identity.Value.Value, ExistingValue))
+			{
+				Result.AddUnique(Pair.Key);
+				break;
+			}
+		}
+	}
+	return Result;
+}
+
+bool FJsonAiAgentConfig::Configure()
+{
+	if (ConfigPath.IsEmpty())
+		return false;
+
+	const TArray<FString> Segments = BodyPathSegments(BodyPath);
+
+	TSharedPtr<FJsonObject> Root;
+	if (!TryReadRoot(Root))
+	{
+		// Missing / empty / invalid file → write a clean expected-content file (parent dirs created in WriteRoot).
+		const FString Dir = FPaths::GetPath(ConfigPath);
+		if (!Dir.IsEmpty())
+			IFileManager::Get().MakeDirectory(*Dir, /*Tree*/ true);
+		if (!FFileHelper::SaveStringToFile(GetExpectedFileContent(), *ConfigPath))
+			return false;
+		return IsConfigured();
+	}
+
+	TSharedPtr<FJsonObject> Body = EnsureBody(Root, Segments);
+
+	// Remove deprecated server entries.
+	for (const FString& Deprecated : DeprecatedMcpServerNames())
+		Body->RemoveField(Deprecated);
+
+	// Remove sibling duplicates (same server under a different name).
+	for (const FString& DupKey : FindDuplicateServerEntryKeys(Body))
+		Body->RemoveField(DupKey);
+
+	// Get-or-create the canonical server entry.
+	TSharedPtr<FJsonObject> Entry;
+	const TSharedPtr<FJsonObject>* ExistingEntry = nullptr;
+	if (Body->TryGetObjectField(FString(DefaultMcpServerName), ExistingEntry) && ExistingEntry != nullptr)
+		Entry = *ExistingEntry;
+	else
+		Entry = MakeShared<FJsonObject>();
+
+	// Drop the keys that must not be present (the other transport's keys / stale headers).
+	for (const FString& Key : PropertiesToRemove)
+		Entry->RemoveField(Key);
+
+	// Set the desired properties (deterministic key order).
+	TArray<FString> SortedKeys = PropertyOrder;
+	SortedKeys.Sort();
+	for (const FString& Key : SortedKeys)
+		Entry->SetField(Key, Properties[Key].Value);
+
+	Body->SetObjectField(DefaultMcpServerName, Entry);
+
+	if (!WriteRoot(Root))
+		return false;
+
+	return IsConfigured();
+}
+
+bool FJsonAiAgentConfig::Remove()
+{
+	if (ConfigPath.IsEmpty())
+		return false;
+
+	const TArray<FString> Segments = BodyPathSegments(BodyPath);
+
+	TSharedPtr<FJsonObject> Root;
+	if (!TryReadRoot(Root))
+		return false; // nothing to remove from
+
+	TSharedPtr<FJsonObject> Body = NavigateToBody(Root, Segments);
+	if (!Body.IsValid())
+		return false;
+
+	bool bRemoved = false;
+
+	if (Body->HasField(FString(DefaultMcpServerName)))
+	{
+		Body->RemoveField(DefaultMcpServerName);
+		bRemoved = true;
+	}
+
+	for (const FString& Deprecated : DeprecatedMcpServerNames())
+	{
+		if (Body->HasField(Deprecated))
+		{
+			Body->RemoveField(Deprecated);
+			bRemoved = true;
+		}
+	}
+
+	for (const FString& DupKey : FindDuplicateServerEntryKeys(Body))
+	{
+		Body->RemoveField(DupKey);
+		bRemoved = true;
+	}
+
+	if (!bRemoved)
+		return false;
+
+	return WriteRoot(Root);
+}
+
+bool FJsonAiAgentConfig::IsDetected() const
+{
+	const TArray<FString> Segments = BodyPathSegments(BodyPath);
+
+	TSharedPtr<FJsonObject> Root;
+	if (!TryReadRoot(Root))
+		return false;
+
+	TSharedPtr<FJsonObject> Body = NavigateToBody(Root, Segments);
+	if (!Body.IsValid())
+		return false;
+
+	if (Body->HasField(FString(DefaultMcpServerName)))
+		return true;
+
+	for (const FString& Deprecated : DeprecatedMcpServerNames())
+		if (Body->HasField(Deprecated))
+			return true;
+
+	return FindDuplicateServerEntryKeys(Body).Num() > 0;
+}
+
+bool FJsonAiAgentConfig::IsConfigured() const
+{
+	const TArray<FString> Segments = BodyPathSegments(BodyPath);
+
+	TSharedPtr<FJsonObject> Root;
+	if (!TryReadRoot(Root))
+		return false;
+
+	TSharedPtr<FJsonObject> Body = NavigateToBody(Root, Segments);
+	if (!Body.IsValid())
+		return false;
+
+	const TSharedPtr<FJsonObject>* Entry = nullptr;
+	if (!Body->TryGetObjectField(FString(DefaultMcpServerName), Entry) || Entry == nullptr)
+		return false;
+
+	return AreRequiredPropertiesMatching(*Entry) && !HasAnyPropertyToRemove(*Entry);
+}
+
+bool FJsonAiAgentConfig::AreRequiredPropertiesMatching(const TSharedPtr<FJsonObject>& Entry) const
+{
+	if (!Entry.IsValid())
+		return false;
+
+	for (const FString& Key : PropertyOrder)
+	{
+		const FDesiredProperty& Prop = Properties[Key];
+		if (!Prop.bRequired)
+			continue;
+		const TSharedPtr<FJsonValue> Existing = Entry->TryGetField(Key);
+		if (!Existing.IsValid())
+			return false;
+		if (!AreValuesEquivalent(Prop.Comparison, Prop.Value, Existing))
+			return false;
+	}
+	return true;
+}
+
+bool FJsonAiAgentConfig::HasAnyPropertyToRemove(const TSharedPtr<FJsonObject>& Entry) const
+{
+	if (!Entry.IsValid() || PropertiesToRemove.Num() == 0)
+		return false;
+	for (const FString& Key : PropertiesToRemove)
+		if (Entry->HasField(Key))
+			return true;
+	return false;
+}
+
+bool FJsonAiAgentConfig::AreValuesEquivalent(EUnrealMcpValueComparison Comparison, const TSharedPtr<FJsonValue>& Expected, const TSharedPtr<FJsonValue>& Actual)
+{
+	if (!Expected.IsValid() || !Actual.IsValid())
+		return false;
+
+	if (Comparison == EUnrealMcpValueComparison::Url)
+	{
+		FString ExpectedStr, ActualStr;
+		if (Expected->TryGetString(ExpectedStr) && Actual->TryGetString(ActualStr))
+			return NormalizeUrl(ExpectedStr) == NormalizeUrl(ActualStr);
+	}
+
+	return JsonValueToString(Expected) == JsonValueToString(Actual);
+}
+
+FString FJsonAiAgentConfig::NormalizeUrl(const FString& Url)
+{
+	// Lowercase + trim a single trailing slash. Good enough for the http(s)://host:port/mcp shapes we emit
+	// (no need for full URI parsing — the server URL is always our own deterministic form).
+	FString Normalized = Url.ToLower();
+	Normalized.TrimStartAndEndInline();
+	while (Normalized.EndsWith(TEXT("/")))
+		Normalized.LeftChopInline(1);
+	return Normalized;
+}
+
+FString FJsonAiAgentConfig::JsonValueToString(const TSharedPtr<FJsonValue>& Value)
+{
+	if (!Value.IsValid())
+		return FString();
+
+	// Serialize the value into a canonical JSON string so objects/arrays/scalars all compare structurally.
+	// Wrap it under a fixed key and serialize the object (the always-available object-serialize overload),
+	// sidestepping the single-value writer overload's element-name handling.
+	TSharedPtr<FJsonObject> Wrapper = MakeShared<FJsonObject>();
+	Wrapper->SetField(TEXT("v"), Value);
+
+	FString Out;
+	const TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =
+		TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&Out);
+	FJsonSerializer::Serialize(Wrapper.ToSharedRef(), Writer);
+	return Out;
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/JsonAiAgentConfig.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/JsonAiAgentConfig.h
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfig.h"
+
+/**
+ * JSON read-merge-write implementation of FAiAgentConfig (docs/ARCHITECTURE.md §8), the C++/UE-Json analog of
+ * Unity's JsonAiAgentConfig and Godot's AgentConfigJson. Handles every Phase-A agent (Claude Code's `.mcp.json`
+ * and Cursor's `.cursor/mcp.json` both nest under "mcpServers").
+ *
+ * Desired-entry model: properties are accumulated via SetProperty (a value, whether it is required for the entry
+ * to be considered "configured", and how it is compared) and SetPropertyToRemove (a key that must NOT be present
+ * on the entry — used to drop the OTHER transport's keys, e.g. an HTTP config removes "command"/"args"). On
+ * Configure(), the file is parsed, the body path is navigated/created, deprecated + duplicate sibling entries are
+ * pruned, the server entry under DefaultMcpServerName is created-or-merged, the to-remove keys are deleted, and
+ * every desired property is set (deterministic key order). Sibling servers + unrelated top-level keys survive.
+ *
+ * Robustness (the Unity/Godot lessons, spec-covered): a missing/empty/whitespace/invalid/non-object file is
+ * treated as "no config" and replaced with the clean expected content rather than throwing; parent directories
+ * are created. Identity keys (default {"command","url"}) let RemoveDuplicateServerEntries collapse the same
+ * server written under a different name.
+ *
+ * All symbols are UNREALMCPEDITOR_API-exported so the UnrealMcpEditorTests Automation specs drive them directly
+ * against temp files with no live editor / agent.
+ */
+class FJsonAiAgentConfig : public FAiAgentConfig
+{
+public:
+	UNREALMCPEDITOR_API FJsonAiAgentConfig(const FString& InName, const FString& InConfigPath, const FString& InBodyPath = TEXT("mcpServers"));
+
+	/** Add/replace a desired property on the server entry. @p bRequired gates IsConfigured(); @p Comparison gates match. */
+	UNREALMCPEDITOR_API FJsonAiAgentConfig& SetProperty(const FString& Key, const TSharedPtr<FJsonValue>& Value, bool bRequired = false, EUnrealMcpValueComparison Comparison = EUnrealMcpValueComparison::Exact);
+	/** Convenience string-value overload for SetProperty. */
+	UNREALMCPEDITOR_API FJsonAiAgentConfig& SetStringProperty(const FString& Key, const FString& Value, bool bRequired = false, EUnrealMcpValueComparison Comparison = EUnrealMcpValueComparison::Exact);
+	/** Mark a key that must be ABSENT from the server entry (drops the other transport's keys / stale headers). */
+	UNREALMCPEDITOR_API FJsonAiAgentConfig& SetPropertyToRemove(const FString& Key);
+	/** Add an identity key used to detect the same server written under a different sibling name (default command/url). */
+	UNREALMCPEDITOR_API FJsonAiAgentConfig& AddIdentityKey(const FString& Key);
+
+	virtual FString GetExpectedFileContent() const override;
+	virtual bool Configure() override;
+	virtual bool Remove() override;
+	virtual bool IsDetected() const override;
+	virtual bool IsConfigured() const override;
+
+private:
+	struct FDesiredProperty
+	{
+		TSharedPtr<FJsonValue> Value;
+		bool bRequired = false;
+		EUnrealMcpValueComparison Comparison = EUnrealMcpValueComparison::Exact;
+	};
+
+	// Insertion order is preserved for deterministic output; the map keys are the property names.
+	TArray<FString> PropertyOrder;
+	TMap<FString, FDesiredProperty> Properties;
+	TArray<FString> PropertiesToRemove;
+	TArray<FString> IdentityKeys;
+
+	// Build the server entry object from the desired properties (deterministic, alphabetical key order).
+	TSharedPtr<FJsonObject> BuildServerEntry() const;
+	// Split a body path like "a/b" into segments; an empty/whitespace body path yields no segments (root).
+	static TArray<FString> BodyPathSegments(const FString& InBodyPath);
+
+	// Parse the file at ConfigPath into a root object; returns false (Out left null) for missing/empty/invalid.
+	bool TryReadRoot(TSharedPtr<FJsonObject>& OutRoot) const;
+	// Serialize @p Root to ConfigPath (creating parent dirs). Returns false on a genuine write failure.
+	bool WriteRoot(const TSharedPtr<FJsonObject>& Root) const;
+
+	// Navigate to the body-path object (read-only; null if any segment is missing/non-object).
+	static TSharedPtr<FJsonObject> NavigateToBody(const TSharedPtr<FJsonObject>& Root, const TArray<FString>& Segments);
+	// Navigate to the body-path object, CREATING intermediate objects as needed (for Configure()).
+	static TSharedPtr<FJsonObject> EnsureBody(const TSharedPtr<FJsonObject>& Root, const TArray<FString>& Segments);
+
+	// Sibling keys (≠ DefaultMcpServerName) whose entry matches one of our identity-key values (same server, alias).
+	TArray<FString> FindDuplicateServerEntryKeys(const TSharedPtr<FJsonObject>& Body) const;
+
+	bool AreRequiredPropertiesMatching(const TSharedPtr<FJsonObject>& Entry) const;
+	bool HasAnyPropertyToRemove(const TSharedPtr<FJsonObject>& Entry) const;
+
+	static bool AreValuesEquivalent(EUnrealMcpValueComparison Comparison, const TSharedPtr<FJsonValue>& Expected, const TSharedPtr<FJsonValue>& Actual);
+	static FString NormalizeUrl(const FString& Url);
+	static FString JsonValueToString(const TSharedPtr<FJsonValue>& Value);
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
@@ -44,6 +44,7 @@ namespace
 	const TCHAR* KeyStartServer    = TEXT("startServer");
 	const TCHAR* KeyEnabledTools   = TEXT("enabledTools");
 	const TCHAR* KeyDisabledTools  = TEXT("disabledTools");
+	const TCHAR* KeySelectedAgentId = TEXT("selectedAgentId");
 
 	// Read a JSON array field into a string array (skipping empty/non-string entries). Shared by the
 	// enabledTools / disabledTools list fields so their parsing stays identical.
@@ -154,6 +155,10 @@ void FUnrealMcpConfig::LoadFromJson(const TSharedPtr<FJsonObject>& Json)
 
 		ReadStringArrayField(Json, KeyEnabledTools, EnabledTools);
 		ReadStringArrayField(Json, KeyDisabledTools, DisabledTools);
+
+		// Pure UI persistence (no env override). A blank/missing value keeps the default selection.
+		if (Json->TryGetStringField(KeySelectedAgentId, Str) && !Str.IsEmpty())
+			SelectedAgentId = Str;
 	}
 
 	// Snapshot the (defaults + disk) baseline AFTER loading — this is what Save() restores for any key an
@@ -330,6 +335,8 @@ TSharedPtr<FJsonObject> FUnrealMcpConfig::ToJson() const
 	for (const FString& Tool : DisabledTools)
 		Disabled.Add(MakeShared<FJsonValueString>(Tool));
 	Obj->SetArrayField(KeyDisabledTools, Disabled);
+
+	Obj->SetStringField(KeySelectedAgentId, SelectedAgentId);
 
 	return Obj;
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
@@ -88,6 +88,10 @@ public:
 	// a tool is served iff (EnabledTools empty OR it is in EnabledTools) AND it is NOT in DisabledTools. This
 	// field has no env override — it is pure UI persistence, so Save() always round-trips the live value.
 	TArray<FString> DisabledTools; // "disabledTools"
+	// "selectedAgentId" — the AI-agent-configurator dropdown selection persisted by the §7 Agent Configurators
+	// panel (e.g. "claude-code"/"cursor"). Pure presentation state, NO env override — Save() always round-trips
+	// the live value. Defaults to the first reference agent so a fresh project opens on a valid selection.
+	FString SelectedAgentId = TEXT("claude-code"); // "selectedAgentId"
 
 	UNREALMCPEDITOR_API FUnrealMcpConfig();
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
@@ -1,0 +1,329 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UI/SUnrealMcpAgentConfigurators.h"
+#include "UI/UnrealMcpEditorViewModel.h"
+#include "Agents/AiAgentConfiguratorRegistry.h"
+#include "Agents/JsonAiAgentConfig.h"
+#include "UnrealMcpLog.h"
+
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SSeparator.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SComboBox.h"
+#include "Widgets/Input/SCheckBox.h"
+#include "Widgets/Input/SMultiLineEditableTextBox.h"
+#include "Styling/AppStyle.h"
+#include "Misc/Paths.h"
+#include "HAL/PlatformProcess.h"
+#include "HAL/PlatformApplicationMisc.h"
+
+#define LOCTEXT_NAMESPACE "UnrealMcp"
+
+void SUnrealMcpAgentConfigurators::Construct(const FArguments& InArgs)
+{
+	ViewModel = InArgs._ViewModel;
+	ConnectionInfoProvider = InArgs._ConnectionInfoProvider;
+	ProjectRootProvider = InArgs._ProjectRootProvider;
+
+	if (!ProjectRootProvider)
+		ProjectRootProvider = []() { return FPaths::ConvertRelativePathToFull(FPaths::ProjectDir()); };
+
+	Registry = MakeShared<FAiAgentConfiguratorRegistry>();
+
+	// Build the dropdown's item source (agent display names in registry order).
+	AgentNameItems.Reset();
+	for (const FString& Name : Registry->GetAgentNames())
+		AgentNameItems.Add(MakeShared<FString>(Name));
+
+	// Resolve the initial selection from the persisted SelectedAgentId (clamped to a valid index).
+	const FString PersistedId = IsViewModelValid() ? ViewModel->GetSelectedAgentId() : FString();
+	int32 InitialIndex = Registry->GetIndexByAgentId(PersistedId);
+	if (InitialIndex == INDEX_NONE)
+		InitialIndex = Registry->Num() > 0 ? 0 : INDEX_NONE;
+
+	TSharedPtr<FString> InitialItem = AgentNameItems.IsValidIndex(InitialIndex) ? AgentNameItems[InitialIndex] : nullptr;
+
+	ChildSlot
+	[
+		SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+		.Padding(8.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight()
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("AgentConfigHeader", "AI Agent Configurators"))
+				.Font(FCoreStyle::GetDefaultFontStyle("Bold", 11))
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
+			[
+				SNew(STextBlock)
+				.AutoWrapText(true)
+				.Text(LOCTEXT("AgentConfigDesc", "Pick an AI agent / MCP client and configure it to connect to this project's MCP server."))
+			]
+			// Agent dropdown.
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)
+			[
+				SAssignNew(AgentCombo, SComboBox<TSharedPtr<FString>>)
+				.OptionsSource(&AgentNameItems)
+				.InitiallySelectedItem(InitialItem)
+				.OnGenerateWidget_Lambda([](TSharedPtr<FString> Item)
+				{
+					return SNew(STextBlock).Text(FText::FromString(Item.IsValid() ? *Item : FString()));
+				})
+				.OnSelectionChanged_Lambda([this](TSharedPtr<FString> NewItem, ESelectInfo::Type)
+				{
+					if (!NewItem.IsValid())
+						return;
+					const int32 Index = AgentNameItems.IndexOfByPredicate(
+						[&NewItem](const TSharedPtr<FString>& I) { return I == NewItem; });
+					TSharedPtr<FAiAgentConfigurator> Configurator = Registry->GetByIndex(Index);
+					if (Configurator.IsValid() && IsViewModelValid())
+						ViewModel->SetSelectedAgentId(Configurator->GetAgentId());
+					bRevealToken = false; // reset reveal on agent switch (§8)
+					RefreshSelectedConfigurator();
+				})
+				[
+					SNew(STextBlock)
+					.Text_Lambda([this]()
+					{
+						return Selected.IsValid() ? FText::FromString(Selected->GetAgentName()) : LOCTEXT("NoAgent", "Select an agent");
+					})
+				]
+			]
+			// Per-agent panel container (rebuilt on selection change).
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)
+			[
+				SAssignNew(AgentPanelContainer, SVerticalBox)
+			]
+		]
+	];
+
+	RefreshSelectedConfigurator();
+}
+
+void SUnrealMcpAgentConfigurators::RefreshSelectedConfigurator()
+{
+	const FString PersistedId = IsViewModelValid() ? ViewModel->GetSelectedAgentId() : FString();
+	Selected = Registry->GetByAgentId(PersistedId);
+	if (!Selected.IsValid())
+		Selected = Registry->GetByIndex(0);
+
+	BindSelected();
+	RebuildAgentPanel();
+}
+
+void SUnrealMcpAgentConfigurators::BindSelected()
+{
+	if (!Selected.IsValid())
+		return;
+	const FAiAgentConnectionInfo Connection = ConnectionInfoProvider ? ConnectionInfoProvider() : FAiAgentConnectionInfo();
+	const FString ProjectRoot = ProjectRootProvider ? ProjectRootProvider() : FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
+	Selected->Initialize(Connection, ProjectRoot);
+}
+
+FString SUnrealMcpAgentConfigurators::MaskTokenInSnippet(const FString& Snippet, const FString& Token, bool bReveal)
+{
+	if (bReveal || Token.IsEmpty())
+		return Snippet;
+	// Replace every literal occurrence of the raw token with a fixed mask (length not leaked). The token shows up
+	// in the HTTP "Bearer <token>" header and the STDIO "token=<token>" arg; replacing the bare value covers both.
+	return Snippet.Replace(*Token, TEXT("********"), ESearchCase::CaseSensitive);
+}
+
+FString SUnrealMcpAgentConfigurators::BuildSnippetPreview(bool bStdio) const
+{
+	if (!Selected.IsValid())
+		return FString();
+	FJsonAiAgentConfig& Config = bStdio ? Selected->GetConfigStdio() : Selected->GetConfigHttp();
+	const FString Snippet = Config.GetExpectedFileContent();
+	const FAiAgentConnectionInfo Connection = ConnectionInfoProvider ? ConnectionInfoProvider() : FAiAgentConnectionInfo();
+	return MaskTokenInSnippet(Snippet, Connection.Token, bRevealToken);
+}
+
+void SUnrealMcpAgentConfigurators::RebuildAgentPanel()
+{
+	if (!AgentPanelContainer.IsValid())
+		return;
+
+	AgentPanelContainer->ClearChildren();
+
+	if (!Selected.IsValid())
+	{
+		AgentPanelContainer->AddSlot().AutoHeight()
+		[
+			SNew(STextBlock).Text(LOCTEXT("NoAgentSelected", "No agent selected."))
+		];
+		return;
+	}
+
+	const FString DownloadUrl = Selected->GetDownloadUrl();
+	const FString TutorialUrl = Selected->GetTutorialUrl();
+	const FString ConfigPath = Selected->GetConfigFilePath(ProjectRootProvider ? ProjectRootProvider() : FPaths::ProjectDir());
+
+	// Links row (download + optional tutorial).
+	TSharedRef<SHorizontalBox> LinksRow = SNew(SHorizontalBox);
+	LinksRow->AddSlot().AutoWidth().Padding(0, 0, 6, 0)
+	[
+		SNew(SButton)
+		.Text(LOCTEXT("DownloadAgent", "Download / Docs"))
+		.OnClicked_Lambda([DownloadUrl]()
+		{
+			if (!DownloadUrl.IsEmpty())
+				FPlatformProcess::LaunchURL(*DownloadUrl, nullptr, nullptr);
+			return FReply::Handled();
+		})
+	];
+	if (!TutorialUrl.IsEmpty())
+	{
+		LinksRow->AddSlot().AutoWidth()
+		[
+			SNew(SButton)
+			.Text(LOCTEXT("TutorialAgent", "Tutorial"))
+			.OnClicked_Lambda([TutorialUrl]()
+			{
+				FPlatformProcess::LaunchURL(*TutorialUrl, nullptr, nullptr);
+				return FReply::Handled();
+			})
+		];
+	}
+
+	// A reusable transport section builder (STDIO and HTTP share the same shape).
+	auto BuildTransportSection = [this](const FText& Heading, bool bStdio) -> TSharedRef<SWidget>
+	{
+		return SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)
+			[
+				SNew(STextBlock).Text(Heading).Font(FCoreStyle::GetDefaultFontStyle("Bold", 10))
+			]
+			// Status line.
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 2, 0, 0)
+			[
+				SNew(STextBlock)
+				.Text_Lambda([this, bStdio]()
+				{
+					if (!Selected.IsValid())
+						return FText::GetEmpty();
+					return Selected->IsConfigured(bStdio)
+						? LOCTEXT("StatusConfigured", "Status: configured")
+						: (Selected->IsAnyDetected()
+							? LOCTEXT("StatusDetectedOutdated", "Status: detected (needs reconfigure)")
+							: LOCTEXT("StatusNotConfigured", "Status: not configured"));
+				})
+				.ColorAndOpacity_Lambda([this, bStdio]()
+				{
+					if (Selected.IsValid() && Selected->IsConfigured(bStdio))
+						return FSlateColor(FLinearColor(0.16f, 0.74f, 0.30f));
+					return FSlateColor(FLinearColor(0.85f, 0.65f, 0.20f));
+				})
+			]
+			// Snippet preview (read-only, token-masked).
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
+			[
+				SNew(SMultiLineEditableTextBox)
+				.IsReadOnly(true)
+				.AlwaysShowScrollbars(false)
+				.Text_Lambda([this, bStdio]()
+				{
+					return FText::FromString(BuildSnippetPreview(bStdio));
+				})
+			]
+			// Action buttons.
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
+			[
+				SNew(SHorizontalBox)
+				+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 6, 0)
+				[
+					SNew(SButton)
+					.Text_Lambda([this, bStdio]()
+					{
+						return (Selected.IsValid() && Selected->IsConfigured(bStdio))
+							? LOCTEXT("Reconfigure", "Reconfigure")
+							: LOCTEXT("Configure", "Configure");
+					})
+					.OnClicked_Lambda([this, bStdio]()
+					{
+						if (Selected.IsValid())
+						{
+							const bool bOk = Selected->Configure(bStdio);
+							UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] agent '%s' %s configure %s."),
+								*Selected->GetAgentName(), bStdio ? TEXT("STDIO") : TEXT("HTTP"),
+								bOk ? TEXT("succeeded") : TEXT("failed"));
+							BindSelected(); // rebuild configs after the write
+						}
+						return FReply::Handled();
+					})
+				]
+				+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 6, 0)
+				[
+					SNew(SButton)
+					.Text(LOCTEXT("CopySnippet", "Copy"))
+					.ToolTipText(LOCTEXT("CopySnippetHint", "Copy the config snippet (with the real token) to the clipboard."))
+					.OnClicked_Lambda([this, bStdio]()
+					{
+						if (Selected.IsValid())
+						{
+							// Copy the REAL snippet (unmasked) — the user is pasting it into their own config.
+							FJsonAiAgentConfig& Config = bStdio ? Selected->GetConfigStdio() : Selected->GetConfigHttp();
+							FPlatformApplicationMisc::ClipboardCopy(*Config.GetExpectedFileContent());
+						}
+						return FReply::Handled();
+					})
+				]
+			];
+	};
+
+	AgentPanelContainer->AddSlot().AutoHeight()[ LinksRow ];
+
+	// Config path line.
+	AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 6, 0, 0)
+	[
+		SNew(STextBlock)
+		.AutoWrapText(true)
+		.Text(FText::Format(LOCTEXT("ConfigPathFmt", "Config file: {0}"), FText::FromString(ConfigPath)))
+	];
+
+	// Reveal-token toggle (per-agent; default masked, §8).
+	AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 6, 0, 0)
+	[
+		SNew(SCheckBox)
+		.IsChecked_Lambda([this]() { return bRevealToken ? ECheckBoxState::Checked : ECheckBoxState::Unchecked; })
+		.OnCheckStateChanged_Lambda([this](ECheckBoxState NewState)
+		{
+			bRevealToken = (NewState == ECheckBoxState::Checked);
+		})
+		[
+			SNew(STextBlock).Text(LOCTEXT("RevealToken", "Reveal token in preview"))
+		]
+	];
+
+	// STDIO + HTTP sections.
+	AgentPanelContainer->AddSlot().AutoHeight()[ BuildTransportSection(LOCTEXT("StdioHeader", "STDIO (launch the server)"), /*bStdio*/ true) ];
+	AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 4, 0, 0)[ SNew(SSeparator) ];
+	AgentPanelContainer->AddSlot().AutoHeight()[ BuildTransportSection(LOCTEXT("HttpHeader", "HTTP (connect to URL)"), /*bStdio*/ false) ];
+
+	// Remove (clears both transports).
+	AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 8, 0, 0)
+	[
+		SNew(SButton)
+		.Text(LOCTEXT("RemoveAgent", "Remove"))
+		.IsEnabled_Lambda([this]() { return Selected.IsValid() && Selected->IsAnyDetected(); })
+		.OnClicked_Lambda([this]()
+		{
+			if (Selected.IsValid())
+			{
+				const bool bOk = Selected->RemoveAll();
+				UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] agent '%s' remove %s."),
+					*Selected->GetAgentName(), bOk ? TEXT("succeeded") : TEXT("(nothing to remove)"));
+				BindSelected();
+			}
+			return FReply::Handled();
+		})
+	];
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.h
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Agents/AiAgentConfigurator.h"
+
+class FUnrealMcpEditorViewModel;
+class FAiAgentConfiguratorRegistry;
+class FAiAgentConfigurator;
+class SVerticalBox;
+template <typename T> class SComboBox;
+
+/**
+ * The "AI Agent Configurators" Slate panel (docs/ARCHITECTURE.md §7) — the Unreal/Slate analog of Unity's
+ * AiAgentConfigurators UI and Godot's AgentConfiguratorsPanel. Lets the user pick an external AI agent / MCP
+ * client from a dropdown and auto-configure it to reach this project's MCP server by writing/merging that
+ * client's config file (STDIO and HTTP forms), with live status + Configure/Reconfigure/Remove.
+ *
+ * State sources, kept thin (the view is dumb, the model owns state):
+ *  - ViewModel — persists the dropdown selection (SelectedAgentId) and is the single config store.
+ *  - ConnectionInfoProvider — yields the live FAiAgentConnectionInfo (server path / port / url / auth / token)
+ *    so the assembled STDIO/HTTP snippets always reflect the current connection. Resolving this needs the
+ *    runtime's bridge port + the §6 server path, which the panel cannot reach directly — hence a provider sink
+ *    (mirrors the aux-windows PortStatusProvider pattern), wired by the runtime; a spec injects a stub.
+ *  - ProjectRootProvider — yields the live project root for resolving per-agent config file paths.
+ *
+ * Token discipline (§8): the assembled snippet preview masks the bearer token by default; a per-agent Reveal
+ * toggle shows the raw value only while explicitly enabled. Configure() and Copy write/copy the REAL token; the
+ * raw value never reaches a log line. Switching agents resets the reveal toggle.
+ *
+ * Built with its own registry instance (fresh configurators), so it can be hosted as a section inside the main
+ * window without sharing config-cache state with any spec's registry.
+ */
+class SUnrealMcpAgentConfigurators : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SUnrealMcpAgentConfigurators) {}
+		/** The shared view-model (owned by the runtime). Required for persistence. */
+		SLATE_ARGUMENT(TSharedPtr<FUnrealMcpEditorViewModel>, ViewModel)
+		/** Yields the live connection facts used to assemble the STDIO/HTTP snippets. Required for correct output. */
+		SLATE_ARGUMENT(TFunction<FAiAgentConnectionInfo()>, ConnectionInfoProvider)
+		/** Yields the live project root for per-agent config-file path resolution. Defaults to the project dir. */
+		SLATE_ARGUMENT(TFunction<FString()>, ProjectRootProvider)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	TSharedPtr<FUnrealMcpEditorViewModel> ViewModel;
+	TFunction<FAiAgentConnectionInfo()> ConnectionInfoProvider;
+	TFunction<FString()> ProjectRootProvider;
+
+	TSharedPtr<FAiAgentConfiguratorRegistry> Registry;
+	// The dropdown's item source (agent display names, registry order).
+	TArray<TSharedPtr<FString>> AgentNameItems;
+	TSharedPtr<SComboBox<TSharedPtr<FString>>> AgentCombo;
+	// The container holding the currently-selected agent's per-agent panel (rebuilt on selection change).
+	TSharedPtr<SVerticalBox> AgentPanelContainer;
+
+	// The currently-selected configurator (resolved from the view-model's persisted SelectedAgentId, clamped).
+	TSharedPtr<FAiAgentConfigurator> Selected;
+	// Whether the snippet preview reveals the raw token (per-agent; reset on selection change). Default masked.
+	bool bRevealToken = false;
+
+	bool IsViewModelValid() const { return ViewModel.IsValid(); }
+
+	// Re-resolve the selected configurator from the view-model + provider and rebuild its panel.
+	void RefreshSelectedConfigurator();
+	// (Re)build the per-agent panel for the current Selected configurator into AgentPanelContainer.
+	void RebuildAgentPanel();
+	// Bind the selected configurator to the live connection info + project root.
+	void BindSelected();
+
+	// The snippet preview text for a transport, masking the token unless bRevealToken (§8).
+	FString BuildSnippetPreview(bool bStdio) const;
+	// Mask the bearer token inside an assembled snippet string unless revealed.
+	static FString MaskTokenInSnippet(const FString& Snippet, const FString& Token, bool bReveal);
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -2,6 +2,7 @@
 // See the LICENSE file in the repository root for more information.
 
 #include "UI/SUnrealMcpMainWindow.h"
+#include "UI/SUnrealMcpAgentConfigurators.h"
 #include "UnrealMcpLog.h"
 
 #include "Widgets/SBoxPanel.h"
@@ -36,6 +37,7 @@ void SUnrealMcpMainWindow::Construct(const FArguments& InArgs)
 	PluginVersion = InArgs._PluginVersion;
 	OnRestartBridge = InArgs._OnRestartBridge;
 	BridgeStatusProvider = InArgs._BridgeStatusProvider;
+	ConnectionInfoProvider = InArgs._ConnectionInfoProvider;
 
 	ChildSlot
 	[
@@ -50,6 +52,7 @@ void SUnrealMcpMainWindow::Construct(const FArguments& InArgs)
 			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildCustomAuthSection() ]
 			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildBridgeStatusSection() ]
 			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildAiAgentsSection() ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildAgentConfiguratorsSection() ]
 			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 8)[ BuildFooterSection() ]
 		]
 	];
@@ -505,6 +508,16 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildAiAgentsSection()
 				})
 			]
 		];
+}
+
+TSharedRef<SWidget> SUnrealMcpMainWindow::BuildAgentConfiguratorsSection()
+{
+	// The AI Agent Configurators panel (§7/§8): pick an external AI client and auto-write its MCP config. It is a
+	// self-contained compound widget bound to the same view-model (for the persisted dropdown selection) and the
+	// runtime-supplied connection-info provider (for the live server path / port / url / auth / token).
+	return SNew(SUnrealMcpAgentConfigurators)
+		.ViewModel(ViewModel)
+		.ConnectionInfoProvider(ConnectionInfoProvider);
 }
 
 TSharedRef<SWidget> SUnrealMcpMainWindow::BuildFooterSection()

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
@@ -7,6 +7,7 @@
 #include "Widgets/SCompoundWidget.h"
 #include "Widgets/DeclarativeSyntaxSupport.h"
 #include "UI/UnrealMcpEditorViewModel.h"
+#include "Agents/AiAgentConfigurator.h"
 
 /**
  * The "AI Game Developer" main window (docs/ARCHITECTURE.md §7), a pure-Slate compound widget — NO UMG /
@@ -31,6 +32,8 @@ public:
 		SLATE_EVENT(FSimpleDelegate, OnRestartBridge)
 		/** Optional: a provider for the one-line bridge status string (§7 item 7). */
 		SLATE_ARGUMENT(TFunction<FString()>, BridgeStatusProvider)
+		/** Optional: yields the live connection facts for the AI Agent Configurators panel (§7/§8). */
+		SLATE_ARGUMENT(TFunction<FAiAgentConnectionInfo()>, ConnectionInfoProvider)
 	SLATE_END_ARGS()
 
 	void Construct(const FArguments& InArgs);
@@ -40,6 +43,7 @@ private:
 	FString PluginVersion;
 	FSimpleDelegate OnRestartBridge;
 	TFunction<FString()> BridgeStatusProvider;
+	TFunction<FAiAgentConnectionInfo()> ConnectionInfoProvider;
 
 	// Whether the masked Custom-mode token field is currently revealed (reveal-on-hold, §8).
 	bool bRevealToken = false;
@@ -52,6 +56,7 @@ private:
 	TSharedRef<SWidget> BuildCustomAuthSection();
 	TSharedRef<SWidget> BuildBridgeStatusSection();
 	TSharedRef<SWidget> BuildAiAgentsSection();
+	TSharedRef<SWidget> BuildAgentConfiguratorsSection();
 	TSharedRef<SWidget> BuildFooterSection();
 
 	// A bold section header row.

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -270,6 +270,18 @@ void FUnrealMcpEditorViewModel::SetToolEnabled(const FString& ToolName, bool bEn
 		*ToolName, bEnabled ? TEXT("enabled") : TEXT("disabled"));
 }
 
+void FUnrealMcpEditorViewModel::SetSelectedAgentId(const FString& InAgentId)
+{
+	if (Config.SelectedAgentId == InAgentId)
+		return; // already selected — no persist churn.
+	Config.SelectedAgentId = InAgentId;
+
+	// Persist-only: the dropdown selection is pure presentation state. Deliberately NO OnPushConfig — the
+	// selection does not change the live connection (mirrors SetToolEnabled's "manifest-only, not config" note).
+	if (OnPersistConfig)
+		OnPersistConfig(Config);
+}
+
 // --- Pure helpers ----------------------------------------------------------------------------------
 
 bool FUnrealMcpEditorViewModel::ValidateServerUrl(const FString& Url, FString& OutError)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
@@ -157,6 +157,17 @@ public:
 	 */
 	UNREALMCPEDITOR_API void SetToolEnabled(const FString& ToolName, bool bEnabled);
 
+	// --- §7 AI agent configurators panel (persisted dropdown selection). ---
+
+	/** The persisted AI-agent-configurator dropdown selection (e.g. "claude-code"). */
+	const FString& GetSelectedAgentId() const { return Config.SelectedAgentId; }
+	/**
+	 * Persist the AI-agent-configurator dropdown selection (the §7 Agent Configurators panel). Pure presentation
+	 * state: persists via OnPersistConfig so the choice survives an editor restart, but does NOT push the §1.3
+	 * `config` (the selection has no effect on the live connection). A no-op change does nothing. Game-thread only.
+	 */
+	UNREALMCPEDITOR_API void SetSelectedAgentId(const FString& InAgentId);
+
 	// --- Pure helpers (no instance state; the spec-friendly heart of the view-model). ---
 
 	/**

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.cpp
@@ -23,7 +23,8 @@ void FUnrealMcpMainWindowTab::Register(
 	const TSharedRef<FUnrealMcpEditorViewModel>& InViewModel,
 	const FString& InPluginVersion,
 	FSimpleDelegate InOnRestartBridge,
-	TFunction<FString()> InBridgeStatusProvider)
+	TFunction<FString()> InBridgeStatusProvider,
+	TFunction<FAiAgentConnectionInfo()> InConnectionInfoProvider)
 {
 	if (bRegistered)
 		return;
@@ -32,6 +33,7 @@ void FUnrealMcpMainWindowTab::Register(
 	PluginVersion = InPluginVersion;
 	OnRestartBridge = InOnRestartBridge;
 	BridgeStatusProvider = MoveTemp(InBridgeStatusProvider);
+	ConnectionInfoProvider = MoveTemp(InConnectionInfoProvider);
 
 	// Slate may be unavailable in a commandlet / -nullrhi headless run without a slate application; guard so
 	// the Automation/smoke runs (which load the module) never crash on tab registration.
@@ -79,7 +81,8 @@ TSharedRef<SDockTab> FUnrealMcpMainWindowTab::SpawnTab(const FSpawnTabArgs& Args
 		.ViewModel(ViewModel)
 		.PluginVersion(PluginVersion)
 		.OnRestartBridge(OnRestartBridge)
-		.BridgeStatusProvider(BridgeStatusProvider));
+		.BridgeStatusProvider(BridgeStatusProvider)
+		.ConnectionInfoProvider(ConnectionInfoProvider));
 	return Tab;
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "Delegates/Delegate.h"
+#include "Agents/AiAgentConfigurator.h"
 
 class FUnrealMcpEditorViewModel;
 class SDockTab;
@@ -37,7 +38,8 @@ public:
 		const TSharedRef<FUnrealMcpEditorViewModel>& InViewModel,
 		const FString& InPluginVersion,
 		FSimpleDelegate InOnRestartBridge,
-		TFunction<FString()> InBridgeStatusProvider);
+		TFunction<FString()> InBridgeStatusProvider,
+		TFunction<FAiAgentConnectionInfo()> InConnectionInfoProvider);
 
 	/** Unregister the tab spawner (Shutdown). Idempotent. */
 	void Unregister();
@@ -49,5 +51,6 @@ private:
 	FString PluginVersion;
 	FSimpleDelegate OnRestartBridge;
 	TFunction<FString()> BridgeStatusProvider;
+	TFunction<FAiAgentConnectionInfo()> ConnectionInfoProvider;
 	bool bRegistered = false;
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -193,6 +193,18 @@ void FUnrealMcpRuntime::Startup()
 			if (SidecarPtr && SidecarPtr->IsRunning())
 				return FString::Printf(TEXT("Running (restarts: %d)"), SidecarPtr->GetRestartCount());
 			return TEXT("Stopped");
+		},
+		// §7/§8 AI Agent Configurators: yield the live connection facts so the assembled STDIO/HTTP snippets
+		// reflect the current config. Re-resolve the §8 config on each call (the user may have just edited the
+		// host/token in the same window) and read the bound IPC port from the bridge. The local server binary
+		// path is owned by the cli/§6 install layout — not the plugin — so it is left empty here; the STDIO
+		// snippet is still a valid template (the user supplies the binary, exactly the cli's stance), and the
+		// HTTP form is fully self-contained.
+		[BridgeServerPtr]() -> FAiAgentConnectionInfo
+		{
+			const FUnrealMcpConfig Live = FUnrealMcpConfig::LoadAndResolve();
+			const int32 Port = BridgeServerPtr ? BridgeServerPtr->GetBoundPort() : 0;
+			return FAiAgentConnectionInfo::FromPluginConfig(Live, /*ServerPath*/ FString(), Port);
 		});
 
 	// §7 auxiliary windows (MCP Tools / Prompts / Resources / Settings). The Tools window snapshots the registry on

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfiguratorSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfiguratorSpec.cpp
@@ -1,0 +1,379 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/Paths.h"
+#include "Misc/Guid.h"
+#include "Misc/FileHelper.h"
+#include "HAL/FileManager.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+#include "Agents/AiAgentConfig.h"
+#include "Agents/JsonAiAgentConfig.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Agents/AiAgentConfiguratorRegistry.h"
+#include "Agents/Impl/ClaudeCodeConfigurator.h"
+#include "Agents/Impl/CursorConfigurator.h"
+#include "Config/UnrealMcpConfig.h"
+
+/**
+ * AI Agent Configurators specs (docs/ARCHITECTURE.md §7/§8, issue #44 Phase A). Covers the JSON read-merge-write
+ * core (preserve siblings + unrelated keys, robust to missing/empty/invalid files, identity-key dedup, deprecated
+ * migration, IsDetected/IsConfigured), the configurator base STDIO/HTTP assembly + auth injection, and the
+ * registry ordering/lookups. Pure file/JSON work — no live editor, bridge, or agent.
+ *
+ * Names are unique under the UnrealMcp. filter prefix; helpers are spec members (the unity-build ODR rule).
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpAgentConfiguratorSpec, "UnrealMcp.AgentConfigurators",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	// A unique temp config-file path per call (cleaned up by the spec when done).
+	FString MakeTempConfigPath() const
+	{
+		const FString Dir = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("UnrealMcpAgentSpec"), FGuid::NewGuid().ToString());
+		return FPaths::Combine(Dir, TEXT("mcp.json"));
+	}
+
+	void DeleteTempDirFor(const FString& ConfigPath) const
+	{
+		const FString Dir = FPaths::GetPath(ConfigPath);
+		if (!Dir.IsEmpty())
+			IFileManager::Get().DeleteDirectory(*Dir, /*RequireExists*/ false, /*Tree*/ true);
+	}
+
+	// Parse a file into a root object (or null).
+	TSharedPtr<FJsonObject> ReadJsonFile(const FString& Path) const
+	{
+		FString Json;
+		if (!FFileHelper::LoadFileToString(Json, *Path))
+			return nullptr;
+		const TSharedRef<TJsonReader<TCHAR>> Reader = TJsonReaderFactory<TCHAR>::Create(Json);
+		TSharedPtr<FJsonObject> Parsed;
+		FJsonSerializer::Deserialize(Reader, Parsed);
+		return Parsed;
+	}
+
+	// Build a Claude-Code-style HTTP config at a path (type=http, url, no headers).
+	TSharedRef<FJsonAiAgentConfig> MakeHttpConfig(const FString& Path, const FString& Url) const
+	{
+		TSharedRef<FJsonAiAgentConfig> Config = MakeShared<FJsonAiAgentConfig>(TEXT("Test"), Path, TEXT("mcpServers"));
+		Config->SetStringProperty(TEXT("type"), TEXT("http"), /*bRequired*/ true);
+		Config->SetStringProperty(TEXT("url"), Url, /*bRequired*/ true, EUnrealMcpValueComparison::Url);
+		Config->SetPropertyToRemove(TEXT("command"));
+		Config->SetPropertyToRemove(TEXT("args"));
+		return Config;
+	}
+
+END_DEFINE_SPEC(FUnrealMcpAgentConfiguratorSpec)
+
+void FUnrealMcpAgentConfiguratorSpec::Define()
+{
+	Describe("JSON read-merge-write", [this]()
+	{
+		It("creates a fresh file (with parent dirs) when none exists, nesting under the body path", [this]()
+		{
+			const FString Path = MakeTempConfigPath();
+			TSharedRef<FJsonAiAgentConfig> Config = MakeHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+
+			TestTrue(TEXT("Configure succeeds"), Config->Configure());
+			TestTrue(TEXT("file exists"), FPaths::FileExists(Path));
+
+			TSharedPtr<FJsonObject> Root = ReadJsonFile(Path);
+			TestTrue(TEXT("root parsed"), Root.IsValid());
+			const TSharedPtr<FJsonObject>* Body = nullptr;
+			TestTrue(TEXT("mcpServers present"), Root.IsValid() && Root->TryGetObjectField(TEXT("mcpServers"), Body) && Body);
+			if (Body)
+			{
+				const TSharedPtr<FJsonObject>* Entry = nullptr;
+				TestTrue(TEXT("unreal-mcp entry present"), (*Body)->TryGetObjectField(TEXT("unreal-mcp"), Entry) && Entry);
+			}
+			TestTrue(TEXT("IsConfigured after write"), Config->IsConfigured());
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("preserves sibling servers and unrelated top-level keys on merge", [this]()
+		{
+			const FString Path = MakeTempConfigPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			const FString Existing = TEXT("{\n  \"someTopLevel\": 42,\n  \"mcpServers\": {\n    \"other-server\": { \"type\": \"http\", \"url\": \"http://elsewhere/mcp\" }\n  }\n}");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			TSharedRef<FJsonAiAgentConfig> Config = MakeHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			TestTrue(TEXT("Configure succeeds"), Config->Configure());
+
+			TSharedPtr<FJsonObject> Root = ReadJsonFile(Path);
+			TestTrue(TEXT("unrelated top-level key preserved"), Root.IsValid() && Root->HasField(TEXT("someTopLevel")));
+			const TSharedPtr<FJsonObject>* Body = nullptr;
+			Root->TryGetObjectField(TEXT("mcpServers"), Body);
+			TestTrue(TEXT("sibling server preserved"), Body && (*Body)->HasField(TEXT("other-server")));
+			TestTrue(TEXT("our entry added"), Body && (*Body)->HasField(TEXT("unreal-mcp")));
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("tolerates an invalid (non-JSON) file by replacing it with clean content", [this]()
+		{
+			const FString Path = MakeTempConfigPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			FFileHelper::SaveStringToFile(FString(TEXT("this is not json {{{")), *Path);
+
+			TSharedRef<FJsonAiAgentConfig> Config = MakeHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			TestTrue(TEXT("Configure succeeds over garbage"), Config->Configure());
+			TestTrue(TEXT("IsConfigured after replace"), Config->IsConfigured());
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("tolerates an empty file", [this]()
+		{
+			const FString Path = MakeTempConfigPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			FFileHelper::SaveStringToFile(FString(TEXT("")), *Path);
+
+			TSharedRef<FJsonAiAgentConfig> Config = MakeHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			TestTrue(TEXT("Configure succeeds over empty"), Config->Configure());
+			TestTrue(TEXT("IsConfigured after empty"), Config->IsConfigured());
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("IsDetected false for a missing file, true once configured", [this]()
+		{
+			const FString Path = MakeTempConfigPath();
+			TSharedRef<FJsonAiAgentConfig> Config = MakeHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			TestFalse(TEXT("not detected before write"), Config->IsDetected());
+			Config->Configure();
+			TestTrue(TEXT("detected after write"), Config->IsDetected());
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("Remove deletes our entry but preserves siblings", [this]()
+		{
+			const FString Path = MakeTempConfigPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			const FString Existing = TEXT("{\n  \"mcpServers\": {\n    \"other-server\": { \"type\": \"http\", \"url\": \"http://elsewhere/mcp\" }\n  }\n}");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			TSharedRef<FJsonAiAgentConfig> Config = MakeHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			Config->Configure();
+			TestTrue(TEXT("Remove returns true"), Config->Remove());
+
+			TSharedPtr<FJsonObject> Root = ReadJsonFile(Path);
+			const TSharedPtr<FJsonObject>* Body = nullptr;
+			Root->TryGetObjectField(TEXT("mcpServers"), Body);
+			TestFalse(TEXT("our entry removed"), Body && (*Body)->HasField(TEXT("unreal-mcp")));
+			TestTrue(TEXT("sibling preserved after remove"), Body && (*Body)->HasField(TEXT("other-server")));
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("migrates a deprecated server name to the canonical one", [this]()
+		{
+			const FString Path = MakeTempConfigPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			const FString Existing = TEXT("{\n  \"mcpServers\": {\n    \"ai-game-developer\": { \"type\": \"http\", \"url\": \"http://old/mcp\" }\n  }\n}");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			TSharedRef<FJsonAiAgentConfig> Config = MakeHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			Config->Configure();
+
+			TSharedPtr<FJsonObject> Root = ReadJsonFile(Path);
+			const TSharedPtr<FJsonObject>* Body = nullptr;
+			Root->TryGetObjectField(TEXT("mcpServers"), Body);
+			TestFalse(TEXT("deprecated name removed"), Body && (*Body)->HasField(TEXT("ai-game-developer")));
+			TestTrue(TEXT("canonical name present"), Body && (*Body)->HasField(TEXT("unreal-mcp")));
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("collapses a duplicate sibling that shares our url (identity-key dedup)", [this]()
+		{
+			const FString Path = MakeTempConfigPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			// A differently-named sibling with the SAME url is the same server under another name → removed.
+			const FString Existing = TEXT("{\n  \"mcpServers\": {\n    \"my-alias\": { \"type\": \"http\", \"url\": \"http://localhost:8080/mcp\" }\n  }\n}");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			TSharedRef<FJsonAiAgentConfig> Config = MakeHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			Config->Configure();
+
+			TSharedPtr<FJsonObject> Root = ReadJsonFile(Path);
+			const TSharedPtr<FJsonObject>* Body = nullptr;
+			Root->TryGetObjectField(TEXT("mcpServers"), Body);
+			TestFalse(TEXT("duplicate alias removed"), Body && (*Body)->HasField(TEXT("my-alias")));
+			TestTrue(TEXT("canonical entry present"), Body && (*Body)->HasField(TEXT("unreal-mcp")));
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("IsConfigured tolerates URL trailing-slash / case differences", [this]()
+		{
+			const FString Path = MakeTempConfigPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			const FString Existing = TEXT("{\n  \"mcpServers\": {\n    \"unreal-mcp\": { \"type\": \"http\", \"url\": \"http://localhost:8080/mcp/\" }\n  }\n}");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			TSharedRef<FJsonAiAgentConfig> Config = MakeHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			TestTrue(TEXT("trailing slash treated as configured"), Config->IsConfigured());
+
+			DeleteTempDirFor(Path);
+		});
+	});
+
+	Describe("Configurator base (STDIO + HTTP assembly + auth injection)", [this]()
+	{
+		It("HTTP form points at <host>/mcp and injects the Authorization header when auth required", [this]()
+		{
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.CustomHost = TEXT("http://localhost:9000");
+			Config.AuthOption = EUnrealMcpAuthOption::Required;
+			Config.CustomToken = TEXT("secret-token");
+
+			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, FString(), 30001);
+			TestEqual(TEXT("http url is host + /mcp"), Info.HttpUrl, FString(TEXT("http://localhost:9000/mcp")));
+			TestTrue(TEXT("auth required"), Info.bAuthRequired);
+			TestEqual(TEXT("token resolved"), Info.Token, FString(TEXT("secret-token")));
+
+			FClaudeCodeConfigurator Configurator;
+			Configurator.Initialize(Info, FPaths::ProjectDir());
+			const FString Http = Configurator.GetConfigHttp().GetExpectedFileContent();
+			TestTrue(TEXT("http snippet has url"), Http.Contains(TEXT("http://localhost:9000/mcp")));
+			TestTrue(TEXT("http snippet has Authorization header"), Http.Contains(TEXT("Bearer secret-token")));
+		});
+
+		It("HTTP form omits the Authorization header when auth is not required (Custom + None)", [this]()
+		{
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.CustomHost = TEXT("http://localhost:9000");
+			Config.AuthOption = EUnrealMcpAuthOption::None;
+			Config.CustomToken = TEXT("stored-but-unused");
+
+			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, FString(), 30001);
+			TestFalse(TEXT("auth not required"), Info.bAuthRequired);
+
+			FCursorConfigurator Configurator;
+			Configurator.Initialize(Info, FPaths::ProjectDir());
+			const FString Http = Configurator.GetConfigHttp().GetExpectedFileContent();
+			TestFalse(TEXT("no Authorization header"), Http.Contains(TEXT("Authorization")));
+			TestFalse(TEXT("token never present"), Http.Contains(TEXT("stored-but-unused")));
+		});
+
+		It("Cloud mode always requires auth and uses the cloud base url + /mcp", [this]()
+		{
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Cloud;
+			Config.CloudToken = TEXT("cloud-token");
+
+			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, FString(), 30001);
+			TestTrue(TEXT("cloud always auth-required"), Info.bAuthRequired);
+			TestTrue(TEXT("cloud url ends with /mcp"), Info.HttpUrl.EndsWith(TEXT("/mcp")));
+			TestEqual(TEXT("cloud token resolved"), Info.Token, FString(TEXT("cloud-token")));
+		});
+
+		It("STDIO form emits the port, client-transport, authorization and token args", [this]()
+		{
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.CustomHost = TEXT("http://localhost:9000");
+			Config.AuthOption = EUnrealMcpAuthOption::Required;
+			Config.CustomToken = TEXT("tok");
+
+			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, TEXT("C:/srv/gamedev-mcp-server.exe"), 31234);
+			FClaudeCodeConfigurator Configurator;
+			Configurator.Initialize(Info, FPaths::ProjectDir());
+			const FString Stdio = Configurator.GetConfigStdio().GetExpectedFileContent();
+			TestTrue(TEXT("has port arg"), Stdio.Contains(TEXT("port=31234")));
+			TestTrue(TEXT("has client-transport arg"), Stdio.Contains(TEXT("client-transport=stdio")));
+			TestTrue(TEXT("has authorization=required"), Stdio.Contains(TEXT("authorization=required")));
+			TestTrue(TEXT("has token arg"), Stdio.Contains(TEXT("token=tok")));
+			TestTrue(TEXT("command uses forward slashes"), Stdio.Contains(TEXT("C:/srv/gamedev-mcp-server.exe")));
+		});
+
+		It("Configure writes to the agent's config path and Remove reverts it", [this]()
+		{
+			const FString ProjectRoot = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("UnrealMcpAgentSpecRoot"), FGuid::NewGuid().ToString());
+
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.CustomHost = TEXT("http://localhost:9000");
+			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, FString(), 30001);
+
+			FClaudeCodeConfigurator Configurator;
+			Configurator.Initialize(Info, ProjectRoot);
+
+			const FString ExpectedPath = FPaths::ConvertRelativePathToFull(FPaths::Combine(ProjectRoot, TEXT(".mcp.json")));
+			TestEqual(TEXT("config path is project/.mcp.json"), Configurator.GetConfigFilePath(ProjectRoot), ExpectedPath);
+
+			TestTrue(TEXT("Configure HTTP"), Configurator.Configure(/*bStdio*/ false));
+			TestTrue(TEXT("file written"), FPaths::FileExists(ExpectedPath));
+			TestTrue(TEXT("detected"), Configurator.IsAnyDetected());
+
+			TestTrue(TEXT("RemoveAll"), Configurator.RemoveAll());
+			TestFalse(TEXT("no longer detected"), Configurator.IsAnyDetected());
+
+			IFileManager::Get().DeleteDirectory(*ProjectRoot, false, true);
+		});
+	});
+
+	Describe("Registry", [this]()
+	{
+		It("registers the two Phase-A reference agents, sorted by name", [this]()
+		{
+			FAiAgentConfiguratorRegistry Registry;
+			TestEqual(TEXT("two agents"), Registry.Num(), 2);
+			const TArray<FString> Names = Registry.GetAgentNames();
+			TestEqual(TEXT("first is Claude Code"), Names[0], FString(TEXT("Claude Code")));
+			TestEqual(TEXT("second is Cursor"), Names[1], FString(TEXT("Cursor")));
+		});
+
+		It("looks up by id and index, returns INDEX_NONE for unknown", [this]()
+		{
+			FAiAgentConfiguratorRegistry Registry;
+			TestTrue(TEXT("claude-code found"), Registry.GetByAgentId(TEXT("claude-code")).IsValid());
+			TestTrue(TEXT("cursor found"), Registry.GetByAgentId(TEXT("cursor")).IsValid());
+			TestFalse(TEXT("unknown id null"), Registry.GetByAgentId(TEXT("nope")).IsValid());
+			TestEqual(TEXT("claude index 0"), Registry.GetIndexByAgentId(TEXT("claude-code")), 0);
+			TestEqual(TEXT("unknown index NONE"), Registry.GetIndexByAgentId(TEXT("nope")), (int32)INDEX_NONE);
+			TestTrue(TEXT("index 1 valid"), Registry.GetByIndex(1).IsValid());
+			TestFalse(TEXT("index 5 null"), Registry.GetByIndex(5).IsValid());
+		});
+	});
+
+	Describe("Config selectedAgentId persistence", [this]()
+	{
+		It("defaults to claude-code and round-trips through ToJson/LoadFromJson", [this]()
+		{
+			FUnrealMcpConfig Config;
+			TestEqual(TEXT("default selection"), Config.SelectedAgentId, FString(TEXT("claude-code")));
+
+			Config.SelectedAgentId = TEXT("cursor");
+			const TSharedPtr<FJsonObject> Json = Config.ToJson();
+			TestTrue(TEXT("json has selectedAgentId"), Json->HasField(TEXT("selectedAgentId")));
+
+			FUnrealMcpConfig Loaded;
+			Loaded.LoadFromJson(Json);
+			TestEqual(TEXT("round-tripped selection"), Loaded.SelectedAgentId, FString(TEXT("cursor")));
+		});
+
+		It("keeps the default when the persisted value is blank/missing", [this]()
+		{
+			TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+			Json->SetStringField(TEXT("selectedAgentId"), TEXT(""));
+			FUnrealMcpConfig Loaded;
+			Loaded.LoadFromJson(Json);
+			TestEqual(TEXT("blank keeps default"), Loaded.SelectedAgentId, FString(TEXT("claude-code")));
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfiguratorSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfiguratorSpec.cpp
@@ -70,6 +70,22 @@ BEGIN_DEFINE_SPEC(FUnrealMcpAgentConfiguratorSpec, "UnrealMcp.AgentConfigurators
 		return Config;
 	}
 
+	// Build a STDIO config at a path (type=stdio, command, args) that scrubs the HTTP-only keys (url, headers) —
+	// mirrors FAiAgentConfigurator::BuildStdio so a transport switch over a prior HTTP entry leaves no stale keys.
+	TSharedRef<FJsonAiAgentConfig> MakeStdioConfig(const FString& Path, const FString& Command) const
+	{
+		TSharedRef<FJsonAiAgentConfig> Config = MakeShared<FJsonAiAgentConfig>(TEXT("Test"), Path, TEXT("mcpServers"));
+		TArray<TSharedPtr<FJsonValue>> Args;
+		Args.Add(MakeShared<FJsonValueString>(TEXT("port=8080")));
+		Args.Add(MakeShared<FJsonValueString>(TEXT("client-transport=stdio")));
+		Config->SetStringProperty(TEXT("type"), TEXT("stdio"), /*bRequired*/ true);
+		Config->SetStringProperty(TEXT("command"), Command, /*bRequired*/ true);
+		Config->SetProperty(TEXT("args"), MakeShared<FJsonValueArray>(Args), /*bRequired*/ true);
+		Config->SetPropertyToRemove(TEXT("url"));
+		Config->SetPropertyToRemove(TEXT("headers"));
+		return Config;
+	}
+
 END_DEFINE_SPEC(FUnrealMcpAgentConfiguratorSpec)
 
 void FUnrealMcpAgentConfiguratorSpec::Define()
@@ -223,6 +239,49 @@ void FUnrealMcpAgentConfiguratorSpec::Define()
 
 			TSharedRef<FJsonAiAgentConfig> Config = MakeHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
 			TestTrue(TEXT("trailing slash treated as configured"), Config->IsConfigured());
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("switches an existing HTTP entry to STDIO cleanly (drops url/headers, adds command/args)", [this]()
+		{
+			const FString Path = MakeTempConfigPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			// A pre-existing HTTP "unreal-mcp" entry, complete with an Authorization header.
+			const FString Existing = TEXT("{\n  \"mcpServers\": {\n    \"unreal-mcp\": { \"type\": \"http\", \"url\": \"http://localhost:8080/mcp\", \"headers\": { \"Authorization\": \"Bearer stale\" } }\n  }\n}");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			TSharedRef<FJsonAiAgentConfig> Config = MakeStdioConfig(Path, TEXT("C:/srv/gamedev-mcp-server.exe"));
+			TestTrue(TEXT("STDIO Configure over HTTP succeeds"), Config->Configure());
+
+			TSharedPtr<FJsonObject> Root = ReadJsonFile(Path);
+			const TSharedPtr<FJsonObject>* Body = nullptr;
+			Root->TryGetObjectField(TEXT("mcpServers"), Body);
+			const TSharedPtr<FJsonObject>* Entry = nullptr;
+			TestTrue(TEXT("unreal-mcp entry present"), Body && (*Body)->TryGetObjectField(TEXT("unreal-mcp"), Entry) && Entry);
+			if (Entry)
+			{
+				TestFalse(TEXT("stale url removed"), (*Entry)->HasField(TEXT("url")));
+				TestFalse(TEXT("stale headers removed"), (*Entry)->HasField(TEXT("headers")));
+				TestTrue(TEXT("command present"), (*Entry)->HasField(TEXT("command")));
+				TestTrue(TEXT("args present"), (*Entry)->HasField(TEXT("args")));
+			}
+			TestTrue(TEXT("IsConfigured after switch"), Config->IsConfigured());
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("IsConfigured is false when a to-remove key still survives in the entry", [this]()
+		{
+			const FString Path = MakeTempConfigPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			// An entry that already matches our desired STDIO properties BUT still carries a stale "url" key —
+			// the very key the STDIO config asks to remove. HasAnyPropertyToRemove must veto IsConfigured.
+			const FString Existing = TEXT("{\n  \"mcpServers\": {\n    \"unreal-mcp\": { \"type\": \"stdio\", \"command\": \"C:/srv/gamedev-mcp-server.exe\", \"args\": [\"port=8080\", \"client-transport=stdio\"], \"url\": \"http://localhost:8080/mcp\" }\n  }\n}");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			TSharedRef<FJsonAiAgentConfig> Config = MakeStdioConfig(Path, TEXT("C:/srv/gamedev-mcp-server.exe"));
+			TestFalse(TEXT("surviving to-remove key vetoes IsConfigured"), Config->IsConfigured());
 
 			DeleteTempDirFor(Path);
 		});


### PR DESCRIPTION
## Summary
- Greenfield port of Unity-MCP's **AI Agent Configurators** into the Unreal-MCP C++ editor plugin (Phase A vertical slice).
- C++ core under `Private/Agents/`: `FAiAgentConfig`/`FJsonAiAgentConfig` robust JSON read-merge-write (preserve siblings + unrelated keys, tolerate missing/empty/invalid files, identity-key dedup, deprecated-name migration), `FAiAgentConfigurator` base emitting BOTH STDIO + HTTP client forms with auth-token injection sourced from `FUnrealMcpConfig::BuildEffectiveConnectionConfig` (effective host, deterministic IPC port, mode-resolved bearer; server key `unreal-mcp`, url `<host>/mcp` — matching the cli's `setup-mcp` contract), and `FAiAgentConfiguratorRegistry` (Custom-last, id/index/name lookups).
- Two reference agents: **Claude Code** (`.mcp.json`) and **Cursor** (`.cursor/mcp.json`).
- Slate `SUnrealMcpAgentConfigurators` panel (dropdown + per-agent download/tutorial links, STDIO/HTTP snippet previews, config path, Configure/Reconfigure/Remove + live status) wired into `SUnrealMcpMainWindow`; selected agent id persisted via the view-model/config (`selectedAgentId`, default `claude-code`).
- Security: bearer token never logged; on-screen snippet masked by default with a reveal toggle; only the real token is written to the config file / copied to clipboard.

## Test plan
- [x] UBT build on the UE 5.7 `Unreal-Test-Project` testbed — exit 0.
- [x] Headless boot smoke — `[Unreal-MCP] plugin loaded`, engine initialized.
- [x] Automation specs `UnrealMcp.` — **182 specs, 0 failed** (18 new `UnrealMcp.AgentConfigurators`: JSON read-merge-write core, STDIO/HTTP assembly + auth injection, registry ordering/lookups, `selectedAgentId` persistence).
- Windowed (Slate panel) verification pending operator — not verifiable headless.

Closes #44