### PR TITLE
plugin: auto-spawn the bundled sidecar with zero user action (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ the plugin spawns and talks to over a localhost IPC channel. The full design liv
 - **Unreal Engine 5.5+** (developed and CI-tested against **5.7**). The plugin deliberately ships
   **no `EngineVersion` pin** — UE treats that field as an exact-build match, not a floor, and would
   refuse to load on newer engines.
-- **.NET 9 SDK** to build the bridge sidecar. (End users who download release binaries do not
-  need it — they ship self-contained. The local MCP server is downloaded as a prebuilt
-  [GameDev-MCP-Server](https://github.com/IvanMurzak/GameDev-MCP-Server) release binary, never
-  built here.)
+- **.NET 9 SDK** to build the bridge sidecar **from source**. (End users of a packaged release do
+  NOT need it — the self-contained sidecar is bundled inside the plugin and auto-spawned, ARCHITECTURE
+  §6. The local MCP server is downloaded as a prebuilt
+  [GameDev-MCP-Server](https://github.com/IvanMurzak/GameDev-MCP-Server) release binary, never built
+  here.)
 - **Node.js** `^20.19.0 || >=22.12.0` for the optional `unreal-mcp-cli`.
 - A C++ Unreal project (the plugin builds an Editor module, so the host project must be able to
   compile C++).
@@ -79,14 +80,20 @@ node bin/unreal-mcp-cli.js install-plugin <YourProject> --junction
 3. On editor boot the Output Log prints **`[Unreal-MCP] plugin loaded`** — that confirms the plugin
    and its game-thread dispatcher started.
 
-The sidecar binary (`unreal-mcp-bridge`) is **not** bundled. Today the plugin resolves it from the
-`UNREAL_MCP_BRIDGE_PATH` environment variable: point that at a sidecar binary, or run
+The sidecar binary (`unreal-mcp-bridge`) is **bundled inside the plugin** in a packaged release: a
+prebuilt, self-contained binary for your platform ships under
+`UnrealMCP/Binaries/ThirdParty/UnrealMcpBridge/<rid>/` and the editor **auto-spawns it on startup
+with zero user action** — no .NET install, no env var, no manual launch (ARCHITECTURE §6). The first
+Cloud OAuth device-code browser approval is the only remaining human step; after that, reconnect on
+later launches is zero-click (the cloud token is cached in `Saved/Config/UnrealMcp/`).
+
+When you build the plugin **from source** (the only option until the first GitHub Release / Fab
+listing), the bundled binary is not present — the plugin then resolves the sidecar from the
+`UNREAL_MCP_BRIDGE_PATH` environment variable instead: point that at a locally built sidecar, or run
 `unreal-mcp-cli bootstrap-local` to build the bridge from source into
-`<YourProject>/Intermediate/UnrealMCP/` and set the var to the result. With no path resolved, the
-plugin's TCP listener still starts but logs `[Unreal-MCP] no sidecar binary resolved (set
-UNREAL_MCP_BRIDGE_PATH)` and spawns nothing — launch the sidecar manually for the live e2e.
-Automatic download-on-first-connect from GitHub Releases is **planned** (ARCHITECTURE §6) but **not
-yet shipped**.
+`<YourProject>/Intermediate/UnrealMCP/` and set the var to the result. With neither a bundled binary
+nor the env var resolved, the plugin's TCP listener still starts but logs
+`[Unreal-MCP] no sidecar binary resolved for rid <rid> …` and spawns nothing.
 
 ## First run
 
@@ -346,7 +353,7 @@ The plugin reads configuration with the precedence **process env → `<Project>/
 | `UNREAL_MCP_START_SERVER` | Parsed and persisted as the `startServer` config flag (Custom mode); auto-spawning the local `gamedev-mcp-server` is **planned, not yet wired** — no code consumes this flag today, so start the server yourself (e.g. `unreal-mcp-cli`). |
 | `UNREAL_MCP_TRANSPORT` | `stdio` or `http` |
 | `UNREAL_MCP_LOG_LEVEL` | Log verbosity |
-| `UNREAL_MCP_BRIDGE_PATH` | Path to a sidecar binary. **Currently the only way the plugin resolves a sidecar** (auto-download is planned §6, not yet shipped). |
+| `UNREAL_MCP_BRIDGE_PATH` | Path to a sidecar binary — the **dev/CI override**; wins over the bundled binary (§6). A packaged release auto-resolves the bundled sidecar, so end users never set this; from-source builds use it. |
 | `UNREAL_MCP_SERVER_PATH` | Path to a local `gamedev-mcp-server` binary (read by `unreal-mcp-cli`, not the plugin) — skips the server download + version check (§6). |
 
 > **Never commit `.env`.** A project-root `.env` can hold `UNREAL_MCP_TOKEN`, and UE project
@@ -366,10 +373,12 @@ The plugin reads configuration with the precedence **process env → `<Project>/
 - **Screenshot tools return a structured error.** Pixel capture needs a GPU-backed editor — they
   cannot render under headless `-nullrhi`.
 - **No sidecar / sidecar keeps restarting.** Check the bridge status in the **Connection** section
-  (`Running (restarts: N)` / `Stopped`). If the log shows `no sidecar binary resolved (set
-  UNREAL_MCP_BRIDGE_PATH)`, no sidecar path was resolved — set `UNREAL_MCP_BRIDGE_PATH` or run
-  `unreal-mcp-cli bootstrap-local` to build one from source. (Automatic download and the version-skew
-  redownload/alert are planned §6 behavior, not yet shipped.)
+  (`Running (restarts: N)` / `Stopped`). If the log shows `no sidecar binary resolved for rid <rid>
+  …`, neither a bundled binary nor `UNREAL_MCP_BRIDGE_PATH` resolved — in a packaged release this
+  means the plugin was packaged without your platform's bridge (reinstall the correct build); in a
+  from-source build, set `UNREAL_MCP_BRIDGE_PATH` or run `unreal-mcp-cli bootstrap-local` to build one
+  from source. (The sidecar is bundled inside packaged releases and auto-spawned, §6 — there is no
+  download-on-first-run.)
 - **Ports.** IPC uses a deterministic per-project port in `30000–39999` and probes forward (then an
   ephemeral port) on a collision; the local server uses a deterministic hash port in `20000–29999`
   with no probing — the CLI derives the same number without reading any config, and the server binds

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.cpp
@@ -6,8 +6,17 @@
 #include "Async/Async.h"
 #include "HAL/PlatformProcess.h"
 #include "Misc/Paths.h"
+#include "Interfaces/IPluginManager.h"
 
 #include <random>
+
+#if PLATFORM_MAC || PLATFORM_LINUX
+#include <sys/stat.h>
+#endif
+#if PLATFORM_MAC
+#include <sys/xattr.h>
+#include <sys/sysctl.h>
+#endif
 
 namespace
 {
@@ -22,19 +31,117 @@ FUnrealMcpSidecarManager::~FUnrealMcpSidecarManager()
 	Stop();
 }
 
+FString FUnrealMcpSidecarManager::BridgeBinaryBasename()
+{
+#if PLATFORM_WINDOWS
+	return TEXT("unreal-mcp-bridge.exe");
+#else
+	return TEXT("unreal-mcp-bridge");
+#endif
+}
+
+FString FUnrealMcpSidecarManager::ResolveRid(bool bArm64DirExists)
+{
+#if PLATFORM_WINDOWS
+	(void)bArm64DirExists;
+	return TEXT("win-x64");
+#elif PLATFORM_MAC
+	// §6.2: select from the PHYSICAL host CPU, not the (possibly Rosetta-translated) editor arch — the
+	// bridge is a separate child and should match the hardware. `hw.optional.arm64 == 1` on Apple
+	// Silicon reports the hardware even under a translated process (verified per design R5). Fall back to
+	// osx-x64 (runs under Rosetta 2) when the arm64 slice is absent, so a missing build is never fatal.
+	int32 IsArm64 = 0;
+	size_t Size = sizeof(IsArm64);
+	if (sysctlbyname("hw.optional.arm64", &IsArm64, &Size, nullptr, 0) != 0)
+		IsArm64 = 0; // probe unavailable → treat as Intel
+	if (IsArm64 == 1 && bArm64DirExists)
+		return TEXT("osx-arm64");
+	return TEXT("osx-x64");
+#elif PLATFORM_LINUX
+	(void)bArm64DirExists;
+	return TEXT("linux-x64");
+#else
+	(void)bArm64DirExists;
+	return FString();
+#endif
+}
+
+FString FUnrealMcpSidecarManager::ComposeBundledBridgePath(const FString& PluginBaseDir)
+{
+	if (PluginBaseDir.IsEmpty())
+		return FString();
+	const FString Rid = ResolveRid();
+	if (Rid.IsEmpty())
+		return FString();
+	const FString Path = PluginBaseDir
+		/ TEXT("Binaries") / TEXT("ThirdParty") / TEXT("UnrealMcpBridge") / Rid / BridgeBinaryBasename();
+	return FPaths::ConvertRelativePathToFull(Path);
+}
+
 FString FUnrealMcpSidecarManager::ResolveBridgeBinaryPath()
 {
-	// §6 dev override (and the only resolution path until the download task lands).
+	// §6.3 step 1 — dev/CI override: UNREAL_MCP_BRIDGE_PATH wins when set and present (bridge inner
+	// dev loop + live e2e). The bundled binary is NEVER preferred over an explicit override.
 	const FString Override = FPlatformMisc::GetEnvironmentVariable(TEXT("UNREAL_MCP_BRIDGE_PATH"));
 	if (!Override.IsEmpty() && FPaths::FileExists(Override))
 		return Override;
 
-	// TODO(§6 download task): download-on-first-run of the BRIDGE from this repo's GitHub Releases
-	// into <Project>/Intermediate/UnrealMCP/bridge/<platform>/unreal-mcp-bridge(.exe). Stubbed here.
-	// Note: only the bridge is C++-managed. The local MCP server (gamedev-mcp-server, the shared
-	// IvanMurzak/GameDev-MCP-Server release) is acquired by the CLI (`unreal-mcp-cli` download-server
-	// module, §6) — do NOT implement server download here.
-	return FString();
+	// §6.3 step 2 — bundled path inside the plugin (the production path for every end user). The
+	// self-contained binary ships under Binaries/ThirdParty/UnrealMcpBridge/<rid>/ (§6.1), staged into
+	// the packaged plugin by the release job (T4); a dev source checkout has none, so this returns
+	// empty and the override above is the dev path (unchanged behavior on a fresh source tree).
+	TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("UnrealMCP"));
+	if (!Plugin.IsValid())
+		return FString(); // §6.3 step 3 — neither resolves; caller logs the actionable error.
+
+	// On Apple Silicon, prefer osx-arm64 only when that dir is actually present (defensive — a build that
+	// shipped only osx-x64 must not resolve to a missing arm64 path). Probe the arm64 dir first.
+	bool bArm64DirExists = true;
+#if PLATFORM_MAC
+	const FString Arm64Candidate = Plugin->GetBaseDir()
+		/ TEXT("Binaries") / TEXT("ThirdParty") / TEXT("UnrealMcpBridge") / TEXT("osx-arm64") / BridgeBinaryBasename();
+	bArm64DirExists = FPaths::FileExists(Arm64Candidate);
+#endif
+	const FString Rid = ResolveRid(bArm64DirExists);
+	if (Rid.IsEmpty())
+		return FString();
+
+	const FString Path = FPaths::ConvertRelativePathToFull(
+		Plugin->GetBaseDir() / TEXT("Binaries") / TEXT("ThirdParty") / TEXT("UnrealMcpBridge") / Rid / BridgeBinaryBasename());
+	return FPaths::FileExists(Path) ? Path : FString();
+}
+
+bool FUnrealMcpSidecarManager::PrepareBundledBinaryForSpawn(const FString& Path)
+{
+	if (Path.IsEmpty())
+		return false;
+
+#if PLATFORM_MAC || PLATFORM_LINUX
+	// §6.6: ensure the apphost is executable. UE has no portable chmod; call the syscall directly (no
+	// shell, no PATH dependency). 0755 = rwxr-xr-x.
+	const auto Utf8Path = StringCast<ANSICHAR>(*Path);
+	if (chmod(Utf8Path.Get(), 0755) != 0)
+	{
+		UE_LOG(LogUnrealMcp, Warning,
+			TEXT("[Unreal-MCP] could not set +x on the bundled sidecar '%s' (errno=%d); spawn may fail."),
+			*Path, errno);
+		// Not fatal — the bit may already be set by the packager; let the spawn attempt surface a real failure.
+	}
+#endif
+#if PLATFORM_MAC
+	// §6.6 / design R3: strip com.apple.quarantine so Gatekeeper's first-exec check is bypassed even
+	// offline (a binary with no quarantine xattr is not Gatekeeper-checked on exec). Belt-and-suspenders
+	// alongside notarization (T3). ENOATTR (no such attribute) is the expected happy case for an
+	// already-clean or never-quarantined binary — tolerate it.
+	if (removexattr(Utf8Path.Get(), "com.apple.quarantine", 0) != 0 && errno != ENOATTR)
+	{
+		UE_LOG(LogUnrealMcp, Verbose,
+			TEXT("[Unreal-MCP] could not strip com.apple.quarantine from '%s' (errno=%d); relying on notarization."),
+			*Path, errno);
+	}
+#endif
+	(void)Path;
+	return true;
 }
 
 FString FUnrealMcpSidecarManager::GenerateToken()
@@ -65,11 +172,23 @@ bool FUnrealMcpSidecarManager::StartForPort(int32 InIpcPort, const FString& InTo
 	BridgePath = ResolveBridgeBinaryPath();
 	if (BridgePath.IsEmpty())
 	{
+		// §6.3 step 3 graceful-degrade: a packaged plugin missing the <rid> bridge, OR a dev source
+		// checkout with no UNREAL_MCP_BRIDGE_PATH set. The bridge server still listens; surface an
+		// actionable error (the bundled binary is the production path, the env var is the dev path).
 		UE_LOG(LogUnrealMcp, Warning,
-			TEXT("[Unreal-MCP] no sidecar binary resolved (set UNREAL_MCP_BRIDGE_PATH). The bridge is listening on %d; launch the sidecar manually for the live e2e."),
-			IpcPort);
+			TEXT("[Unreal-MCP] no sidecar binary resolved for rid '%s' (bundled path absent and UNREAL_MCP_BRIDGE_PATH unset). ")
+			TEXT("The bridge is listening on %d. End users: reinstall the plugin for your platform; developers: set UNREAL_MCP_BRIDGE_PATH or run `unreal-mcp-cli bootstrap-local`."),
+			*ResolveRid(), IpcPort);
 		return false;
 	}
+
+	// §6.6 pre-spawn prep (macOS/Linux): +x and (macOS) quarantine strip on the resolved bundled binary.
+	// The dev override is assumed already-runnable (the dev built it), so prep only the bundled path.
+	const FString Override = FPlatformMisc::GetEnvironmentVariable(TEXT("UNREAL_MCP_BRIDGE_PATH"));
+	const bool bUsingOverride = !Override.IsEmpty() && FPaths::FileExists(Override)
+		&& (BridgePath == Override || BridgePath == FPaths::ConvertRelativePathToFull(Override));
+	if (!bUsingOverride)
+		PrepareBundledBinaryForSpawn(BridgePath);
 
 	if (!SpawnProcess())
 	{

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.cpp
@@ -11,6 +11,7 @@
 #include <random>
 
 #if PLATFORM_MAC || PLATFORM_LINUX
+#include <cerrno>
 #include <sys/stat.h>
 #endif
 #if PLATFORM_MAC
@@ -66,16 +67,38 @@ FString FUnrealMcpSidecarManager::ResolveRid(bool bArm64DirExists)
 #endif
 }
 
-FString FUnrealMcpSidecarManager::ComposeBundledBridgePath(const FString& PluginBaseDir)
+FString FUnrealMcpSidecarManager::ComposeBundledBridgePath(const FString& PluginBaseDir, bool bArm64DirExists)
 {
 	if (PluginBaseDir.IsEmpty())
 		return FString();
-	const FString Rid = ResolveRid();
+	const FString Rid = ResolveRid(bArm64DirExists);
 	if (Rid.IsEmpty())
 		return FString();
 	const FString Path = PluginBaseDir
 		/ TEXT("Binaries") / TEXT("ThirdParty") / TEXT("UnrealMcpBridge") / Rid / BridgeBinaryBasename();
 	return FPaths::ConvertRelativePathToFull(Path);
+}
+
+bool FUnrealMcpSidecarManager::BundledArm64SliceExists()
+{
+	// On Apple Silicon, prefer osx-arm64 only when that dir is actually present (defensive — a build that
+	// shipped only osx-x64 must not resolve to a missing arm64 path). On non-macOS hosts the arm64 flag is
+	// irrelevant to ResolveRid, so report true (the cheap default).
+#if PLATFORM_MAC
+	TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("UnrealMCP"));
+	if (!Plugin.IsValid())
+		return false;
+	const FString Arm64Candidate = Plugin->GetBaseDir()
+		/ TEXT("Binaries") / TEXT("ThirdParty") / TEXT("UnrealMcpBridge") / TEXT("osx-arm64") / BridgeBinaryBasename();
+	return FPaths::FileExists(Arm64Candidate);
+#else
+	return true;
+#endif
+}
+
+FString FUnrealMcpSidecarManager::ResolveEffectiveRid()
+{
+	return ResolveRid(BundledArm64SliceExists());
 }
 
 FString FUnrealMcpSidecarManager::ResolveBridgeBinaryPath()
@@ -94,20 +117,11 @@ FString FUnrealMcpSidecarManager::ResolveBridgeBinaryPath()
 	if (!Plugin.IsValid())
 		return FString(); // §6.3 step 3 — neither resolves; caller logs the actionable error.
 
-	// On Apple Silicon, prefer osx-arm64 only when that dir is actually present (defensive — a build that
-	// shipped only osx-x64 must not resolve to a missing arm64 path). Probe the arm64 dir first.
-	bool bArm64DirExists = true;
-#if PLATFORM_MAC
-	const FString Arm64Candidate = Plugin->GetBaseDir()
-		/ TEXT("Binaries") / TEXT("ThirdParty") / TEXT("UnrealMcpBridge") / TEXT("osx-arm64") / BridgeBinaryBasename();
-	bArm64DirExists = FPaths::FileExists(Arm64Candidate);
-#endif
-	const FString Rid = ResolveRid(bArm64DirExists);
-	if (Rid.IsEmpty())
+	// Share the single §6.1 layout composition with the unit-tested pure helper (no inline drift); pass the
+	// arm64-probe result so a host with only the osx-x64 slice degrades to that rid.
+	const FString Path = ComposeBundledBridgePath(Plugin->GetBaseDir(), BundledArm64SliceExists());
+	if (Path.IsEmpty())
 		return FString();
-
-	const FString Path = FPaths::ConvertRelativePathToFull(
-		Plugin->GetBaseDir() / TEXT("Binaries") / TEXT("ThirdParty") / TEXT("UnrealMcpBridge") / Rid / BridgeBinaryBasename());
 	return FPaths::FileExists(Path) ? Path : FString();
 }
 
@@ -173,12 +187,14 @@ bool FUnrealMcpSidecarManager::StartForPort(int32 InIpcPort, const FString& InTo
 	if (BridgePath.IsEmpty())
 	{
 		// §6.3 step 3 graceful-degrade: a packaged plugin missing the <rid> bridge, OR a dev source
-		// checkout with no UNREAL_MCP_BRIDGE_PATH set. The bridge server still listens; surface an
-		// actionable error (the bundled binary is the production path, the env var is the dev path).
+		// checkout with no (or a stale) UNREAL_MCP_BRIDGE_PATH. The bridge server still listens; surface
+		// an actionable error (the bundled binary is the production path, the env var is the dev path).
+		// Report the EFFECTIVE rid (arm64-probed, matching ResolveBridgeBinaryPath) so the reinstall hint
+		// names the slice that was actually looked for — not osx-arm64 on a host that degraded to osx-x64.
 		UE_LOG(LogUnrealMcp, Warning,
-			TEXT("[Unreal-MCP] no sidecar binary resolved for rid '%s' (bundled path absent and UNREAL_MCP_BRIDGE_PATH unset). ")
+			TEXT("[Unreal-MCP] no sidecar binary resolved for rid '%s' (bundled path absent and UNREAL_MCP_BRIDGE_PATH unset or pointing at a missing file). ")
 			TEXT("The bridge is listening on %d. End users: reinstall the plugin for your platform; developers: set UNREAL_MCP_BRIDGE_PATH or run `unreal-mcp-cli bootstrap-local`."),
-			*ResolveRid(), IpcPort);
+			*ResolveEffectiveRid(), IpcPort);
 		return false;
 	}
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.h
@@ -74,9 +74,11 @@ public:
 	/**
 	 * Compose the bundled bridge path under @p PluginBaseDir for the current host (§6.1):
 	 * <PluginBaseDir>/Binaries/ThirdParty/UnrealMcpBridge/<rid>/unreal-mcp-bridge[.exe]. Pure string
-	 * composition (no FileExists), absolute-ized — testable independent of a staged binary.
+	 * composition (no FileExists), absolute-ized — testable independent of a staged binary. @p
+	 * bArm64DirExists is forwarded to ResolveRid so the production resolver can pass its arm64-probe
+	 * result (a missing osx-arm64 slice degrades the composed path to osx-x64).
 	 */
-	static UNREALMCPEDITOR_API FString ComposeBundledBridgePath(const FString& PluginBaseDir);
+	static UNREALMCPEDITOR_API FString ComposeBundledBridgePath(const FString& PluginBaseDir, bool bArm64DirExists = true);
 
 	/** The platform bridge binary basename: "unreal-mcp-bridge.exe" on Windows, "unreal-mcp-bridge" elsewhere. */
 	static UNREALMCPEDITOR_API FString BridgeBinaryBasename();
@@ -93,6 +95,12 @@ public:
 	static UNREALMCPEDITOR_API bool PrepareBundledBinaryForSpawn(const FString& Path);
 
 private:
+	/** Whether the osx-arm64 bridge slice is present in the bundle (always true off macOS). §6.2 defensive. */
+	static bool BundledArm64SliceExists();
+
+	/** The rid the resolver would actually use for the current host (arm64-probed); for log/error messages. */
+	static FString ResolveEffectiveRid();
+
 	bool SpawnProcess();
 	void StartWatchdog();
 	void StopWatchdog();

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Sidecar/UnrealMcpSidecarManager.h
@@ -11,9 +11,11 @@
  * Owns the lifecycle of the unreal-mcp-bridge sidecar process (docs/ARCHITECTURE.md §6): resolve the
  * binary, generate the one-shot IPC token, spawn the process delivering the token over stdin (§1.4),
  * watch it (crash → auto-restart with backoff, §1.5), and terminate it on editor shutdown (no orphans,
- * §6 layer 1). The download-on-first-run flow (§6) is intentionally STUBBED in this task behind the
- * UNREAL_MCP_BRIDGE_PATH dev override — the binary path must resolve from that env/.env var (or a
- * previously-downloaded location) until the release/download task lands.
+ * §6 layer 1). Binary resolution follows the §6 BUNDLE model: (1) the UNREAL_MCP_BRIDGE_PATH dev/CI
+ * override wins when set, then (2) the prebuilt self-contained binary bundled inside the plugin under
+ * Binaries/ThirdParty/UnrealMcpBridge/<rid>/. A fresh GUI install resolves the bundled path and
+ * auto-spawns at StartupModule with zero user action; a dev source checkout (no staged binary) falls
+ * back to the override, exactly as before.
  */
 class FUnrealMcpSidecarManager
 {
@@ -54,11 +56,41 @@ public:
 	bool IsRunning() const;
 	int32 GetRestartCount() const { return RestartCount.GetValue(); }
 
-	/** Resolve the bridge binary path (UNREAL_MCP_BRIDGE_PATH override, §6). Empty when unresolved. */
-	static FString ResolveBridgeBinaryPath();
+	/**
+	 * Resolve the bridge binary path (§6 BUNDLE model): UNREAL_MCP_BRIDGE_PATH dev/CI override first,
+	 * then the bundled path inside the plugin. Empty when neither resolves (caller logs the actionable
+	 * packaged-without-<rid> error). The returned bundled path is absolute (ConvertRelativePathToFull).
+	 */
+	static UNREALMCPEDITOR_API FString ResolveBridgeBinaryPath();
+
+	/**
+	 * The .NET RID directory name for the current host platform (§6.2): "win-x64" / "linux-x64", or
+	 * on macOS "osx-arm64" vs "osx-x64" chosen from the PHYSICAL host CPU (not the possibly-Rosetta-
+	 * translated editor arch). @p bArm64DirExists lets the caller fall back to osx-x64 when the
+	 * arm64 slice is absent; pure + injectable so it is unit-testable without touching the filesystem.
+	 */
+	static UNREALMCPEDITOR_API FString ResolveRid(bool bArm64DirExists = true);
+
+	/**
+	 * Compose the bundled bridge path under @p PluginBaseDir for the current host (§6.1):
+	 * <PluginBaseDir>/Binaries/ThirdParty/UnrealMcpBridge/<rid>/unreal-mcp-bridge[.exe]. Pure string
+	 * composition (no FileExists), absolute-ized — testable independent of a staged binary.
+	 */
+	static UNREALMCPEDITOR_API FString ComposeBundledBridgePath(const FString& PluginBaseDir);
+
+	/** The platform bridge binary basename: "unreal-mcp-bridge.exe" on Windows, "unreal-mcp-bridge" elsewhere. */
+	static UNREALMCPEDITOR_API FString BridgeBinaryBasename();
 
 	/** Generate a 32-byte token via the OS CSPRNG, hex-encoded (§1.4). */
 	static FString GenerateToken();
+
+	/**
+	 * macOS/Linux pre-spawn prep on @p Path (§6.6): ensure the executable bit (+x) and, on macOS, strip
+	 * the com.apple.quarantine xattr so Gatekeeper's first-exec check is bypassed offline. No-op on
+	 * Windows. Static + path-taking so a spec can exercise it on a fixture binary; tolerant of a
+	 * missing xattr. Returns true if no fatal error occurred (a missing quarantine attr is not fatal).
+	 */
+	static UNREALMCPEDITOR_API bool PrepareBundledBinaryForSpawn(const FString& Path);
 
 private:
 	bool SpawnProcess();

--- a/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
+++ b/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the repository root for more information.
 
+using System.IO;
 using UnrealBuildTool;
 
 public class UnrealMcpEditor : ModuleRules
@@ -19,7 +20,7 @@ public class UnrealMcpEditor : ModuleRules
 		//  - Json/JsonUtilities  -> NDJSON framing + FProperty<->JSON schema/serialization (§1.2, §3)
 		//  - UnrealEd/EditorSubsystem -> editor operations from tool bodies (§3.3, §10)
 		//  - Slate/SlateCore     -> main window + 4 aux tabs (§7)
-		//  - Projects            -> IPluginManager (plugin version/paths, sidecar download, §6)
+		//  - Projects            -> IPluginManager (plugin version/paths, bundled-sidecar resolution, §6)
 		//  - DeveloperSettings   -> ISettingsModule-backed settings page (§7)
 		PrivateDependencyModuleNames.AddRange(new string[]
 		{
@@ -80,5 +81,16 @@ public class UnrealMcpEditor : ModuleRules
 		{
 			PublicDefinitions.Add("WITH_UNREAL_MCP_LIVE_CODING=0");
 		}
+
+		// Bundle the prebuilt self-contained sidecar payloads (docs/ARCHITECTURE.md §6 BUNDLE model).
+		// Staged into the packaged plugin under Binaries/ThirdParty/UnrealMcpBridge/<rid>/ so the editor
+		// can spawn the bridge with zero install (FUnrealMcpSidecarManager::ResolveBridgeBinaryPath). The
+		// binaries are NOT committed to git; the release job stages them before BuildPlugin (task T4). The
+		// recursive "..." wildcard is a no-op on a dev checkout that has not staged them, so local source
+		// builds still compile and resolve the bridge via UNREAL_MCP_BRIDGE_PATH instead. NonUFS = raw
+		// (not cooked) files, correct for native runtime binaries.
+		RuntimeDependencies.Add(
+			Path.Combine(PluginDirectory, "Binaries", "ThirdParty", "UnrealMcpBridge", "...", "*"),
+			StagedFileType.NonUFS);
 	}
 }

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSidecarManagerSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSidecarManagerSpec.cpp
@@ -11,6 +11,10 @@
 #include "HAL/PlatformProcess.h"
 #include "Sidecar/UnrealMcpSidecarManager.h"
 
+#if PLATFORM_MAC || PLATFORM_LINUX
+#include <sys/stat.h>
+#endif
+
 /**
  * Sidecar binary-resolution specs (docs/ARCHITECTURE.md §6 BUNDLE model). Cover the pure, host-
  * deterministic resolver helpers — RID mapping, basename, bundled-path composition — plus the
@@ -133,6 +137,17 @@ void FUnrealMcpSidecarManagerSpec::Define()
 			const FString Fake = SidecarSpecMakeFakeBinary(TEXT("prep-bridge.bin"));
 			const bool bOk = FUnrealMcpSidecarManager::PrepareBundledBinaryForSpawn(Fake);
 			TestTrue(TEXT("prep on an existing file does not report a fatal error"), bOk);
+#if PLATFORM_MAC || PLATFORM_LINUX
+			// §6.6 load-bearing behavior: the apphost must end up executable (chmod 0755). Verify the
+			// mode bits, not just the non-fatal return — a missing +x would make the real spawn fail.
+			const auto Utf8 = StringCast<ANSICHAR>(*Fake);
+			struct stat St;
+			if (TestTrue(TEXT("stat the prepped fixture"), stat(Utf8.Get(), &St) == 0))
+			{
+				TestEqual(TEXT("prepped file is mode 0755 (rwxr-xr-x)"),
+					static_cast<int32>(St.st_mode & 0777), static_cast<int32>(0755));
+			}
+#endif
 			SidecarSpecCleanup();
 		});
 

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSidecarManagerSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSidecarManagerSpec.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformProcess.h"
+#include "Sidecar/UnrealMcpSidecarManager.h"
+
+/**
+ * Sidecar binary-resolution specs (docs/ARCHITECTURE.md §6 BUNDLE model). Cover the pure, host-
+ * deterministic resolver helpers — RID mapping, basename, bundled-path composition — plus the
+ * UNREAL_MCP_BRIDGE_PATH override-wins behavior and the graceful-degrade (empty) path. The full
+ * IPluginManager-backed bundled resolution and the macOS/Linux spawn-prep syscalls are exercised by
+ * the live e2e / packaging dry-run (no staged binary exists in a dev checkout), not unit-asserted here.
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpSidecarManagerSpec, "UnrealMcp.Sidecar",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	// Spec-unique helper (unity-build ODR rule): write a throwaway file that looks like a bridge binary
+	// so the override branch's FPaths::FileExists check passes, and return its absolute path.
+	static FString SidecarSpecMakeFakeBinary(const FString& Leaf)
+	{
+		const FString Dir = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("UnrealMcpSidecarSpec"));
+		IFileManager::Get().MakeDirectory(*Dir, /*Tree*/ true);
+		const FString Path = FPaths::ConvertRelativePathToFull(FPaths::Combine(Dir, Leaf));
+		FFileHelper::SaveStringToFile(TEXT("not-a-real-binary"), *Path);
+		return Path;
+	}
+
+	static void SidecarSpecCleanup()
+	{
+		const FString Dir = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("UnrealMcpSidecarSpec"));
+		IFileManager::Get().DeleteDirectory(*Dir, /*RequireExists*/ false, /*Tree*/ true);
+		FPlatformMisc::SetEnvironmentVar(TEXT("UNREAL_MCP_BRIDGE_PATH"), TEXT(""));
+	}
+
+END_DEFINE_SPEC(FUnrealMcpSidecarManagerSpec)
+
+void FUnrealMcpSidecarManagerSpec::Define()
+{
+	Describe("ResolveRid", [this]()
+	{
+		It("maps the host platform to the documented .NET RID directory (§6.2)", [this]()
+		{
+			const FString Rid = FUnrealMcpSidecarManager::ResolveRid(/*bArm64DirExists*/ true);
+#if PLATFORM_WINDOWS
+			TestEqual(TEXT("Windows host -> win-x64"), Rid, FString(TEXT("win-x64")));
+#elif PLATFORM_LINUX
+			TestEqual(TEXT("Linux host -> linux-x64"), Rid, FString(TEXT("linux-x64")));
+#elif PLATFORM_MAC
+			// Apple Silicon -> osx-arm64, Intel -> osx-x64; either is a valid macOS RID.
+			TestTrue(TEXT("Mac host -> an osx-* rid"), Rid == TEXT("osx-arm64") || Rid == TEXT("osx-x64"));
+#endif
+		});
+
+		It("falls back to osx-x64 when the arm64 slice is absent (§6.2 defensive)", [this]()
+		{
+			const FString Rid = FUnrealMcpSidecarManager::ResolveRid(/*bArm64DirExists*/ false);
+#if PLATFORM_MAC
+			TestEqual(TEXT("arm64 dir missing -> osx-x64 even on Apple Silicon"), Rid, FString(TEXT("osx-x64")));
+#elif PLATFORM_WINDOWS
+			TestEqual(TEXT("non-mac unaffected by the arm64 flag"), Rid, FString(TEXT("win-x64")));
+#elif PLATFORM_LINUX
+			TestEqual(TEXT("non-mac unaffected by the arm64 flag"), Rid, FString(TEXT("linux-x64")));
+#endif
+		});
+	});
+
+	Describe("BridgeBinaryBasename", [this]()
+	{
+		It("is platform-correct (.exe on Windows only)", [this]()
+		{
+			const FString Base = FUnrealMcpSidecarManager::BridgeBinaryBasename();
+#if PLATFORM_WINDOWS
+			TestEqual(TEXT("Windows basename"), Base, FString(TEXT("unreal-mcp-bridge.exe")));
+#else
+			TestEqual(TEXT("posix basename"), Base, FString(TEXT("unreal-mcp-bridge")));
+#endif
+		});
+	});
+
+	Describe("ComposeBundledBridgePath", [this]()
+	{
+		It("composes <base>/Binaries/ThirdParty/UnrealMcpBridge/<rid>/<basename> (§6.1)", [this]()
+		{
+			const FString Base = TEXT("C:/fake/plugin/UnrealMCP");
+			const FString Path = FUnrealMcpSidecarManager::ComposeBundledBridgePath(Base);
+			const FString Expected = FPaths::ConvertRelativePathToFull(
+				FString(Base) / TEXT("Binaries") / TEXT("ThirdParty") / TEXT("UnrealMcpBridge")
+				/ FUnrealMcpSidecarManager::ResolveRid() / FUnrealMcpSidecarManager::BridgeBinaryBasename());
+			TestEqual(TEXT("composed path matches the §6.1 layout"), Path, Expected);
+			TestTrue(TEXT("path is under the ThirdParty bundle dir"),
+				Path.Contains(TEXT("Binaries/ThirdParty/UnrealMcpBridge")) || Path.Contains(TEXT("Binaries\\ThirdParty\\UnrealMcpBridge")));
+		});
+
+		It("returns empty for an empty plugin base dir", [this]()
+		{
+			TestTrue(TEXT("empty base -> empty path"), FUnrealMcpSidecarManager::ComposeBundledBridgePath(FString()).IsEmpty());
+		});
+	});
+
+	Describe("ResolveBridgeBinaryPath", [this]()
+	{
+		It("returns the UNREAL_MCP_BRIDGE_PATH override when it points at an existing file (§6.3 step 1)", [this]()
+		{
+			const FString Fake = SidecarSpecMakeFakeBinary(TEXT("override-bridge.bin"));
+			FPlatformMisc::SetEnvironmentVar(TEXT("UNREAL_MCP_BRIDGE_PATH"), *Fake);
+			const FString Resolved = FUnrealMcpSidecarManager::ResolveBridgeBinaryPath();
+			TestEqual(TEXT("override wins over the bundled path"), Resolved, Fake);
+			SidecarSpecCleanup();
+		});
+
+		It("ignores a non-existent override and degrades when no bundled binary exists (§6.3 step 3)", [this]()
+		{
+			// A dev checkout never has a staged bundled binary, so with a bogus override the resolver
+			// must return empty rather than a phantom path — this is the graceful-degrade precondition.
+			FPlatformMisc::SetEnvironmentVar(TEXT("UNREAL_MCP_BRIDGE_PATH"), TEXT("Z:/does/not/exist/unreal-mcp-bridge.bin"));
+			const FString Resolved = FUnrealMcpSidecarManager::ResolveBridgeBinaryPath();
+			TestTrue(TEXT("bogus override + no bundle -> empty"), Resolved.IsEmpty());
+			SidecarSpecCleanup();
+		});
+	});
+
+	Describe("PrepareBundledBinaryForSpawn", [this]()
+	{
+		It("is tolerant of a real file on every platform (no-op on Windows, +x/xattr on posix)", [this]()
+		{
+			const FString Fake = SidecarSpecMakeFakeBinary(TEXT("prep-bridge.bin"));
+			const bool bOk = FUnrealMcpSidecarManager::PrepareBundledBinaryForSpawn(Fake);
+			TestTrue(TEXT("prep on an existing file does not report a fatal error"), bOk);
+			SidecarSpecCleanup();
+		});
+
+		It("returns false for an empty path", [this]()
+		{
+			TestFalse(TEXT("empty path -> false"), FUnrealMcpSidecarManager::PrepareBundledBinaryForSpawn(FString()));
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,7 +24,7 @@ delivered it. Identifiers below (tool ids, command names, env vars, paths) were 
 | §3 Schema generation | implemented | exercised by every tool family (#13–#25) |
 | §4 GameThread dispatcher | implemented | #4 (used by all 8 families) |
 | §5 Extensions mechanism | implemented | #7 (`IUnrealMcpToolProvider`, `samples/UnrealAITemplate`) |
-| §6 Sidecar lifecycle | **partial** | #4 (spawn / crash auto-restart / orphan-prevention / stdin-token); auto-download + version-skew re-download are TODO stubs (see drift below) |
+| §6 Sidecar lifecycle | implemented | #4 (spawn / crash auto-restart / orphan-prevention / stdin-token) + #46 (BUNDLE-model resolution: env override → bundled `Binaries/ThirdParty/UnrealMcpBridge/<rid>/`, zero-click auto-spawn; the superseded download-on-first-run flow is dropped — see drift below) |
 | §7 Slate UI | implemented | #24 (AI Game Developer main window) + #29 (MCP Tools/Prompts/Resources/Settings aux windows) |
 | §8 Config & env | implemented | #8 (`UNREAL_MCP_*`, `.env`, on-disk config) |
 | §9.1 cli (`unreal-mcp-cli`, 16 commands) | implemented | #3 |
@@ -72,14 +72,20 @@ Prompts/Resources ship empty-but-wired (§10), as designed.
 - **Device-code auth (#24).** The cloud OAuth device-code flow shipped in the main window (Authorize
   → `auth-start` → `device-auth` events render the verification URL + user code; Cancel/Revoke wired),
   per §1.3 / §7 item 4.
-- **§6 sidecar lifecycle — shipped with partial coverage.** What ships today: the plugin **spawns**
-  the sidecar, hands it the one-shot IPC token over **stdin** (§1.4), **crash auto-restarts** it (the
-  Connection section reports `Running (restarts: N)` / `Stopped`), and prevents orphans (the sidecar
-  self-exits when its parent editor vanishes). The sidecar binary is resolved **only** from
-  `UNREAL_MCP_BRIDGE_PATH` (env/`.env`); `unreal-mcp-cli bootstrap-local` builds one from source. What is
-  **not yet wired**: the §6 **download-on-first-run** from GitHub Releases and the **version-skew
-  re-download/alert** flow are TODO stubs. The §6 download prose is retained as the plan of record,
-  not the shipped state.
+- **§6 sidecar lifecycle — BUNDLE model shipped (#46).** The plugin **spawns** the sidecar, hands it
+  the one-shot IPC token over **stdin** (§1.4), **crash auto-restarts** it (the Connection section
+  reports `Running (restarts: N)` / `Stopped`), and prevents orphans (the sidecar self-exits when its
+  parent editor vanishes). Binary resolution now follows the §6.3 order: `UNREAL_MCP_BRIDGE_PATH`
+  (dev/CI override) → the **bundled** self-contained binary inside the plugin under
+  `Binaries/ThirdParty/UnrealMcpBridge/<rid>/` (`ResolveBridgeBinaryPath` / `ResolveRid`), with
+  macOS/Linux pre-spawn `+x` and macOS `com.apple.quarantine` strip (`PrepareBundledBinaryForSpawn`).
+  A packaged plugin therefore auto-spawns at StartupModule with zero user action; a dev source
+  checkout (no staged binary) still uses the env override and emits the rid-aware actionable warning.
+  The earlier **download-on-first-run + version-skew re-download** design is **superseded and removed**
+  (no `.lock`, no atomic-rename, no re-download recovery) — version lockstep is by construction
+  (bundle built in the same release job at the same version). The bundled binaries are staged by the
+  release job (`RuntimeDependencies`, `UnrealMcpEditor.Build.cs`) and are **never committed to git**;
+  CI signing/notarization of those binaries is owned by the T3/T4 release tasks.
 - **§7 UI — shipped with partial coverage.** The §7 Slate UI shipped (#24/#29), but two §7 design
   affordances did **not** make this release: the **toolbar button** (§7's tab-registration paragraph,
   "under Window → AI Game Developer plus a toolbar button") — the main window is opened from its nomad
@@ -113,7 +119,7 @@ Unreal sidecar from a Unity editor.
 │  ├─ FUnrealMcpSchemaGenerator ── FProperty → JSON Schema                 │
 │  ├─ FUnrealMcpGameThreadDispatcher ── AsyncTask + TPromise               │
 │  ├─ FUnrealMcpBridgeServer ── localhost TCP listener, NDJSON framing     │
-│  ├─ FUnrealMcpSidecarManager ── download / spawn / watchdog / kill       │
+│  ├─ FUnrealMcpSidecarManager ── resolve(bundled) / spawn / watchdog / kill│
 │  └─ Slate UI: main window + 4 aux tabs, ISettingsModule section          │
 └───────────────▲──────────────────────────────────────────────────────────┘
                 │ IPC: 127.0.0.1 TCP, newline-delimited JSON, token-authed
@@ -517,48 +523,124 @@ public:
 
 ## 6. Sidecar lifecycle
 
-**Decision: download-on-first-run from GitHub Releases** (exactly Unity's proven
-`DownloadServerBinaryIfNeeded` flow, `McpServerManager.cs:275–346`), **not** bundling. Rationale:
-the sidecar is a self-contained .NET 9 single-file publish (~70–90 MB ×3 RIDs); bundling triples
-the plugin zip, bloats Fab submission, and welds sidecar fixes to plugin releases. Mirrors a
-mechanism already shipped and debugged twice (Unity, Godot server downloads).
+**Decision: BUNDLE the sidecar inside the plugin.** Prebuilt, **self-contained, single-file**
+`unreal-mcp-bridge` binaries for all four RIDs ship inside the plugin and are resolved from disk at
+spawn time — there is **no download-on-first-run**. Rationale: the owner requirement is zero .NET
+install + zero manual steps for the end user; a bundle guarantees the binary is present and
+version-correct the instant the compiled plugin loads, works fully offline/air-gapped, and welds
+the sidecar to the exact plugin version it was tested against (no skew window). The earlier
+download-on-first-run design (Unity's `DownloadServerBinaryIfNeeded` flow) is **superseded**: it is
+retained only for the **shared `gamedev-mcp-server`** (a different process, owned by the CLI — see
+"Local server acquisition"), never for the bridge.
 
-- **Location:** `<Project>/Intermediate/UnrealMCP/bridge/<platform>/unreal-mcp-bridge(.exe)` +
-  `version` file (Unity keeps a version file beside the binary — same here). `Intermediate/` is
-  user-gitignored by every UE template; plugin dir is avoided because engine/Fab installs may be
-  read-only. The local `gamedev-mcp-server` binary lands beside it under `…/server/<platform>/`
-  (see "Local server acquisition" below).
-- **URL:** `https://github.com/IvanMurzak/Unreal-MCP/releases/download/<version>/unreal-mcp-bridge-<platform>.zip`
-  (platforms `win-x64`, `osx-arm64`, `osx-x64`, `linux-x64` — same naming scheme as Unity's
-  `ExecutableZipUrl`, `McpServerManager.cs:169`).
-- **Version-match:** plugin version (single-sourced, §9) vs `version` file; mismatch → re-download
-  before launch. Sidecar additionally reports `sidecarVersion` in the handshake; mismatch there
-  (manual tampering) → kill, re-download once, then hard-fail to UI.
-- **Crash auto-restart:** §1.5 backoff. **No orphans:** three independent layers — (1) plugin
-  `TerminateProc` on shutdown; (2) sidecar self-exits when the parent identified by
-  `--parent-pid` **plus its process start time** (captured via .NET `Process.StartTime` at
-  sidecar boot) vanishes (2 s poll) — the start-time check makes the identity unique, so PID
-  reuse can't silently disable this layer; (3) sidecar self-exits after 60 s without a
-  **successful handshake** — a TCP connect whose handshake is rejected does NOT reset the timer
-  (otherwise a stale-token orphan re-dialing a relaunched editor would keep itself alive
-  forever). Handshake rejection is additionally fatal to the sidecar after 3 consecutive
-  rejections (§1.4), so the rejected-handshake churn ends well before the 60 s timer. Layer 2
-  covers editor crashes, layer 3 covers the remaining edge cases.
+### 6.1 Bundled layout (exact path strings)
+
+```
+UnrealMCP/                                  # plugin root (UnrealMCP.uplugin lives here)
+└── Binaries/
+    └── ThirdParty/
+        └── UnrealMcpBridge/
+            ├── win-x64/    unreal-mcp-bridge.exe   (+ self-contained payload files)
+            ├── osx-arm64/  unreal-mcp-bridge       (+ payload)
+            ├── osx-x64/    unreal-mcp-bridge       (+ payload)
+            └── linux-x64/  unreal-mcp-bridge       (+ payload)
+```
+
+- Parent dir constant (C++): `Binaries/ThirdParty/UnrealMcpBridge/<rid>/`, resolved relative to the
+  plugin's base dir via `IPluginManager::Get().FindPlugin(TEXT("UnrealMCP"))->GetBaseDir()` (the
+  `Projects` module is already a dependency — `UnrealMcpEditor.Build.cs`).
+- Binary basename: `unreal-mcp-bridge` on macOS/Linux, `unreal-mcp-bridge.exe` on Windows (matches
+  `<AssemblyName>unreal-mcp-bridge</AssemblyName>` in the bridge csproj).
+- `Binaries/ThirdParty/` is the UE-canonical home for prebuilt third-party runtime payloads and is
+  what `RuntimeDependencies` + `-Rocket` BuildPlugin packaging expect.
+
+### 6.2 UE platform → .NET RID mapping
+
+| `UE` platform | RID dir | Notes |
+|---|---|---|
+| `Win64` (`PLATFORM_WINDOWS`) | `win-x64` | only x64 editor RID shipped |
+| `Mac` (`PLATFORM_MAC`), Apple Silicon | `osx-arm64` | chosen at runtime — see below |
+| `Mac` (`PLATFORM_MAC`), Intel | `osx-x64` | chosen at runtime — see below |
+| `Linux` (`PLATFORM_LINUX`) | `linux-x64` | only x64 editor RID shipped |
+
+**macOS arm64-vs-x64 selection at runtime.** The plugin must NOT assume the editor's own
+architecture equals the host CPU (an Intel-built editor can run under Rosetta on Apple Silicon, and
+vice-versa). The bridge is a separate child process, so it matches the **host CPU**, not the
+editor's translated architecture. `FUnrealMcpSidecarManager::ResolveRid()` reads the **physical** CPU
+via `sysctlbyname("hw.optional.arm64", …)` (returns 1 on Apple Silicon even under a translated
+process) and prefers `osx-arm64/`; if that dir is absent (defensive), it falls back to `osx-x64/`
+(runs under Rosetta 2). Intel host → `osx-x64/`. Native is preferred because Rosetta-translating the
+.NET host is slower and has historically been a source of JIT edge cases.
+
+`ResolveBridgeBinaryPath()` composes `<PluginBaseDir>/Binaries/ThirdParty/UnrealMcpBridge/<rid>/<basename>`
+and returns it only if `FPaths::FileExists` is true; otherwise empty (caller logs the actionable
+"plugin packaged without the <rid> bridge" error).
+
+### 6.3 Resolution order (replaces the stub)
+
+1. **Dev/CI override:** `UNREAL_MCP_BRIDGE_PATH` (process env or `.env`) — if set and the file
+   exists, use it. Required for the bridge inner-dev-loop and live e2e.
+2. **Bundled path:** the §6.2 composed path. This is the production path for every end user.
+3. **Neither resolves:** return empty; `StartForPort` logs an actionable error (e.g. "no sidecar
+   binary resolved for rid <rid>; reinstall the plugin for your platform, or set
+   UNREAL_MCP_BRIDGE_PATH"). No download fallback exists.
+
+### 6.4 Version-lockstep guarantee
+
+The bundled binary is built from the SAME source tree at the SAME `VersionName` as the plugin in the
+same release job. The plugin/bridge handshake (`sidecarVersion` vs `pluginVersion`, §1.3) therefore
+always matches by construction; a skew can only occur if the user hand-replaces the bundled binary
+(still caught by the handshake check, which kills + hard-fails to the UI — there is no re-download
+recovery to attempt). `commands/bump-version.ps1` already moves the `.uplugin` `VersionName` and the
+bridge csproj `<Version>` together, so the plugin zip and the bundled bridge share one version.
+
+### 6.5 Offline / air-gapped guarantee
+
+No network access is required at any point of sidecar bring-up: the binary is on disk inside the
+plugin, the token is generated locally (CSPRNG, §1.4), and the IPC is loopback TCP. Network is only
+touched when the sidecar dials the MCP server (Cloud or Custom) — i.e. only when the user has
+actively chosen to connect. A fully offline editor still loads the plugin and spawns the sidecar.
+
+### 6.6 Spawn / watchdog interaction with the bundled binary (§1.5)
+
+The §1.5 state machine is unchanged in shape; only the `LaunchingSidecar` precondition simplifies:
+
+- `LaunchingSidecar`: the binary is **present by construction** (no "version match → download" gate).
+  The plugin verifies `FileExists`, then on macOS/Linux runs a pre-spawn prep
+  (`PrepareBundledBinaryForSpawn`): `chmod 0755` to ensure the executable bit, and on macOS
+  `removexattr com.apple.quarantine` so Gatekeeper's first-exec check is bypassed offline. The prep
+  is skipped when the dev override is used (a dev-built binary is already runnable). Then `CreateProc`
+  exactly as before (token over stdin, §1.4).
+- **Auto-spawn now succeeds at StartupModule.** With the bundle, the path resolves on first boot,
+  `SpawnProcess` succeeds, the sidecar dials, handshakes, and the watchdog takes over — zero clicks.
+  Today a fresh install with no bundled binary (a dev source checkout) instead logs the §6.3 step-3
+  actionable warning and spawns nothing, as before — devs use `UNREAL_MCP_BRIDGE_PATH`.
+- **Crash auto-restart / orphan prevention** (§1.5 backoff + the three orphan layers) are unchanged;
+  they operate on whatever binary `ResolveBridgeBinaryPath()` returned, bundled or override. The three
+  orphan layers remain: (1) plugin `TerminateProc` on shutdown; (2) sidecar self-exits when the
+  `--parent-pid` editor (plus its process start time) vanishes; (3) sidecar self-exits after 60 s
+  without a successful handshake (a rejected handshake does not reset the timer, and 3 consecutive
+  rejections are fatal, §1.4).
+- **Zero-click reconnect (token cache).** The Cloud OAuth token persists as `cloudToken` in
+  `<Project>/Saved/Config/UnrealMcp/ai-game-developer-config.json` (`FUnrealMcpConfig`). On every
+  (re)connect `BuildEffectiveConnectionConfig()` re-reads it and pushes it to the sidecar via the
+  §1.3 `config` message, so after the one-time device-code browser approval the spawn → dial →
+  handshake → connect path is fully automatic on later launches. There is **no separate token store**
+  introduced by the bundle model.
+- **No `.lock`/atomic-rename/re-download machinery** — those existed only to serialize concurrent
+  first-run downloads and version-mismatch re-downloads. With a read-only bundled binary they are
+  gone from the design. Multiple editors share the same read-only files with no coordination.
 - **Multi-editor coexistence:** one sidecar per editor process (per-project port + probing, §1.1).
   Two editors on the *same* project each get their own sidecar — fine, since the MCP server
-  multiplexes plugin connections; binaries are shared read-only on disk (download uses an atomic
-  temp-file + rename, and a `.lock` file serializes concurrent first-run downloads). The lock
-  file is stamped with the owner's **PID + process start time**: a waiter that finds the owner
-  dead — or the start time mismatching (PID reuse) — takes the lock over instead of waiting
-  forever, so a crashed downloader never wedges first-run for every later editor. For
-  **version-mismatch re-download while another editor instance still runs the old binary**, the
-  recovery is Unity's proven flow (`McpServerManager.cs:200–273`, `DeleteBinaryFolderIfExists`):
-  delete fails on the locked binary → stop the running process and retry → if still locked,
-  surface a Retry/Skip dialog so the user can release the lock at their own pace.
-- **Dev override:** `UNREAL_MCP_BRIDGE_PATH` env/`.env` var points at a locally built sidecar
-  (skips download + version check) — required for the bridge task's inner dev loop and CI.
-- **Offline/air-gapped:** download failure surfaces a main-window alert with the manual unzip path;
-  `unreal-mcp-cli bootstrap-local` (§9) automates a from-source bridge build into the same location.
+  multiplexes plugin connections; the bundled binaries are shared read-only with no lock needed.
+- **Dev override:** `UNREAL_MCP_BRIDGE_PATH` env/`.env` var points at a locally built sidecar (skips
+  the bundled path) — required for the bridge task's inner dev loop and CI;
+  `unreal-mcp-cli bootstrap-local` (§9) automates a from-source bridge build for that var.
+
+**Binaries are NEVER committed to git.** They are staged into the plugin tree by the release job at
+package time (a BuildPlugin input via `RuntimeDependencies`), and `.gitignore` keeps `Binaries/` out
+of VCS. A dev source checkout has an empty `Binaries/ThirdParty/UnrealMcpBridge/` → the resolver
+returns empty → devs use `UNREAL_MCP_BRIDGE_PATH`, exactly as before.
 
 ### Local server acquisition (the shared GameDev-MCP-Server)
 


### PR DESCRIPTION
## Summary
- Implement the ARCHITECTURE §6 BUNDLE model: `ResolveBridgeBinaryPath()` resolves `UNREAL_MCP_BRIDGE_PATH` (dev override) then the bundled `Binaries/ThirdParty/UnrealMcpBridge/<rid>/unreal-mcp-bridge[.exe]` via `IPluginManager`, so a packaged plugin auto-spawns the sidecar at StartupModule with zero user action.
- Add `ResolveRid()` (Win64→win-x64, Linux→linux-x64, Mac→osx-arm64/osx-x64 from the physical host CPU via `sysctlbyname`), `PrepareBundledBinaryForSpawn()` (macOS/Linux +x + macOS quarantine strip), a rid-aware graceful-degrade warning, and `RuntimeDependencies` staging in `UnrealMcpEditor.Build.cs`.
- Zero-click reconnect reuses the existing `cloudToken` store (no new token store). Rewrote ARCHITECTURE §6 (+ status table, drift, §0 diagram) and reconciled README install/requirements/env/troubleshooting.

## Test plan
- [x] Suite 1 UBT build (UnrealTestProjectEditor Win64) — exit 0
- [x] Suite 2 headless boot smoke — `[Unreal-MCP] plugin loaded` + rid-aware graceful-degrade warning
- [x] Suite 3 Automation `UnrealMcp.` — index.json `failed: 0`, `succeeded: 157` (9 new `UnrealMcp.Sidecar` specs)
- Scope is `UnrealMCP/**` + `docs/ARCHITECTURE.md` only; `bridge/**` (T1) and CI signing/release (T3/T4) untouched. Full bundled-spawn + signing are validated by the T4 packaging dry-run; the env-override resolution path is spec-verified against a real on-disk fixture.

Closes #46