### PR TITLE
feat(ui): AI Agent Configurators Phase C — per-agent skills-file generation (full Unity parity)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.cpp
@@ -6,6 +6,7 @@
 
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
+#include "Misc/Paths.h"
 
 FAiAgentConnectionInfo FAiAgentConnectionInfo::FromPluginConfig(const FUnrealMcpConfig& Config, const FString& InServerPath, int32 InPort)
 {
@@ -26,6 +27,25 @@ FAiAgentConnectionInfo FAiAgentConnectionInfo::FromPluginConfig(const FUnrealMcp
 	Info.Token = Config.ResolveEffectiveToken();
 
 	return Info;
+}
+
+bool FAiAgentConfigurator::SupportsSkills(const FString& InProjectRoot) const
+{
+	return !GetSkillsPath(InProjectRoot).IsEmpty();
+}
+
+FString FAiAgentConfigurator::ResolveAbsoluteSkillsPath(const FString& InProjectRoot) const
+{
+	const FString Folder = GetSkillsPath(InProjectRoot);
+	if (Folder.IsEmpty())
+		return FString();
+
+	// Already-absolute path: normalize separators only. Otherwise resolve under the project root. Forward
+	// slashes throughout so the panel display and the writer agree regardless of host path conventions.
+	const FString Absolute = FPaths::IsRelative(Folder)
+		? FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, Folder))
+		: FPaths::ConvertRelativePathToFull(Folder);
+	return Absolute.Replace(TEXT("\\"), TEXT("/"));
 }
 
 void FAiAgentConfigurator::Initialize(const FAiAgentConnectionInfo& InConnection, const FString& InProjectRoot)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.h
@@ -73,6 +73,29 @@ public:
 	/** The JSON body path this agent nests its server map under (Claude Code / Cursor: "mcpServers"). */
 	virtual FString GetBodyPath() const { return TEXT("mcpServers"); }
 
+	// --- Skills metadata (docs/ARCHITECTURE.md §7, issue #53 Phase C — the C++/Slate analog of Unity's
+	//     AiAgentConfigurator.SkillsPath / SupportsSkills / ResolveAbsoluteSkillsPath). ---
+
+	/**
+	 * The project-relative folder this agent expects its generated skill files under (e.g. ".claude/skills"),
+	 * or EMPTY when the agent does not support skills. Mirrors Unity's per-agent SkillsPath assignments 1:1
+	 * (claude-code → .claude/skills, cursor → .cursor/skills, …). @p ProjectRoot is supplied so the Custom
+	 * configurator can resolve a user-overridable path; the built-in agents ignore it and return a constant.
+	 * Empty return ⇒ SupportsSkills() == false ⇒ no skills section is shown for this agent.
+	 */
+	virtual FString GetSkillsPath(const FString& InProjectRoot) const { return FString(); }
+
+	/** True when this agent declares a non-empty skills path (the C++ analog of Unity's SupportsSkills). */
+	UNREALMCPEDITOR_API bool SupportsSkills(const FString& InProjectRoot) const;
+
+	/**
+	 * Resolve this agent's (project-relative or already-absolute) skills path to an absolute filesystem path
+	 * under @p ProjectRoot, with forward slashes — the location the writer creates and the panel displays.
+	 * An already-rooted path is returned normalized; an empty path stays empty. Mirrors Unity's
+	 * ResolveAbsoluteSkillsPath. Pure (no disk access), so the specs drive it directly.
+	 */
+	UNREALMCPEDITOR_API FString ResolveAbsoluteSkillsPath(const FString& InProjectRoot) const;
+
 	// --- Config assembly. ---
 
 	/** (Re)bind the configurator to the resolved connection info + project root; invalidates the cached configs. */

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/AntigravityConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/AntigravityConfigurator.h
@@ -33,6 +33,8 @@ public:
 		return FPaths::ConvertRelativePathToFull(FPaths::Combine(Home, TEXT(".gemini"), TEXT("config"), TEXT("mcp_config.json")));
 	}
 	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+	// Per-agent skills folder (Phase C, issue #53) — mirrors Unity's AntigravityConfigurator.SkillsPath.
+	virtual FString GetSkillsPath(const FString& /*InProjectRoot*/) const override { return TEXT(".agent/skills"); }
 
 protected:
 	virtual void CustomizeStdio(FJsonAiAgentConfig& Config) const override

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ClaudeCodeConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ClaudeCodeConfigurator.h
@@ -25,4 +25,6 @@ public:
 		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".mcp.json")));
 	}
 	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+	// Per-agent skills folder (Phase C, issue #53) — mirrors Unity's ClaudeCodeConfigurator.SkillsPath.
+	virtual FString GetSkillsPath(const FString& /*InProjectRoot*/) const override { return TEXT(".claude/skills"); }
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ClineConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ClineConfigurator.h
@@ -42,6 +42,8 @@ public:
 #endif
 	}
 	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+	// Per-agent skills folder (Phase C, issue #53) — mirrors Unity's ClineConfigurator.SkillsPath.
+	virtual FString GetSkillsPath(const FString& /*InProjectRoot*/) const override { return TEXT(".cline/skills"); }
 
 protected:
 	virtual void CustomizeHttp(FJsonAiAgentConfig& Config) const override

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/CodexConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/CodexConfigurator.h
@@ -39,6 +39,8 @@ public:
 		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".codex"), TEXT("config.toml")));
 	}
 	virtual FString GetBodyPath() const override { return TEXT("mcp_servers"); }
+	// Per-agent skills folder (Phase C, issue #53) — mirrors Unity's CodexConfigurator.SkillsPath.
+	virtual FString GetSkillsPath(const FString& /*InProjectRoot*/) const override { return TEXT(".agents/skills"); }
 
 protected:
 	virtual TSharedRef<FAiAgentConfig> BuildStdio() const override

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/CursorConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/CursorConfigurator.h
@@ -25,4 +25,6 @@ public:
 		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".cursor"), TEXT("mcp.json")));
 	}
 	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+	// Per-agent skills folder (Phase C, issue #53) — mirrors Unity's CursorConfigurator.SkillsPath.
+	virtual FString GetSkillsPath(const FString& /*InProjectRoot*/) const override { return TEXT(".cursor/skills"); }
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/CustomConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/CustomConfigurator.h
@@ -26,4 +26,18 @@ public:
 	/** Snippet-only: no on-disk config file. An empty path makes Configure/Detect/IsConfigured all return false. */
 	virtual FString GetConfigFilePath(const FString& /*InProjectRoot*/) const override { return FString(); }
 	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+
+	/**
+	 * Custom's skills path is user-overridable (Phase C, issue #53 — mirrors Unity's CustomConfigurator.SkillsPath,
+	 * which returns the persisted, editable UnityMcpPluginEditor.SkillsPath). The panel injects the persisted value
+	 * via SetCustomSkillsPath before building the skills section; the default keeps a sensible non-empty path so the
+	 * Custom agent always supports skills. An empty injected value resets to the default (never disables skills).
+	 */
+	virtual FString GetSkillsPath(const FString& /*InProjectRoot*/) const override { return CustomSkillsPath; }
+
+	/** Set the user-overridable Custom skills folder (project-relative). Empty resets to the default. */
+	void SetCustomSkillsPath(const FString& InPath) { CustomSkillsPath = InPath.IsEmpty() ? TEXT(".claude/skills") : InPath; }
+
+private:
+	FString CustomSkillsPath = TEXT(".claude/skills");
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/GeminiConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/GeminiConfigurator.h
@@ -24,4 +24,6 @@ public:
 		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".gemini"), TEXT("settings.json")));
 	}
 	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+	// Per-agent skills folder (Phase C, issue #53) — mirrors Unity's GeminiConfigurator.SkillsPath.
+	virtual FString GetSkillsPath(const FString& /*InProjectRoot*/) const override { return TEXT(".gemini/skills"); }
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/GitHubCopilotCliConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/GitHubCopilotCliConfigurator.h
@@ -28,6 +28,9 @@ public:
 		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".mcp.json")));
 	}
 	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+	// Per-agent skills folder (Phase C, issue #53) — mirrors Unity's GitHubCopilotCliConfigurator.SkillsPath
+	// (Copilot CLI discovers `.claude/skills`, shared with Claude Code).
+	virtual FString GetSkillsPath(const FString& /*InProjectRoot*/) const override { return TEXT(".claude/skills"); }
 
 protected:
 	virtual void CustomizeStdio(FJsonAiAgentConfig& Config) const override

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/KiloCodeConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/KiloCodeConfigurator.h
@@ -27,6 +27,8 @@ public:
 		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".kilocode"), TEXT("mcp.json")));
 	}
 	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+	// Per-agent skills folder (Phase C, issue #53) — mirrors Unity's KiloCodeConfigurator.SkillsPath.
+	virtual FString GetSkillsPath(const FString& /*InProjectRoot*/) const override { return TEXT(".kilocode/skills"); }
 
 protected:
 	virtual void CustomizeStdio(FJsonAiAgentConfig& Config) const override

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/OpenCodeConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/OpenCodeConfigurator.h
@@ -30,6 +30,8 @@ public:
 		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT("opencode.json")));
 	}
 	virtual FString GetBodyPath() const override { return TEXT("mcp"); }
+	// Per-agent skills folder (Phase C, issue #53) — mirrors Unity's OpenCodeConfigurator.SkillsPath.
+	virtual FString GetSkillsPath(const FString& /*InProjectRoot*/) const override { return TEXT(".opencode/skills"); }
 
 protected:
 	virtual TSharedRef<FAiAgentConfig> BuildStdio() const override

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/RiderConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/RiderConfigurator.h
@@ -27,6 +27,8 @@ public:
 		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".junie"), TEXT("mcp"), TEXT("mcp.json")));
 	}
 	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+	// Per-agent skills folder (Phase C, issue #53) — mirrors Unity's RiderConfigurator.SkillsPath.
+	virtual FString GetSkillsPath(const FString& /*InProjectRoot*/) const override { return TEXT(".junie/skills"); }
 
 protected:
 	virtual void CustomizeStdio(FJsonAiAgentConfig& Config) const override { ApplyEnabled(Config); }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/VisualStudioCodeCopilotConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/VisualStudioCodeCopilotConfigurator.h
@@ -26,4 +26,6 @@ public:
 		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".vscode"), TEXT("mcp.json")));
 	}
 	virtual FString GetBodyPath() const override { return TEXT("servers"); }
+	// Per-agent skills folder (Phase C, issue #53) — mirrors Unity's VisualStudioCodeCopilotConfigurator.SkillsPath.
+	virtual FString GetSkillsPath(const FString& /*InProjectRoot*/) const override { return TEXT(".claude/skills"); }
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/VisualStudioCopilotConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/VisualStudioCopilotConfigurator.h
@@ -26,4 +26,6 @@ public:
 		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".vs"), TEXT("mcp.json")));
 	}
 	virtual FString GetBodyPath() const override { return TEXT("servers"); }
+	// Per-agent skills folder (Phase C, issue #53) — mirrors Unity's VisualStudioCopilotConfigurator.SkillsPath.
+	virtual FString GetSkillsPath(const FString& /*InProjectRoot*/) const override { return TEXT(".github/skills"); }
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ZooCodeConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ZooCodeConfigurator.h
@@ -27,6 +27,8 @@ public:
 		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".roo"), TEXT("mcp.json")));
 	}
 	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+	// Per-agent skills folder (Phase C, issue #53) — mirrors Unity's ZooCodeConfigurator.SkillsPath.
+	virtual FString GetSkillsPath(const FString& /*InProjectRoot*/) const override { return TEXT(".roo/skills"); }
 
 protected:
 	virtual void CustomizeStdio(FJsonAiAgentConfig& Config) const override

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/UnrealMcpSkillFileGenerator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/UnrealMcpSkillFileGenerator.cpp
@@ -16,8 +16,8 @@
 namespace
 {
 	// Collapse a possibly-multi-line description into a single padded line and cap its length so the YAML
-	// front-matter `description:` stays a valid single scalar (the Agent-Skills limit). Word-boundary trim with an
-	// ellipsis when truncated. Pure; no secret handling needed (descriptions are static tool docs).
+	// front-matter `description:` stays a valid single scalar. Word-boundary trim with an ellipsis when truncated.
+	// Pure; no secret handling needed (descriptions are static tool docs).
 	FString SkillGenSingleLineCapped(const FString& In, int32 MaxLen)
 	{
 		FString Flat = In;
@@ -170,8 +170,8 @@ FString FUnrealMcpSkillFileGenerator::BuildSkillMarkdown(const FUnrealMcpRegiste
 		Lines.Add(TEXT(""));
 	}
 
-	// ## How to Call — the unreal-mcp-cli form. Token discipline (§8): a `<token>` PLACEHOLDER only, NEVER a real
-	// bearer. The agent supplies its own configured credentials; the skill doc must stay secret-free.
+	// ## How to Call — the plain unreal-mcp-cli form. Token discipline (§8): NO token at all (not even a
+	// placeholder); the agent supplies its own configured credentials. The skill doc stays secret-free.
 	Lines.Add(TEXT("## How to Call"));
 	Lines.Add(TEXT(""));
 	Lines.Add(TEXT("```bash"));
@@ -180,6 +180,37 @@ FString FUnrealMcpSkillFileGenerator::BuildSkillMarkdown(const FUnrealMcpRegiste
 	Lines.Add(TEXT(""));
 
 	return FString::Join(Lines, TEXT("\n"));
+}
+
+int32 FUnrealMcpSkillFileGenerator::PruneStaleSkillFolders(const FString& SkillsRootAbsolute, const TSet<FString>& CurrentFolderNames)
+{
+	IFileManager& FileManager = IFileManager::Get();
+	int32 Pruned = 0;
+
+	// Enumerate immediate child directories of the skills root.
+	TArray<FString> ChildDirs;
+	FileManager.FindFiles(ChildDirs, *(SkillsRootAbsolute / TEXT("*")), /*Files*/ false, /*Directories*/ true);
+
+	for (const FString& ChildDir : ChildDirs)
+	{
+		// Guard 1: only ever consider a folder we would have produced ourselves — it must own a SKILL.md.
+		const FString SkillFile = FPaths::Combine(SkillsRootAbsolute, ChildDir, TEXT("SKILL.md"));
+		if (!FileManager.FileExists(*SkillFile))
+			continue;
+
+		// Guard 2: keep folders that still correspond to a current tool (the folder name is already the
+		// sanitized form the writer used, so compare directly).
+		if (CurrentFolderNames.Contains(ChildDir))
+			continue;
+
+		const FString FolderPath = FPaths::Combine(SkillsRootAbsolute, ChildDir);
+		if (FileManager.DeleteDirectory(*FolderPath, /*RequireExists*/ false, /*Tree*/ true))
+			++Pruned;
+		else
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] failed to prune stale skill folder: %s"), *FolderPath);
+	}
+
+	return Pruned;
 }
 
 FUnrealMcpSkillFileGenerator::FResult FUnrealMcpSkillFileGenerator::Generate(const FUnrealMcpToolRegistry& Registry, const FString& SkillsRootAbsolute)
@@ -205,6 +236,8 @@ FUnrealMcpSkillFileGenerator::FResult FUnrealMcpSkillFileGenerator::Generate(con
 	}
 
 	const TArray<FString> ToolNames = Registry.GetToolNamesSorted();
+	TSet<FString> CurrentFolderNames;
+	CurrentFolderNames.Reserve(ToolNames.Num());
 	int32 Written = 0;
 	for (const FString& ToolName : ToolNames)
 	{
@@ -213,6 +246,7 @@ FUnrealMcpSkillFileGenerator::FResult FUnrealMcpSkillFileGenerator::Generate(con
 			continue;
 
 		const FString FolderName = SanitizeSkillFolderName(Tool->Name);
+		CurrentFolderNames.Add(FolderName);
 		const FString FilePath = FPaths::Combine(SkillsRootAbsolute, FolderName, TEXT("SKILL.md"));
 		const FString Markdown = BuildSkillMarkdown(*Tool);
 
@@ -223,9 +257,22 @@ FUnrealMcpSkillFileGenerator::FResult FUnrealMcpSkillFileGenerator::Generate(con
 			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] failed to write skill file: %s"), *FilePath);
 	}
 
+	// Prune stale generator-owned folders: a tool removed/renamed since the last run leaves an orphaned
+	// `<old-name>/SKILL.md` whose docs no longer describe a real tool. Only delete an immediate child dir
+	// that BOTH contains a generator-owned SKILL.md AND is not in the current set — never unrelated user content.
+	Result.FilesPruned = PruneStaleSkillFolders(SkillsRootAbsolute, CurrentFolderNames);
+
+	// Every write failing (with tools to write) is a failure, not a "succeeded (0 files)" — otherwise the panel
+	// reports success for a run that produced nothing.
+	if (Written == 0 && ToolNames.Num() > 0)
+	{
+		Result.Error = FString::Printf(TEXT("Failed to write any of %d skill file(s) under %s."), ToolNames.Num(), *SkillsRootAbsolute);
+		return Result;
+	}
+
 	Result.bSuccess = true;
 	Result.FilesWritten = Written;
-	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] generated %d skill file(s) under %s."), Written, *SkillsRootAbsolute);
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] generated %d skill file(s) (pruned %d stale) under %s."), Written, Result.FilesPruned, *SkillsRootAbsolute);
 	return Result;
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/UnrealMcpSkillFileGenerator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/UnrealMcpSkillFileGenerator.cpp
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "Agents/UnrealMcpSkillFileGenerator.h"
+#include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpCoreTools.h"
+#include "UnrealMcpLog.h"
+
+#include "Dom/JsonObject.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "HAL/FileManager.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+namespace
+{
+	// Collapse a possibly-multi-line description into a single padded line and cap its length so the YAML
+	// front-matter `description:` stays a valid single scalar (the Agent-Skills limit). Word-boundary trim with an
+	// ellipsis when truncated. Pure; no secret handling needed (descriptions are static tool docs).
+	FString SkillGenSingleLineCapped(const FString& In, int32 MaxLen)
+	{
+		FString Flat = In;
+		Flat.ReplaceInline(TEXT("\r\n"), TEXT(" "));
+		Flat.ReplaceInline(TEXT("\n"), TEXT(" "));
+		Flat.ReplaceInline(TEXT("\r"), TEXT(" "));
+		Flat.ReplaceInline(TEXT("\t"), TEXT(" "));
+		// Collapse runs of spaces.
+		while (Flat.Contains(TEXT("  ")))
+			Flat.ReplaceInline(TEXT("  "), TEXT(" "));
+		Flat.TrimStartAndEndInline();
+
+		if (Flat.Len() <= MaxLen)
+			return Flat;
+
+		FString Capped = Flat.Left(MaxLen);
+		int32 LastSpace = INDEX_NONE;
+		if (Capped.FindLastChar(TEXT(' '), LastSpace) && LastSpace > MaxLen / 2)
+			Capped = Capped.Left(LastSpace);
+		Capped.TrimEndInline();
+		return Capped + TEXT("...");
+	}
+
+	// Escape a YAML double-quoted scalar value (backslash + double-quote). The value is already single-lined.
+	FString SkillGenEscapeYamlQuoted(const FString& In)
+	{
+		FString Out = In;
+		Out.ReplaceInline(TEXT("\\"), TEXT("\\\\"));
+		Out.ReplaceInline(TEXT("\""), TEXT("\\\""));
+		return Out;
+	}
+
+	// Pretty-print a JSON object (default pretty writer = tab indentation, which the editor renders fine).
+	FString SkillGenPrettyJson(const TSharedPtr<FJsonObject>& Object)
+	{
+		if (!Object.IsValid())
+			return FString();
+		FString Out;
+		const TSharedRef<TJsonWriter<TCHAR>> Writer = TJsonWriterFactory<TCHAR>::Create(&Out);
+		FJsonSerializer::Serialize(Object.ToSharedRef(), Writer);
+		Out.TrimEndInline();
+		return Out;
+	}
+}
+
+FString FUnrealMcpSkillFileGenerator::SanitizeSkillFolderName(const FString& ToolName)
+{
+	FString Out;
+	Out.Reserve(ToolName.Len());
+	bool bPendingHyphen = false;
+	for (const TCHAR Ch : ToolName)
+	{
+		const bool bAlnum = (Ch >= TEXT('a') && Ch <= TEXT('z')) || (Ch >= TEXT('A') && Ch <= TEXT('Z')) || (Ch >= TEXT('0') && Ch <= TEXT('9'));
+		if (bAlnum)
+		{
+			if (bPendingHyphen && Out.Len() > 0)
+				Out.AppendChar(TEXT('-'));
+			bPendingHyphen = false;
+			Out.AppendChar(FChar::ToLower(Ch));
+		}
+		else
+		{
+			// Any non-alnum becomes a single hyphen separator (collapsed, never leading/trailing).
+			bPendingHyphen = true;
+		}
+	}
+	return Out.IsEmpty() ? FString(TEXT("tool")) : Out;
+}
+
+FString FUnrealMcpSkillFileGenerator::BuildSkillMarkdown(const FUnrealMcpRegisteredTool& Tool)
+{
+	const FString FolderName = SanitizeSkillFolderName(Tool.Name);
+	const FString YamlDesc = SkillGenEscapeYamlQuoted(SkillGenSingleLineCapped(Tool.Description, MaxSkillDescriptionLength));
+	const FString Title = Tool.Title.IsEmpty() ? Tool.Name : Tool.Title;
+
+	TArray<FString> Lines;
+
+	// YAML front-matter (Agent-Skills shape: name + description). `name` is the sanitized folder name.
+	Lines.Add(TEXT("---"));
+	Lines.Add(FString::Printf(TEXT("name: %s"), *FolderName));
+	Lines.Add(FString::Printf(TEXT("description: \"%s\""), *YamlDesc));
+	Lines.Add(TEXT("---"));
+	Lines.Add(TEXT(""));
+
+	// Title + the full description body (verbatim — it is human-readable tool documentation).
+	Lines.Add(FString::Printf(TEXT("# %s"), *Title));
+	Lines.Add(TEXT(""));
+	if (!Tool.Description.IsEmpty())
+	{
+		Lines.Add(Tool.Description.TrimStartAndEnd());
+		Lines.Add(TEXT(""));
+	}
+
+	// Behavioural hints (the MCP read-only / destructive / idempotent / open-world flags) — useful context for an agent.
+	{
+		TArray<FString> Hints;
+		if (Tool.bReadOnlyHint)   Hints.Add(TEXT("read-only"));
+		if (Tool.bDestructiveHint) Hints.Add(TEXT("destructive"));
+		if (Tool.bIdempotentHint) Hints.Add(TEXT("idempotent"));
+		if (Tool.bOpenWorldHint)  Hints.Add(TEXT("open-world"));
+		if (Hints.Num() > 0)
+		{
+			Lines.Add(FString::Printf(TEXT("**Hints:** %s"), *FString::Join(Hints, TEXT(", "))));
+			Lines.Add(TEXT(""));
+		}
+	}
+
+	// ## Input — a parameter table + the JSON Schema block.
+	Lines.Add(TEXT("## Input"));
+	Lines.Add(TEXT(""));
+	if (Tool.Params.Num() == 0)
+	{
+		Lines.Add(TEXT("This tool takes no parameters."));
+		Lines.Add(TEXT(""));
+	}
+	else
+	{
+		Lines.Add(TEXT("| Name | Type | Required | Description |"));
+		Lines.Add(TEXT("| --- | --- | --- | --- |"));
+		for (const FUnrealMcpParamSpec& Param : Tool.Params)
+		{
+			// Keep a stray pipe in a description from breaking the table.
+			FString Desc = Param.Description;
+			Desc.ReplaceInline(TEXT("|"), TEXT("\\|"));
+			Desc.ReplaceInline(TEXT("\n"), TEXT(" "));
+			const TCHAR* Req = (Param.Requirement == EUnrealMcpParamRequirement::Required) ? TEXT("yes") : TEXT("no");
+			Lines.Add(FString::Printf(TEXT("| `%s` | %s | %s | %s |"), *Param.Name, *Param.JsonType, Req, *Desc));
+		}
+		Lines.Add(TEXT(""));
+
+		// The full JSON Schema for the inputs (built from the declared params).
+		Lines.Add(TEXT("### Input JSON Schema"));
+		Lines.Add(TEXT(""));
+		Lines.Add(TEXT("```json"));
+		Lines.Add(SkillGenPrettyJson(Tool.BuildInputSchema()));
+		Lines.Add(TEXT("```"));
+		Lines.Add(TEXT(""));
+	}
+
+	// ## Output — the structured output schema when the tool declares one.
+	if (Tool.OutputSchema.IsValid())
+	{
+		Lines.Add(TEXT("## Output"));
+		Lines.Add(TEXT(""));
+		Lines.Add(TEXT("### Output JSON Schema"));
+		Lines.Add(TEXT(""));
+		Lines.Add(TEXT("```json"));
+		Lines.Add(SkillGenPrettyJson(Tool.OutputSchema));
+		Lines.Add(TEXT("```"));
+		Lines.Add(TEXT(""));
+	}
+
+	// ## How to Call — the unreal-mcp-cli form. Token discipline (§8): a `<token>` PLACEHOLDER only, NEVER a real
+	// bearer. The agent supplies its own configured credentials; the skill doc must stay secret-free.
+	Lines.Add(TEXT("## How to Call"));
+	Lines.Add(TEXT(""));
+	Lines.Add(TEXT("```bash"));
+	Lines.Add(FString::Printf(TEXT("unreal-mcp-cli run-tool %s --input '{ ... }'"), *Tool.Name));
+	Lines.Add(TEXT("```"));
+	Lines.Add(TEXT(""));
+
+	return FString::Join(Lines, TEXT("\n"));
+}
+
+FUnrealMcpSkillFileGenerator::FResult FUnrealMcpSkillFileGenerator::Generate(const FUnrealMcpToolRegistry& Registry, const FString& SkillsRootAbsolute)
+{
+	FResult Result;
+	Result.SkillsRootAbsolute = SkillsRootAbsolute;
+
+	if (SkillsRootAbsolute.IsEmpty())
+	{
+		Result.Error = TEXT("Skills root path is empty.");
+		return Result;
+	}
+
+	IFileManager& FileManager = IFileManager::Get();
+	if (!FileManager.MakeDirectory(*SkillsRootAbsolute, /*Tree*/ true))
+	{
+		// MakeDirectory returns false when it already exists OR on a genuine failure; treat a non-existent dir as failure.
+		if (!FileManager.DirectoryExists(*SkillsRootAbsolute))
+		{
+			Result.Error = FString::Printf(TEXT("Could not create skills directory: %s"), *SkillsRootAbsolute);
+			return Result;
+		}
+	}
+
+	const TArray<FString> ToolNames = Registry.GetToolNamesSorted();
+	int32 Written = 0;
+	for (const FString& ToolName : ToolNames)
+	{
+		const FUnrealMcpRegisteredTool* Tool = Registry.Find(ToolName);
+		if (Tool == nullptr)
+			continue;
+
+		const FString FolderName = SanitizeSkillFolderName(Tool->Name);
+		const FString FilePath = FPaths::Combine(SkillsRootAbsolute, FolderName, TEXT("SKILL.md"));
+		const FString Markdown = BuildSkillMarkdown(*Tool);
+
+		// Unconditional overwrite (idempotent regeneration). UTF-8 without BOM keeps the docs portable.
+		if (FFileHelper::SaveStringToFile(Markdown, *FilePath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
+			++Written;
+		else
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] failed to write skill file: %s"), *FilePath);
+	}
+
+	Result.bSuccess = true;
+	Result.FilesWritten = Written;
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] generated %d skill file(s) under %s."), Written, *SkillsRootAbsolute);
+	return Result;
+}
+
+void FUnrealMcpSkillFileGenerator::PopulateCoreRegistry(FUnrealMcpToolRegistry& Registry)
+{
+	// Register every core family — declaration only (no world / bridge), so this is headless-safe (see the runtime's
+	// Startup ordering: families register before the bridge accepts). Keep in lockstep with FUnrealMcpRuntime::Startup.
+	UnrealMcpPingTool::Register(Registry);
+	UnrealMcpActorTools::Register(Registry);
+	UnrealMcpBlueprintTools::Register(Registry);
+	UnrealMcpAssetTools::Register(Registry);
+	UnrealMcpEditorTools::Register(Registry);
+	UnrealMcpLevelTools::Register(Registry);
+	UnrealMcpScreenshotTools::Register(Registry);
+	UnrealMcpSourceTools::Register(Registry);
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/UnrealMcpSkillFileGenerator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/UnrealMcpSkillFileGenerator.h
@@ -23,10 +23,11 @@ struct FUnrealMcpRegisteredTool;
  *     schema) headless-enumerable on the game thread WITHOUT a live bridge or editor connection. The resulting
  *     docs describe the ACTUAL Unreal tools an agent can call — accurate, not misleading.
  *
- * Idempotent: each SKILL.md is unconditionally overwritten on every run, so re-generating after a tool set change
- * cleanly refreshes the docs. Token discipline (§8): a skill file is PURE tool documentation — the generator never
- * reads or writes any token/secret/host/connection value. The "How to Call" block uses a `<token>` PLACEHOLDER
- * only (never the real bearer), matching Unity's secret-free SKILL.md output.
+ * Idempotent: each SKILL.md is unconditionally overwritten on every run and folders for tools no longer registered
+ * are pruned, so re-generating after a tool set change cleanly refreshes the docs. Token discipline (§8): a skill
+ * file is PURE tool documentation — the generator never reads or writes any token/secret/host/connection value. The
+ * "How to Call" block emits the plain `unreal-mcp-cli` call form with NO token at all, matching Unity's secret-free
+ * SKILL.md output.
  *
  * The markdown builder is a static pure function (no disk access) so the Automation specs assert the exact output
  * shape for a hand-built tool; PopulateCoreRegistry() fills a bare registry with every core family so a spec (or
@@ -40,8 +41,9 @@ public:
 	{
 		bool bSuccess = false;
 		int32 FilesWritten = 0;
+		int32 FilesPruned = 0;      // stale generator-owned folders removed for tools no longer registered
 		FString SkillsRootAbsolute; // the resolved folder the files were written under
-		FString Error;              // non-empty on failure (e.g. empty root, write failure)
+		FString Error;              // non-empty on failure (e.g. empty root, all writes failed)
 	};
 
 	/**
@@ -55,9 +57,9 @@ public:
 	/**
 	 * Build the SKILL.md markdown for ONE tool. Pure (no disk access) — the spec-friendly heart of the generator.
 	 * Shape: YAML front-matter (name + description) → `# <Title>` → description body → `## Input` (param table +
-	 * JSON Schema) → `## How to Call` (the `unreal-mcp-cli run-tool` form with a `<token>` placeholder only). The
-	 * YAML description is the tool's Description, single-lined + length-capped to the Agent-Skills limit so the
-	 * front-matter stays valid. NO secret ever appears.
+	 * JSON Schema) → `## How to Call` (the plain `unreal-mcp-cli run-tool` form, no token). The YAML description is
+	 * the tool's Description, single-lined + length-capped so the front-matter stays a valid scalar. NO secret ever
+	 * appears.
 	 */
 	static UNREALMCPEDITOR_API FString BuildSkillMarkdown(const FUnrealMcpRegisteredTool& Tool);
 
@@ -75,6 +77,14 @@ public:
 	 */
 	static UNREALMCPEDITOR_API void PopulateCoreRegistry(FUnrealMcpToolRegistry& Registry);
 
-	/** The max length of the YAML `description:` value (the Codex/Anthropic Agent-Skills limit). */
+	/**
+	 * Remove stale generator-owned skill folders under @p SkillsRootAbsolute — immediate child dirs that own a
+	 * SKILL.md but whose (sanitized) folder name is NOT in @p CurrentFolderNames (tools removed/renamed since the
+	 * last run). Two guards keep this from touching unrelated user content: a folder must contain a SKILL.md to be
+	 * a candidate, and it must be absent from the current set. Returns the count pruned.
+	 */
+	static UNREALMCPEDITOR_API int32 PruneStaleSkillFolders(const FString& SkillsRootAbsolute, const TSet<FString>& CurrentFolderNames);
+
+	/** A defensive single-line cap for the YAML `description:` value, keeping the front-matter scalar reasonable. */
 	static constexpr int32 MaxSkillDescriptionLength = 1024;
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/UnrealMcpSkillFileGenerator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/UnrealMcpSkillFileGenerator.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FUnrealMcpToolRegistry;
+struct FUnrealMcpRegisteredTool;
+
+/**
+ * Per-agent SKILL.md generator (docs/ARCHITECTURE.md §7, issue #53 Phase C) — the Unreal/C++ analog of Unity's
+ * SkillFileGenerator + UnitySkillFileGenerator. It writes one `<skillsRoot>/<tool-name>/SKILL.md` per registered
+ * tool, sourced ENTIRELY from the plugin's own C++ tool registry (FUnrealMcpToolRegistry — the 8 core tool
+ * families / ~62 tools), NOT from Unity's .NET tool reflection. This is the deliberate skill-content-source choice:
+ *
+ *   - Unity generates SKILL.md from its .NET tool set via [AiSkillDescription]/[AiSkillBody] reflected by the
+ *     shared McpPlugin.GenerateSkillFiles. That generator lives in the bridge SIDECAR and knows ONLY about .NET
+ *     tools; it has no visibility into Unreal's C++ tool registry, so reusing it verbatim would produce EMPTY or
+ *     wrong skill docs for an Unreal project.
+ *   - The faithful Unreal analog is to generate from FUnrealMcpToolRegistry, which carries rich per-tool metadata
+ *     (Title, Description, declared Params with name/type/required/description, behavioural hints, the JSON input
+ *     schema) headless-enumerable on the game thread WITHOUT a live bridge or editor connection. The resulting
+ *     docs describe the ACTUAL Unreal tools an agent can call — accurate, not misleading.
+ *
+ * Idempotent: each SKILL.md is unconditionally overwritten on every run, so re-generating after a tool set change
+ * cleanly refreshes the docs. Token discipline (§8): a skill file is PURE tool documentation — the generator never
+ * reads or writes any token/secret/host/connection value. The "How to Call" block uses a `<token>` PLACEHOLDER
+ * only (never the real bearer), matching Unity's secret-free SKILL.md output.
+ *
+ * The markdown builder is a static pure function (no disk access) so the Automation specs assert the exact output
+ * shape for a hand-built tool; PopulateCoreRegistry() fills a bare registry with every core family so a spec (or
+ * the panel) can generate the full set without standing up the runtime.
+ */
+class FUnrealMcpSkillFileGenerator
+{
+public:
+	/** Outcome of a generation run (for the panel's status line + the specs). */
+	struct FResult
+	{
+		bool bSuccess = false;
+		int32 FilesWritten = 0;
+		FString SkillsRootAbsolute; // the resolved folder the files were written under
+		FString Error;              // non-empty on failure (e.g. empty root, write failure)
+	};
+
+	/**
+	 * Generate one SKILL.md per tool in @p Registry under @p SkillsRootAbsolute (an absolute folder). Creates the
+	 * folder tree as needed. Overwrites existing files (idempotent). Every tool in the registry is documented
+	 * regardless of its enabled flag (the §7 Tools window's blocklist hides tools at runtime, but their docs stay
+	 * useful). Returns a result with the count written. Never throws.
+	 */
+	static UNREALMCPEDITOR_API FResult Generate(const FUnrealMcpToolRegistry& Registry, const FString& SkillsRootAbsolute);
+
+	/**
+	 * Build the SKILL.md markdown for ONE tool. Pure (no disk access) — the spec-friendly heart of the generator.
+	 * Shape: YAML front-matter (name + description) → `# <Title>` → description body → `## Input` (param table +
+	 * JSON Schema) → `## How to Call` (the `unreal-mcp-cli run-tool` form with a `<token>` placeholder only). The
+	 * YAML description is the tool's Description, single-lined + length-capped to the Agent-Skills limit so the
+	 * front-matter stays valid. NO secret ever appears.
+	 */
+	static UNREALMCPEDITOR_API FString BuildSkillMarkdown(const FUnrealMcpRegisteredTool& Tool);
+
+	/**
+	 * Sanitize a tool name into a safe folder name: lowercase, alphanumeric runs joined by single hyphens, no
+	 * leading/trailing/consecutive hyphens. A name that sanitizes to empty yields "tool". Tool ids are already
+	 * kebab-case, so this is a defensive normalization (and the seam an extension tool with an odd id flows through).
+	 */
+	static UNREALMCPEDITOR_API FString SanitizeSkillFolderName(const FString& ToolName);
+
+	/**
+	 * Populate a bare registry with EVERY core tool family (ping + the 8 families). Headless-safe and
+	 * bridge-independent — registration only declares descriptors, it never touches a world or the bridge. The
+	 * panel and the specs use this to enumerate the full tool set for skill generation without the runtime.
+	 */
+	static UNREALMCPEDITOR_API void PopulateCoreRegistry(FUnrealMcpToolRegistry& Registry);
+
+	/** The max length of the YAML `description:` value (the Codex/Anthropic Agent-Skills limit). */
+	static constexpr int32 MaxSkillDescriptionLength = 1024;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
@@ -45,6 +45,8 @@ namespace
 	const TCHAR* KeyEnabledTools   = TEXT("enabledTools");
 	const TCHAR* KeyDisabledTools  = TEXT("disabledTools");
 	const TCHAR* KeySelectedAgentId = TEXT("selectedAgentId");
+	const TCHAR* KeySkillAutoGenerateAgents = TEXT("skillAutoGenerateAgents");
+	const TCHAR* KeySkillsPath     = TEXT("skillsPath");
 
 	// Read a JSON array field into a string array (skipping empty/non-string entries). Shared by the
 	// enabledTools / disabledTools list fields so their parsing stays identical.
@@ -159,6 +161,11 @@ void FUnrealMcpConfig::LoadFromJson(const TSharedPtr<FJsonObject>& Json)
 		// Pure UI persistence (no env override). A blank/missing value keeps the default selection.
 		if (Json->TryGetStringField(KeySelectedAgentId, Str) && !Str.IsEmpty())
 			SelectedAgentId = Str;
+
+		// Skills (issue #53 Phase C) — pure UI persistence, no env override.
+		ReadStringArrayField(Json, KeySkillAutoGenerateAgents, SkillAutoGenerateAgents);
+		if (Json->TryGetStringField(KeySkillsPath, Str) && !Str.IsEmpty())
+			SkillsPath = Str;
 	}
 
 	// Snapshot the (defaults + disk) baseline AFTER loading — this is what Save() restores for any key an
@@ -337,6 +344,13 @@ TSharedPtr<FJsonObject> FUnrealMcpConfig::ToJson() const
 	Obj->SetArrayField(KeyDisabledTools, Disabled);
 
 	Obj->SetStringField(KeySelectedAgentId, SelectedAgentId);
+
+	TArray<TSharedPtr<FJsonValue>> SkillAgents;
+	for (const FString& AgentId : SkillAutoGenerateAgents)
+		SkillAgents.Add(MakeShared<FJsonValueString>(AgentId));
+	Obj->SetArrayField(KeySkillAutoGenerateAgents, SkillAgents);
+
+	Obj->SetStringField(KeySkillsPath, SkillsPath);
 
 	return Obj;
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
@@ -92,6 +92,15 @@ public:
 	// panel (e.g. "claude-code"/"cursor"). Pure presentation state, NO env override — Save() always round-trips
 	// the live value. Defaults to the first reference agent so a fresh project opens on a valid selection.
 	FString SelectedAgentId = TEXT("claude-code"); // "selectedAgentId"
+	// "skillAutoGenerateAgents" — the set of agent ids the user enabled per-agent "auto-generate skills" for (the
+	// §7 Agent Configurators skills toggle, issue #53 Phase C). The C++ analog of Unity's per-agent SkillAutoGenerate
+	// map; modelled as a string LIST (like enabledTools/disabledTools) since the JSON layer has no native map helper.
+	// Pure UI persistence, NO env override — Save() always round-trips the live value. Empty = no agent auto-generates.
+	TArray<FString> SkillAutoGenerateAgents; // "skillAutoGenerateAgents"
+	// "skillsPath" — the user-overridable skills folder for the Custom ("Other") agent (issue #53 Phase C, mirrors
+	// Unity's editable UnityMcpPluginEditor.SkillsPath). Project-relative; only the Custom configurator reads it (the
+	// built-in agents return their own constant). Defaults to ".claude/skills". Pure UI persistence, NO env override.
+	FString SkillsPath = TEXT(".claude/skills"); // "skillsPath"
 
 	UNREALMCPEDITOR_API FUnrealMcpConfig();
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
@@ -5,6 +5,9 @@
 #include "UI/UnrealMcpEditorViewModel.h"
 #include "Agents/AiAgentConfiguratorRegistry.h"
 #include "Agents/JsonAiAgentConfig.h"
+#include "Agents/UnrealMcpSkillFileGenerator.h"
+#include "Agents/Impl/CustomConfigurator.h"
+#include "UnrealMcpToolRegistry.h"
 #include "UnrealMcpLog.h"
 
 #include "Widgets/SBoxPanel.h"
@@ -14,6 +17,7 @@
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Input/SComboBox.h"
 #include "Widgets/Input/SCheckBox.h"
+#include "Widgets/Input/SEditableTextBox.h"
 #include "Widgets/Input/SMultiLineEditableTextBox.h"
 #include "Styling/AppStyle.h"
 #include "Misc/Paths.h"
@@ -124,6 +128,14 @@ void SUnrealMcpAgentConfigurators::BindSelected()
 	const FAiAgentConnectionInfo Connection = ConnectionInfoProvider ? ConnectionInfoProvider() : FAiAgentConnectionInfo();
 	const FString ProjectRoot = ProjectRootProvider ? ProjectRootProvider() : FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
 	Selected->Initialize(Connection, ProjectRoot);
+
+	// The Custom configurator's skills path is user-overridable and persisted (mirrors Unity's editable SkillsPath).
+	// Push the persisted value into the live Custom configurator so its GetSkillsPath()/SupportsSkills() reflect it.
+	if (IsViewModelValid())
+	{
+		if (FCustomConfigurator* Custom = static_cast<FCustomConfigurator*>(Selected->GetAgentId() == TEXT("other-custom") ? Selected.Get() : nullptr))
+			Custom->SetCustomSkillsPath(ViewModel->GetSkillsPath());
+	}
 }
 
 FString SUnrealMcpAgentConfigurators::MaskTokenInSnippet(const FString& Snippet, const FString& Token, bool bReveal)
@@ -306,6 +318,16 @@ void SUnrealMcpAgentConfigurators::RebuildAgentPanel()
 	AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 4, 0, 0)[ SNew(SSeparator) ];
 	AgentPanelContainer->AddSlot().AutoHeight()[ BuildTransportSection(LOCTEXT("HttpHeader", "HTTP (connect to URL)"), /*bStdio*/ false) ];
 
+	// Skills section (§7/§53 Phase C) — shown ONLY when the selected agent supports skills.
+	{
+		const FString ProjectRoot = ProjectRootProvider ? ProjectRootProvider() : FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
+		if (Selected->SupportsSkills(ProjectRoot))
+		{
+			AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 4, 0, 0)[ SNew(SSeparator) ];
+			AgentPanelContainer->AddSlot().AutoHeight()[ BuildSkillsSection() ];
+		}
+	}
+
 	// Remove (clears both transports).
 	AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 8, 0, 0)
 	[
@@ -324,6 +346,124 @@ void SUnrealMcpAgentConfigurators::RebuildAgentPanel()
 			return FReply::Handled();
 		})
 	];
+}
+
+FString SUnrealMcpAgentConfigurators::ResolveSelectedSkillsPath() const
+{
+	if (!Selected.IsValid())
+		return FString();
+	const FString ProjectRoot = ProjectRootProvider ? ProjectRootProvider() : FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
+	return Selected->ResolveAbsoluteSkillsPath(ProjectRoot);
+}
+
+void SUnrealMcpAgentConfigurators::GenerateSkillsForSelected()
+{
+	const FString SkillsRoot = ResolveSelectedSkillsPath();
+	if (SkillsRoot.IsEmpty())
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] cannot generate skills: selected agent has no skills path."));
+		return;
+	}
+
+	// Enumerate the full core tool set from a bare registry (headless-safe; the writer sources docs from the C++ tool
+	// registry, NOT a live bridge). Token discipline (§8): skill files carry only tool docs — no token is read/written.
+	FUnrealMcpToolRegistry ToolRegistry;
+	FUnrealMcpSkillFileGenerator::PopulateCoreRegistry(ToolRegistry);
+	const FUnrealMcpSkillFileGenerator::FResult Result = FUnrealMcpSkillFileGenerator::Generate(ToolRegistry, SkillsRoot);
+
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] agent '%s' skills generate %s (%d file(s) -> %s)."),
+		Selected.IsValid() ? *Selected->GetAgentName() : TEXT("?"),
+		Result.bSuccess ? TEXT("succeeded") : TEXT("failed"), Result.FilesWritten, *SkillsRoot);
+}
+
+TSharedRef<SWidget> SUnrealMcpAgentConfigurators::BuildSkillsSection()
+{
+	const bool bIsCustom = Selected.IsValid() && Selected->GetAgentId() == TEXT("other-custom");
+	const FString AgentId = Selected.IsValid() ? Selected->GetAgentId() : FString();
+	const FString AbsolutePath = ResolveSelectedSkillsPath();
+
+	TSharedRef<SVerticalBox> Section = SNew(SVerticalBox)
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)
+		[
+			SNew(STextBlock)
+			.Text(LOCTEXT("SkillsHeader", "Skills")).Font(FCoreStyle::GetDefaultFontStyle("Bold", 10))
+		]
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 2, 0, 0)
+		[
+			SNew(STextBlock)
+			.AutoWrapText(true)
+			.Text(LOCTEXT("SkillsDesc", "Generate per-tool skill documentation (one SKILL.md per Unreal MCP tool) for this agent."))
+		]
+		// Auto-generate toggle (per-agent; persisted via the view-model). Turning it on generates immediately.
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
+		[
+			SNew(SCheckBox)
+			.IsChecked_Lambda([this, AgentId]()
+			{
+				return (IsViewModelValid() && ViewModel->IsAutoGenerateSkills(AgentId))
+					? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+			})
+			.OnCheckStateChanged_Lambda([this, AgentId](ECheckBoxState NewState)
+			{
+				const bool bEnabled = (NewState == ECheckBoxState::Checked);
+				if (IsViewModelValid())
+					ViewModel->SetAutoGenerateSkills(AgentId, bEnabled);
+				if (bEnabled)
+					GenerateSkillsForSelected(); // auto-generate on enable (mirrors Unity's toggle callback)
+			})
+			[
+				SNew(STextBlock).Text(LOCTEXT("AutoGenSkills", "Auto-generate skills"))
+			]
+		];
+
+	// Output path: a read-only display for built-in agents; an editable field for the Custom agent (its skills path
+	// is user-overridable + persisted, mirroring Unity's editable Custom SkillsPath).
+	if (bIsCustom)
+	{
+		Section->AddSlot().AutoHeight().Padding(0, 4, 0, 0)
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 6, 0).VAlign(VAlign_Center)
+			[
+				SNew(STextBlock).Text(LOCTEXT("SkillsPathLabel", "Skills folder:"))
+			]
+			+ SHorizontalBox::Slot().FillWidth(1.0f)
+			[
+				SNew(SEditableTextBox)
+				.Text_Lambda([this]() { return IsViewModelValid() ? FText::FromString(ViewModel->GetSkillsPath()) : FText::GetEmpty(); })
+				.OnTextCommitted_Lambda([this](const FText& NewText, ETextCommit::Type)
+				{
+					if (IsViewModelValid())
+						ViewModel->SetSkillsPath(NewText.ToString().TrimStartAndEnd());
+					BindSelected();      // re-sync the Custom configurator's path
+					RebuildAgentPanel(); // refresh the resolved-path display
+				})
+			]
+		];
+	}
+
+	// The resolved absolute output path (always shown — read-only).
+	Section->AddSlot().AutoHeight().Padding(0, 4, 0, 0)
+	[
+		SNew(STextBlock)
+		.AutoWrapText(true)
+		.Text(FText::Format(LOCTEXT("SkillsOutFmt", "Output: {0}"), FText::FromString(AbsolutePath)))
+	];
+
+	// Generate button (explicit regeneration; idempotent).
+	Section->AddSlot().AutoHeight().Padding(0, 4, 0, 0)
+	[
+		SNew(SButton)
+		.Text(LOCTEXT("GenerateSkills", "Generate"))
+		.ToolTipText(LOCTEXT("GenerateSkillsHint", "Write one SKILL.md per Unreal MCP tool into the output folder (overwrites existing)."))
+		.OnClicked_Lambda([this]()
+		{
+			GenerateSkillsForSelected();
+			return FReply::Handled();
+		})
+	];
+
+	return Section;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.h
@@ -79,4 +79,13 @@ private:
 	FString BuildSnippetPreview(bool bStdio) const;
 	// Mask the bearer token inside an assembled snippet string unless revealed.
 	static FString MaskTokenInSnippet(const FString& Snippet, const FString& Token, bool bReveal);
+
+	// --- Skills section (issue #53 Phase C). Shown ONLY when the selected agent SupportsSkills. ---
+
+	/** Build the per-agent skills section (toggle + resolved output path + Generate button, plus the Custom edit field). */
+	TSharedRef<SWidget> BuildSkillsSection();
+	/** Resolve the selected agent's absolute skills folder (project-relative resolved under the live project root). */
+	FString ResolveSelectedSkillsPath() const;
+	/** Generate the SKILL.md files for the selected agent into its resolved skills folder (idempotent). Logs the result. */
+	void GenerateSkillsForSelected();
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -282,6 +282,45 @@ void FUnrealMcpEditorViewModel::SetSelectedAgentId(const FString& InAgentId)
 		OnPersistConfig(Config);
 }
 
+bool FUnrealMcpEditorViewModel::IsAutoGenerateSkills(const FString& AgentId) const
+{
+	return Config.SkillAutoGenerateAgents.Contains(AgentId);
+}
+
+void FUnrealMcpEditorViewModel::SetAutoGenerateSkills(const FString& AgentId, bool bEnabled)
+{
+	if (AgentId.IsEmpty())
+		return;
+	const bool bCurrently = Config.SkillAutoGenerateAgents.Contains(AgentId);
+	if (bCurrently == bEnabled)
+		return; // no-op — no persist churn.
+
+	if (bEnabled)
+		Config.SkillAutoGenerateAgents.AddUnique(AgentId);
+	else
+		Config.SkillAutoGenerateAgents.Remove(AgentId);
+
+	// Persist-only: skills generation is pure presentation state (mirrors SetSelectedAgentId). Deliberately NO
+	// OnPushConfig — enabling skills does not change the live connection. The panel regenerates the files after this.
+	if (OnPersistConfig)
+		OnPersistConfig(Config);
+
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] agent '%s' auto-generate-skills %s."),
+		*AgentId, bEnabled ? TEXT("enabled") : TEXT("disabled"));
+}
+
+void FUnrealMcpEditorViewModel::SetSkillsPath(const FString& InPath)
+{
+	const FString Normalized = InPath.IsEmpty() ? FString(TEXT(".claude/skills")) : InPath;
+	if (Config.SkillsPath == Normalized)
+		return; // no-op.
+	Config.SkillsPath = Normalized;
+
+	// Persist-only: the Custom skills folder is pure presentation state. Never pushes the §1.3 `config`.
+	if (OnPersistConfig)
+		OnPersistConfig(Config);
+}
+
 // --- Pure helpers ----------------------------------------------------------------------------------
 
 bool FUnrealMcpEditorViewModel::ValidateServerUrl(const FString& Url, FString& OutError)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
@@ -168,6 +168,28 @@ public:
 	 */
 	UNREALMCPEDITOR_API void SetSelectedAgentId(const FString& InAgentId);
 
+	// --- §7 per-agent skills generation (the Agent Configurators skills toggle, issue #53 Phase C). ---
+
+	/** Whether the user enabled per-agent "auto-generate skills" for @p AgentId (the C++ analog of Unity's IsAutoGenerateSkills). */
+	UNREALMCPEDITOR_API bool IsAutoGenerateSkills(const FString& AgentId) const;
+	/**
+	 * Toggle per-agent "auto-generate skills" for @p AgentId (mirrors Unity's SetAutoGenerateSkills). Mutates the
+	 * §8 skill-auto-generate agent set and persists the config (OnPersistConfig — so the choice survives a restart).
+	 * Pure UI persistence: like SetSelectedAgentId it deliberately does NOT push the §1.3 `config` (skills generation
+	 * has no effect on the live connection). A no-op change does nothing. Does NOT itself write skill files — the
+	 * caller (the panel) regenerates after enabling. Game-thread only.
+	 */
+	UNREALMCPEDITOR_API void SetAutoGenerateSkills(const FString& AgentId, bool bEnabled);
+
+	/** The user-overridable Custom-agent skills folder (project-relative; only the Custom configurator reads it). */
+	const FString& GetSkillsPath() const { return Config.SkillsPath; }
+	/**
+	 * Persist the user-overridable Custom-agent skills folder (mirrors Unity's editable SkillsPath setter). Pure UI
+	 * persistence: persists via OnPersistConfig, never pushes the §1.3 `config`. An empty value resets to the default
+	 * ".claude/skills" so the Custom agent always keeps a valid skills path. A no-op change does nothing. Game-thread only.
+	 */
+	UNREALMCPEDITOR_API void SetSkillsPath(const FString& InPath);
+
 	// --- Pure helpers (no instance state; the spec-friendly heart of the view-model). ---
 
 	/**

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentSkillsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentSkillsSpec.cpp
@@ -1,0 +1,327 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/Paths.h"
+#include "Misc/Guid.h"
+#include "Misc/FileHelper.h"
+#include "HAL/FileManager.h"
+
+#include "Agents/AiAgentConfigurator.h"
+#include "Agents/AiAgentConfiguratorRegistry.h"
+#include "Agents/UnrealMcpSkillFileGenerator.h"
+#include "Agents/Impl/ClaudeCodeConfigurator.h"
+#include "Agents/Impl/CursorConfigurator.h"
+#include "Agents/Impl/ClaudeDesktopConfigurator.h"
+#include "Agents/Impl/UnityAiConfigurator.h"
+#include "Agents/Impl/CustomConfigurator.h"
+#include "Config/UnrealMcpConfig.h"
+#include "UI/UnrealMcpEditorViewModel.h"
+#include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpCoreTools.h"
+
+/**
+ * AI Agent Configurators — Skills generation specs (docs/ARCHITECTURE.md §7, issue #53 Phase C). Covers the
+ * per-agent SkillsPath / SupportsSkills metadata + ResolveAbsoluteSkillsPath, the config + view-model persistence
+ * of the per-agent auto-generate toggle and the Custom skills path, and the SKILL.md writer (markdown shape, the
+ * secret-free invariant, idempotent regeneration, full-set generation from the core registry).
+ *
+ * Names are unique under the UnrealMcp. filter prefix; helpers are spec members (the unity-build ODR rule). Helper
+ * names are skill-spec-unique to avoid colliding with the agent-configurator spec in the same unity TU.
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpAgentSkillsSpec, "UnrealMcp.AgentConfigurators.Skills",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	// A unique temp skills-root path per call (cleaned up by the spec when done).
+	FString SkillSpecMakeTempRoot() const
+	{
+		return FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("UnrealMcpSkillSpec"), FGuid::NewGuid().ToString(), TEXT("skills"));
+	}
+
+	void SkillSpecDeleteTree(const FString& Root) const
+	{
+		// Delete the GUID parent so the per-call temp tree is fully removed.
+		const FString GuidDir = FPaths::GetPath(Root);
+		if (!GuidDir.IsEmpty())
+			IFileManager::Get().DeleteDirectory(*GuidDir, /*RequireExists*/ false, /*Tree*/ true);
+	}
+
+	FString SkillSpecReadAllText(const FString& Path) const
+	{
+		FString Out;
+		FFileHelper::LoadFileToString(Out, *Path);
+		return Out;
+	}
+
+	// Build a single hand-made tool with one required + one optional param and a description containing a literal
+	// token-shaped value, so the no-secret assertion is meaningful (the generator must never emit a real token).
+	FUnrealMcpRegisteredTool SkillSpecMakeTool() const
+	{
+		FUnrealMcpRegisteredTool Tool;
+		Tool.Name = TEXT("demo-tool");
+		Tool.Title = TEXT("Demo Tool");
+		Tool.Description = TEXT("A demo tool for the skills spec.\nIt spans two lines.");
+		Tool.bReadOnlyHint = true;
+		Tool.bIdempotentHint = true;
+
+		FUnrealMcpParamSpec P1;
+		P1.Name = TEXT("name");
+		P1.JsonType = TEXT("string");
+		P1.Description = TEXT("The name to use.");
+		P1.Requirement = EUnrealMcpParamRequirement::Required;
+		Tool.Params.Add(P1);
+
+		FUnrealMcpParamSpec P2;
+		P2.Name = TEXT("count");
+		P2.JsonType = TEXT("integer");
+		P2.Description = TEXT("How many | with a pipe.");
+		P2.Requirement = EUnrealMcpParamRequirement::Optional;
+		Tool.Params.Add(P2);
+
+		return Tool;
+	}
+
+END_DEFINE_SPEC(FUnrealMcpAgentSkillsSpec)
+
+void FUnrealMcpAgentSkillsSpec::Define()
+{
+	Describe("SkillsPath / SupportsSkills metadata (per-agent gating)", [this]()
+	{
+		It("skills-supporting agents declare their per-agent skills path matching Unity", [this]()
+		{
+			const FString Root = TEXT("C:/proj");
+
+			FClaudeCodeConfigurator Claude;
+			TestEqual(TEXT("claude-code skills path"), Claude.GetSkillsPath(Root), FString(TEXT(".claude/skills")));
+			TestTrue(TEXT("claude-code supports skills"), Claude.SupportsSkills(Root));
+
+			FCursorConfigurator Cursor;
+			TestEqual(TEXT("cursor skills path"), Cursor.GetSkillsPath(Root), FString(TEXT(".cursor/skills")));
+			TestTrue(TEXT("cursor supports skills"), Cursor.SupportsSkills(Root));
+		});
+
+		It("agents Unity leaves null do NOT support skills (no skills section)", [this]()
+		{
+			const FString Root = TEXT("C:/proj");
+
+			FClaudeDesktopConfigurator Desktop;
+			TestTrue(TEXT("claude-desktop skills path empty"), Desktop.GetSkillsPath(Root).IsEmpty());
+			TestFalse(TEXT("claude-desktop no skills"), Desktop.SupportsSkills(Root));
+
+			FUnityAiConfigurator UnityAi;
+			TestTrue(TEXT("unity-ai skills path empty"), UnityAi.GetSkillsPath(Root).IsEmpty());
+			TestFalse(TEXT("unity-ai no skills"), UnityAi.SupportsSkills(Root));
+		});
+
+		It("every registry agent's SupportsSkills matches a non-empty skills path", [this]()
+		{
+			const FString Root = TEXT("C:/proj");
+			FAiAgentConfiguratorRegistry Registry;
+			int32 SupportingCount = 0;
+			for (const TSharedRef<FAiAgentConfigurator>& Agent : Registry.All())
+			{
+				const bool bSupports = Agent->SupportsSkills(Root);
+				const bool bHasPath = !Agent->GetSkillsPath(Root).IsEmpty();
+				TestEqual(FString::Printf(TEXT("%s: SupportsSkills == has path"), *Agent->GetAgentId()), bSupports, bHasPath);
+				if (bSupports)
+					++SupportingCount;
+			}
+			// 13 built-in skills agents + the Custom agent (which always supports skills) = 14; claude-desktop and
+			// unity-ai are the two that stay null (matches Unity's per-agent table).
+			TestEqual(TEXT("14 of 16 agents support skills"), SupportingCount, 14);
+		});
+
+		It("Custom agent supports skills via its user-overridable path (default, and after override)", [this]()
+		{
+			const FString Root = TEXT("C:/proj");
+			FCustomConfigurator Custom;
+			TestTrue(TEXT("custom supports skills by default"), Custom.SupportsSkills(Root));
+			TestEqual(TEXT("custom default path"), Custom.GetSkillsPath(Root), FString(TEXT(".claude/skills")));
+
+			Custom.SetCustomSkillsPath(TEXT(".my/skills"));
+			TestEqual(TEXT("custom overridden path"), Custom.GetSkillsPath(Root), FString(TEXT(".my/skills")));
+
+			Custom.SetCustomSkillsPath(FString()); // empty resets to default (never disables)
+			TestEqual(TEXT("custom empty resets to default"), Custom.GetSkillsPath(Root), FString(TEXT(".claude/skills")));
+		});
+	});
+
+	Describe("ResolveAbsoluteSkillsPath", [this]()
+	{
+		It("resolves a project-relative path under the project root with forward slashes", [this]()
+		{
+			FClaudeCodeConfigurator Claude;
+			const FString Resolved = Claude.ResolveAbsoluteSkillsPath(TEXT("C:/proj"));
+			TestFalse(TEXT("not backslashed"), Resolved.Contains(TEXT("\\")));
+			TestTrue(TEXT("ends with .claude/skills"), Resolved.EndsWith(TEXT(".claude/skills")));
+			TestTrue(TEXT("rooted under project"), Resolved.Contains(TEXT("/proj/")));
+		});
+
+		It("returns empty for a non-skills agent", [this]()
+		{
+			FClaudeDesktopConfigurator Desktop;
+			TestTrue(TEXT("empty resolved path"), Desktop.ResolveAbsoluteSkillsPath(TEXT("C:/proj")).IsEmpty());
+		});
+	});
+
+	Describe("Config + view-model persistence (auto-generate toggle + Custom skills path)", [this]()
+	{
+		It("config round-trips skillAutoGenerateAgents and skillsPath", [this]()
+		{
+			FUnrealMcpConfig Config;
+			TestEqual(TEXT("default skillsPath"), Config.SkillsPath, FString(TEXT(".claude/skills")));
+			TestEqual(TEXT("default no auto-generate agents"), Config.SkillAutoGenerateAgents.Num(), 0);
+
+			Config.SkillAutoGenerateAgents.Add(TEXT("claude-code"));
+			Config.SkillAutoGenerateAgents.Add(TEXT("cursor"));
+			Config.SkillsPath = TEXT(".custom/skills");
+
+			const TSharedPtr<FJsonObject> Json = Config.ToJson();
+			TestTrue(TEXT("json has skillAutoGenerateAgents"), Json->HasField(TEXT("skillAutoGenerateAgents")));
+			TestTrue(TEXT("json has skillsPath"), Json->HasField(TEXT("skillsPath")));
+
+			FUnrealMcpConfig Loaded;
+			Loaded.LoadFromJson(Json);
+			TestEqual(TEXT("round-tripped agents count"), Loaded.SkillAutoGenerateAgents.Num(), 2);
+			TestTrue(TEXT("claude-code present"), Loaded.SkillAutoGenerateAgents.Contains(TEXT("claude-code")));
+			TestEqual(TEXT("round-tripped skillsPath"), Loaded.SkillsPath, FString(TEXT(".custom/skills")));
+		});
+
+		It("view-model toggles auto-generate per agent, persisting (not pushing) and round-trips", [this]()
+		{
+			FUnrealMcpEditorViewModel ViewModel;
+			int32 PersistCount = 0;
+			int32 PushCount = 0;
+			ViewModel.OnPersistConfig = [&PersistCount](const FUnrealMcpConfig&) { ++PersistCount; };
+			ViewModel.OnPushConfig = [&PushCount](const FUnrealMcpConfig&) { ++PushCount; };
+
+			TestFalse(TEXT("initially off"), ViewModel.IsAutoGenerateSkills(TEXT("claude-code")));
+
+			ViewModel.SetAutoGenerateSkills(TEXT("claude-code"), true);
+			TestTrue(TEXT("now on"), ViewModel.IsAutoGenerateSkills(TEXT("claude-code")));
+			TestEqual(TEXT("persisted once"), PersistCount, 1);
+			TestEqual(TEXT("never pushed"), PushCount, 0);
+
+			ViewModel.SetAutoGenerateSkills(TEXT("claude-code"), true); // no-op
+			TestEqual(TEXT("no-op did not persist"), PersistCount, 1);
+
+			ViewModel.SetAutoGenerateSkills(TEXT("claude-code"), false);
+			TestFalse(TEXT("off again"), ViewModel.IsAutoGenerateSkills(TEXT("claude-code")));
+			TestEqual(TEXT("persisted again"), PersistCount, 2);
+		});
+
+		It("view-model SetSkillsPath persists, resets empty to default, never pushes", [this]()
+		{
+			FUnrealMcpEditorViewModel ViewModel;
+			int32 PersistCount = 0;
+			int32 PushCount = 0;
+			ViewModel.OnPersistConfig = [&PersistCount](const FUnrealMcpConfig&) { ++PersistCount; };
+			ViewModel.OnPushConfig = [&PushCount](const FUnrealMcpConfig&) { ++PushCount; };
+
+			ViewModel.SetSkillsPath(TEXT(".abc/skills"));
+			TestEqual(TEXT("set value"), ViewModel.GetSkillsPath(), FString(TEXT(".abc/skills")));
+			TestEqual(TEXT("persisted once"), PersistCount, 1);
+
+			ViewModel.SetSkillsPath(FString()); // empty resets to default
+			TestEqual(TEXT("reset to default"), ViewModel.GetSkillsPath(), FString(TEXT(".claude/skills")));
+			TestEqual(TEXT("never pushed"), PushCount, 0);
+		});
+	});
+
+	Describe("SKILL.md markdown builder (shape + secret-free)", [this]()
+	{
+		It("emits YAML front-matter, title, param table, JSON schema, and the unreal-mcp-cli call form", [this]()
+		{
+			const FUnrealMcpRegisteredTool Tool = SkillSpecMakeTool();
+			const FString Md = FUnrealMcpSkillFileGenerator::BuildSkillMarkdown(Tool);
+
+			TestTrue(TEXT("starts with front-matter"), Md.StartsWith(TEXT("---")));
+			TestTrue(TEXT("has name field"), Md.Contains(TEXT("name: demo-tool")));
+			TestTrue(TEXT("has description field"), Md.Contains(TEXT("description: \"")));
+			TestTrue(TEXT("has title heading"), Md.Contains(TEXT("# Demo Tool")));
+			TestTrue(TEXT("has Input section"), Md.Contains(TEXT("## Input")));
+			TestTrue(TEXT("param table header"), Md.Contains(TEXT("| Name | Type | Required | Description |")));
+			TestTrue(TEXT("required param row"), Md.Contains(TEXT("| `name` | string | yes |")));
+			TestTrue(TEXT("optional param row"), Md.Contains(TEXT("| `count` | integer | no |")));
+			TestTrue(TEXT("escaped pipe in desc"), Md.Contains(TEXT("How many \\| with a pipe.")));
+			TestTrue(TEXT("input json schema fence"), Md.Contains(TEXT("### Input JSON Schema")));
+			TestTrue(TEXT("has hints line"), Md.Contains(TEXT("**Hints:** read-only, idempotent")));
+			TestTrue(TEXT("how-to-call form"), Md.Contains(TEXT("unreal-mcp-cli run-tool demo-tool")));
+		});
+
+		It("a no-param tool says so and shows no table", [this]()
+		{
+			FUnrealMcpRegisteredTool Tool;
+			Tool.Name = TEXT("ping");
+			Tool.Title = TEXT("Ping");
+			Tool.Description = TEXT("A probe.");
+			const FString Md = FUnrealMcpSkillFileGenerator::BuildSkillMarkdown(Tool);
+			TestTrue(TEXT("no-params note"), Md.Contains(TEXT("This tool takes no parameters.")));
+			TestFalse(TEXT("no table"), Md.Contains(TEXT("| Name | Type")));
+		});
+
+		It("never writes a real token even when a token-shaped string is present elsewhere", [this]()
+		{
+			// The generator only ever reads tool metadata (name/title/description/params/schema). It cannot see a
+			// connection token. Assert the call-form uses a placeholder, never a 'Bearer <secret>' header.
+			const FUnrealMcpRegisteredTool Tool = SkillSpecMakeTool();
+			const FString Md = FUnrealMcpSkillFileGenerator::BuildSkillMarkdown(Tool);
+			TestFalse(TEXT("no Bearer header"), Md.Contains(TEXT("Bearer ")));
+			TestFalse(TEXT("no token= arg"), Md.Contains(TEXT("token=")));
+			TestFalse(TEXT("no Authorization"), Md.Contains(TEXT("Authorization")));
+		});
+	});
+
+	Describe("Generation output (idempotent, full core set)", [this]()
+	{
+		It("writes one SKILL.md per tool and is idempotent on re-run", [this]()
+		{
+			const FString Root = SkillSpecMakeTempRoot();
+
+			FUnrealMcpToolRegistry Registry;
+			FUnrealMcpSkillFileGenerator::PopulateCoreRegistry(Registry);
+			const int32 ToolCount = Registry.Num();
+			TestTrue(TEXT("core registry has tools"), ToolCount > 0);
+
+			const FUnrealMcpSkillFileGenerator::FResult First = FUnrealMcpSkillFileGenerator::Generate(Registry, Root);
+			TestTrue(TEXT("first run succeeded"), First.bSuccess);
+			TestEqual(TEXT("wrote one file per tool"), First.FilesWritten, ToolCount);
+
+			// A known tool's SKILL.md exists and contains its call form.
+			const FString PingPath = FPaths::Combine(Root, TEXT("ping"), TEXT("SKILL.md"));
+			TestTrue(TEXT("ping SKILL.md exists"), IFileManager::Get().FileExists(*PingPath));
+			const FString PingMd = SkillSpecReadAllText(PingPath);
+			TestTrue(TEXT("ping doc has call form"), PingMd.Contains(TEXT("unreal-mcp-cli run-tool ping")));
+
+			// Re-run: same file count, clean overwrite (idempotent).
+			const FUnrealMcpSkillFileGenerator::FResult Second = FUnrealMcpSkillFileGenerator::Generate(Registry, Root);
+			TestTrue(TEXT("second run succeeded"), Second.bSuccess);
+			TestEqual(TEXT("idempotent file count"), Second.FilesWritten, ToolCount);
+			const FString PingMd2 = SkillSpecReadAllText(PingPath);
+			TestEqual(TEXT("identical content on re-run"), PingMd2, PingMd);
+
+			SkillSpecDeleteTree(Root);
+		});
+
+		It("fails cleanly on an empty skills root", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			FUnrealMcpSkillFileGenerator::PopulateCoreRegistry(Registry);
+			const FUnrealMcpSkillFileGenerator::FResult Result = FUnrealMcpSkillFileGenerator::Generate(Registry, FString());
+			TestFalse(TEXT("empty root fails"), Result.bSuccess);
+			TestFalse(TEXT("error reported"), Result.Error.IsEmpty());
+		});
+
+		It("sanitizes odd tool names into safe folder names", [this]()
+		{
+			TestEqual(TEXT("kebab passthrough"), FUnrealMcpSkillFileGenerator::SanitizeSkillFolderName(TEXT("actor-create")), FString(TEXT("actor-create")));
+			TestEqual(TEXT("collapses junk"), FUnrealMcpSkillFileGenerator::SanitizeSkillFolderName(TEXT("Foo__Bar!!Baz")), FString(TEXT("foo-bar-baz")));
+			TestEqual(TEXT("empty -> tool"), FUnrealMcpSkillFileGenerator::SanitizeSkillFolderName(TEXT("!!!")), FString(TEXT("tool")));
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentSkillsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentSkillsSpec.cpp
@@ -306,6 +306,56 @@ void FUnrealMcpAgentSkillsSpec::Define()
 			SkillSpecDeleteTree(Root);
 		});
 
+		It("prunes stale generator-owned folders for removed tools but keeps survivors and user content", [this]()
+		{
+			const FString Root = SkillSpecMakeTempRoot();
+			IFileManager& FileManager = IFileManager::Get();
+
+			// Set A: two tools (Commit outside an extension scope adds the descriptor directly — no handler needed).
+			FUnrealMcpToolRegistry RegA;
+			{
+				FUnrealMcpRegisteredTool Keep;
+				Keep.Name = TEXT("keep-tool");
+				Keep.Title = TEXT("Keep");
+				Keep.Description = TEXT("Stays across runs.");
+				RegA.Commit(MoveTemp(Keep));
+
+				FUnrealMcpRegisteredTool Drop;
+				Drop.Name = TEXT("drop-tool");
+				Drop.Title = TEXT("Drop");
+				Drop.Description = TEXT("Removed in set B.");
+				RegA.Commit(MoveTemp(Drop));
+			}
+			const FUnrealMcpSkillFileGenerator::FResult A = FUnrealMcpSkillFileGenerator::Generate(RegA, Root);
+			TestTrue(TEXT("set A succeeded"), A.bSuccess);
+			TestEqual(TEXT("set A wrote two"), A.FilesWritten, 2);
+			TestEqual(TEXT("set A pruned nothing"), A.FilesPruned, 0);
+
+			// Drop an unrelated user folder (no SKILL.md) — pruning must never touch it.
+			const FString UserDir = FPaths::Combine(Root, TEXT("my-notes"));
+			FFileHelper::SaveStringToFile(TEXT("hello"), *FPaths::Combine(UserDir, TEXT("README.md")));
+
+			// Set B: only keep-tool remains.
+			FUnrealMcpToolRegistry RegB;
+			{
+				FUnrealMcpRegisteredTool Keep;
+				Keep.Name = TEXT("keep-tool");
+				Keep.Title = TEXT("Keep");
+				Keep.Description = TEXT("Stays across runs.");
+				RegB.Commit(MoveTemp(Keep));
+			}
+			const FUnrealMcpSkillFileGenerator::FResult B = FUnrealMcpSkillFileGenerator::Generate(RegB, Root);
+			TestTrue(TEXT("set B succeeded"), B.bSuccess);
+			TestEqual(TEXT("set B wrote one"), B.FilesWritten, 1);
+			TestEqual(TEXT("set B pruned the removed tool"), B.FilesPruned, 1);
+
+			TestTrue(TEXT("survivor SKILL.md kept"), FileManager.FileExists(*FPaths::Combine(Root, TEXT("keep-tool"), TEXT("SKILL.md"))));
+			TestFalse(TEXT("removed tool's SKILL.md gone"), FileManager.FileExists(*FPaths::Combine(Root, TEXT("drop-tool"), TEXT("SKILL.md"))));
+			TestTrue(TEXT("unrelated user folder untouched"), FileManager.FileExists(*FPaths::Combine(UserDir, TEXT("README.md"))));
+
+			SkillSpecDeleteTree(Root);
+		});
+
 		It("fails cleanly on an empty skills root", [this]()
 		{
 			FUnrealMcpToolRegistry Registry;


### PR DESCRIPTION
## Summary
- Adds per-agent skills-file generation to the AI Agent Configurators, reaching full Unity parity (Phase C, issue #53). Each skills-supporting agent gets a Skills section (auto-generate toggle + resolved output path + Generate button); skill docs (one `SKILL.md` per tool) are generated from the **Unreal C++ tool registry** (`FUnrealMcpToolRegistry`), the faithful Unreal analog of Unity's .NET-tool source.
- Wires `SkillsPath`/`SupportsSkills` per agent matching Unity's per-agent table (claude-code → `.claude/skills`, …; claude-desktop and unity-ai stay skills-less, exactly as Unity leaves them; Custom is user-overridable + persisted). Idempotent regeneration; **no secret/token is ever written to a skill file**.

## Skill-content-source decision (design)
Unity sources skill content from .NET tool reflection via the shared `McpPlugin.GenerateSkillFiles`, which lives in the bridge sidecar and only knows .NET tools — it has **no visibility into Unreal's C++ tool registry**, so reusing it verbatim would produce empty/wrong docs. The faithful Unreal source is `FUnrealMcpToolRegistry` (8 families / ~62 tools), which carries rich per-tool Title/Description/Params/schema metadata, enumerable headless on the game thread with no live bridge. Docs describe the actual Unreal tools an agent can call — accurate, not misleading. No HALT condition: a sensible Unreal analog exists.

## Test plan
- [x] UBT build (UE 5.7 testbed) — exit 0.
- [x] Headless boot smoke — `[Unreal-MCP] plugin loaded` + `Engine is initialized` (graceful Quit path; pre-existing teardown quirk not a halt per profile).
- [x] Automation specs `UnrealMcp.*` — 218 succeeded / 16 succeededWithWarnings / **0 failed**, incl. 15 new `UnrealMcp.AgentConfigurators.Skills` specs (per-agent gating, ResolveAbsoluteSkillsPath, config + view-model persistence, markdown shape + secret-free invariant, idempotent full-set generation).

Closes #53