### PR TITLE
feat(ui): AI Agent configurators Phase B — remaining agents + Custom + TOML

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfig.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfig.h
@@ -67,19 +67,10 @@ public:
 	/** The full file content the entry would produce when written into an otherwise-empty file (UI preview). */
 	virtual FString GetExpectedFileContent() const = 0;
 
-	/**
-	 * Inject the STDIO bearer token into this config's transport-specific shape (Unity's ApplyStdioAuthorization).
-	 * The default is a no-op: FJsonAiAgentConfig bakes the token into its `args` at build time, so it needs no
-	 * post-hoc injection. Override in a format whose token lives elsewhere (e.g. a TOML env-var indirection).
-	 * @p bRequired is true when auth is required AND a token exists; @p Token is the REAL bearer (never logged).
-	 */
-	virtual void ApplyStdioAuthorization(bool bRequired, const FString& Token) {}
-	/**
-	 * Inject the HTTP bearer token into this config's transport-specific shape (Unity's ApplyHttpAuthorization).
-	 * The default is a no-op (FJsonAiAgentConfig bakes the Authorization header at build time). Override for a
-	 * format that carries auth differently (e.g. Codex's TOML `bearer_token_env_var` indirection).
-	 */
-	virtual void ApplyHttpAuthorization(bool bRequired, const FString& Token) {}
+	// Auth injection is baked at build time by each configurator (FJsonAiAgentConfig writes the token into `args` /
+	// the Authorization header; Codex's FTomlAiAgentConfig writes the `bearer_token_env_var` env-var-NAME indirection
+	// directly in BuildStdio/BuildHttp). There is therefore no post-hoc Apply*Authorization seam — token discipline
+	// lives entirely in the configurators, not here.
 
 	/** Write/merge this server entry into the file, preserving siblings + unrelated keys. Returns IsConfigured(). */
 	virtual bool Configure() = 0;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfig.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfig.h
@@ -14,7 +14,9 @@
 enum class EUnrealMcpValueComparison : uint8
 {
 	Exact,
-	Url
+	Url,
+	/** Path-equivalence: separators unified to '/', trailing slash trimmed (Codex `command` comparison). */
+	Path
 };
 
 /**
@@ -64,6 +66,20 @@ public:
 
 	/** The full file content the entry would produce when written into an otherwise-empty file (UI preview). */
 	virtual FString GetExpectedFileContent() const = 0;
+
+	/**
+	 * Inject the STDIO bearer token into this config's transport-specific shape (Unity's ApplyStdioAuthorization).
+	 * The default is a no-op: FJsonAiAgentConfig bakes the token into its `args` at build time, so it needs no
+	 * post-hoc injection. Override in a format whose token lives elsewhere (e.g. a TOML env-var indirection).
+	 * @p bRequired is true when auth is required AND a token exists; @p Token is the REAL bearer (never logged).
+	 */
+	virtual void ApplyStdioAuthorization(bool bRequired, const FString& Token) {}
+	/**
+	 * Inject the HTTP bearer token into this config's transport-specific shape (Unity's ApplyHttpAuthorization).
+	 * The default is a no-op (FJsonAiAgentConfig bakes the Authorization header at build time). Override for a
+	 * format that carries auth differently (e.g. Codex's TOML `bearer_token_env_var` indirection).
+	 */
+	virtual void ApplyHttpAuthorization(bool bRequired, const FString& Token) {}
 
 	/** Write/merge this server entry into the file, preserving siblings + unrelated keys. Returns IsConfigured(). */
 	virtual bool Configure() = 0;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.cpp
@@ -41,21 +41,38 @@ void FAiAgentConfigurator::Invalidate()
 	ConfigHttp.Reset();
 }
 
-FJsonAiAgentConfig& FAiAgentConfigurator::GetConfigStdio()
+FAiAgentConfig& FAiAgentConfigurator::GetConfigStdio()
 {
 	if (!ConfigStdio.IsValid())
 		ConfigStdio = BuildStdio();
 	return *ConfigStdio;
 }
 
-FJsonAiAgentConfig& FAiAgentConfigurator::GetConfigHttp()
+FAiAgentConfig& FAiAgentConfigurator::GetConfigHttp()
 {
 	if (!ConfigHttp.IsValid())
 		ConfigHttp = BuildHttp();
 	return *ConfigHttp;
 }
 
-TSharedRef<FJsonAiAgentConfig> FAiAgentConfigurator::BuildStdio() const
+FString FAiAgentConfigurator::GetStdioCommand() const
+{
+	return Connection.ServerPath.Replace(TEXT("\\"), TEXT("/"));
+}
+
+TArray<FString> FAiAgentConfigurator::GetStdioArgs() const
+{
+	// The shared GameDev-MCP-Server CLI contract (identical to the cli's buildServerEntry args, sans plugin-timeout
+	// which the Unreal cli does not emit). The token arg is empty unless auth is required.
+	TArray<FString> Args;
+	Args.Add(FString::Printf(TEXT("port=%d"), Connection.Port));
+	Args.Add(TEXT("client-transport=stdio"));
+	Args.Add(FString::Printf(TEXT("authorization=%s"), Connection.bAuthRequired ? TEXT("required") : TEXT("none")));
+	Args.Add(FString::Printf(TEXT("token=%s"), Connection.bAuthRequired ? *Connection.Token : TEXT("")));
+	return Args;
+}
+
+TSharedRef<FAiAgentConfig> FAiAgentConfigurator::BuildStdio() const
 {
 	// STDIO form (the shared GameDev-MCP-Server CLI contract, identical to the cli's buildServerEntry):
 	//   { "type": "stdio", "command": <serverPath>, "args": ["port=N", "client-transport=stdio",
@@ -63,13 +80,11 @@ TSharedRef<FJsonAiAgentConfig> FAiAgentConfigurator::BuildStdio() const
 	// command is an identity key (ValueComparison::Path-equivalent → Exact is fine since we always emit the
 	// same normalized path). The HTTP-only keys (type=http url headers) are explicitly removed so a transport
 	// switch in the same file leaves no stale HTTP entry.
-	const FString Command = Connection.ServerPath.Replace(TEXT("\\"), TEXT("/"));
+	const FString Command = GetStdioCommand();
 
 	TArray<TSharedPtr<FJsonValue>> Args;
-	Args.Add(MakeShared<FJsonValueString>(FString::Printf(TEXT("port=%d"), Connection.Port)));
-	Args.Add(MakeShared<FJsonValueString>(TEXT("client-transport=stdio")));
-	Args.Add(MakeShared<FJsonValueString>(FString::Printf(TEXT("authorization=%s"), Connection.bAuthRequired ? TEXT("required") : TEXT("none"))));
-	Args.Add(MakeShared<FJsonValueString>(FString::Printf(TEXT("token=%s"), Connection.bAuthRequired ? *Connection.Token : TEXT(""))));
+	for (const FString& Arg : GetStdioArgs())
+		Args.Add(MakeShared<FJsonValueString>(Arg));
 
 	TSharedRef<FJsonAiAgentConfig> Config = MakeShared<FJsonAiAgentConfig>(
 		GetAgentName(),
@@ -83,10 +98,13 @@ TSharedRef<FJsonAiAgentConfig> FAiAgentConfigurator::BuildStdio() const
 	Config->SetPropertyToRemove(TEXT("url"));
 	Config->SetPropertyToRemove(TEXT("headers"));
 
+	// Per-agent additions (e.g. Rider/KiloCode/ZooCode `disabled`, GitHubCopilotCli `tools`).
+	CustomizeStdio(*Config);
+
 	return Config;
 }
 
-TSharedRef<FJsonAiAgentConfig> FAiAgentConfigurator::BuildHttp() const
+TSharedRef<FAiAgentConfig> FAiAgentConfigurator::BuildHttp() const
 {
 	// HTTP form (identical to the cli's buildServerEntry):
 	//   { "type": "http", "url": "<host>/mcp", "headers": { "Authorization": "Bearer <token>" }? }
@@ -114,6 +132,9 @@ TSharedRef<FJsonAiAgentConfig> FAiAgentConfigurator::BuildHttp() const
 	// Drop the STDIO-only keys so an http write over a prior stdio entry is clean.
 	Config->SetPropertyToRemove(TEXT("command"));
 	Config->SetPropertyToRemove(TEXT("args"));
+
+	// Per-agent additions (e.g. Rider/KiloCode/ZooCode `disabled`).
+	CustomizeHttp(*Config);
 
 	return Config;
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.h
@@ -81,9 +81,9 @@ public:
 	UNREALMCPEDITOR_API void Invalidate();
 
 	/** The STDIO (launch-the-server) MCP-client config for this agent. Lazily built; never null after Initialize. */
-	UNREALMCPEDITOR_API FJsonAiAgentConfig& GetConfigStdio();
+	UNREALMCPEDITOR_API FAiAgentConfig& GetConfigStdio();
 	/** The HTTP (connect-to-URL) MCP-client config for this agent. Lazily built; never null after Initialize. */
-	UNREALMCPEDITOR_API FJsonAiAgentConfig& GetConfigHttp();
+	UNREALMCPEDITOR_API FAiAgentConfig& GetConfigHttp();
 
 	// --- Status helpers (across both transports, like Unity's RefreshConfigurationUI). ---
 
@@ -100,10 +100,31 @@ protected:
 	FAiAgentConnectionInfo Connection;
 	FString ProjectRoot;
 
-private:
-	TSharedPtr<FJsonAiAgentConfig> ConfigStdio;
-	TSharedPtr<FJsonAiAgentConfig> ConfigHttp;
+	/**
+	 * Build the STDIO config for this agent. The base produces the canonical JSON shape (the cli's buildServerEntry:
+	 * type=stdio, command=<server>, args=[port, client-transport, authorization, token], with url/headers removed)
+	 * and then calls CustomizeStdio() so a subclass can add per-agent keys (e.g. `disabled`, `tools`). Override the
+	 * whole method only for a fundamentally different shape (a TOML agent, OpenCode's array-command, Antigravity's
+	 * serverUrl). The default is virtual so the 16 JSON agents reuse it and only the outliers replace it.
+	 */
+	UNREALMCPEDITOR_API virtual TSharedRef<FAiAgentConfig> BuildStdio() const;
+	/** Build the HTTP config (canonical JSON: type=http, url=<host>/mcp, headers.Authorization when auth+token). */
+	UNREALMCPEDITOR_API virtual TSharedRef<FAiAgentConfig> BuildHttp() const;
 
-	TSharedRef<FJsonAiAgentConfig> BuildStdio() const;
-	TSharedRef<FJsonAiAgentConfig> BuildHttp() const;
+	/** Hook for a JSON subclass to add per-agent STDIO keys (default no-op). Called by the base BuildStdio(). */
+	virtual void CustomizeStdio(FJsonAiAgentConfig& Config) const {}
+	/** Hook for a JSON subclass to add per-agent HTTP keys (default no-op). Called by the base BuildHttp(). */
+	virtual void CustomizeHttp(FJsonAiAgentConfig& Config) const {}
+
+	// --- Connection-fact accessors for subclasses that build their own config shape (read-only). ---
+	const FAiAgentConnectionInfo& GetConnection() const { return Connection; }
+	const FString& GetProjectRoot() const { return ProjectRoot; }
+	/** The STDIO server-launch args shared by every agent (port / client-transport / authorization / token). */
+	UNREALMCPEDITOR_API TArray<FString> GetStdioArgs() const;
+	/** The server binary path with forward slashes (the `command` for STDIO agents). */
+	UNREALMCPEDITOR_API FString GetStdioCommand() const;
+
+private:
+	TSharedPtr<FAiAgentConfig> ConfigStdio;
+	TSharedPtr<FAiAgentConfig> ConfigHttp;
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfiguratorRegistry.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfiguratorRegistry.cpp
@@ -5,22 +5,50 @@
 #include "Agents/AiAgentConfigurator.h"
 #include "Agents/Impl/ClaudeCodeConfigurator.h"
 #include "Agents/Impl/CursorConfigurator.h"
+#include "Agents/Impl/ClaudeDesktopConfigurator.h"
+#include "Agents/Impl/VisualStudioCodeCopilotConfigurator.h"
+#include "Agents/Impl/VisualStudioCopilotConfigurator.h"
+#include "Agents/Impl/RiderConfigurator.h"
+#include "Agents/Impl/GitHubCopilotCliConfigurator.h"
+#include "Agents/Impl/GeminiConfigurator.h"
+#include "Agents/Impl/AntigravityConfigurator.h"
+#include "Agents/Impl/ClineConfigurator.h"
+#include "Agents/Impl/OpenCodeConfigurator.h"
+#include "Agents/Impl/CodexConfigurator.h"
+#include "Agents/Impl/KiloCodeConfigurator.h"
+#include "Agents/Impl/UnityAiConfigurator.h"
+#include "Agents/Impl/ZooCodeConfigurator.h"
+#include "Agents/Impl/CustomConfigurator.h"
 
 TArray<TSharedRef<FAiAgentConfigurator>> FAiAgentConfiguratorRegistry::MakeDefault()
 {
-	// Phase A: the two reference agents. Sorted alphabetically by display name (matches Unity/Godot), which keeps
-	// the dropdown stable as Phase B adds agents. A future Custom configurator is appended AFTER the sort so it
-	// always stays last regardless of its name.
+	// All Unity-parity agents. Sorted alphabetically by display name (matches Unity/Godot), which keeps the dropdown
+	// stable. The Custom configurator is appended AFTER the sort so it always stays last regardless of its name
+	// (the Custom-last invariant). 16 agents + Custom.
 	TArray<TSharedRef<FAiAgentConfigurator>> Configurators;
+	Configurators.Add(MakeShared<FAntigravityConfigurator>());
 	Configurators.Add(MakeShared<FClaudeCodeConfigurator>());
+	Configurators.Add(MakeShared<FClaudeDesktopConfigurator>());
+	Configurators.Add(MakeShared<FClineConfigurator>());
+	Configurators.Add(MakeShared<FCodexConfigurator>());
 	Configurators.Add(MakeShared<FCursorConfigurator>());
+	Configurators.Add(MakeShared<FGeminiConfigurator>());
+	Configurators.Add(MakeShared<FGitHubCopilotCliConfigurator>());
+	Configurators.Add(MakeShared<FKiloCodeConfigurator>());
+	Configurators.Add(MakeShared<FOpenCodeConfigurator>());
+	Configurators.Add(MakeShared<FRiderConfigurator>());
+	Configurators.Add(MakeShared<FUnityAiConfigurator>());
+	Configurators.Add(MakeShared<FVisualStudioCodeCopilotConfigurator>());
+	Configurators.Add(MakeShared<FVisualStudioCopilotConfigurator>());
+	Configurators.Add(MakeShared<FZooCodeConfigurator>());
 
 	Configurators.Sort([](const TSharedRef<FAiAgentConfigurator>& A, const TSharedRef<FAiAgentConfigurator>& B)
 	{
 		return A->GetAgentName() < B->GetAgentName();
 	});
 
-	// (Phase B) append the Custom configurator here, after the sort, to preserve the Custom-last invariant.
+	// Append the Custom configurator AFTER the sort to preserve the Custom-last invariant.
+	Configurators.Add(MakeShared<FCustomConfigurator>());
 
 	return Configurators;
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/AntigravityConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/AntigravityConfigurator.h
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Agents/JsonAiAgentConfig.h"
+#include "Misc/Paths.h"
+#include "HAL/PlatformProcess.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+
+/**
+ * Antigravity configurator (docs/ARCHITECTURE.md §7). Global config file `~/.gemini/config/mcp_config.json` (shared
+ * across projects, independent of @p ProjectRoot) — mirrors Unity's AntigravityConfigurator. Two quirks vs the base
+ * JSON shape:
+ *   - the HTTP transport stores the URL under `serverUrl` (NOT `url`), so HTTP is built explicitly here;
+ *   - both transports add a required `disabled: false`, and `serverUrl` is an identity key for dedup.
+ * The STDIO transport additionally scrubs `serverUrl`/`type` so a transport switch leaves no stale HTTP key.
+ */
+class FAntigravityConfigurator : public FAiAgentConfigurator
+{
+public:
+	virtual FString GetAgentName() const override { return TEXT("Antigravity"); }
+	virtual FString GetAgentId() const override { return TEXT("antigravity"); }
+	virtual FString GetDownloadUrl() const override { return TEXT("https://antigravity.google/download"); }
+	virtual FString GetIconFileName() const override { return TEXT("antigravity-64.png"); }
+
+	virtual FString GetConfigFilePath(const FString& /*InProjectRoot*/) const override
+	{
+		const FString Home = FPlatformProcess::UserHomeDir();
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(Home, TEXT(".gemini"), TEXT("config"), TEXT("mcp_config.json")));
+	}
+	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+
+protected:
+	virtual void CustomizeStdio(FJsonAiAgentConfig& Config) const override
+	{
+		Config.AddIdentityKey(TEXT("serverUrl"));
+		Config.SetProperty(TEXT("disabled"), MakeShared<FJsonValueBoolean>(false), /*bRequired*/ true);
+		// STDIO has no URL key — scrub Antigravity's HTTP `serverUrl` (and the base already scrubs `url`).
+		Config.SetPropertyToRemove(TEXT("serverUrl"));
+	}
+
+	virtual TSharedRef<FAiAgentConfig> BuildHttp() const override
+	{
+		// Antigravity's HTTP transport puts the URL under `serverUrl`, not the base's `url`. Build it explicitly.
+		TSharedRef<FJsonAiAgentConfig> Config = MakeShared<FJsonAiAgentConfig>(
+			GetAgentName(), GetConfigFilePath(GetProjectRoot()), GetBodyPath());
+
+		Config->AddIdentityKey(TEXT("serverUrl"));
+		Config->SetProperty(TEXT("disabled"), MakeShared<FJsonValueBoolean>(false), /*bRequired*/ true);
+		Config->SetStringProperty(TEXT("serverUrl"), GetConnection().HttpUrl, /*bRequired*/ true, EUnrealMcpValueComparison::Url);
+
+		// Inject auth on the HTTP entry like the base does (header only when auth required AND a token exists).
+		const FAiAgentConnectionInfo& Conn = GetConnection();
+		if (Conn.bAuthRequired && !Conn.Token.IsEmpty())
+		{
+			TSharedPtr<FJsonObject> Headers = MakeShared<FJsonObject>();
+			Headers->SetStringField(TEXT("Authorization"), FString::Printf(TEXT("Bearer %s"), *Conn.Token));
+			Config->SetProperty(TEXT("headers"), MakeShared<FJsonValueObject>(Headers), /*bRequired*/ true);
+		}
+		else
+		{
+			Config->SetPropertyToRemove(TEXT("headers"));
+		}
+
+		// Scrub the STDIO-only keys and the base `url` (Antigravity uses `serverUrl`).
+		Config->SetPropertyToRemove(TEXT("command"));
+		Config->SetPropertyToRemove(TEXT("args"));
+		Config->SetPropertyToRemove(TEXT("url"));
+		Config->SetPropertyToRemove(TEXT("type"));
+		return Config;
+	}
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ClaudeDesktopConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ClaudeDesktopConfigurator.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Misc/Paths.h"
+#include "HAL/PlatformMisc.h"
+#include "HAL/PlatformProcess.h"
+
+/**
+ * Claude Desktop configurator (docs/ARCHITECTURE.md §7). Per-OS GLOBAL config file under the user profile, nesting
+ * under "mcpServers" — mirrors Unity's ClaudeDesktopConfigurator. Unlike Claude Code (Anthropic's terminal agent,
+ * project-local .mcp.json) this is the desktop app's machine-global config:
+ *   - Windows: %APPDATA%\Claude\claude_desktop_config.json
+ *   - macOS:   ~/Library/Application Support/Claude/claude_desktop_config.json
+ *   - Linux:   ~/.config/Claude/claude_desktop_config.json
+ * The path is independent of @p ProjectRoot (global config), so GetConfigFilePath ignores it.
+ */
+class FClaudeDesktopConfigurator : public FAiAgentConfigurator
+{
+public:
+	virtual FString GetAgentName() const override { return TEXT("Claude Desktop"); }
+	virtual FString GetAgentId() const override { return TEXT("claude-desktop"); }
+	virtual FString GetDownloadUrl() const override { return TEXT("https://code.claude.com/docs/en/desktop"); }
+	virtual FString GetIconFileName() const override { return TEXT("claude-64.png"); }
+
+	virtual FString GetConfigFilePath(const FString& /*InProjectRoot*/) const override
+	{
+#if PLATFORM_WINDOWS
+		const FString AppData = FPlatformMisc::GetEnvironmentVariable(TEXT("APPDATA"));
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(AppData, TEXT("Claude"), TEXT("claude_desktop_config.json")));
+#elif PLATFORM_MAC
+		const FString Home = FPlatformProcess::UserHomeDir();
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(Home, TEXT("Library"), TEXT("Application Support"), TEXT("Claude"), TEXT("claude_desktop_config.json")));
+#else
+		const FString Home = FPlatformProcess::UserHomeDir();
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(Home, TEXT(".config"), TEXT("Claude"), TEXT("claude_desktop_config.json")));
+#endif
+	}
+	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ClineConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ClineConfigurator.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Agents/JsonAiAgentConfig.h"
+#include "Misc/Paths.h"
+#include "HAL/PlatformMisc.h"
+#include "HAL/PlatformProcess.h"
+
+/**
+ * Cline configurator (docs/ARCHITECTURE.md §7). Cline is a VS Code extension that stores its MCP servers in a GLOBAL
+ * config file under VS Code's globalStorage (shared across all projects, independent of @p ProjectRoot) — mirrors
+ * Unity's ClineConfigurator:
+ *   - Windows: %APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json
+ *   - macOS:   ~/Library/Application Support/Code/User/globalStorage/.../cline_mcp_settings.json
+ *   - Linux:   ~/.config/Code/User/globalStorage/.../cline_mcp_settings.json
+ * Body key "mcpServers"; the HTTP entry uses Cline's `streamableHttp` transport type.
+ */
+class FClineConfigurator : public FAiAgentConfigurator
+{
+public:
+	virtual FString GetAgentName() const override { return TEXT("Cline"); }
+	virtual FString GetAgentId() const override { return TEXT("cline"); }
+	virtual FString GetDownloadUrl() const override { return TEXT("https://cline.bot/"); }
+	virtual FString GetIconFileName() const override { return TEXT("cline-64.png"); }
+
+	virtual FString GetConfigFilePath(const FString& /*InProjectRoot*/) const override
+	{
+		const TCHAR* Ext = TEXT("saoudrizwan.claude-dev");
+#if PLATFORM_WINDOWS
+		const FString Base = FPlatformMisc::GetEnvironmentVariable(TEXT("APPDATA"));
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(Base, TEXT("Code"), TEXT("User"), TEXT("globalStorage"), Ext, TEXT("settings"), TEXT("cline_mcp_settings.json")));
+#elif PLATFORM_MAC
+		const FString Home = FPlatformProcess::UserHomeDir();
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(Home, TEXT("Library"), TEXT("Application Support"), TEXT("Code"), TEXT("User"), TEXT("globalStorage"), Ext, TEXT("settings"), TEXT("cline_mcp_settings.json")));
+#else
+		const FString Home = FPlatformProcess::UserHomeDir();
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(Home, TEXT(".config"), TEXT("Code"), TEXT("User"), TEXT("globalStorage"), Ext, TEXT("settings"), TEXT("cline_mcp_settings.json")));
+#endif
+	}
+	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+
+protected:
+	virtual void CustomizeHttp(FJsonAiAgentConfig& Config) const override
+	{
+		// Cline uses the camelCase `streamableHttp` transport type (distinct from Kilo/Zoo's `streamable-http`).
+		Config.SetStringProperty(TEXT("type"), TEXT("streamableHttp"), /*bRequired*/ true);
+	}
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/CodexConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/CodexConfigurator.h
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Agents/TomlAiAgentConfig.h"
+#include "Misc/Paths.h"
+
+/**
+ * Codex configurator (docs/ARCHITECTURE.md §7/§8). The one Phase-B agent that writes TOML: project-local
+ * `.codex/config.toml`, server entry under the dotted-table `[mcp_servers.unreal-mcp]` — mirrors Unity's
+ * CodexConfigurator. Built on FTomlAiAgentConfig (the second concrete FAiAgentConfig subclass after the JSON one).
+ *
+ * STDIO: `enabled=true`, `command=<server>` (Path-compared), `args=[port, client-transport, authorization]`,
+ *        optional `tool_timeout_sec=300`; removes url/type/startup_timeout_sec.
+ * HTTP:  `enabled=true`, `url=<host>/mcp` (Url-compared), optional `tool_timeout_sec=300`/`startup_timeout_sec=30`;
+ *        removes command/args/type.
+ *
+ * Token discipline (§8): Codex reads its bearer from an ENVIRONMENT VARIABLE, not from the config file. We therefore
+ * NEVER write the raw token into the TOML — the STDIO args omit `token=` entirely, and HTTP auth is expressed only as
+ * a `bearer_token_env_var` indirection (the env-var NAME, never the value) when auth is required. This keeps the
+ * on-disk Codex config secret-free.
+ */
+class FCodexConfigurator : public FAiAgentConfigurator
+{
+public:
+	/** The env-var name Codex reads the bearer token from (NAME only ever written to disk; never the value). */
+	static constexpr const TCHAR* EnvVarNameAuthToken = TEXT("GAME_DEV_AUTH_TOKEN");
+
+	virtual FString GetAgentName() const override { return TEXT("Codex"); }
+	virtual FString GetAgentId() const override { return TEXT("codex"); }
+	virtual FString GetDownloadUrl() const override { return TEXT("https://openai.com/codex/"); }
+	virtual FString GetIconFileName() const override { return TEXT("codex-64.png"); }
+
+	virtual FString GetConfigFilePath(const FString& InProjectRoot) const override
+	{
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".codex"), TEXT("config.toml")));
+	}
+	virtual FString GetBodyPath() const override { return TEXT("mcp_servers"); }
+
+protected:
+	virtual TSharedRef<FAiAgentConfig> BuildStdio() const override
+	{
+		TSharedRef<FTomlAiAgentConfig> Config = MakeShared<FTomlAiAgentConfig>(
+			GetAgentName(), GetConfigFilePath(GetProjectRoot()), GetBodyPath());
+
+		// Codex STDIO args mirror the shared CLI contract but OMIT the token (it comes from the env var, §8).
+		const FAiAgentConnectionInfo& Conn = GetConnection();
+		TArray<FString> Args;
+		Args.Add(FString::Printf(TEXT("port=%d"), Conn.Port));
+		Args.Add(TEXT("client-transport=stdio"));
+		Args.Add(FString::Printf(TEXT("authorization=%s"), Conn.bAuthRequired ? TEXT("required") : TEXT("none")));
+
+		Config->SetBoolProperty(TEXT("enabled"), true, /*bRequired*/ true);
+		Config->SetStringProperty(TEXT("command"), GetStdioCommand(), /*bRequired*/ true, EUnrealMcpValueComparison::Path);
+		Config->SetStringArrayProperty(TEXT("args"), Args, /*bRequired*/ true);
+		Config->SetIntProperty(TEXT("tool_timeout_sec"), 300, /*bRequired*/ false);
+		Config->SetPropertyToRemove(TEXT("url"));
+		Config->SetPropertyToRemove(TEXT("type"));
+		Config->SetPropertyToRemove(TEXT("startup_timeout_sec"));
+
+		// Auth indirection: when required, point Codex at the env var holding the token (NAME only).
+		if (Conn.bAuthRequired && !Conn.Token.IsEmpty())
+			Config->SetStringProperty(TEXT("bearer_token_env_var"), EnvVarNameAuthToken, /*bRequired*/ true);
+		else
+			Config->SetPropertyToRemove(TEXT("bearer_token_env_var"));
+
+		return Config;
+	}
+
+	virtual TSharedRef<FAiAgentConfig> BuildHttp() const override
+	{
+		TSharedRef<FTomlAiAgentConfig> Config = MakeShared<FTomlAiAgentConfig>(
+			GetAgentName(), GetConfigFilePath(GetProjectRoot()), GetBodyPath());
+
+		const FAiAgentConnectionInfo& Conn = GetConnection();
+		Config->SetBoolProperty(TEXT("enabled"), true, /*bRequired*/ true);
+		Config->SetStringProperty(TEXT("url"), Conn.HttpUrl, /*bRequired*/ true, EUnrealMcpValueComparison::Url);
+		Config->SetIntProperty(TEXT("tool_timeout_sec"), 300, /*bRequired*/ false);
+		Config->SetIntProperty(TEXT("startup_timeout_sec"), 30, /*bRequired*/ false);
+		Config->SetPropertyToRemove(TEXT("command"));
+		Config->SetPropertyToRemove(TEXT("args"));
+		Config->SetPropertyToRemove(TEXT("type"));
+
+		if (Conn.bAuthRequired && !Conn.Token.IsEmpty())
+			Config->SetStringProperty(TEXT("bearer_token_env_var"), EnvVarNameAuthToken, /*bRequired*/ true);
+		else
+			Config->SetPropertyToRemove(TEXT("bearer_token_env_var"));
+
+		return Config;
+	}
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/CustomConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/CustomConfigurator.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+
+/**
+ * Custom (Other) configurator (docs/ARCHITECTURE.md §7). The catch-all snippet-only entry for any MCP client not in
+ * the built-in roster — mirrors Unity's CustomConfigurator. It has NO config-file path: GetConfigFilePath returns an
+ * empty string, which makes the underlying FJsonAiAgentConfig refuse to Configure/Detect (every file op early-returns
+ * on an empty path). The user copies the generated STDIO/HTTP snippet by hand into their own client config.
+ *
+ * The registry guarantees this entry is ALWAYS last regardless of name (the Custom-last invariant Phase A left a hook
+ * for), so it sorts to the bottom of the dropdown.
+ */
+class FCustomConfigurator : public FAiAgentConfigurator
+{
+public:
+	virtual FString GetAgentName() const override { return TEXT("Other - Custom"); }
+	virtual FString GetAgentId() const override { return TEXT("other-custom"); }
+	virtual FString GetDownloadUrl() const override { return FString(); }
+	virtual FString GetIconFileName() const override { return FString(); }
+
+	/** Snippet-only: no on-disk config file. An empty path makes Configure/Detect/IsConfigured all return false. */
+	virtual FString GetConfigFilePath(const FString& /*InProjectRoot*/) const override { return FString(); }
+	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/GeminiConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/GeminiConfigurator.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Misc/Paths.h"
+
+/**
+ * Gemini configurator (docs/ARCHITECTURE.md §7). Writes project-local `.gemini/settings.json`, nesting under
+ * "mcpServers" — mirrors Unity's GeminiConfigurator. Canonical STDIO + HTTP JSON shape (no per-agent extra keys).
+ */
+class FGeminiConfigurator : public FAiAgentConfigurator
+{
+public:
+	virtual FString GetAgentName() const override { return TEXT("Gemini"); }
+	virtual FString GetAgentId() const override { return TEXT("gemini"); }
+	virtual FString GetDownloadUrl() const override { return TEXT("https://geminicli.com/docs/get-started/installation/"); }
+	virtual FString GetIconFileName() const override { return TEXT("gemini-64.png"); }
+
+	virtual FString GetConfigFilePath(const FString& InProjectRoot) const override
+	{
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".gemini"), TEXT("settings.json")));
+	}
+	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/GitHubCopilotCliConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/GitHubCopilotCliConfigurator.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Agents/JsonAiAgentConfig.h"
+#include "Misc/Paths.h"
+#include "Dom/JsonValue.h"
+
+/**
+ * GitHub Copilot CLI configurator (docs/ARCHITECTURE.md §7). Uses the project-local `.mcp.json` (shared with Claude
+ * Code — Copilot CLI v1.0.12+ discovers workspace-local MCP configs from the cwd up to the git root). Mirrors Unity's
+ * GitHubCopilotCliConfigurator: the STDIO entry drops the `type` key and adds a `tools: ["*"]` allowlist; both
+ * transports carry `tools`. The shared `.mcp.json` body key is "mcpServers".
+ */
+class FGitHubCopilotCliConfigurator : public FAiAgentConfigurator
+{
+public:
+	virtual FString GetAgentName() const override { return TEXT("GitHub Copilot CLI"); }
+	virtual FString GetAgentId() const override { return TEXT("github-copilot-cli"); }
+	virtual FString GetDownloadUrl() const override { return TEXT("https://github.com/features/copilot/cli"); }
+	virtual FString GetIconFileName() const override { return TEXT("github-copilot-64.png"); }
+
+	virtual FString GetConfigFilePath(const FString& InProjectRoot) const override
+	{
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".mcp.json")));
+	}
+	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+
+protected:
+	virtual void CustomizeStdio(FJsonAiAgentConfig& Config) const override
+	{
+		// Copilot CLI infers stdio from the presence of command/args — drop the explicit "type".
+		Config.SetPropertyToRemove(TEXT("type"));
+		Config.SetProperty(TEXT("tools"), MakeShared<FJsonValueArray>(MakeToolsAll()), /*bRequired*/ false);
+	}
+	virtual void CustomizeHttp(FJsonAiAgentConfig& Config) const override
+	{
+		Config.SetProperty(TEXT("tools"), MakeShared<FJsonValueArray>(MakeToolsAll()), /*bRequired*/ false);
+	}
+
+private:
+	static TArray<TSharedPtr<FJsonValue>> MakeToolsAll()
+	{
+		TArray<TSharedPtr<FJsonValue>> Tools;
+		Tools.Add(MakeShared<FJsonValueString>(TEXT("*")));
+		return Tools;
+	}
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/KiloCodeConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/KiloCodeConfigurator.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Agents/JsonAiAgentConfig.h"
+#include "Misc/Paths.h"
+#include "Dom/JsonValue.h"
+
+/**
+ * Kilo Code configurator (docs/ARCHITECTURE.md §7). Writes project-local `.kilocode/mcp.json`, nesting under
+ * "mcpServers" — mirrors Unity's KiloCodeConfigurator. Both transports add a required `disabled: false`; the HTTP
+ * entry uses Kilo Code's `streamable-http` transport type rather than the plain `http` the base emits.
+ */
+class FKiloCodeConfigurator : public FAiAgentConfigurator
+{
+public:
+	virtual FString GetAgentName() const override { return TEXT("Kilo Code"); }
+	virtual FString GetAgentId() const override { return TEXT("kilo-code"); }
+	virtual FString GetDownloadUrl() const override { return TEXT("https://app.kilo.ai/get-started"); }
+	virtual FString GetIconFileName() const override { return TEXT("kilo-code-64.png"); }
+
+	virtual FString GetConfigFilePath(const FString& InProjectRoot) const override
+	{
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".kilocode"), TEXT("mcp.json")));
+	}
+	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+
+protected:
+	virtual void CustomizeStdio(FJsonAiAgentConfig& Config) const override
+	{
+		Config.SetProperty(TEXT("disabled"), MakeShared<FJsonValueBoolean>(false), /*bRequired*/ true);
+	}
+	virtual void CustomizeHttp(FJsonAiAgentConfig& Config) const override
+	{
+		Config.SetProperty(TEXT("disabled"), MakeShared<FJsonValueBoolean>(false), /*bRequired*/ true);
+		Config.SetStringProperty(TEXT("type"), TEXT("streamable-http"), /*bRequired*/ true);
+	}
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/OpenCodeConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/OpenCodeConfigurator.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Agents/JsonAiAgentConfig.h"
+#include "Misc/Paths.h"
+#include "Dom/JsonValue.h"
+
+/**
+ * Open Code configurator (docs/ARCHITECTURE.md §7). Writes project-local `opencode.json`, nesting under "mcp" — mirrors
+ * Unity's OpenCodeConfigurator. Open Code's schema is distinct from the canonical MCP shape, so both transports are
+ * built explicitly:
+ *   - STDIO: `{ type: "local", enabled: true, command: [<server>, <args...>] }` — the binary AND its args live in a
+ *     single `command` ARRAY (there is no separate `args` key);
+ *   - HTTP:  `{ type: "remote", enabled: true, url: "<host>/mcp" }`.
+ */
+class FOpenCodeConfigurator : public FAiAgentConfigurator
+{
+public:
+	virtual FString GetAgentName() const override { return TEXT("Open Code"); }
+	virtual FString GetAgentId() const override { return TEXT("open-code"); }
+	virtual FString GetDownloadUrl() const override { return TEXT("https://opencode.ai/download"); }
+	virtual FString GetIconFileName() const override { return TEXT("open-code-64.png"); }
+
+	virtual FString GetConfigFilePath(const FString& InProjectRoot) const override
+	{
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT("opencode.json")));
+	}
+	virtual FString GetBodyPath() const override { return TEXT("mcp"); }
+
+protected:
+	virtual TSharedRef<FAiAgentConfig> BuildStdio() const override
+	{
+		TSharedRef<FJsonAiAgentConfig> Config = MakeShared<FJsonAiAgentConfig>(
+			GetAgentName(), GetConfigFilePath(GetProjectRoot()), GetBodyPath());
+
+		// command is a single array: [binary, port=, client-transport=, authorization=, token=].
+		TArray<TSharedPtr<FJsonValue>> Command;
+		Command.Add(MakeShared<FJsonValueString>(GetStdioCommand()));
+		for (const FString& Arg : GetStdioArgs())
+			Command.Add(MakeShared<FJsonValueString>(Arg));
+
+		Config->SetStringProperty(TEXT("type"), TEXT("local"), /*bRequired*/ true);
+		Config->SetProperty(TEXT("enabled"), MakeShared<FJsonValueBoolean>(true), /*bRequired*/ true);
+		Config->SetProperty(TEXT("command"), MakeShared<FJsonValueArray>(Command), /*bRequired*/ true);
+		// `url`/`args` belong to the other shape — scrub them.
+		Config->SetPropertyToRemove(TEXT("url"));
+		Config->SetPropertyToRemove(TEXT("args"));
+		return Config;
+	}
+
+	virtual TSharedRef<FAiAgentConfig> BuildHttp() const override
+	{
+		TSharedRef<FJsonAiAgentConfig> Config = MakeShared<FJsonAiAgentConfig>(
+			GetAgentName(), GetConfigFilePath(GetProjectRoot()), GetBodyPath());
+
+		Config->SetStringProperty(TEXT("type"), TEXT("remote"), /*bRequired*/ true);
+		Config->SetProperty(TEXT("enabled"), MakeShared<FJsonValueBoolean>(true), /*bRequired*/ true);
+		Config->SetStringProperty(TEXT("url"), GetConnection().HttpUrl, /*bRequired*/ true, EUnrealMcpValueComparison::Url);
+		// Scrub the STDIO-only keys (Open Code's STDIO `command` is an array — removing it is correct on switch).
+		Config->SetPropertyToRemove(TEXT("command"));
+		Config->SetPropertyToRemove(TEXT("args"));
+		return Config;
+	}
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/RiderConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/RiderConfigurator.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Agents/JsonAiAgentConfig.h"
+#include "Misc/Paths.h"
+#include "Dom/JsonValue.h"
+
+/**
+ * Rider (Junie) configurator (docs/ARCHITECTURE.md §7). Writes project-local `.junie/mcp/mcp.json`, nesting under
+ * "mcpServers" — mirrors Unity's RiderConfigurator. Junie requires an explicit `enabled: true` flag on the entry and
+ * has no `disabled` key, so both transports add `enabled` (required) and scrub a stale `disabled`.
+ */
+class FRiderConfigurator : public FAiAgentConfigurator
+{
+public:
+	virtual FString GetAgentName() const override { return TEXT("Rider (Junie)"); }
+	virtual FString GetAgentId() const override { return TEXT("rider-junie"); }
+	virtual FString GetDownloadUrl() const override { return TEXT("https://www.jetbrains.com/rider/download/"); }
+	virtual FString GetIconFileName() const override { return TEXT("rider-64.png"); }
+
+	virtual FString GetConfigFilePath(const FString& InProjectRoot) const override
+	{
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".junie"), TEXT("mcp"), TEXT("mcp.json")));
+	}
+	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+
+protected:
+	virtual void CustomizeStdio(FJsonAiAgentConfig& Config) const override { ApplyEnabled(Config); }
+	virtual void CustomizeHttp(FJsonAiAgentConfig& Config) const override { ApplyEnabled(Config); }
+
+private:
+	static void ApplyEnabled(FJsonAiAgentConfig& Config)
+	{
+		Config.SetProperty(TEXT("enabled"), MakeShared<FJsonValueBoolean>(true), /*bRequired*/ true);
+		Config.SetPropertyToRemove(TEXT("disabled"));
+	}
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/UnityAiConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/UnityAiConfigurator.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Misc/Paths.h"
+
+/**
+ * Unity AI configurator (docs/ARCHITECTURE.md §7). Mirrors Unity's UnityAiConfigurator for registry parity.
+ *
+ * Unreal note (design decision, issue #50): Unity AI is Unity-Editor-specific and has no meaning inside an Unreal
+ * project. It is retained here ONLY for 1:1 parity with the Unity agent roster (so the agent count/order matches
+ * across the three engine plugins and a future shared roster spec). It writes its config exactly like any other JSON
+ * agent — a project-local `UserSettings/mcp.json` under "mcpServers" (the same relative path Unity uses) — so it is
+ * harmless if a user never picks it. Not blocking; recorded in design_notes.
+ */
+class FUnityAiConfigurator : public FAiAgentConfigurator
+{
+public:
+	virtual FString GetAgentName() const override { return TEXT("Unity AI"); }
+	virtual FString GetAgentId() const override { return TEXT("unity-ai"); }
+	virtual FString GetDownloadUrl() const override { return TEXT("https://unity.com/features/ai"); }
+	virtual FString GetIconFileName() const override { return TEXT("unity-64.png"); }
+
+	virtual FString GetConfigFilePath(const FString& InProjectRoot) const override
+	{
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT("UserSettings"), TEXT("mcp.json")));
+	}
+	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/VisualStudioCodeCopilotConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/VisualStudioCodeCopilotConfigurator.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Misc/Paths.h"
+
+/**
+ * Visual Studio Code (Copilot) configurator (docs/ARCHITECTURE.md §7). Writes project-local `.vscode/mcp.json` —
+ * matching the cli's `vscode` agent def (cli/src/lib/setup-mcp.ts) and Unity's VisualStudioCodeCopilotConfigurator.
+ * VS Code nests its servers under "servers" (NOT "mcpServers" — writing mcpServers there is silently ignored).
+ */
+class FVisualStudioCodeCopilotConfigurator : public FAiAgentConfigurator
+{
+public:
+	virtual FString GetAgentName() const override { return TEXT("Visual Studio Code (Copilot)"); }
+	virtual FString GetAgentId() const override { return TEXT("vscode-copilot"); }
+	virtual FString GetDownloadUrl() const override { return TEXT("https://code.visualstudio.com/download"); }
+	virtual FString GetTutorialUrl() const override { return TEXT("https://www.youtube.com/watch?v=ZhP7Ju91mOE"); }
+	virtual FString GetIconFileName() const override { return TEXT("vs-code-64.png"); }
+
+	virtual FString GetConfigFilePath(const FString& InProjectRoot) const override
+	{
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".vscode"), TEXT("mcp.json")));
+	}
+	virtual FString GetBodyPath() const override { return TEXT("servers"); }
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/VisualStudioCopilotConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/VisualStudioCopilotConfigurator.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Misc/Paths.h"
+
+/**
+ * Visual Studio (Copilot) configurator (docs/ARCHITECTURE.md §7). Writes project-local `.vs/mcp.json`, nesting under
+ * "servers" — mirrors Unity's VisualStudioCopilotConfigurator. Visual Studio (the full IDE) and VS Code are distinct
+ * agents with distinct config files; both Copilot integrations use the "servers" body key.
+ */
+class FVisualStudioCopilotConfigurator : public FAiAgentConfigurator
+{
+public:
+	virtual FString GetAgentName() const override { return TEXT("Visual Studio (Copilot)"); }
+	virtual FString GetAgentId() const override { return TEXT("vs-copilot"); }
+	virtual FString GetDownloadUrl() const override { return TEXT("https://visualstudio.microsoft.com/downloads/"); }
+	virtual FString GetTutorialUrl() const override { return TEXT("https://www.youtube.com/watch?v=RGdak4T69mc"); }
+	virtual FString GetIconFileName() const override { return TEXT("visual-studio-64.png"); }
+
+	virtual FString GetConfigFilePath(const FString& InProjectRoot) const override
+	{
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".vs"), TEXT("mcp.json")));
+	}
+	virtual FString GetBodyPath() const override { return TEXT("servers"); }
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ZooCodeConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ZooCodeConfigurator.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfigurator.h"
+#include "Agents/JsonAiAgentConfig.h"
+#include "Misc/Paths.h"
+#include "Dom/JsonValue.h"
+
+/**
+ * Zoo Code configurator (docs/ARCHITECTURE.md §7). Writes project-local `.roo/mcp.json`, nesting under "mcpServers"
+ * — mirrors Unity's ZooCodeConfigurator (a Roo Code fork: config lives under `.roo/`). Same shape as Kilo Code:
+ * required `disabled: false` on both transports, `streamable-http` for the HTTP type.
+ */
+class FZooCodeConfigurator : public FAiAgentConfigurator
+{
+public:
+	virtual FString GetAgentName() const override { return TEXT("Zoo Code"); }
+	virtual FString GetAgentId() const override { return TEXT("zoo-code"); }
+	virtual FString GetDownloadUrl() const override { return TEXT("https://www.zoocode.dev/"); }
+	virtual FString GetIconFileName() const override { return TEXT("zoo-code-64.png"); }
+
+	virtual FString GetConfigFilePath(const FString& InProjectRoot) const override
+	{
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".roo"), TEXT("mcp.json")));
+	}
+	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+
+protected:
+	virtual void CustomizeStdio(FJsonAiAgentConfig& Config) const override
+	{
+		Config.SetProperty(TEXT("disabled"), MakeShared<FJsonValueBoolean>(false), /*bRequired*/ true);
+	}
+	virtual void CustomizeHttp(FJsonAiAgentConfig& Config) const override
+	{
+		Config.SetProperty(TEXT("disabled"), MakeShared<FJsonValueBoolean>(false), /*bRequired*/ true);
+		Config.SetStringProperty(TEXT("type"), TEXT("streamable-http"), /*bRequired*/ true);
+	}
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/JsonAiAgentConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/JsonAiAgentConfig.cpp
@@ -407,6 +407,13 @@ bool FJsonAiAgentConfig::AreValuesEquivalent(EUnrealMcpValueComparison Compariso
 			return NormalizeUrl(ExpectedStr) == NormalizeUrl(ActualStr);
 	}
 
+	if (Comparison == EUnrealMcpValueComparison::Path)
+	{
+		FString ExpectedStr, ActualStr;
+		if (Expected->TryGetString(ExpectedStr) && Actual->TryGetString(ActualStr))
+			return NormalizePath(ExpectedStr) == NormalizePath(ActualStr);
+	}
+
 	return JsonValueToString(Expected) == JsonValueToString(Actual);
 }
 
@@ -415,6 +422,17 @@ FString FJsonAiAgentConfig::NormalizeUrl(const FString& Url)
 	// Lowercase + trim a single trailing slash. Good enough for the http(s)://host:port/mcp shapes we emit
 	// (no need for full URI parsing — the server URL is always our own deterministic form).
 	FString Normalized = Url.ToLower();
+	Normalized.TrimStartAndEndInline();
+	while (Normalized.EndsWith(TEXT("/")))
+		Normalized.LeftChopInline(1);
+	return Normalized;
+}
+
+FString FJsonAiAgentConfig::NormalizePath(const FString& Path)
+{
+	// Unify separators to '/' and trim a trailing slash. The server command is always our own deterministic
+	// forward-slashed path, so this is enough to match a hand-edited backslash variant.
+	FString Normalized = Path.Replace(TEXT("\\"), TEXT("/"));
 	Normalized.TrimStartAndEndInline();
 	while (Normalized.EndsWith(TEXT("/")))
 		Normalized.LeftChopInline(1);

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/JsonAiAgentConfig.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/JsonAiAgentConfig.h
@@ -83,5 +83,6 @@ private:
 
 	static bool AreValuesEquivalent(EUnrealMcpValueComparison Comparison, const TSharedPtr<FJsonValue>& Expected, const TSharedPtr<FJsonValue>& Actual);
 	static FString NormalizeUrl(const FString& Url);
+	static FString NormalizePath(const FString& Path);
 	static FString JsonValueToString(const TSharedPtr<FJsonValue>& Value);
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/TomlAiAgentConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/TomlAiAgentConfig.cpp
@@ -183,15 +183,34 @@ int32 FTomlAiAgentConfig::FindSection(const TArray<FString>& Lines, const FStrin
 	return INDEX_NONE;
 }
 
-int32 FTomlAiAgentConfig::FindSectionEnd(const TArray<FString>& Lines, int32 SectionStart)
+int32 FTomlAiAgentConfig::FindSectionEnd(const TArray<FString>& Lines, int32 SectionStart, const FString& SectionName)
 {
+	// A nested dotted sub-table of our section (e.g. `[mcp_servers.unreal-mcp.env]`) belongs to this section and
+	// must NOT terminate it — otherwise it gets orphaned outside the span and corrupted on merge/remove.
+	const FString NestedPrefix = FString::Printf(TEXT("[%s."), *SectionName);
 	for (int32 i = SectionStart + 1; i < Lines.Num(); ++i)
 	{
 		const FString Trimmed = Lines[i].TrimStartAndEnd();
 		if (Trimmed.StartsWith(TEXT("[")) && Trimmed.EndsWith(TEXT("]")))
+		{
+			if (Trimmed.StartsWith(NestedPrefix))
+				continue; // nested sub-table → still part of our section
 			return i;
+		}
 	}
 	return Lines.Num();
+}
+
+int32 FTomlAiAgentConfig::FindNestedSubTableStart(const TArray<FString>& Lines, int32 SectionStart, int32 SectionEnd, const FString& SectionName)
+{
+	const FString NestedPrefix = FString::Printf(TEXT("[%s."), *SectionName);
+	for (int32 i = SectionStart + 1; i < SectionEnd; ++i)
+	{
+		const FString Trimmed = Lines[i].TrimStartAndEnd();
+		if (Trimmed.StartsWith(NestedPrefix) && Trimmed.EndsWith(TEXT("]")))
+			return i;
+	}
+	return SectionEnd;
 }
 
 TMap<FString, FString> FTomlAiAgentConfig::ParseSectionProps(const TArray<FString>& Lines, int32 Start, int32 End)
@@ -239,7 +258,9 @@ TArray<TPair<int32, int32>> FTomlAiAgentConfig::FindDuplicateSectionRanges(const
 		if (Trimmed == OwnHeader)
 			continue;
 
-		const int32 SectionEnd = FindSectionEnd(Lines, i);
+		// The sibling's own name (strip the surrounding "[" / "]") so its nested sub-tables stay within its span.
+		const FString SiblingName = Trimmed.Mid(1, Trimmed.Len() - 2);
+		const int32 SectionEnd = FindSectionEnd(Lines, i, SiblingName);
 		const TMap<FString, FString> Props = ParseSectionProps(Lines, i + 1, SectionEnd);
 
 		for (const auto& Identity : OurIdentities)
@@ -267,7 +288,13 @@ bool FTomlAiAgentConfig::Configure()
 	TArray<FString> Lines;
 	if (!TryReadLines(ConfigPath, Lines))
 	{
-		// Missing / unreadable file → write a clean expected-content file.
+		// A read failure on an EXISTING file (locked / I/O error) must NOT take the clean-write path: clobbering
+		// it would wipe sibling sections + comments, violating the read-merge-write sibling-preservation contract.
+		// Only a genuinely missing file is safe to create fresh.
+		if (FPaths::FileExists(ConfigPath))
+			return false;
+
+		// Missing file → write a clean expected-content file.
 		const FString Dir = FPaths::GetPath(ConfigPath);
 		if (!Dir.IsEmpty())
 			IFileManager::Get().MakeDirectory(*Dir, /*Tree*/ true);
@@ -276,14 +303,19 @@ bool FTomlAiAgentConfig::Configure()
 		return IsConfigured();
 	}
 
-	// Remove deprecated sections.
+	// Remove deprecated sections. NOTE: FString comparison (and thus FindSection) is case-INSENSITIVE, so a
+	// deprecated name that differs from the canonical one only by case (e.g. "Unreal-MCP" vs "unreal-mcp") would
+	// otherwise match — and remove — our own canonical section here, before the merge step gets to own it. Skip any
+	// deprecated name equal to the canonical Section so the merge below (which preserves nested sub-tables) handles it.
 	for (const FString& Deprecated : DeprecatedMcpServerNames())
 	{
 		const FString DeprecatedSection = FString::Printf(TEXT("%s.%s"), *BodyPath, *Deprecated);
+		if (DeprecatedSection == Section)
+			continue;
 		const int32 DepIndex = FindSection(Lines, DeprecatedSection);
 		if (DepIndex != INDEX_NONE)
 		{
-			const int32 DepEnd = FindSectionEnd(Lines, DepIndex);
+			const int32 DepEnd = FindSectionEnd(Lines, DepIndex, DeprecatedSection);
 			Lines.RemoveAt(DepIndex, DepEnd - DepIndex);
 		}
 	}
@@ -297,8 +329,15 @@ bool FTomlAiAgentConfig::Configure()
 	const int32 SectionIndex = FindSection(Lines, Section);
 	if (SectionIndex != INDEX_NONE)
 	{
-		const int32 SectionEnd = FindSectionEnd(Lines, SectionIndex);
-		TMap<FString, FString> Merged = ParseSectionProps(Lines, SectionIndex + 1, SectionEnd);
+		const int32 SectionEnd = FindSectionEnd(Lines, SectionIndex, Section);
+		// Only the flat scalar lines BEFORE any nested sub-table (`[<section>.env]`) belong to the merge; the nested
+		// tail is preserved verbatim so a sub-table round-trips intact rather than being flattened/dropped.
+		const int32 NestedStart = FindNestedSubTableStart(Lines, SectionIndex, SectionEnd, Section);
+		TMap<FString, FString> Merged = ParseSectionProps(Lines, SectionIndex + 1, NestedStart);
+
+		TArray<FString> NestedTail;
+		for (int32 i = NestedStart; i < SectionEnd; ++i)
+			NestedTail.Add(Lines[i]);
 
 		for (const FString& Key : PropertiesToRemove)
 			Merged.Remove(Key);
@@ -307,10 +346,11 @@ bool FTomlAiAgentConfig::Configure()
 		for (const auto& Pair : Desired)
 			Merged.Add(Pair.Key, Pair.Value);
 
-		// Replace the old section lines with the rebuilt section.
+		// Replace the old section lines with the rebuilt flat section, then re-append the preserved nested tail.
 		Lines.RemoveAt(SectionIndex, SectionEnd - SectionIndex);
 		TArray<FString> NewSectionLines;
 		BuildSection(Section, Merged).ParseIntoArray(NewSectionLines, TEXT("\n"), /*CullEmpty*/ false);
+		NewSectionLines.Append(NestedTail);
 		Lines.Insert(NewSectionLines, SectionIndex);
 	}
 	else
@@ -344,7 +384,7 @@ bool FTomlAiAgentConfig::Remove()
 	const int32 SectionIndex = FindSection(Lines, Section);
 	if (SectionIndex != INDEX_NONE)
 	{
-		const int32 SectionEnd = FindSectionEnd(Lines, SectionIndex);
+		const int32 SectionEnd = FindSectionEnd(Lines, SectionIndex, Section);
 		Lines.RemoveAt(SectionIndex, SectionEnd - SectionIndex);
 		bRemoved = true;
 	}
@@ -352,10 +392,12 @@ bool FTomlAiAgentConfig::Remove()
 	for (const FString& Deprecated : DeprecatedMcpServerNames())
 	{
 		const FString DeprecatedSection = FString::Printf(TEXT("%s.%s"), *BodyPath, *Deprecated);
+		if (DeprecatedSection == Section)
+			continue; // case-only variant of the canonical section — already handled above (FString '==' is case-insensitive)
 		const int32 DepIndex = FindSection(Lines, DeprecatedSection);
 		if (DepIndex != INDEX_NONE)
 		{
-			const int32 DepEnd = FindSectionEnd(Lines, DepIndex);
+			const int32 DepEnd = FindSectionEnd(Lines, DepIndex, DeprecatedSection);
 			Lines.RemoveAt(DepIndex, DepEnd - DepIndex);
 			bRemoved = true;
 		}
@@ -396,12 +438,15 @@ bool FTomlAiAgentConfig::IsConfigured() const
 	if (!TryReadLines(ConfigPath, Lines))
 		return false;
 
-	const int32 SectionIndex = FindSection(Lines, SectionName());
+	const FString Section = SectionName();
+	const int32 SectionIndex = FindSection(Lines, Section);
 	if (SectionIndex == INDEX_NONE)
 		return false;
 
-	const int32 SectionEnd = FindSectionEnd(Lines, SectionIndex);
-	const TMap<FString, FString> Existing = ParseSectionProps(Lines, SectionIndex + 1, SectionEnd);
+	const int32 SectionEnd = FindSectionEnd(Lines, SectionIndex, Section);
+	// Match only the section's own flat scalars, not keys nested inside a `[<section>.env]` sub-table.
+	const int32 NestedStart = FindNestedSubTableStart(Lines, SectionIndex, SectionEnd, Section);
+	const TMap<FString, FString> Existing = ParseSectionProps(Lines, SectionIndex + 1, NestedStart);
 
 	return AreRequiredPropertiesMatching(Existing) && !HasAnyPropertyToRemove(Existing);
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/TomlAiAgentConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/TomlAiAgentConfig.cpp
@@ -1,0 +1,498 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "Agents/TomlAiAgentConfig.h"
+
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "HAL/FileManager.h"
+
+FTomlAiAgentConfig::FTomlAiAgentConfig(const FString& InName, const FString& InConfigPath, const FString& InBodyPath)
+	: FAiAgentConfig(InName, InConfigPath, InBodyPath)
+{
+	// Default identity keys mirror the JSON config: a sibling section sharing our command or url is the same server.
+	IdentityKeys = { TEXT("command"), TEXT("url") };
+}
+
+FTomlAiAgentConfig& FTomlAiAgentConfig::SetStringProperty(const FString& Key, const FString& Value, bool bRequired, EUnrealMcpValueComparison Comparison)
+{
+	if (!Properties.Contains(Key))
+		PropertyOrder.Add(Key);
+	FDesiredValue V;
+	V.Kind = EValueKind::String;
+	V.StringValue = Value;
+	V.bRequired = bRequired;
+	V.Comparison = Comparison;
+	Properties.Add(Key, V);
+	PropertiesToRemove.Remove(Key);
+	return *this;
+}
+
+FTomlAiAgentConfig& FTomlAiAgentConfig::SetStringArrayProperty(const FString& Key, const TArray<FString>& Values, bool bRequired)
+{
+	if (!Properties.Contains(Key))
+		PropertyOrder.Add(Key);
+	FDesiredValue V;
+	V.Kind = EValueKind::StringArray;
+	V.ArrayValue = Values;
+	V.bRequired = bRequired;
+	Properties.Add(Key, V);
+	PropertiesToRemove.Remove(Key);
+	return *this;
+}
+
+FTomlAiAgentConfig& FTomlAiAgentConfig::SetIntProperty(const FString& Key, int32 Value, bool bRequired)
+{
+	if (!Properties.Contains(Key))
+		PropertyOrder.Add(Key);
+	FDesiredValue V;
+	V.Kind = EValueKind::Int;
+	V.IntValue = Value;
+	V.bRequired = bRequired;
+	Properties.Add(Key, V);
+	PropertiesToRemove.Remove(Key);
+	return *this;
+}
+
+FTomlAiAgentConfig& FTomlAiAgentConfig::SetBoolProperty(const FString& Key, bool Value, bool bRequired)
+{
+	if (!Properties.Contains(Key))
+		PropertyOrder.Add(Key);
+	FDesiredValue V;
+	V.Kind = EValueKind::Bool;
+	V.BoolValue = Value;
+	V.bRequired = bRequired;
+	Properties.Add(Key, V);
+	PropertiesToRemove.Remove(Key);
+	return *this;
+}
+
+FTomlAiAgentConfig& FTomlAiAgentConfig::SetPropertyToRemove(const FString& Key)
+{
+	if (Properties.Contains(Key))
+	{
+		Properties.Remove(Key);
+		PropertyOrder.Remove(Key);
+	}
+	PropertiesToRemove.AddUnique(Key);
+	return *this;
+}
+
+FTomlAiAgentConfig& FTomlAiAgentConfig::AddIdentityKey(const FString& Key)
+{
+	IdentityKeys.AddUnique(Key);
+	return *this;
+}
+
+FString FTomlAiAgentConfig::SectionName() const
+{
+	return FString::Printf(TEXT("%s.%s"), *BodyPath, DefaultMcpServerName);
+}
+
+FString FTomlAiAgentConfig::FormatProperty(const FString& Key, const FDesiredValue& Value)
+{
+	switch (Value.Kind)
+	{
+		case EValueKind::String:
+		{
+			FString Escaped = Value.StringValue.Replace(TEXT("\\"), TEXT("\\\\")).Replace(TEXT("\""), TEXT("\\\""));
+			return FString::Printf(TEXT("%s = \"%s\""), *Key, *Escaped);
+		}
+		case EValueKind::StringArray:
+		{
+			TArray<FString> Quoted;
+			for (const FString& E : Value.ArrayValue)
+			{
+				FString Escaped = E.Replace(TEXT("\\"), TEXT("\\\\")).Replace(TEXT("\""), TEXT("\\\""));
+				Quoted.Add(FString::Printf(TEXT("\"%s\""), *Escaped));
+			}
+			return FString::Printf(TEXT("%s = [%s]"), *Key, *FString::Join(Quoted, TEXT(",")));
+		}
+		case EValueKind::Int:
+			return FString::Printf(TEXT("%s = %d"), *Key, Value.IntValue);
+		case EValueKind::Bool:
+			return FString::Printf(TEXT("%s = %s"), *Key, Value.BoolValue ? TEXT("true") : TEXT("false"));
+		default:
+			return FString();
+	}
+}
+
+FString FTomlAiAgentConfig::FormatRawProperty(const FString& Key, const FString& RawValue)
+{
+	return FString::Printf(TEXT("%s = %s"), *Key, *RawValue);
+}
+
+TMap<FString, FString> FTomlAiAgentConfig::DesiredRawProperties() const
+{
+	TMap<FString, FString> Raw;
+	for (const FString& Key : PropertyOrder)
+	{
+		const FDesiredValue& V = Properties[Key];
+		// Build the raw TOML literal (right-hand side of "key = ") by formatting then trimming the "key = " prefix.
+		const FString Formatted = FormatProperty(Key, V);
+		const FString Prefix = Key + TEXT(" = ");
+		Raw.Add(Key, Formatted.RightChop(Prefix.Len()));
+	}
+	return Raw;
+}
+
+FString FTomlAiAgentConfig::BuildSection(const FString& InSectionName, const TMap<FString, FString>& Props) const
+{
+	TArray<FString> Keys;
+	Props.GetKeys(Keys);
+	Keys.Sort(); // deterministic alphabetical order (matches Unity's OrderBy(Ordinal))
+
+	TArray<FString> Lines;
+	Lines.Add(FString::Printf(TEXT("[%s]"), *InSectionName));
+	for (const FString& Key : Keys)
+		Lines.Add(FormatRawProperty(Key, Props[Key]));
+	return FString::Join(Lines, TEXT("\n"));
+}
+
+FString FTomlAiAgentConfig::GetExpectedFileContent() const
+{
+	return BuildSection(SectionName(), DesiredRawProperties()) + TEXT("\n");
+}
+
+bool FTomlAiAgentConfig::TryReadLines(const FString& Path, TArray<FString>& OutLines)
+{
+	OutLines.Reset();
+	if (Path.IsEmpty() || !FPaths::FileExists(Path))
+		return false;
+	return FFileHelper::LoadFileToStringArray(OutLines, *Path);
+}
+
+bool FTomlAiAgentConfig::WriteLines(const TArray<FString>& Lines) const
+{
+	if (ConfigPath.IsEmpty())
+		return false;
+	const FString Dir = FPaths::GetPath(ConfigPath);
+	if (!Dir.IsEmpty())
+		IFileManager::Get().MakeDirectory(*Dir, /*Tree*/ true);
+	// Force UTF-8 without a BOM (the TOML parsers in agent CLIs expect plain UTF-8). Join with "\n" lines.
+	const FString Content = FString::Join(Lines, TEXT("\n")) + TEXT("\n");
+	return FFileHelper::SaveStringToFile(Content, *ConfigPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
+}
+
+int32 FTomlAiAgentConfig::FindSection(const TArray<FString>& Lines, const FString& InSectionName)
+{
+	const FString Header = FString::Printf(TEXT("[%s]"), *InSectionName);
+	for (int32 i = 0; i < Lines.Num(); ++i)
+		if (Lines[i].TrimStartAndEnd() == Header)
+			return i;
+	return INDEX_NONE;
+}
+
+int32 FTomlAiAgentConfig::FindSectionEnd(const TArray<FString>& Lines, int32 SectionStart)
+{
+	for (int32 i = SectionStart + 1; i < Lines.Num(); ++i)
+	{
+		const FString Trimmed = Lines[i].TrimStartAndEnd();
+		if (Trimmed.StartsWith(TEXT("[")) && Trimmed.EndsWith(TEXT("]")))
+			return i;
+	}
+	return Lines.Num();
+}
+
+TMap<FString, FString> FTomlAiAgentConfig::ParseSectionProps(const TArray<FString>& Lines, int32 Start, int32 End)
+{
+	TMap<FString, FString> Props;
+	for (int32 i = Start; i < End; ++i)
+	{
+		const FString Trimmed = Lines[i].TrimStartAndEnd();
+		if (Trimmed.IsEmpty() || Trimmed.StartsWith(TEXT("#")))
+			continue;
+		int32 EqIndex;
+		if (!Trimmed.FindChar(TEXT('='), EqIndex))
+			continue;
+		const FString Key = Trimmed.Left(EqIndex).TrimStartAndEnd();
+		const FString RawValue = Trimmed.RightChop(EqIndex + 1).TrimStartAndEnd();
+		if (!Key.IsEmpty())
+			Props.Add(Key, RawValue); // store the raw TOML literal verbatim (round-trips opaque values)
+	}
+	return Props;
+}
+
+TArray<TPair<int32, int32>> FTomlAiAgentConfig::FindDuplicateSectionRanges(const TArray<FString>& Lines, const FString& OwnSection) const
+{
+	TArray<TPair<int32, int32>> Result;
+
+	// Our identity values (only those we set as desired string properties).
+	TArray<TPair<FString, FDesiredValue>> OurIdentities;
+	for (const FString& IdKey : IdentityKeys)
+	{
+		if (const FDesiredValue* V = Properties.Find(IdKey))
+			if (V->Kind == EValueKind::String)
+				OurIdentities.Add(TPair<FString, FDesiredValue>(IdKey, *V));
+	}
+	if (OurIdentities.Num() == 0)
+		return Result;
+
+	const FString BodyPrefix = FString::Printf(TEXT("[%s."), *BodyPath);
+	const FString OwnHeader = FString::Printf(TEXT("[%s]"), *OwnSection);
+
+	for (int32 i = 0; i < Lines.Num(); ++i)
+	{
+		const FString Trimmed = Lines[i].TrimStartAndEnd();
+		if (!Trimmed.StartsWith(BodyPrefix) || !Trimmed.EndsWith(TEXT("]")))
+			continue;
+		if (Trimmed == OwnHeader)
+			continue;
+
+		const int32 SectionEnd = FindSectionEnd(Lines, i);
+		const TMap<FString, FString> Props = ParseSectionProps(Lines, i + 1, SectionEnd);
+
+		for (const auto& Identity : OurIdentities)
+		{
+			if (const FString* Existing = Props.Find(Identity.Key))
+			{
+				if (RawMatchesDesired(Identity.Value, *Existing))
+				{
+					Result.Add(TPair<int32, int32>(i, SectionEnd));
+					break;
+				}
+			}
+		}
+	}
+	return Result;
+}
+
+bool FTomlAiAgentConfig::Configure()
+{
+	if (ConfigPath.IsEmpty())
+		return false;
+
+	const FString Section = SectionName();
+
+	TArray<FString> Lines;
+	if (!TryReadLines(ConfigPath, Lines))
+	{
+		// Missing / unreadable file → write a clean expected-content file.
+		const FString Dir = FPaths::GetPath(ConfigPath);
+		if (!Dir.IsEmpty())
+			IFileManager::Get().MakeDirectory(*Dir, /*Tree*/ true);
+		if (!FFileHelper::SaveStringToFile(GetExpectedFileContent(), *ConfigPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
+			return false;
+		return IsConfigured();
+	}
+
+	// Remove deprecated sections.
+	for (const FString& Deprecated : DeprecatedMcpServerNames())
+	{
+		const FString DeprecatedSection = FString::Printf(TEXT("%s.%s"), *BodyPath, *Deprecated);
+		const int32 DepIndex = FindSection(Lines, DeprecatedSection);
+		if (DepIndex != INDEX_NONE)
+		{
+			const int32 DepEnd = FindSectionEnd(Lines, DepIndex);
+			Lines.RemoveAt(DepIndex, DepEnd - DepIndex);
+		}
+	}
+
+	// Remove duplicate sibling sections (same server under a different name). Remove bottom-up to keep indices valid.
+	TArray<TPair<int32, int32>> Dups = FindDuplicateSectionRanges(Lines, Section);
+	for (int32 d = Dups.Num() - 1; d >= 0; --d)
+		Lines.RemoveAt(Dups[d].Key, Dups[d].Value - Dups[d].Key);
+
+	// Merge desired props onto the existing section (or append a fresh one).
+	const int32 SectionIndex = FindSection(Lines, Section);
+	if (SectionIndex != INDEX_NONE)
+	{
+		const int32 SectionEnd = FindSectionEnd(Lines, SectionIndex);
+		TMap<FString, FString> Merged = ParseSectionProps(Lines, SectionIndex + 1, SectionEnd);
+
+		for (const FString& Key : PropertiesToRemove)
+			Merged.Remove(Key);
+
+		const TMap<FString, FString> Desired = DesiredRawProperties();
+		for (const auto& Pair : Desired)
+			Merged.Add(Pair.Key, Pair.Value);
+
+		// Replace the old section lines with the rebuilt section.
+		Lines.RemoveAt(SectionIndex, SectionEnd - SectionIndex);
+		TArray<FString> NewSectionLines;
+		BuildSection(Section, Merged).ParseIntoArray(NewSectionLines, TEXT("\n"), /*CullEmpty*/ false);
+		Lines.Insert(NewSectionLines, SectionIndex);
+	}
+	else
+	{
+		// Append, separated by a blank line if the file does not already end on one.
+		if (Lines.Num() > 0 && !Lines.Last().TrimStartAndEnd().IsEmpty())
+			Lines.Add(TEXT(""));
+		TArray<FString> NewSectionLines;
+		BuildSection(Section, DesiredRawProperties()).ParseIntoArray(NewSectionLines, TEXT("\n"), /*CullEmpty*/ false);
+		Lines.Append(NewSectionLines);
+	}
+
+	if (!WriteLines(Lines))
+		return false;
+
+	return IsConfigured();
+}
+
+bool FTomlAiAgentConfig::Remove()
+{
+	if (ConfigPath.IsEmpty())
+		return false;
+
+	TArray<FString> Lines;
+	if (!TryReadLines(ConfigPath, Lines))
+		return false;
+
+	const FString Section = SectionName();
+	bool bRemoved = false;
+
+	const int32 SectionIndex = FindSection(Lines, Section);
+	if (SectionIndex != INDEX_NONE)
+	{
+		const int32 SectionEnd = FindSectionEnd(Lines, SectionIndex);
+		Lines.RemoveAt(SectionIndex, SectionEnd - SectionIndex);
+		bRemoved = true;
+	}
+
+	for (const FString& Deprecated : DeprecatedMcpServerNames())
+	{
+		const FString DeprecatedSection = FString::Printf(TEXT("%s.%s"), *BodyPath, *Deprecated);
+		const int32 DepIndex = FindSection(Lines, DeprecatedSection);
+		if (DepIndex != INDEX_NONE)
+		{
+			const int32 DepEnd = FindSectionEnd(Lines, DepIndex);
+			Lines.RemoveAt(DepIndex, DepEnd - DepIndex);
+			bRemoved = true;
+		}
+	}
+
+	TArray<TPair<int32, int32>> Dups = FindDuplicateSectionRanges(Lines, Section);
+	for (int32 d = Dups.Num() - 1; d >= 0; --d)
+	{
+		Lines.RemoveAt(Dups[d].Key, Dups[d].Value - Dups[d].Key);
+		bRemoved = true;
+	}
+
+	if (!bRemoved)
+		return false;
+
+	return WriteLines(Lines);
+}
+
+bool FTomlAiAgentConfig::IsDetected() const
+{
+	TArray<FString> Lines;
+	if (!TryReadLines(ConfigPath, Lines))
+		return false;
+
+	if (FindSection(Lines, SectionName()) != INDEX_NONE)
+		return true;
+
+	for (const FString& Deprecated : DeprecatedMcpServerNames())
+		if (FindSection(Lines, FString::Printf(TEXT("%s.%s"), *BodyPath, *Deprecated)) != INDEX_NONE)
+			return true;
+
+	return FindDuplicateSectionRanges(Lines, SectionName()).Num() > 0;
+}
+
+bool FTomlAiAgentConfig::IsConfigured() const
+{
+	TArray<FString> Lines;
+	if (!TryReadLines(ConfigPath, Lines))
+		return false;
+
+	const int32 SectionIndex = FindSection(Lines, SectionName());
+	if (SectionIndex == INDEX_NONE)
+		return false;
+
+	const int32 SectionEnd = FindSectionEnd(Lines, SectionIndex);
+	const TMap<FString, FString> Existing = ParseSectionProps(Lines, SectionIndex + 1, SectionEnd);
+
+	return AreRequiredPropertiesMatching(Existing) && !HasAnyPropertyToRemove(Existing);
+}
+
+bool FTomlAiAgentConfig::AreRequiredPropertiesMatching(const TMap<FString, FString>& Existing) const
+{
+	for (const FString& Key : PropertyOrder)
+	{
+		const FDesiredValue& V = Properties[Key];
+		if (!V.bRequired)
+			continue;
+		const FString* RawExisting = Existing.Find(Key);
+		if (!RawExisting)
+			return false;
+		if (!RawMatchesDesired(V, *RawExisting))
+			return false;
+	}
+	return true;
+}
+
+bool FTomlAiAgentConfig::HasAnyPropertyToRemove(const TMap<FString, FString>& Existing) const
+{
+	for (const FString& Key : PropertiesToRemove)
+		if (Existing.Contains(Key))
+			return true;
+	return false;
+}
+
+bool FTomlAiAgentConfig::RawMatchesDesired(const FDesiredValue& Desired, const FString& RawExisting)
+{
+	const FString Trimmed = RawExisting.TrimStartAndEnd();
+	switch (Desired.Kind)
+	{
+		case EValueKind::String:
+		{
+			const FString Existing = StripQuotes(Trimmed);
+			if (Desired.Comparison == EUnrealMcpValueComparison::Url)
+				return NormalizeUrl(Desired.StringValue) == NormalizeUrl(Existing);
+			if (Desired.Comparison == EUnrealMcpValueComparison::Path)
+				return NormalizePath(Desired.StringValue) == NormalizePath(Existing);
+			return Desired.StringValue == Existing;
+		}
+		case EValueKind::StringArray:
+		{
+			// Compare the raw existing array literal against a freshly-formatted desired literal (both deterministic).
+			FDesiredValue Tmp = Desired;
+			const FString DesiredLiteral = FormatProperty(TEXT("k"), Tmp).RightChop(FString(TEXT("k = ")).Len());
+			return DesiredLiteral == Trimmed;
+		}
+		case EValueKind::Int:
+		{
+			int32 ExistingInt = 0;
+			return LexTryParseString(ExistingInt, *Trimmed) && ExistingInt == Desired.IntValue;
+		}
+		case EValueKind::Bool:
+		{
+			const FString Lower = Trimmed.ToLower();
+			const bool bExisting = (Lower == TEXT("true"));
+			const bool bValidBool = (Lower == TEXT("true") || Lower == TEXT("false"));
+			return bValidBool && bExisting == Desired.BoolValue;
+		}
+		default:
+			return false;
+	}
+}
+
+FString FTomlAiAgentConfig::StripQuotes(const FString& Raw)
+{
+	FString S = Raw.TrimStartAndEnd();
+	if (S.Len() >= 2 && S.StartsWith(TEXT("\"")) && S.EndsWith(TEXT("\"")))
+	{
+		S = S.Mid(1, S.Len() - 2);
+		// Unescape the two escapes our writer emits.
+		S = S.Replace(TEXT("\\\""), TEXT("\"")).Replace(TEXT("\\\\"), TEXT("\\"));
+	}
+	return S;
+}
+
+FString FTomlAiAgentConfig::NormalizeUrl(const FString& Url)
+{
+	FString Normalized = Url.ToLower();
+	Normalized.TrimStartAndEndInline();
+	while (Normalized.EndsWith(TEXT("/")))
+		Normalized.LeftChopInline(1);
+	return Normalized;
+}
+
+FString FTomlAiAgentConfig::NormalizePath(const FString& Path)
+{
+	FString Normalized = Path.Replace(TEXT("\\"), TEXT("/"));
+	while (Normalized.EndsWith(TEXT("/")))
+		Normalized.LeftChopInline(1);
+	return Normalized;
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/TomlAiAgentConfig.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/TomlAiAgentConfig.h
@@ -84,7 +84,13 @@ private:
 
 	// --- Line-wise section navigation ---
 	static int32 FindSection(const TArray<FString>& Lines, const FString& InSectionName); // index of `[<name>]` line, or INDEX_NONE
-	static int32 FindSectionEnd(const TArray<FString>& Lines, int32 SectionStart);        // first line of the NEXT section, or Lines.Num()
+	// First line of the NEXT unrelated section, or Lines.Num(). Nested dotted sub-tables of @p SectionName
+	// (e.g. `[<SectionName>.env]`) are absorbed into the span so they travel with the section on merge/remove.
+	static int32 FindSectionEnd(const TArray<FString>& Lines, int32 SectionStart, const FString& SectionName);
+	// Index of the first nested dotted sub-table header (`[<SectionName>.…]`) within (SectionStart, SectionEnd),
+	// or SectionEnd when the section has none. The lines from here to SectionEnd are the section's nested tail,
+	// preserved verbatim across a merge (the flat scalar merge only owns the lines before this point).
+	static int32 FindNestedSubTableStart(const TArray<FString>& Lines, int32 SectionStart, int32 SectionEnd, const FString& SectionName);
 	static TMap<FString, FString> ParseSectionProps(const TArray<FString>& Lines, int32 Start, int32 End); // key→raw literal
 	TArray<TPair<int32, int32>> FindDuplicateSectionRanges(const TArray<FString>& Lines, const FString& OwnSection) const;
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/TomlAiAgentConfig.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/TomlAiAgentConfig.h
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Agents/AiAgentConfig.h"
+
+/**
+ * TOML read-merge-write implementation of FAiAgentConfig (docs/ARCHITECTURE.md §8), the C++/UE analog of Unity's
+ * TomlAiAgentConfig. Codex is the Phase-B agent that uses TOML (`.codex/config.toml`), nesting its server entry
+ * under a dotted-table header `[mcp_servers.unreal-mcp]`. This is the second concrete subclass of the FAiAgentConfig
+ * seam Phase A left for exactly this purpose (FJsonAiAgentConfig is the first).
+ *
+ * Desired-entry model mirrors FJsonAiAgentConfig: typed properties (string / string-array / int / bool) accumulated
+ * via SetProperty, with a `bRequired` gate (drives IsConfigured) and a comparison mode (Exact / Url / Path). Keys
+ * marked via SetPropertyToRemove must NOT be present on the entry (drops the other transport's keys). On Configure()
+ * the file is parsed line-wise, the dotted-table section is found/created, deprecated + duplicate-identity sibling
+ * sections are pruned, the section's properties are merged (existing scalar lines re-emitted with the desired values
+ * overriding, to-remove keys dropped), and the file is rewritten. Sibling sections + comments outside the section
+ * survive (the merge is section-scoped). Robust to a missing file (writes clean expected content) — an empty/invalid
+ * file degrades to "no section found" → append, never throws.
+ *
+ * Deliberately a focused TOML subset: dotted-table section headers, scalar `key = value` lines (string / int / bool),
+ * and string arrays `["a","b"]`. That covers every shape the Codex config emits; richer TOML (inline tables, multi-
+ * line arrays, datetimes) is out of scope and round-trips as opaque raw lines when encountered in an existing file.
+ *
+ * All symbols are UNREALMCPEDITOR_API-exported so the UnrealMcpEditorTests Automation specs drive them against temp
+ * files with no live editor / agent.
+ */
+class FTomlAiAgentConfig : public FAiAgentConfig
+{
+public:
+	UNREALMCPEDITOR_API FTomlAiAgentConfig(const FString& InName, const FString& InConfigPath, const FString& InBodyPath = TEXT("mcp_servers"));
+
+	/** A typed desired value: exactly one of the variants is populated, selected by Kind. */
+	enum class EValueKind : uint8 { String, StringArray, Int, Bool };
+
+	/** Add/replace a desired string property. @p bRequired gates IsConfigured(); @p Comparison gates the match. */
+	UNREALMCPEDITOR_API FTomlAiAgentConfig& SetStringProperty(const FString& Key, const FString& Value, bool bRequired = false, EUnrealMcpValueComparison Comparison = EUnrealMcpValueComparison::Exact);
+	/** Add/replace a desired string-array property (e.g. Codex `args`). */
+	UNREALMCPEDITOR_API FTomlAiAgentConfig& SetStringArrayProperty(const FString& Key, const TArray<FString>& Values, bool bRequired = false);
+	/** Add/replace a desired integer property (e.g. Codex `tool_timeout_sec`). */
+	UNREALMCPEDITOR_API FTomlAiAgentConfig& SetIntProperty(const FString& Key, int32 Value, bool bRequired = false);
+	/** Add/replace a desired boolean property (e.g. Codex `enabled`). */
+	UNREALMCPEDITOR_API FTomlAiAgentConfig& SetBoolProperty(const FString& Key, bool Value, bool bRequired = false);
+	/** Mark a key that must be ABSENT from the section (drops the other transport's keys). */
+	UNREALMCPEDITOR_API FTomlAiAgentConfig& SetPropertyToRemove(const FString& Key);
+	/** Add an identity key used to detect the same server written under a different section name (default command/url). */
+	UNREALMCPEDITOR_API FTomlAiAgentConfig& AddIdentityKey(const FString& Key);
+
+	virtual FString GetExpectedFileContent() const override;
+	virtual bool Configure() override;
+	virtual bool Remove() override;
+	virtual bool IsDetected() const override;
+	virtual bool IsConfigured() const override;
+
+private:
+	struct FDesiredValue
+	{
+		EValueKind Kind = EValueKind::String;
+		FString StringValue;
+		TArray<FString> ArrayValue;
+		int32 IntValue = 0;
+		bool BoolValue = false;
+		bool bRequired = false;
+		EUnrealMcpValueComparison Comparison = EUnrealMcpValueComparison::Exact;
+	};
+
+	TArray<FString> PropertyOrder;             // insertion order (output is sorted alphabetically, like Unity)
+	TMap<FString, FDesiredValue> Properties;
+	TArray<FString> PropertiesToRemove;
+	TArray<FString> IdentityKeys;
+
+	FString SectionName() const;               // "<BodyPath>.<DefaultMcpServerName>"
+	static FString FormatProperty(const FString& Key, const FDesiredValue& Value);
+	static FString FormatRawProperty(const FString& Key, const FString& RawValue); // a value already in TOML literal form
+	FString BuildSection(const FString& InSectionName, const TMap<FString, FString>& Props) const; // Props = key→raw TOML literal
+	TMap<FString, FString> DesiredRawProperties() const; // desired props as key→raw TOML literal (deterministic order applied at emit)
+
+	// --- File IO ---
+	static bool TryReadLines(const FString& Path, TArray<FString>& OutLines);  // false for missing/unreadable
+	bool WriteLines(const TArray<FString>& Lines) const;                       // creates parent dirs
+
+	// --- Line-wise section navigation ---
+	static int32 FindSection(const TArray<FString>& Lines, const FString& InSectionName); // index of `[<name>]` line, or INDEX_NONE
+	static int32 FindSectionEnd(const TArray<FString>& Lines, int32 SectionStart);        // first line of the NEXT section, or Lines.Num()
+	static TMap<FString, FString> ParseSectionProps(const TArray<FString>& Lines, int32 Start, int32 End); // key→raw literal
+	TArray<TPair<int32, int32>> FindDuplicateSectionRanges(const TArray<FString>& Lines, const FString& OwnSection) const;
+
+	// --- Matching ---
+	bool AreRequiredPropertiesMatching(const TMap<FString, FString>& Existing) const;
+	bool HasAnyPropertyToRemove(const TMap<FString, FString>& Existing) const;
+	static bool RawMatchesDesired(const FDesiredValue& Desired, const FString& RawExisting);
+	static FString StripQuotes(const FString& Raw);
+	static FString NormalizeUrl(const FString& Url);
+	static FString NormalizePath(const FString& Path);
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
@@ -139,7 +139,7 @@ FString SUnrealMcpAgentConfigurators::BuildSnippetPreview(bool bStdio) const
 {
 	if (!Selected.IsValid())
 		return FString();
-	FJsonAiAgentConfig& Config = bStdio ? Selected->GetConfigStdio() : Selected->GetConfigHttp();
+	FAiAgentConfig& Config = bStdio ? Selected->GetConfigStdio() : Selected->GetConfigHttp();
 	const FString Snippet = Config.GetExpectedFileContent();
 	const FAiAgentConnectionInfo Connection = ConnectionInfoProvider ? ConnectionInfoProvider() : FAiAgentConnectionInfo();
 	return MaskTokenInSnippet(Snippet, Connection.Token, bRevealToken);
@@ -268,7 +268,7 @@ void SUnrealMcpAgentConfigurators::RebuildAgentPanel()
 						if (Selected.IsValid())
 						{
 							// Copy the REAL snippet (unmasked) — the user is pasting it into their own config.
-							FJsonAiAgentConfig& Config = bStdio ? Selected->GetConfigStdio() : Selected->GetConfigHttp();
+							FAiAgentConfig& Config = bStdio ? Selected->GetConfigStdio() : Selected->GetConfigHttp();
 							FPlatformApplicationMisc::ClipboardCopy(*Config.GetExpectedFileContent());
 						}
 						return FReply::Handled();

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfiguratorSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfiguratorSpec.cpp
@@ -36,6 +36,8 @@
 #include "Agents/Impl/ZooCodeConfigurator.h"
 #include "Agents/Impl/CustomConfigurator.h"
 #include "Config/UnrealMcpConfig.h"
+#include "GenericPlatform/GenericPlatformFile.h"
+#include "HAL/PlatformFileManager.h"
 
 /**
  * AI Agent Configurators specs (docs/ARCHITECTURE.md §7/§8, issue #44 Phase A). Covers the JSON read-merge-write
@@ -839,6 +841,72 @@ void FUnrealMcpAgentConfiguratorSpec::Define()
 
 			TSharedRef<FTomlAiAgentConfig> Config = MakeTomlStdioConfig(Path, TEXT("C:/srv/gamedev-mcp-server.exe"));
 			TestFalse(TEXT("surviving to-remove key vetoes IsConfigured"), Config->IsConfigured());
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("absorbs a nested dotted sub-table into our section so [mcp_servers.unreal-mcp.env] round-trips on merge", [this]()
+		{
+			const FString Path = MakeTempTomlPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			// Our section already carries a nested env sub-table; a sibling section follows it. The merge must keep the
+			// nested sub-table glued to our section (not orphan/flatten it) AND must not swallow the sibling.
+			const FString Existing = TEXT("[mcp_servers.unreal-mcp]\nenabled = true\nurl = \"http://localhost:8080/mcp\"\n[mcp_servers.unreal-mcp.env]\nGAME_DEV_AUTH_TOKEN = \"placeholder\"\n[mcp_servers.other]\nurl = \"http://elsewhere/mcp\"\n");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			TSharedRef<FTomlAiAgentConfig> Config = MakeTomlHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			TestTrue(TEXT("Configure succeeds"), Config->Configure());
+
+			const FString Content = ReadAllText(Path);
+			TestTrue(TEXT("our section present"), Content.Contains(TEXT("[mcp_servers.unreal-mcp]")));
+			TestTrue(TEXT("nested env sub-table survives"), Content.Contains(TEXT("[mcp_servers.unreal-mcp.env]")));
+			TestTrue(TEXT("nested env key survives"), Content.Contains(TEXT("GAME_DEV_AUTH_TOKEN = \"placeholder\"")));
+			TestTrue(TEXT("sibling section preserved"), Content.Contains(TEXT("[mcp_servers.other]")));
+			TestTrue(TEXT("sibling url preserved"), Content.Contains(TEXT("http://elsewhere/mcp")));
+			// The nested env key must NOT have been flattened up into our flat section as a scalar line.
+			TestTrue(TEXT("env key only inside its sub-table"), Content.Find(TEXT("GAME_DEV_AUTH_TOKEN")) > Content.Find(TEXT("[mcp_servers.unreal-mcp.env]")));
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("does NOT clobber an existing-but-unreadable file (read failure must not take the clean-write path)", [this]()
+		{
+			const FString Path = MakeTempTomlPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			const FString Existing = TEXT("[mcp_servers.other]\nurl = \"http://elsewhere/mcp\"\n");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			// Hold an EXCLUSIVE write handle (bAllowRead = false) so the config's LoadFileToStringArray fails while
+			// the file still EXISTS — the exact missing-vs-unreadable distinction the guard protects. On platforms
+			// whose filesystem grants the read anyway (the exclusive open is advisory), the lock acquire is skipped
+			// and the spec degrades to asserting the merge path simply preserves the sibling.
+			IFileHandle* Locked = FPlatformFileManager::Get().GetPlatformFile().OpenWrite(*Path, /*bAppend*/ true, /*bAllowRead*/ false);
+			TestNotNull(TEXT("write handle opened"), Locked);
+
+			TArray<FString> Probe;
+			const bool bUnreadableWhileLocked = !FFileHelper::LoadFileToStringArray(Probe, *Path);
+
+			TSharedRef<FTomlAiAgentConfig> Config = MakeTomlHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			const bool bConfigured = Config->Configure();
+
+			if (Locked)
+				delete Locked; // releases the exclusive lock
+
+			if (bUnreadableWhileLocked)
+			{
+				// The file existed but could not be read → Configure must refuse rather than clobber.
+				TestFalse(TEXT("Configure refuses to clobber an unreadable existing file"), bConfigured);
+				const FString After = ReadAllText(Path);
+				TestTrue(TEXT("original sibling content untouched"), After.Contains(TEXT("[mcp_servers.other]")));
+				TestFalse(TEXT("our section was NOT written over the locked file"), After.Contains(TEXT("[mcp_servers.unreal-mcp]")));
+			}
+			else
+			{
+				// Platform allowed the read despite the lock → this isn't the read-failure path; just assert the
+				// normal merge preserved the sibling so the spec still has a meaningful invariant.
+				const FString After = ReadAllText(Path);
+				TestTrue(TEXT("sibling preserved on readable merge"), After.Contains(TEXT("[mcp_servers.other]")));
+			}
 
 			DeleteTempDirFor(Path);
 		});

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfiguratorSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfiguratorSpec.cpp
@@ -16,10 +16,25 @@
 
 #include "Agents/AiAgentConfig.h"
 #include "Agents/JsonAiAgentConfig.h"
+#include "Agents/TomlAiAgentConfig.h"
 #include "Agents/AiAgentConfigurator.h"
 #include "Agents/AiAgentConfiguratorRegistry.h"
 #include "Agents/Impl/ClaudeCodeConfigurator.h"
 #include "Agents/Impl/CursorConfigurator.h"
+#include "Agents/Impl/ClaudeDesktopConfigurator.h"
+#include "Agents/Impl/VisualStudioCodeCopilotConfigurator.h"
+#include "Agents/Impl/VisualStudioCopilotConfigurator.h"
+#include "Agents/Impl/RiderConfigurator.h"
+#include "Agents/Impl/GitHubCopilotCliConfigurator.h"
+#include "Agents/Impl/GeminiConfigurator.h"
+#include "Agents/Impl/AntigravityConfigurator.h"
+#include "Agents/Impl/ClineConfigurator.h"
+#include "Agents/Impl/OpenCodeConfigurator.h"
+#include "Agents/Impl/CodexConfigurator.h"
+#include "Agents/Impl/KiloCodeConfigurator.h"
+#include "Agents/Impl/UnityAiConfigurator.h"
+#include "Agents/Impl/ZooCodeConfigurator.h"
+#include "Agents/Impl/CustomConfigurator.h"
 #include "Config/UnrealMcpConfig.h"
 
 /**
@@ -84,6 +99,54 @@ BEGIN_DEFINE_SPEC(FUnrealMcpAgentConfiguratorSpec, "UnrealMcp.AgentConfigurators
 		Config->SetPropertyToRemove(TEXT("url"));
 		Config->SetPropertyToRemove(TEXT("headers"));
 		return Config;
+	}
+
+	// A unique temp TOML config-file path per call.
+	FString MakeTempTomlPath() const
+	{
+		const FString Dir = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("UnrealMcpAgentSpecToml"), FGuid::NewGuid().ToString());
+		return FPaths::Combine(Dir, TEXT("config.toml"));
+	}
+
+	// Build a Codex-style HTTP TOML config (enabled + url) under "mcp_servers".
+	TSharedRef<FTomlAiAgentConfig> MakeTomlHttpConfig(const FString& Path, const FString& Url) const
+	{
+		TSharedRef<FTomlAiAgentConfig> Config = MakeShared<FTomlAiAgentConfig>(TEXT("Test"), Path, TEXT("mcp_servers"));
+		Config->SetBoolProperty(TEXT("enabled"), true, /*bRequired*/ true);
+		Config->SetStringProperty(TEXT("url"), Url, /*bRequired*/ true, EUnrealMcpValueComparison::Url);
+		Config->SetPropertyToRemove(TEXT("command"));
+		Config->SetPropertyToRemove(TEXT("args"));
+		return Config;
+	}
+
+	// Build a Codex-style STDIO TOML config (enabled + command + args) that scrubs url.
+	TSharedRef<FTomlAiAgentConfig> MakeTomlStdioConfig(const FString& Path, const FString& Command) const
+	{
+		TSharedRef<FTomlAiAgentConfig> Config = MakeShared<FTomlAiAgentConfig>(TEXT("Test"), Path, TEXT("mcp_servers"));
+		Config->SetBoolProperty(TEXT("enabled"), true, /*bRequired*/ true);
+		Config->SetStringProperty(TEXT("command"), Command, /*bRequired*/ true, EUnrealMcpValueComparison::Path);
+		Config->SetStringArrayProperty(TEXT("args"), { TEXT("port=8080"), TEXT("client-transport=stdio") }, /*bRequired*/ true);
+		Config->SetPropertyToRemove(TEXT("url"));
+		return Config;
+	}
+
+	// A connection info with auth required (a real token) for configurator config-shape assertions.
+	FAiAgentConnectionInfo MakeAuthConnection(int32 Port = 31000) const
+	{
+		FUnrealMcpConfig Config;
+		Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+		Config.CustomHost = TEXT("http://localhost:9000");
+		Config.AuthOption = EUnrealMcpAuthOption::Required;
+		Config.CustomToken = TEXT("secret-token");
+		return FAiAgentConnectionInfo::FromPluginConfig(Config, TEXT("C:/srv/gamedev-mcp-server.exe"), Port);
+	}
+
+	// Read a whole file into a string (for TOML content assertions).
+	FString ReadAllText(const FString& Path) const
+	{
+		FString Out;
+		FFileHelper::LoadFileToString(Out, *Path);
+		return Out;
 	}
 
 END_DEFINE_SPEC(FUnrealMcpAgentConfiguratorSpec)
@@ -386,25 +449,398 @@ void FUnrealMcpAgentConfiguratorSpec::Define()
 
 	Describe("Registry", [this]()
 	{
-		It("registers the two Phase-A reference agents, sorted by name", [this]()
+		It("registers the full Phase-B roster (15 agents + Custom = 16), sorted by name with Custom last", [this]()
 		{
 			FAiAgentConfiguratorRegistry Registry;
-			TestEqual(TEXT("two agents"), Registry.Num(), 2);
+			TestEqual(TEXT("16 entries (15 agents + Custom)"), Registry.Num(), 16);
+
 			const TArray<FString> Names = Registry.GetAgentNames();
-			TestEqual(TEXT("first is Claude Code"), Names[0], FString(TEXT("Claude Code")));
-			TestEqual(TEXT("second is Cursor"), Names[1], FString(TEXT("Cursor")));
+			// Sorted alphabetically by display name; Custom ("Other - Custom") is forced LAST regardless of sort.
+			TestEqual(TEXT("first is Antigravity"), Names[0], FString(TEXT("Antigravity")));
+			TestEqual(TEXT("Custom entry is last"), Names.Last(), FString(TEXT("Other - Custom")));
+
+			// The non-Custom prefix must be strictly alphabetically sorted.
+			for (int32 i = 1; i < Names.Num() - 1; ++i)
+				TestTrue(FString::Printf(TEXT("sorted at %d (%s <= %s)"), i, *Names[i - 1], *Names[i]), Names[i - 1] <= Names[i]);
+		});
+
+		It("contains every required agent id, each unique", [this]()
+		{
+			FAiAgentConfiguratorRegistry Registry;
+			const TArray<FString> ExpectedIds = {
+				TEXT("antigravity"), TEXT("claude-code"), TEXT("claude-desktop"), TEXT("cline"), TEXT("codex"),
+				TEXT("cursor"), TEXT("gemini"), TEXT("github-copilot-cli"), TEXT("kilo-code"), TEXT("open-code"),
+				TEXT("rider-junie"), TEXT("unity-ai"), TEXT("vscode-copilot"), TEXT("vs-copilot"), TEXT("zoo-code"),
+				TEXT("other-custom")
+			};
+			for (const FString& Id : ExpectedIds)
+				TestTrue(FString::Printf(TEXT("id present: %s"), *Id), Registry.GetByAgentId(Id).IsValid());
+
+			// No duplicate ids.
+			const TArray<FString> Ids = Registry.GetAgentIds();
+			TSet<FString> Unique(Ids);
+			TestEqual(TEXT("ids are unique"), Unique.Num(), Ids.Num());
+		});
+
+		It("Custom is the LAST index, found by id, and is snippet-only (empty config path)", [this]()
+		{
+			FAiAgentConfiguratorRegistry Registry;
+			const int32 CustomIndex = Registry.GetIndexByAgentId(TEXT("other-custom"));
+			TestEqual(TEXT("custom is last index"), CustomIndex, Registry.Num() - 1);
+
+			TSharedPtr<FAiAgentConfigurator> Custom = Registry.GetByAgentId(TEXT("other-custom"));
+			TestTrue(TEXT("custom found"), Custom.IsValid());
+			if (Custom.IsValid())
+				TestTrue(TEXT("custom config path empty"), Custom->GetConfigFilePath(FPaths::ProjectDir()).IsEmpty());
 		});
 
 		It("looks up by id and index, returns INDEX_NONE for unknown", [this]()
 		{
 			FAiAgentConfiguratorRegistry Registry;
 			TestTrue(TEXT("claude-code found"), Registry.GetByAgentId(TEXT("claude-code")).IsValid());
-			TestTrue(TEXT("cursor found"), Registry.GetByAgentId(TEXT("cursor")).IsValid());
 			TestFalse(TEXT("unknown id null"), Registry.GetByAgentId(TEXT("nope")).IsValid());
-			TestEqual(TEXT("claude index 0"), Registry.GetIndexByAgentId(TEXT("claude-code")), 0);
 			TestEqual(TEXT("unknown index NONE"), Registry.GetIndexByAgentId(TEXT("nope")), (int32)INDEX_NONE);
-			TestTrue(TEXT("index 1 valid"), Registry.GetByIndex(1).IsValid());
-			TestFalse(TEXT("index 5 null"), Registry.GetByIndex(5).IsValid());
+			TestTrue(TEXT("index 0 valid"), Registry.GetByIndex(0).IsValid());
+			TestFalse(TEXT("index 999 null"), Registry.GetByIndex(999).IsValid());
+		});
+	});
+
+	Describe("Per-agent path + body-path resolution", [this]()
+	{
+		It("project-local agents resolve their config path under the project root with the right body key", [this]()
+		{
+			const FString Root = TEXT("C:/proj");
+
+			FVisualStudioCodeCopilotConfigurator VsCode;
+			TestTrue(TEXT("vscode path"), VsCode.GetConfigFilePath(Root).Replace(TEXT("\\"), TEXT("/")).EndsWith(TEXT(".vscode/mcp.json")));
+			TestEqual(TEXT("vscode body=servers"), VsCode.GetBodyPath(), FString(TEXT("servers")));
+
+			FVisualStudioCopilotConfigurator Vs;
+			TestTrue(TEXT("vs path"), Vs.GetConfigFilePath(Root).Replace(TEXT("\\"), TEXT("/")).EndsWith(TEXT(".vs/mcp.json")));
+			TestEqual(TEXT("vs body=servers"), Vs.GetBodyPath(), FString(TEXT("servers")));
+
+			FRiderConfigurator Rider;
+			TestTrue(TEXT("rider path"), Rider.GetConfigFilePath(Root).Replace(TEXT("\\"), TEXT("/")).EndsWith(TEXT(".junie/mcp/mcp.json")));
+
+			FGeminiConfigurator Gemini;
+			TestTrue(TEXT("gemini path"), Gemini.GetConfigFilePath(Root).Replace(TEXT("\\"), TEXT("/")).EndsWith(TEXT(".gemini/settings.json")));
+
+			FGitHubCopilotCliConfigurator Copilot;
+			TestTrue(TEXT("copilot-cli path"), Copilot.GetConfigFilePath(Root).Replace(TEXT("\\"), TEXT("/")).EndsWith(TEXT(".mcp.json")));
+
+			FKiloCodeConfigurator Kilo;
+			TestTrue(TEXT("kilo path"), Kilo.GetConfigFilePath(Root).Replace(TEXT("\\"), TEXT("/")).EndsWith(TEXT(".kilocode/mcp.json")));
+
+			FZooCodeConfigurator Zoo;
+			TestTrue(TEXT("zoo path"), Zoo.GetConfigFilePath(Root).Replace(TEXT("\\"), TEXT("/")).EndsWith(TEXT(".roo/mcp.json")));
+
+			FOpenCodeConfigurator OpenCode;
+			TestTrue(TEXT("opencode path"), OpenCode.GetConfigFilePath(Root).Replace(TEXT("\\"), TEXT("/")).EndsWith(TEXT("opencode.json")));
+			TestEqual(TEXT("opencode body=mcp"), OpenCode.GetBodyPath(), FString(TEXT("mcp")));
+
+			FCodexConfigurator Codex;
+			TestTrue(TEXT("codex path"), Codex.GetConfigFilePath(Root).Replace(TEXT("\\"), TEXT("/")).EndsWith(TEXT(".codex/config.toml")));
+			TestEqual(TEXT("codex body=mcp_servers"), Codex.GetBodyPath(), FString(TEXT("mcp_servers")));
+
+			FUnityAiConfigurator UnityAi;
+			TestTrue(TEXT("unity-ai path"), UnityAi.GetConfigFilePath(Root).Replace(TEXT("\\"), TEXT("/")).EndsWith(TEXT("UserSettings/mcp.json")));
+		});
+
+		It("global agents resolve a non-empty machine-global path that ignores the project root", [this]()
+		{
+			FClaudeDesktopConfigurator ClaudeDesktop;
+			const FString P1 = ClaudeDesktop.GetConfigFilePath(TEXT("C:/proj-a"));
+			const FString P2 = ClaudeDesktop.GetConfigFilePath(TEXT("C:/proj-b"));
+			TestTrue(TEXT("claude-desktop non-empty"), !P1.IsEmpty());
+			TestEqual(TEXT("claude-desktop path is project-independent"), P1, P2);
+			TestTrue(TEXT("claude-desktop ends with claude_desktop_config.json"), P1.Replace(TEXT("\\"), TEXT("/")).EndsWith(TEXT("Claude/claude_desktop_config.json")));
+
+			FClineConfigurator Cline;
+			const FString C1 = Cline.GetConfigFilePath(TEXT("C:/proj-a"));
+			const FString C2 = Cline.GetConfigFilePath(TEXT("C:/proj-b"));
+			TestTrue(TEXT("cline non-empty"), !C1.IsEmpty());
+			TestEqual(TEXT("cline path is project-independent"), C1, C2);
+			TestTrue(TEXT("cline ends with cline_mcp_settings.json"), C1.Replace(TEXT("\\"), TEXT("/")).EndsWith(TEXT("cline_mcp_settings.json")));
+
+			FAntigravityConfigurator Antigravity;
+			const FString A1 = Antigravity.GetConfigFilePath(TEXT("C:/proj-a"));
+			TestTrue(TEXT("antigravity non-empty"), !A1.IsEmpty());
+			TestTrue(TEXT("antigravity ends with .gemini/config/mcp_config.json"), A1.Replace(TEXT("\\"), TEXT("/")).EndsWith(TEXT(".gemini/config/mcp_config.json")));
+		});
+	});
+
+	Describe("Per-agent config-shape quirks", [this]()
+	{
+		It("VS Code Copilot nests servers under the 'servers' body key", [this]()
+		{
+			FVisualStudioCodeCopilotConfigurator Configurator;
+			Configurator.Initialize(MakeAuthConnection(), FPaths::ProjectDir());
+			const FString Http = Configurator.GetConfigHttp().GetExpectedFileContent();
+			TestTrue(TEXT("has \"servers\" body key"), Http.Contains(TEXT("\"servers\"")));
+			TestFalse(TEXT("no mcpServers body key"), Http.Contains(TEXT("\"mcpServers\"")));
+		});
+
+		It("Rider/Kilo/Zoo carry the enabled/disabled flags they require", [this]()
+		{
+			FRiderConfigurator Rider;
+			Rider.Initialize(MakeAuthConnection(), FPaths::ProjectDir());
+			TestTrue(TEXT("rider stdio enabled:true"), Rider.GetConfigStdio().GetExpectedFileContent().Contains(TEXT("\"enabled\": true")));
+
+			FKiloCodeConfigurator Kilo;
+			Kilo.Initialize(MakeAuthConnection(), FPaths::ProjectDir());
+			TestTrue(TEXT("kilo stdio disabled:false"), Kilo.GetConfigStdio().GetExpectedFileContent().Contains(TEXT("\"disabled\": false")));
+			TestTrue(TEXT("kilo http streamable-http"), Kilo.GetConfigHttp().GetExpectedFileContent().Contains(TEXT("streamable-http")));
+
+			FZooCodeConfigurator Zoo;
+			Zoo.Initialize(MakeAuthConnection(), FPaths::ProjectDir());
+			TestTrue(TEXT("zoo http streamable-http"), Zoo.GetConfigHttp().GetExpectedFileContent().Contains(TEXT("streamable-http")));
+		});
+
+		It("Cline uses the streamableHttp transport type", [this]()
+		{
+			FClineConfigurator Cline;
+			Cline.Initialize(MakeAuthConnection(), FPaths::ProjectDir());
+			TestTrue(TEXT("cline http streamableHttp"), Cline.GetConfigHttp().GetExpectedFileContent().Contains(TEXT("streamableHttp")));
+		});
+
+		It("GitHub Copilot CLI drops stdio 'type' and adds a tools allowlist", [this]()
+		{
+			FGitHubCopilotCliConfigurator Copilot;
+			Copilot.Initialize(MakeAuthConnection(), FPaths::ProjectDir());
+			const FString Stdio = Copilot.GetConfigStdio().GetExpectedFileContent();
+			TestFalse(TEXT("no \"type\" key in stdio"), Stdio.Contains(TEXT("\"type\"")));
+			TestTrue(TEXT("has tools allowlist"), Stdio.Contains(TEXT("\"tools\"")) && Stdio.Contains(TEXT("\"*\"")));
+		});
+
+		It("Antigravity stores the HTTP url under serverUrl (not url)", [this]()
+		{
+			FAntigravityConfigurator Antigravity;
+			Antigravity.Initialize(MakeAuthConnection(), FPaths::ProjectDir());
+			const FString Http = Antigravity.GetConfigHttp().GetExpectedFileContent();
+			TestTrue(TEXT("has serverUrl"), Http.Contains(TEXT("\"serverUrl\"")));
+			TestTrue(TEXT("auth header present"), Http.Contains(TEXT("Bearer secret-token")));
+		});
+
+		It("Open Code packs binary + args into a single command array (stdio) and uses remote (http)", [this]()
+		{
+			FOpenCodeConfigurator OpenCode;
+			OpenCode.Initialize(MakeAuthConnection(), FPaths::ProjectDir());
+			const FString Stdio = OpenCode.GetConfigStdio().GetExpectedFileContent();
+			TestTrue(TEXT("type local"), Stdio.Contains(TEXT("\"local\"")));
+			TestTrue(TEXT("command array has binary"), Stdio.Contains(TEXT("gamedev-mcp-server.exe")));
+			TestTrue(TEXT("command array has port arg"), Stdio.Contains(TEXT("port=31000")));
+			TestFalse(TEXT("no separate args key"), Stdio.Contains(TEXT("\"args\"")));
+
+			const FString Http = OpenCode.GetConfigHttp().GetExpectedFileContent();
+			TestTrue(TEXT("type remote"), Http.Contains(TEXT("\"remote\"")));
+		});
+
+		It("Custom is snippet-only: still renders a snippet but never writes/detects a file", [this]()
+		{
+			FCustomConfigurator Custom;
+			Custom.Initialize(MakeAuthConnection(), FPaths::ProjectDir());
+			const FString Snippet = Custom.GetConfigHttp().GetExpectedFileContent();
+			TestTrue(TEXT("snippet not empty"), !Snippet.IsEmpty());
+			TestFalse(TEXT("Configure is a no-op (false)"), Custom.Configure(/*bStdio*/ false));
+			TestFalse(TEXT("never detected"), Custom.IsAnyDetected());
+		});
+	});
+
+	Describe("Codex TOML configurator (token discipline)", [this]()
+	{
+		It("STDIO emits a TOML section with command/args and never writes the raw token", [this]()
+		{
+			FCodexConfigurator Codex;
+			Codex.Initialize(MakeAuthConnection(), FPaths::ProjectDir());
+			const FString Stdio = Codex.GetConfigStdio().GetExpectedFileContent();
+			TestTrue(TEXT("dotted-table header"), Stdio.Contains(TEXT("[mcp_servers.unreal-mcp]")));
+			TestTrue(TEXT("enabled true"), Stdio.Contains(TEXT("enabled = true")));
+			TestTrue(TEXT("command present"), Stdio.Contains(TEXT("command = ")));
+			TestTrue(TEXT("args present"), Stdio.Contains(TEXT("args = [")));
+			TestFalse(TEXT("raw token NEVER in toml"), Stdio.Contains(TEXT("secret-token")));
+			TestTrue(TEXT("bearer env-var name (not value)"), Stdio.Contains(TEXT("bearer_token_env_var")) && Stdio.Contains(TEXT("GAME_DEV_AUTH_TOKEN")));
+		});
+
+		It("HTTP emits a TOML url + timeouts and never writes the raw token", [this]()
+		{
+			FCodexConfigurator Codex;
+			Codex.Initialize(MakeAuthConnection(), FPaths::ProjectDir());
+			const FString Http = Codex.GetConfigHttp().GetExpectedFileContent();
+			TestTrue(TEXT("url present"), Http.Contains(TEXT("url = \"http://localhost:9000/mcp\"")));
+			TestTrue(TEXT("tool_timeout_sec present"), Http.Contains(TEXT("tool_timeout_sec = 300")));
+			TestFalse(TEXT("raw token NEVER in toml http"), Http.Contains(TEXT("secret-token")));
+		});
+
+		It("omits the bearer env-var indirection when auth is not required", [this]()
+		{
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.CustomHost = TEXT("http://localhost:9000");
+			Config.AuthOption = EUnrealMcpAuthOption::None;
+			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, TEXT("C:/srv/gamedev-mcp-server.exe"), 31000);
+
+			FCodexConfigurator Codex;
+			Codex.Initialize(Info, FPaths::ProjectDir());
+			TestFalse(TEXT("no bearer env-var when auth none"), Codex.GetConfigStdio().GetExpectedFileContent().Contains(TEXT("bearer_token_env_var")));
+		});
+	});
+
+	Describe("TOML read-merge-write", [this]()
+	{
+		It("creates a fresh TOML file (with parent dirs) when none exists", [this]()
+		{
+			const FString Path = MakeTempTomlPath();
+			TSharedRef<FTomlAiAgentConfig> Config = MakeTomlHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+
+			TestTrue(TEXT("Configure succeeds"), Config->Configure());
+			TestTrue(TEXT("file exists"), FPaths::FileExists(Path));
+			const FString Content = ReadAllText(Path);
+			TestTrue(TEXT("has section"), Content.Contains(TEXT("[mcp_servers.unreal-mcp]")));
+			TestTrue(TEXT("IsConfigured after write"), Config->IsConfigured());
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("preserves a sibling section and unrelated lines on merge", [this]()
+		{
+			const FString Path = MakeTempTomlPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			const FString Existing = TEXT("# top comment\n[mcp_servers.other]\nurl = \"http://elsewhere/mcp\"\n");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			TSharedRef<FTomlAiAgentConfig> Config = MakeTomlHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			TestTrue(TEXT("Configure succeeds"), Config->Configure());
+
+			const FString Content = ReadAllText(Path);
+			TestTrue(TEXT("comment preserved"), Content.Contains(TEXT("# top comment")));
+			TestTrue(TEXT("sibling preserved"), Content.Contains(TEXT("[mcp_servers.other]")));
+			TestTrue(TEXT("our section added"), Content.Contains(TEXT("[mcp_servers.unreal-mcp]")));
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("tolerates an invalid/garbage TOML file by appending a clean section", [this]()
+		{
+			const FString Path = MakeTempTomlPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			FFileHelper::SaveStringToFile(FString(TEXT("not = toml = at = all")), *Path);
+
+			TSharedRef<FTomlAiAgentConfig> Config = MakeTomlHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			TestTrue(TEXT("Configure succeeds over garbage"), Config->Configure());
+			TestTrue(TEXT("IsConfigured after append"), Config->IsConfigured());
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("IsDetected false for a missing file, true once configured; Remove reverts it", [this]()
+		{
+			const FString Path = MakeTempTomlPath();
+			TSharedRef<FTomlAiAgentConfig> Config = MakeTomlHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			TestFalse(TEXT("not detected before write"), Config->IsDetected());
+			Config->Configure();
+			TestTrue(TEXT("detected after write"), Config->IsDetected());
+			TestTrue(TEXT("Remove returns true"), Config->Remove());
+			TestFalse(TEXT("not detected after remove"), Config->IsDetected());
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("Remove deletes our section but preserves siblings", [this]()
+		{
+			const FString Path = MakeTempTomlPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			const FString Existing = TEXT("[mcp_servers.other]\nurl = \"http://elsewhere/mcp\"\n");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			TSharedRef<FTomlAiAgentConfig> Config = MakeTomlHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			Config->Configure();
+			TestTrue(TEXT("Remove returns true"), Config->Remove());
+
+			const FString Content = ReadAllText(Path);
+			TestFalse(TEXT("our section removed"), Content.Contains(TEXT("[mcp_servers.unreal-mcp]")));
+			TestTrue(TEXT("sibling preserved"), Content.Contains(TEXT("[mcp_servers.other]")));
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("migrates a deprecated TOML section name to the canonical one", [this]()
+		{
+			const FString Path = MakeTempTomlPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			const FString Existing = TEXT("[mcp_servers.ai-game-developer]\nurl = \"http://old/mcp\"\n");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			TSharedRef<FTomlAiAgentConfig> Config = MakeTomlHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			Config->Configure();
+
+			const FString Content = ReadAllText(Path);
+			TestFalse(TEXT("deprecated section removed"), Content.Contains(TEXT("[mcp_servers.ai-game-developer]")));
+			TestTrue(TEXT("canonical section present"), Content.Contains(TEXT("[mcp_servers.unreal-mcp]")));
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("collapses a duplicate sibling section that shares our url (identity-key dedup)", [this]()
+		{
+			const FString Path = MakeTempTomlPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			const FString Existing = TEXT("[mcp_servers.my-alias]\nurl = \"http://localhost:8080/mcp\"\n");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			TSharedRef<FTomlAiAgentConfig> Config = MakeTomlHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			Config->Configure();
+
+			const FString Content = ReadAllText(Path);
+			TestFalse(TEXT("duplicate alias removed"), Content.Contains(TEXT("[mcp_servers.my-alias]")));
+			TestTrue(TEXT("canonical section present"), Content.Contains(TEXT("[mcp_servers.unreal-mcp]")));
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("IsConfigured tolerates URL trailing-slash differences", [this]()
+		{
+			const FString Path = MakeTempTomlPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			const FString Existing = TEXT("[mcp_servers.unreal-mcp]\nenabled = true\nurl = \"http://localhost:8080/mcp/\"\n");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			TSharedRef<FTomlAiAgentConfig> Config = MakeTomlHttpConfig(Path, TEXT("http://localhost:8080/mcp"));
+			TestTrue(TEXT("trailing slash treated as configured"), Config->IsConfigured());
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("switches an existing HTTP section to STDIO cleanly (drops url, adds command/args)", [this]()
+		{
+			const FString Path = MakeTempTomlPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			const FString Existing = TEXT("[mcp_servers.unreal-mcp]\nenabled = true\nurl = \"http://localhost:8080/mcp\"\n");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			TSharedRef<FTomlAiAgentConfig> Config = MakeTomlStdioConfig(Path, TEXT("C:/srv/gamedev-mcp-server.exe"));
+			TestTrue(TEXT("STDIO Configure over HTTP succeeds"), Config->Configure());
+
+			const FString Content = ReadAllText(Path);
+			TestFalse(TEXT("stale url removed"), Content.Contains(TEXT("url = ")));
+			TestTrue(TEXT("command present"), Content.Contains(TEXT("command = ")));
+			TestTrue(TEXT("args present"), Content.Contains(TEXT("args = [")));
+			TestTrue(TEXT("IsConfigured after switch"), Config->IsConfigured());
+
+			DeleteTempDirFor(Path);
+		});
+
+		It("IsConfigured is false when a to-remove key still survives in the section", [this]()
+		{
+			const FString Path = MakeTempTomlPath();
+			IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), true);
+			// Matches our desired STDIO props but still carries a stale `url` — the STDIO config asks to remove it.
+			const FString Existing = TEXT("[mcp_servers.unreal-mcp]\nenabled = true\ncommand = \"C:/srv/gamedev-mcp-server.exe\"\nargs = [\"port=8080\",\"client-transport=stdio\"]\nurl = \"http://localhost:8080/mcp\"\n");
+			FFileHelper::SaveStringToFile(Existing, *Path);
+
+			TSharedRef<FTomlAiAgentConfig> Config = MakeTomlStdioConfig(Path, TEXT("C:/srv/gamedev-mcp-server.exe"));
+			TestFalse(TEXT("surviving to-remove key vetoes IsConfigured"), Config->IsConfigured());
+
+			DeleteTempDirFor(Path);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Add the remaining Unity-parity AI-agent configurators on top of the Phase A foundation (#44/#47): **15 agents + Custom** are now selectable in the Slate "AI Agent Configurators" panel (the panel was already registry-driven, so no UI change was needed).
- New **`FTomlAiAgentConfig`** — the second concrete `FAiAgentConfig` subclass (the seam Phase A left), with read-merge-write parity to the JSON path. Codex (`.codex/config.toml`) uses it.
- Base extension: `FAiAgentConfigurator::BuildStdio/BuildHttp` are now virtual with `CustomizeStdio/CustomizeHttp` hooks + connection-fact accessors, so the JSON agents reuse the canonical STDIO+HTTP shape and the outliers (Antigravity `serverUrl`, Open Code array-command, Codex TOML) override cleanly. `EUnrealMcpValueComparison` gains `Path`.
- Security (§8): tokens never logged; on-screen masking unchanged; Codex never writes the raw token to its TOML — it uses a `bearer_token_env_var` NAME indirection.

Agents added (mirror Unity's `Impl/` per-OS paths / bodyPath quirks / format): Claude Desktop, VS Code Copilot (body `servers`), Visual Studio Copilot (body `servers`), Rider/Junie, GitHub Copilot CLI, Gemini, Antigravity, Cline, Open Code, Codex (TOML), Kilo Code, Unity AI (parity only), Zoo Code, and **Custom (snippet-only, registered LAST)**.

## Test plan
- [x] UE 5.7 testbed build (Suite 1): green.
- [x] Headless plugin load (Suite 2 substantive half): `[Unreal-MCP] plugin loaded` confirmed.
- [x] Automation specs (Suite 3) `UnrealMcp.AgentConfigurators`: **44/44 pass, 0 failed** (`index.json` authoritative) — covers the full-roster registry, per-agent path/body resolution, per-agent config-shape quirks, Codex TOML token-discipline, and a TOML read-merge-write suite mirroring the JSON one.

### Note for reviewers
The `-ExecCmds="QUIT_EDITOR"` headless smoke exits 3 with a Slate teardown crash at `FUnrealMcpRuntime::Shutdown()` → aux-window `Unregister()` → `GenericWindow.cpp:113`. This reproduces **identically on pristine `main` (`9638fe0`) with no agent changes**, so it is a pre-existing, out-of-scope shutdown quirk of the `QUIT_EDITOR` path — not introduced by this PR. The graceful `Quit` path (used by the Automation run) shuts down cleanly. The plugin loads successfully in both cases. CI is unaffected (the UE plugin leg is gated/skipped on `UNREAL_RUNNER_READY`; bridge/cli/server legs are untouched by this PR).

Closes #50