### PR TITLE
feat(bridge): self-contained single-file publish for all 4 RIDs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,21 @@ dotnet build   bridge/Unreal-MCP-Bridge.sln --configuration Debug --no-restore
 dotnet test    bridge/Unreal-MCP-Bridge.sln --configuration Debug --no-build
 ```
 
+**Publish (bundle source — docs/ARCHITECTURE.md §6 BUNDLE model).** The sidecar publishes as a
+**self-contained, single-file** binary per RID so the end user needs no .NET installed. Trimming is
+OFF (McpPlugin/ReflectorNet/SignalR are reflection-heavy). Run the repeatable publish script:
+
+```bash
+bash bridge/publish.sh                       # Release, all 4 RIDs (win-x64/linux-x64/osx-x64/osx-arm64), zipped
+bash bridge/publish.sh Release win-x64       # one RID; --no-zip leaves the raw dir (e.g. before signing)
+# PowerShell equivalent: bridge/publish.ps1 [-Platforms <rid> ...] [-NoZip]
+```
+
+Each `bridge/publish/<rid>/` holds exactly one apphost (`unreal-mcp-bridge[.exe]`, ~73–80 MB; no
+`.pdb`, no loose runtime DLLs). The csproj engages `SelfContained` + `PublishSingleFile` ONLY when a
+RID is supplied, so a plain `dotnet build`/`test` (no `-r`) stays framework-dependent at the flat
+`bin/<cfg>/net9.0/unreal-mcp-bridge.exe` path the live-e2e harness (`UNREAL_MCP_BRIDGE_PATH`) reads.
+
 ### server — none in this repo
 
 The MCP server lives in the shared [GameDev-MCP-Server](https://github.com/IvanMurzak/GameDev-MCP-Server)

--- a/bridge/publish.ps1
+++ b/bridge/publish.ps1
@@ -1,24 +1,34 @@
 #!/usr/bin/env pwsh
 # Publish self-contained single-file unreal-mcp-bridge binaries per RID and zip them
-# (docs/ARCHITECTURE.md §6: unreal-mcp-bridge-<platform>.zip release artifacts).
+# (docs/ARCHITECTURE.md §6 BUNDLE model, issue #45: unreal-mcp-bridge-<rid>.zip release artifacts).
 # Works on Windows, macOS, and Linux with PowerShell Core.
+#
+# The published binary is SELF-CONTAINED — the end user needs no .NET SDK/runtime installed.
+# Trimming is OFF (McpPlugin/ReflectorNet/SignalR are reflection-heavy; see the bridge csproj).
+#
+# Usage:
+#   ./publish.ps1                                          # Release, all 4 RIDs, zipped
+#   ./publish.ps1 -Platforms win-x64                       # Release, only win-x64, zipped
+#   ./publish.ps1 -Platforms win-x64 -NoZip               # publish dir only (e.g. before signing)
+#
+# -NoZip skips zipping (T3 Authenticode-signs the raw .exe before re-zip).
 
 param(
     [string]$Configuration = "Release",
     [string]$ProjectFile = "src/com.IvanMurzak.Unreal.MCP.Bridge.csproj",
-    [string[]]$Platforms = @()
+    [string[]]$Platforms = @(),
+    [switch]$NoZip
 )
 
 $ErrorActionPreference = "Stop"
 Push-Location $PSScriptRoot
 
 $PublishRoot = Join-Path $PSScriptRoot "publish"
-if (Test-Path $PublishRoot) {
-    Remove-Item $PublishRoot -Recurse -Force
+if (-not (Test-Path $PublishRoot)) {
+    New-Item -ItemType Directory -Path $PublishRoot | Out-Null
 }
-New-Item -ItemType Directory -Path $PublishRoot | Out-Null
 
-# The 4 RIDs the sidecar download flow serves (§6).
+# The 4 RIDs the bundle model ships (§6).
 $allRuntimes = @("win-x64", "linux-x64", "osx-x64", "osx-arm64")
 $runtimes = if ($Platforms.Count -gt 0) { $allRuntimes | Where-Object { $_ -in $Platforms } } else { $allRuntimes }
 
@@ -30,8 +40,11 @@ if ($runtimes.Count -eq 0) {
 
 $failed = 0
 foreach ($runtime in $runtimes) {
-    Write-Host "Publishing $runtime..." -ForegroundColor Yellow
+    Write-Host "Publishing $runtime ($Configuration)..." -ForegroundColor Yellow
     $outputPath = Join-Path $PublishRoot $runtime
+    if (Test-Path $outputPath) {
+        Remove-Item $outputPath -Recurse -Force
+    }
     dotnet publish $ProjectFile -c $Configuration -r $runtime --self-contained true -p:PublishSingleFile=true -o $outputPath
     if ($LASTEXITCODE -ne 0) {
         Write-Host "Failed to publish $runtime" -ForegroundColor Red
@@ -39,10 +52,15 @@ foreach ($runtime in $runtimes) {
         continue
     }
 
-    $zipPath = Join-Path $PublishRoot "unreal-mcp-bridge-$runtime.zip"
-    Add-Type -AssemblyName System.IO.Compression.FileSystem
-    [System.IO.Compression.ZipFile]::CreateFromDirectory($outputPath, $zipPath)
-    Write-Host "Created $zipPath" -ForegroundColor Green
+    if (-not $NoZip) {
+        $zipPath = Join-Path $PublishRoot "unreal-mcp-bridge-$runtime.zip"
+        if (Test-Path $zipPath) {
+            Remove-Item $zipPath -Force
+        }
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        [System.IO.Compression.ZipFile]::CreateFromDirectory($outputPath, $zipPath)
+        Write-Host "Created $zipPath" -ForegroundColor Green
+    }
 }
 
 Pop-Location

--- a/bridge/publish.sh
+++ b/bridge/publish.sh
@@ -1,27 +1,78 @@
 #!/usr/bin/env bash
 # Publish self-contained single-file unreal-mcp-bridge binaries per RID and zip them
-# (docs/ARCHITECTURE.md §6: unreal-mcp-bridge-<platform>.zip release artifacts).
+# (docs/ARCHITECTURE.md §6 BUNDLE model, issue #45: unreal-mcp-bridge-<rid>.zip release artifacts).
+#
+# The published binary is SELF-CONTAINED — the end user needs no .NET SDK/runtime installed.
+# Trimming is OFF (McpPlugin/ReflectorNet/SignalR are reflection-heavy; see the bridge csproj).
+#
+# Usage:
+#   ./publish.sh [Configuration] [rid ...]
+#   ./publish.sh                          # Release, all 4 RIDs, zipped
+#   ./publish.sh Release win-x64          # Release, only win-x64, zipped
+#   ./publish.sh Release osx-x64 osx-arm64 --no-zip   # publish dirs only (e.g. before signing)
+#
+# Pass --no-zip anywhere in the args to skip zipping (T3 signs the raw apphost before re-zip).
 set -euo pipefail
 
 cd "$(dirname "$0")"
 
-CONFIGURATION="${1:-Release}"
 PROJECT_FILE="src/com.IvanMurzak.Unreal.MCP.Bridge.csproj"
 PUBLISH_ROOT="./publish"
 
-# The 4 RIDs the sidecar download flow serves (§6).
-RUNTIMES=("win-x64" "linux-x64" "osx-x64" "osx-arm64")
+# The 4 RIDs the bundle model ships (§6).
+ALL_RUNTIMES=("win-x64" "linux-x64" "osx-x64" "osx-arm64")
 
-rm -rf "$PUBLISH_ROOT"
+CONFIGURATION="Release"
+NO_ZIP=0
+SELECTED=()
+
+# First non-flag arg is the configuration; remaining non-flag args filter the RID list.
+config_seen=0
+for arg in "$@"; do
+    case "$arg" in
+        --no-zip)
+            NO_ZIP=1
+            ;;
+        *)
+            if [[ $config_seen -eq 0 ]]; then
+                CONFIGURATION="$arg"
+                config_seen=1
+            else
+                SELECTED+=("$arg")
+            fi
+            ;;
+    esac
+done
+
+if [[ ${#SELECTED[@]} -gt 0 ]]; then
+    RUNTIMES=("${SELECTED[@]}")
+    # Validate each selected RID against the known set.
+    for r in "${RUNTIMES[@]}"; do
+        found=0
+        for known in "${ALL_RUNTIMES[@]}"; do
+            [[ "$r" == "$known" ]] && found=1
+        done
+        if [[ $found -eq 0 ]]; then
+            echo "Unknown RID '$r'. Available: ${ALL_RUNTIMES[*]}" >&2
+            exit 1
+        fi
+    done
+else
+    RUNTIMES=("${ALL_RUNTIMES[@]}")
+fi
+
 mkdir -p "$PUBLISH_ROOT"
 
 for runtime in "${RUNTIMES[@]}"; do
-    echo "Publishing $runtime..."
+    echo "Publishing $runtime ($CONFIGURATION)..."
     out="$PUBLISH_ROOT/$runtime"
+    rm -rf "$out"
     dotnet publish "$PROJECT_FILE" -c "$CONFIGURATION" -r "$runtime" \
         --self-contained true -p:PublishSingleFile=true -o "$out"
-    (cd "$out" && zip -r "../unreal-mcp-bridge-$runtime.zip" .)
-    echo "Created $PUBLISH_ROOT/unreal-mcp-bridge-$runtime.zip"
+    if [[ $NO_ZIP -eq 0 ]]; then
+        (cd "$out" && zip -r "../unreal-mcp-bridge-$runtime.zip" .)
+        echo "Created $PUBLISH_ROOT/unreal-mcp-bridge-$runtime.zip"
+    fi
 done
 
 echo "All bridge publishes completed. Artifacts in: $PUBLISH_ROOT"

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -18,6 +18,38 @@
   </PropertyGroup>
 
   <!--
+    Self-contained, single-file publish per RID (docs/ARCHITECTURE.md §6 BUNDLE model, issue #45).
+    The end user installs NO .NET SDK/runtime — the published binary carries the runtime inside it.
+    Self-containment is driven by the publish flags in bridge/publish.sh / bridge/publish.ps1
+    (-r <rid> with self-contained + PublishSingleFile). The properties below are a defensive default
+    so a flagless `dotnet publish -r <rid>` still produces a self-contained single file.
+
+    They are GUARDED on a non-empty RuntimeIdentifier so that a plain `dotnet build` / `dotnet test`
+    (no -r) stays framework-dependent and writes the flat `bin/<cfg>/net9.0/unreal-mcp-bridge.exe`
+    that the inner-dev-loop + live-e2e harness (UNREAL_MCP_BRIDGE_PATH, test.md Suite 7) point at.
+    They engage ONLY when a RID is supplied — i.e. only on the per-RID publish that builds the bundle.
+
+    Trimming is deliberately OFF — McpPlugin + ReflectorNet + SignalR resolve types by reflection at
+    runtime; the trimmer's static analysis cannot see those paths and would silently drop types,
+    yielding runtime MissingMethod/TypeLoad failures that do NOT surface at publish time. Do NOT add
+    a PublishTrimmed=true property. ReadyToRun is likewise skipped (makes output RID-native,
+    breaking cross-build of osx/linux from one host).
+  -->
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+  </PropertyGroup>
+
+  <!--
+    Release publishes drop debug symbols so the bundled binary ships no .pdb (size + cleanliness).
+    Scoped to a real RID publish so a plain Release build keeps its symbols.
+  -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release' and '$(RuntimeIdentifier)' != ''">
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+  </PropertyGroup>
+
+  <!--
     Frozen reused NuGet pins, kept in lockstep with Godot-MCP (Godot-MCP.csproj):
     McpPlugin 6.7.0 + ReflectorNet 5.3.1. The MCP/reflection stack is NOT forked —
     pins are owned by the upstream release pipelines. Do NOT bump here.


### PR DESCRIPTION
## Summary
- Configure the .NET 9 sidecar (`bridge/`) to publish as a **self-contained, single-file** binary per RID (`win-x64`, `osx-arm64`, `osx-x64`, `linux-x64`) so the end user needs no .NET SDK/runtime — task **T1** of the BUNDLE self-bootstrapping-sidecar model (docs/ARCHITECTURE.md §6).
- csproj gains defensive `SelfContained` + `PublishSingleFile` defaults **guarded on a non-empty `RuntimeIdentifier`**, so a plain `dotnet build`/`test` stays framework-dependent at the flat `bin/<cfg>/net9.0/unreal-mcp-bridge.exe` path the inner-dev-loop + live-e2e harness (`UNREAL_MCP_BRIDGE_PATH`) read; Release+RID publishes drop `.pdb`. **Trimming stays OFF** (reflection-heavy stack).
- `publish.sh` gains a positional RID filter + `--no-zip`; `publish.ps1` gains `-NoZip` — so the downstream signing jobs (T3) can build only their slice and sign the raw apphost before re-zip.
- CLAUDE.md documents the repeatable bundle-publish command.

Frozen NuGet pins (ReflectorNet 5.3.1, McpPlugin 6.7.0) untouched; no version bump.

## Test plan
- [x] `bridge/Unreal-MCP-Bridge.sln` restore + build + `dotnet test`: 90/90 xUnit green, 0 errors (profile test.md Suite 4)
- [x] `bridge/publish.sh Release` emits all 4 RIDs — each `publish/<rid>/` holds exactly one apphost (~73–80 MB, no `.pdb`, no loose runtime DLLs)
- [x] win-x64 binary launches with **no .NET on PATH** (cleared PATH + `DOTNET_ROOT` removed) — runs its bundled runtime and returns its own usage error (exit 2), not a runtime-missing error
- [x] Plain `dotnet build` (no `-r`) confirmed framework-dependent at the flat path (no RID subfolder, no CLR copied) — inner-dev-loop preserved

Closes #45