### PR TITLE
ci(release): sign + notarize & bundle the sidecar into the packaged plugin (4 RID)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,30 @@
 #   check-version (read VersionName, compute gate) -> test fan-out -> artifact
 #   build -> GATED publish (tag + GitHub Release + npm).
 #
+# ── Signed self-bootstrapping sidecar BUNDLE (docs/ARCHITECTURE.md §6, #51) ──
+# The self-contained `unreal-mcp-bridge` is built + code-signed per RID, then
+# STAGED INTO the plugin tree before BuildPlugin, so the packaged plugin ships
+# the signed sidecar for all four RIDs and is self-bootstrapping out of the box
+# (no .NET install, no first-run download). Job graph:
+#   check-version ─┬─ bridge (test)            ─┐
+#                  ├─ test-cli                  │
+#                  ├─ plugin (BuildPlugin+Auto) │  (test gate)
+#                  ├─ build-bridge-macos  ──────┤  signs+notarizes osx, builds linux
+#                  ├─ build-bridge-windows ─────┤  Azure-signs win-x64
+#                  └─ build-plugin-zip ◄────────┘  downloads the 4 signed RID
+#                        dirs, stages them under
+#                        UnrealMCP/Binaries/ThirdParty/UnrealMcpBridge/<rid>/,
+#                        runs BuildPlugin -Rocket (RuntimeDependencies bundle
+#                        them), zips -> publish-release attaches the plugin zip
+#                        (bundle inside) + the 4 signed bridge zips.
+# Signing is GRACEFULLY DEGRADING: every sign/notarize step is `if: env.X != ''`
+# guarded, so a run with NO secrets produces UNSIGNED-but-green artifacts. The
+# Unreal-MCP repo has no signing secrets yet (the owner mirrors the 9 from
+# GameDev-MCP-Server out-of-band — see docs/RELEASING.md); this PR merges and
+# runs green without them and begins signing the moment they exist.
+# NOTE: artifacts pass between jobs, so a failed release MUST be FULL-rerun,
+# never `gh run rerun --failed` (a partial rerun loses the bridge artifacts).
+#
 # ── Gating (read docs/RELEASING.md for the full contract) ──────────────────
 # `UnrealMCP/UnrealMCP.uplugin` VersionName is the SINGLE source of truth for the
 # release version (commands/bump-version.ps1 keeps the other four files in sync).
@@ -329,15 +353,39 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  # ── ARTIFACT BUILD (runs on a real release OR a dry-run rehearsal) ─────────
+  # ── ARTIFACT BUILD — SIGNED BRIDGE BUNDLE (runs on a real release OR a
+  #    dry-run rehearsal). The self-contained bridge is built + code-signed per
+  #    RID here, then (T4) STAGED INTO the plugin tree before BuildPlugin so the
+  #    packaged plugin ships the signed sidecar (docs/ARCHITECTURE.md §6 BUNDLE
+  #    model, issue #51). Signing is GRACEFULLY DEGRADING: every sign/notarize
+  #    step is guarded `if: env.X != ''`, so a run with NO secrets still produces
+  #    UNSIGNED-but-green artifacts. The Unreal-MCP repo has no signing secrets
+  #    yet — this pipeline merges and runs green without them; it begins signing
+  #    the moment the owner mirrors the GameDev-MCP-Server secret set.
+  #    Platform split: codesign/notarytool are macOS-only and Azure Trusted
+  #    Signing (signtool) is Windows-only, so the osx/linux RIDs build on a Mac
+  #    runner and win-x64 builds on a Windows runner. ──────────────────────────
 
-  # bridge self-contained single-file binaries -> unreal-mcp-bridge-<rid>.zip ×4
-  # (§6). Cross-compiled from a single ubuntu host (no per-RID native toolchain).
-  build-bridge-zips:
-    name: build bridge zips
+  # macOS + Linux: osx-arm64, osx-x64 (codesign + notarize), linux-x64
+  # (unsigned, cross-built on the mac runner). Uploads the RAW per-RID publish
+  # dirs (NOT zips) as artifacts so build-plugin-zip can stage them into the
+  # plugin tree.
+  build-bridge-macos:
+    name: build bridge (macos + linux, signed)
     needs: [check-version]
     if: needs.check-version.outputs.run_tests == 'true'
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
+    # Job-level env so the signing/notarization guards (`if: env.X != ''`) can
+    # read these. A step's own `env:` is NOT visible to that same step's `if:` —
+    # the condition is evaluated before step env is applied — so the
+    # graceful-degradation guards MUST resolve their values at job scope.
+    env:
+      MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+      MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+      MAC_SIGN_IDENTITY: ${{ secrets.MAC_SIGN_IDENTITY }}
+      APPLE_API_KEY_B64: ${{ secrets.APPLE_API_KEY_B64 }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -347,13 +395,202 @@ jobs:
           dotnet-version: "9.0.x"
       - name: Make publish script executable
         run: chmod +x ./bridge/publish.sh
-      - name: Build self-contained bridge binaries for all RIDs
+      # --no-zip: sign the raw apphost BEFORE zipping. Cross-build linux-x64
+      # here too (no native linux toolchain needed for a portable self-contained
+      # apphost); it ships unsigned (no Linux code-signing standard — matches
+      # GameDev-MCP-Server).
+      - name: Build self-contained bridge (osx + linux, no zip)
         shell: bash
-        run: cd bridge && ./publish.sh Release
-      - name: Upload bridge zips
+        run: cd bridge && ./publish.sh Release osx-arm64 osx-x64 linux-x64 --no-zip
+
+      # Import the Developer ID Application certificate into a temporary
+      # keychain. Guarded on ALL THREE mac signing secrets so a partial-secrets
+      # dispatch skips the whole sign+notarize path cleanly rather than dying
+      # under `set -e` and taking the unsigned-upload fallback down with it.
+      - name: Import macOS signing certificate
+        if: ${{ env.MAC_CSC_LINK != '' && env.MAC_CSC_KEY_PASSWORD != '' && env.MAC_SIGN_IDENTITY != '' }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+
+          echo "$MAC_CSC_LINK" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$MAC_CSC_KEY_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
+          security set-key-partition-list -S apple-tool:,apple: \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+
+          rm -f "$CERT_PATH"
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+      # Code-sign each osx apphost with the hardened runtime + the bridge
+      # entitlements (allow-jit + disable-library-validation — the .NET
+      # single-file host JITs and loads runtime-extracted native libs). Signing
+      # ONLY the apphost suffices for the shipped single-file form;
+      # disable-library-validation is what makes the runtime-extracted libs
+      # legal at exec time. Same all-three-secrets guard as the import step.
+      - name: Code-sign macOS bridge (hardened runtime)
+        if: ${{ env.MAC_CSC_LINK != '' && env.MAC_CSC_KEY_PASSWORD != '' && env.MAC_SIGN_IDENTITY != '' }}
+        run: |
+          set -euo pipefail
+          ENTITLEMENTS="build/entitlements.mac.plist"
+          for rid in osx-arm64 osx-x64; do
+            BIN="bridge/publish/${rid}/unreal-mcp-bridge"
+            echo "Signing ${BIN}..."
+            codesign --force --options runtime --timestamp \
+              --entitlements "$ENTITLEMENTS" \
+              --sign "$MAC_SIGN_IDENTITY" "$BIN"
+            codesign --verify --strict --verbose=2 "$BIN"
+          done
+
+      # Notarize the two macOS apphosts. notarytool submits a ZIP, so zip each
+      # signed osx dir to a throwaway notarization zip, submit, and require
+      # status == "Accepted" (notarytool exits 0 even on Invalid/Rejected — the
+      # exit code alone is NOT proof). The artifact we upload is the signed
+      # publish DIR (not this zip) — the staged-into-plugin form is the binary,
+      # not a zip. Notarization registers the binary's hash with Apple, so the
+      # signed-and-notarized apphost passes Gatekeeper's first-exec check when
+      # the editor spawns it (belt-and-suspenders with the T2 quarantine-xattr
+      # strip for the offline case). Guarded on the signing secrets PLUS the
+      # notarize API key — notarizing an unsigned binary is meaningless.
+      - name: Notarize macOS bridge
+        if: ${{ env.MAC_CSC_LINK != '' && env.MAC_CSC_KEY_PASSWORD != '' && env.MAC_SIGN_IDENTITY != '' && env.APPLE_API_KEY_B64 != '' }}
+        run: |
+          set -euo pipefail
+          KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
+          echo "$APPLE_API_KEY_B64" | base64 --decode > "$KEY_PATH"
+
+          for rid in osx-arm64 osx-x64; do
+            NOTARIZE_ZIP="$RUNNER_TEMP/unreal-mcp-bridge-${rid}-notarize.zip"
+            (cd "bridge/publish/${rid}" && zip -r "$NOTARIZE_ZIP" .)
+            echo "Notarizing ${rid}..."
+            SUBMIT_JSON="$(xcrun notarytool submit "$NOTARIZE_ZIP" \
+              --key "$KEY_PATH" \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_ISSUER" \
+              --wait \
+              --output-format json)"
+            echo "$SUBMIT_JSON"
+            STATUS="$(echo "$SUBMIT_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("status",""))')"
+            if [ "$STATUS" != "Accepted" ]; then
+              echo "::error::Notarization for ${rid} did not succeed (status: ${STATUS:-unknown})"
+              exit 1
+            fi
+            echo "Notarization for ${rid} accepted."
+            rm -f "$NOTARIZE_ZIP"
+          done
+
+          rm -f "$KEY_PATH"
+
+      # Upload the RAW signed per-RID publish dirs (staging input for the plugin
+      # zip job) AND the per-RID release zips (kept as debugging /
+      # UNREAL_MCP_BRIDGE_PATH artifacts on the GitHub Release).
+      - name: Zip signed bridge dirs (release artifacts)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd bridge/publish
+          for rid in osx-arm64 osx-x64 linux-x64; do
+            if [ -d "$rid" ]; then
+              echo "Zipping ${rid}..."
+              (cd "$rid" && zip -r "../unreal-mcp-bridge-${rid}.zip" .)
+            else
+              echo "::error::Expected publish dir ${rid} not found"
+              exit 1
+            fi
+          done
+          ls -la *.zip
+      - name: Upload signed bridge staging dirs (osx + linux)
         uses: actions/upload-artifact@v4
         with:
-          name: unreal-mcp-bridge-zips
+          name: bridge-staging-osx-linux
+          path: |
+            ./bridge/publish/osx-arm64/
+            ./bridge/publish/osx-x64/
+            ./bridge/publish/linux-x64/
+          if-no-files-found: error
+          retention-days: 7
+      - name: Upload bridge release zips (osx + linux)
+        uses: actions/upload-artifact@v4
+        with:
+          name: bridge-release-zips-osx-linux
+          path: ./bridge/publish/*.zip
+          if-no-files-found: error
+          retention-days: 7
+
+  # Windows: win-x64, signed via Azure Trusted Signing (signtool is
+  # Windows-only). Built on windows-latest. Uploads the raw signed publish dir
+  # (staging input) AND the release zip.
+  build-bridge-windows:
+    name: build bridge (windows, signed)
+    needs: [check-version]
+    if: needs.check-version.outputs.run_tests == 'true'
+    runs-on: windows-latest
+    # Job-level env so the Azure Trusted Signing guard (`if: env.AZURE_CLIENT_ID
+    # != ''`) can read it — a step's own `env:` is not visible to that step's own
+    # `if:`. See the macOS job's env comment for the rationale.
+    env:
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+      # -NoZip: sign the raw .exe BEFORE zipping.
+      - name: Build self-contained bridge (win-x64, no zip)
+        shell: pwsh
+        run: ./bridge/publish.ps1 -Configuration Release -Platforms win-x64 -NoZip
+
+      # Sign the win-x64 .exe via Azure Trusted Signing. Guarded: skipped when
+      # AZURE_CLIENT_ID is empty, leaving the .exe unsigned but still stageable.
+      - name: Sign Windows bridge (Azure Trusted Signing)
+        if: ${{ env.AZURE_CLIENT_ID != '' }}
+        uses: azure/trusted-signing-action@v0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: https://eus.codesigning.azure.net
+          trusted-signing-account-name: ivan-murzak
+          certificate-profile-name: ai-game-dev-cert
+          files-folder: ${{ github.workspace }}/bridge/publish
+          files-folder-filter: exe
+          files-folder-recurse: true
+
+      - name: Zip signed bridge dir (release artifact)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $publishRoot = Join-Path $PWD "bridge/publish"
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          $rid = "win-x64"
+          $runtimePath = Join-Path $publishRoot $rid
+          if (-not (Test-Path $runtimePath)) { Write-Error "Expected publish dir $rid not found" }
+          $zipPath = Join-Path $publishRoot "unreal-mcp-bridge-$rid.zip"
+          if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
+          [System.IO.Compression.ZipFile]::CreateFromDirectory($runtimePath, $zipPath)
+          Get-ChildItem -Path $publishRoot -Filter "*.zip" | Select-Object Name, Length
+      - name: Upload signed bridge staging dir (win)
+        uses: actions/upload-artifact@v4
+        with:
+          name: bridge-staging-win
+          path: ./bridge/publish/win-x64/
+          if-no-files-found: error
+          retention-days: 7
+      - name: Upload bridge release zip (win)
+        uses: actions/upload-artifact@v4
+        with:
+          name: bridge-release-zips-win
           path: ./bridge/publish/*.zip
           if-no-files-found: error
           retention-days: 7
@@ -363,12 +600,15 @@ jobs:
   # <rid>.zip) and is released there; the CLI downloads the release pinned by
   # cli/src/lib/server-version.ts SERVER_VERSION.
 
-  # Engine-agnostic source plugin zip (BuildPlugin output). Self-hosted, gated
-  # like the plugin test job. Skipped when no runner is registered; for a real
-  # release the runner must be ready (publish-release `needs` this job).
+  # Engine-agnostic source plugin zip (BuildPlugin output) WITH the signed bridge
+  # bundled in. Self-hosted, gated like the plugin test job. Skipped when no
+  # runner is registered; for a real release the runner must be ready
+  # (publish-release `needs` this job). Depends on the two signed-bridge jobs so
+  # the 4 signed RID payloads can be staged into the plugin tree before
+  # BuildPlugin packages them (docs/ARCHITECTURE.md §6 BUNDLE model, T4).
   build-plugin-zip:
     name: build plugin zip (UE 5.7)
-    needs: [check-version]
+    needs: [check-version, build-bridge-macos, build-bridge-windows]
     if: needs.check-version.outputs.run_tests == 'true' && vars.UNREAL_RUNNER_READY == 'true'
     runs-on: [self-hosted, windows, unreal-5-7]
     env:
@@ -380,6 +620,48 @@ jobs:
           # Self-hosted runner persists between jobs; don't leave this job's
           # GITHUB_TOKEN in the worktree's .git config after checkout.
           persist-credentials: false
+      # Download the signed per-RID publish dirs produced by the two
+      # build-bridge-* jobs. The download lands at ./bridge-staging/<rid>/ —
+      # each artifact was uploaded as a per-RID directory tree (path:
+      # ./bridge/publish/<rid>/), so the artifact's own root holds the <rid>
+      # folder. Merge all into one staging root.
+      - name: Download signed bridge (osx + linux)
+        uses: actions/download-artifact@v4
+        with:
+          name: bridge-staging-osx-linux
+          path: ./bridge-staging
+      - name: Download signed bridge (win)
+        uses: actions/download-artifact@v4
+        with:
+          name: bridge-staging-win
+          path: ./bridge-staging
+      # Stage the signed binaries into the plugin tree at the EXACT path the C++
+      # resolver (FUnrealMcpSidecarManager::ResolveBridgeBinaryPath) and the
+      # Build.cs RuntimeDependencies wildcard both expect:
+      #   UnrealMCP/Binaries/ThirdParty/UnrealMcpBridge/<rid>/
+      # Binaries/ is gitignored — these files exist only transiently on the
+      # runner. With them present, BuildPlugin -Rocket's RuntimeDependencies pull
+      # them into the package; if a future UBT refuses an arbitrary ThirdParty
+      # path (design R6), the fallback is a post-BuildPlugin copy into the package
+      # output under the same relative path (the resolver path is identical).
+      - name: Stage signed bridge into the plugin tree
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $staging = Join-Path $env:GITHUB_WORKSPACE 'bridge-staging'
+          $dest = Join-Path $env:GITHUB_WORKSPACE 'UnrealMCP\Binaries\ThirdParty\UnrealMcpBridge'
+          $rids = @('win-x64', 'osx-arm64', 'osx-x64', 'linux-x64')
+          foreach ($rid in $rids) {
+            $src = Join-Path $staging $rid
+            if (-not (Test-Path $src)) { throw "Staged bridge dir missing for RID '$rid' at $src" }
+            $ridDest = Join-Path $dest $rid
+            if (Test-Path $ridDest) { Remove-Item $ridDest -Recurse -Force }
+            New-Item -ItemType Directory -Force -Path $ridDest | Out-Null
+            Copy-Item -Path (Join-Path $src '*') -Destination $ridDest -Recurse -Force
+            $files = Get-ChildItem -Path $ridDest -Recurse -File
+            Write-Host "Staged $($files.Count) file(s) for $rid -> $ridDest"
+            if ($files.Count -lt 1) { throw "No files staged for RID '$rid'." }
+          }
       - name: BuildPlugin + zip
         shell: pwsh
         env:
@@ -393,6 +675,23 @@ jobs:
           if (Test-Path $package) { Remove-Item $package -Recurse -Force }
           & $runUAT BuildPlugin -Plugin="$uplugin" -Package="$package" -TargetPlatforms=Win64 -Rocket
           if ($LASTEXITCODE -ne 0) { throw "BuildPlugin failed with exit code $LASTEXITCODE" }
+          # Verify the signed bridge bundle landed in the packaged plugin via
+          # RuntimeDependencies. If UBT did not stage the ThirdParty payloads
+          # (design R6), copy them into the package output under the same
+          # relative path as a fallback so the shipped zip always carries them.
+          $pkgThirdParty = Join-Path $package 'Binaries\ThirdParty\UnrealMcpBridge'
+          $srcThirdParty = Join-Path $env:GITHUB_WORKSPACE 'UnrealMCP\Binaries\ThirdParty\UnrealMcpBridge'
+          foreach ($rid in @('win-x64', 'osx-arm64', 'osx-x64', 'linux-x64')) {
+            $pkgRid = Join-Path $pkgThirdParty $rid
+            if (-not (Test-Path $pkgRid) -or @(Get-ChildItem -Path $pkgRid -Recurse -File -ErrorAction SilentlyContinue).Count -lt 1) {
+              Write-Host "RuntimeDependencies did not stage $rid into the package — applying post-step copy (design R6 fallback)."
+              New-Item -ItemType Directory -Force -Path $pkgRid | Out-Null
+              Copy-Item -Path (Join-Path (Join-Path $srcThirdParty $rid) '*') -Destination $pkgRid -Recurse -Force
+            }
+            $n = @(Get-ChildItem -Path $pkgRid -Recurse -File).Count
+            Write-Host "Packaged bridge for ${rid}: $n file(s)."
+            if ($n -lt 1) { throw "Packaged plugin is missing the bundled bridge for RID '$rid'." }
+          }
           $version = $env:PLUGIN_VERSION
           $out = Join-Path $env:GITHUB_WORKSPACE 'dist'
           New-Item -ItemType Directory -Force -Path $out | Out-Null
@@ -419,7 +718,8 @@ jobs:
         bridge,
         test-cli,
         plugin,
-        build-bridge-zips,
+        build-bridge-macos,
+        build-bridge-windows,
         build-plugin-zip,
       ]
     if: needs.check-version.outputs.should_release == 'true' && needs.check-version.outputs.dry_run != 'true' && github.ref == 'refs/heads/main'
@@ -431,10 +731,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Download bridge zips
+      # The END-USER artifact is the plugin zip (the signed bridge is bundled
+      # INSIDE it). The per-RID signed bridge zips are also attached for
+      # debugging / UNREAL_MCP_BRIDGE_PATH users.
+      - name: Download bridge release zips (osx + linux)
         uses: actions/download-artifact@v4
         with:
-          name: unreal-mcp-bridge-zips
+          name: bridge-release-zips-osx-linux
+          path: ./assets
+      - name: Download bridge release zip (win)
+        uses: actions/download-artifact@v4
+        with:
+          name: bridge-release-zips-win
           path: ./assets
       - name: Download plugin zip
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -621,10 +621,18 @@ jobs:
           # GITHUB_TOKEN in the worktree's .git config after checkout.
           persist-credentials: false
       # Download the signed per-RID publish dirs produced by the two
-      # build-bridge-* jobs. The download lands at ./bridge-staging/<rid>/ —
-      # each artifact was uploaded as a per-RID directory tree (path:
-      # ./bridge/publish/<rid>/), so the artifact's own root holds the <rid>
-      # folder. Merge all into one staging root.
+      # build-bridge-* jobs, merging all four RIDs under ./bridge-staging/<rid>/.
+      # The two artifacts were rooted differently by upload-artifact@v4:
+      #   * bridge-staging-osx-linux was uploaded with THREE dir paths
+      #     (osx-arm64/, osx-x64/, linux-x64/), so the artifact is rooted at
+      #     their least-common-ancestor (bridge/publish/) and PRESERVES the
+      #     top-level <rid>/ folders — extracting it to ./bridge-staging yields
+      #     ./bridge-staging/<rid>/ directly.
+      #   * bridge-staging-win was uploaded with a SINGLE dir path
+      #     (./bridge/publish/win-x64/), so the artifact is rooted AT that dir
+      #     and its contents are the win-x64 files WITHOUT the win-x64/ segment.
+      #     Extract it into ./bridge-staging/win-x64 so the segment is restored
+      #     and the staging loop below finds ./bridge-staging/win-x64/.
       - name: Download signed bridge (osx + linux)
         uses: actions/download-artifact@v4
         with:
@@ -634,7 +642,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: bridge-staging-win
-          path: ./bridge-staging
+          path: ./bridge-staging/win-x64
       # Stage the signed binaries into the plugin tree at the EXACT path the C++
       # resolver (FUnrealMcpSidecarManager::ResolveBridgeBinaryPath) and the
       # Build.cs RuntimeDependencies wildcard both expect:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -563,7 +563,7 @@ jobs:
           endpoint: https://eus.codesigning.azure.net
           trusted-signing-account-name: ivan-murzak
           certificate-profile-name: ai-game-dev-cert
-          files-folder: ${{ github.workspace }}/bridge/publish
+          files-folder: ${{ github.workspace }}/bridge/publish/win-x64
           files-folder-filter: exe
           files-folder-recurse: true
 

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    Hardened-runtime entitlements required for the self-contained .NET
+    (single-file) unreal-mcp-bridge host to run under Gatekeeper AND pass
+    Apple notarization. The .NET runtime JITs managed code, so it needs
+    allow-jit; the single-file host extracts/loads native libraries that are
+    not all individually signed under this identity, so it needs
+    disable-library-validation. Trimmed to what the bridge host actually
+    requires — identical to the GameDev-MCP-Server entitlements (the bridge
+    reuses that signing flow verbatim; docs/ARCHITECTURE.md §6 BUNDLE model).
+  -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -377,7 +377,7 @@ Notes:
 ## Re-running a release — full rerun only
 
 If a release run fails partway, **always use a full re-run, never "re-run failed
-jobs"**. The artifact-build jobs (`build-bridge-zips`, `build-plugin-zip`)
+jobs"**. The artifact-build jobs (`build-bridge-macos`, `build-bridge-windows`, `build-plugin-zip`)
 upload artifacts that the `publish-release` job downloads; a
 partial re-run does not re-run the succeeded build jobs, so their artifacts are
 absent on the new attempt and `publish-release` fails with `Artifact not found`.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,7 +43,43 @@ hard-skips every tag/Release/npm-publish job.
 | --- | --- | --- |
 | `test_pull_request.yml` | `pull_request` to `main` (+ manual) | Fans out the PR test legs: bridge build+xUnit (ubuntu + windows), cli node 20/22, and — when a runner is registered — the UE 5.7 plugin BuildPlugin + Automation leg. |
 | `test_cli.yml` | `workflow_call` (reusable) | Builds + tests `unreal-mcp-cli` on Node 20 & 22. Called by both `test_pull_request.yml` and `release.yml`. |
-| `release.yml` | `push` to `main` (+ manual `workflow_dispatch`) | Version-gated release: builds bridge/plugin artifacts and (only on a real version bump) cuts the GitHub Release + tag and publishes `unreal-mcp-cli` to npm. Exposes a `dry_run` input to rehearse everything without publishing. |
+| `release.yml` | `push` to `main` (+ manual `workflow_dispatch`) | Version-gated release: builds + **code-signs** the self-contained bridge per RID, **bundles the signed sidecar into the packaged plugin** (BuildPlugin), and (only on a real version bump) cuts the GitHub Release + tag and publishes `unreal-mcp-cli` to npm. Exposes a `dry_run` input to rehearse everything without publishing. |
+
+### The signed self-bootstrapping sidecar bundle (release.yml artifact graph)
+
+The packaged plugin ships the **signed, self-contained** `unreal-mcp-bridge` for
+all four RIDs (`win-x64`, `osx-arm64`, `osx-x64`, `linux-x64`), so the end user
+installs no .NET and performs no first-run download — the plugin is
+self-bootstrapping out of the box (`docs/ARCHITECTURE.md` §6 BUNDLE model). The
+artifact jobs in `release.yml`:
+
+- **`build-bridge-macos`** (`macos-latest`) — publishes osx-arm64 / osx-x64 /
+  linux-x64 self-contained, **codesigns** the two osx apphosts (hardened runtime
+  + `build/entitlements.mac.plist`) and **notarizes** them, then uploads the raw
+  signed dirs (staging input) + the per-RID release zips. linux-x64 ships
+  unsigned (no Linux code-signing standard — matches GameDev-MCP-Server).
+- **`build-bridge-windows`** (`windows-latest`) — publishes win-x64
+  self-contained and signs the `.exe` via **Azure Trusted Signing**, then uploads
+  the raw signed dir + the release zip. (signtool is Windows-only; codesign /
+  notarytool are macOS-only — hence the two-runner split.)
+- **`build-plugin-zip`** (self-hosted UE 5.7) — downloads the four signed RID
+  dirs, **stages them into `UnrealMCP/Binaries/ThirdParty/UnrealMcpBridge/<rid>/`**
+  (the exact path the C++ resolver + the `UnrealMcpEditor.Build.cs`
+  `RuntimeDependencies` wildcard expect), runs `BuildPlugin -Rocket` so the
+  staged binaries are packaged, then zips the plugin. A post-BuildPlugin guard
+  copies the binaries into the package output if `RuntimeDependencies` did not
+  stage them (a defensive fallback for the one unverified UBT behavior).
+
+**Binaries are never committed to git.** `Binaries/` is gitignored; the signed
+binaries exist only transiently on the runners during a release. A dev source
+checkout has an empty `Binaries/ThirdParty/UnrealMcpBridge/`, so
+`ResolveBridgeBinaryPath` returns empty and devs use `UNREAL_MCP_BRIDGE_PATH`
+(the documented inner loop) — unchanged.
+
+**Graceful degradation:** every sign/notarize step is `if: env.X != ''`-guarded.
+A run with no signing secrets still produces **unsigned-but-green** artifacts, so
+the pipeline merged and runs green before the secrets were provisioned and begins
+signing the moment they are mirrored (see [Signing secrets](#signing-secrets-code-signing--notarization-owner-provisioned) below).
 
 ## Versioning — the single source of truth
 
@@ -111,10 +147,16 @@ gh workflow run release.yml --repo IvanMurzak/Unreal-MCP -f dry_run=true
 gh run watch --repo IvanMurzak/Unreal-MCP "$(gh run list --repo IvanMurzak/Unreal-MCP --workflow release.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
 ```
 
-Expected: `bridge`, `test-cli`, `build-bridge-zips` succeed;
-the `plugin` / `build-plugin-zip` legs run only if the self-hosted runner is
-registered (otherwise skipped); `publish-release` and `publish-npm` are
-**skipped**. Verify nothing was published:
+Expected: `bridge`, `test-cli`, `build-bridge-macos`, `build-bridge-windows`
+succeed (the bridge build + sign jobs run on every rehearsal; with no secrets
+they produce unsigned-but-green artifacts); the `plugin` / `build-plugin-zip`
+legs run only if the self-hosted runner is registered (otherwise skipped);
+`publish-release` and `publish-npm` are **skipped**. A dry-run is the right way
+to confirm the bundle staging works end-to-end: when the runner is ready,
+inspect `build-plugin-zip`'s log for the per-RID "Packaged bridge for <rid>: N
+file(s)." lines (and download the `unreal-mcp-plugin-zip` artifact to confirm
+`Binaries/ThirdParty/UnrealMcpBridge/<rid>/` is populated for all four RIDs).
+Verify nothing was published:
 
 ```bash
 gh release list --repo IvanMurzak/Unreal-MCP     # expect: empty
@@ -290,6 +332,47 @@ handles every subsequent version. See <https://docs.npmjs.com/trusted-publishers
 
 No secret is ever echoed to logs; the sidecar IPC token (`UNREAL_MCP_TOKEN`)
 travels via stdin and is unrelated to CI.
+
+### Signing secrets (code-signing + notarization, owner-provisioned)
+
+The bundled bridge is code-signed in `build-bridge-macos` (Apple codesign +
+notarize) and `build-bridge-windows` (Azure Trusted Signing). These are
+**owner-provisioned** and identical in shape to the GameDev-MCP-Server secret
+set. **The Unreal-MCP repo has none of them yet** — every signing step is
+`if: env.X != ''`-guarded, so the pipeline merges and runs green producing
+**unsigned** artifacts until the owner mirrors them. Releases are unsigned until
+provisioned; signing begins automatically on the next release after they exist.
+
+Provision them via `gh secret set --repo IvanMurzak/Unreal-MCP <NAME>` (or
+*Settings → Secrets and variables → Actions → Secrets*) with the **same values
+as `IvanMurzak/GameDev-MCP-Server`** (GitHub Actions secrets are per-repo — there
+is no org-level inheritance):
+
+| Secret | Used by | Purpose |
+| --- | --- | --- |
+| `MAC_CSC_LINK` | `build-bridge-macos` | Base64 Developer ID Application `.p12` certificate. |
+| `MAC_CSC_KEY_PASSWORD` | `build-bridge-macos` | Password for the `.p12`. |
+| `MAC_SIGN_IDENTITY` | `build-bridge-macos` | `codesign --sign` identity (Developer ID Application: …). |
+| `APPLE_API_KEY_B64` | `build-bridge-macos` | Base64 App Store Connect API key (`.p8`) for `notarytool`. |
+| `APPLE_API_KEY_ID` | `build-bridge-macos` | App Store Connect API key id. |
+| `APPLE_API_ISSUER` | `build-bridge-macos` | App Store Connect API issuer id. |
+| `AZURE_TENANT_ID` | `build-bridge-windows` | Azure Trusted Signing tenant id. |
+| `AZURE_CLIENT_ID` | `build-bridge-windows` | Azure Trusted Signing client id (also the guard for the win sign step). |
+| `AZURE_CLIENT_SECRET` | `build-bridge-windows` | Azure Trusted Signing client secret. |
+
+Notes:
+
+- The macOS sign + notarize steps are guarded on **all three** mac signing
+  secrets together (and notarize additionally on `APPLE_API_KEY_B64`), so a
+  partial-secrets state skips the whole signing path cleanly rather than failing
+  mid-way. The Windows sign step is guarded on `AZURE_CLIENT_ID`.
+- The Azure Trusted Signing account (`ivan-murzak`) and certificate profile
+  (`ai-game-dev-cert`) are hard-coded in the workflow (non-sensitive), matching
+  GameDev-MCP-Server.
+- Signing only the single-file apphost is sufficient for the shipped form: the
+  `disable-library-validation` entitlement makes the runtime-extracted native
+  libs legal at exec time. The C++ side additionally strips the macOS
+  `com.apple.quarantine` xattr at spawn (T2) for the offline-exec case.
 
 ## Re-running a release — full rerun only
 


### PR DESCRIPTION
## Summary
- Completes the BUNDLE self-bootstrapping-sidecar model (**T3 + T4**): the packaged plugin now ships the **signed, self-contained** `unreal-mcp-bridge` for all four RIDs (win-x64/osx-arm64/osx-x64/linux-x64), so the end user installs no .NET and the plugin auto-spawns the bundled bridge with zero clicks (`docs/ARCHITECTURE.md` §6). Builds on merged T1 (#48) + T2 (#49).
- `release.yml`: two signed bridge builders — `build-bridge-macos` (codesign hardened-runtime + notarytool on osx, cross-builds unsigned linux-x64) and `build-bridge-windows` (Azure Trusted Signing on win-x64) — replace the old single unsigned ubuntu job. `build-plugin-zip` downloads the 4 signed RID dirs, stages them at `UnrealMCP/Binaries/ThirdParty/UnrealMcpBridge/<rid>/`, runs `BuildPlugin -Rocket` (RuntimeDependencies bundle them; post-step copy fallback for design R6), and verifies each RID landed. `publish-release` attaches the plugin zip (bundle inside) + the 4 signed bridge zips.
- **Graceful degradation:** every sign/notarize step is `if: env.X != ''`-guarded — a secretless run stays green with **unsigned** artifacts. Unreal-MCP has zero signing secrets today; signing begins automatically once the owner mirrors the 9 from GameDev-MCP-Server (documented). No version bump; `release.yml` stays version-gated (a normal merge — including this one — publishes nothing).
- New `build/entitlements.mac.plist` (allow-jit + disable-library-validation) reuses the GameDev-MCP-Server signing flow verbatim. `docs/RELEASING.md` documents the artifact graph, the 9 signing secrets, and the bundle-staging verification.

## Test plan
- [x] `actionlint` 1.7.12 clean (0 findings) on all `.github/workflows/*.yml`.
- [x] Suite 4 (release.yml `bridge` job legs): `dotnet restore/build` green, xUnit **90/90** pass.
- [x] Replayed the `build-bridge-windows` publish leg (`publish.ps1 -Platforms win-x64 -NoZip`) → produces exactly one self-contained `unreal-mcp-bridge.exe` (~73 MB, 0 `.pdb`, no zip) — confirms the staging-dir shape the plugin job copies and Azure's `files-folder-filter: exe` targets.
- [ ] Full signed-release run can only be exercised on the self-hosted UE 5.7 runner + with secrets (version-gated; not reachable in PR CI). Verify via a `dry_run=true` dispatch after merge (see `docs/RELEASING.md`).

Closes #51