### PR TITLE
feat(ui): AI agent configurators UI polish — Custom-only snippet, relative skills path, live connection refresh

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
@@ -107,7 +107,28 @@ void SUnrealMcpAgentConfigurators::Construct(const FArguments& InArgs)
 		]
 	];
 
+	// Subscribe to connection-setting changes so the panel re-resolves + rebuilds when the user edits the
+	// connection mode / host / auth / token in the main window — without reselecting the agent (§7; the C++/Slate
+	// analog of Unity's InvalidateAndReloadAgentUI). The handle is removed in the destructor.
+	if (IsViewModelValid())
+		ConnectionChangedHandle = ViewModel->OnConnectionSettingsChanged.AddSP(this, &SUnrealMcpAgentConfigurators::OnConnectionSettingsChanged);
+
 	RefreshSelectedConfigurator();
+}
+
+SUnrealMcpAgentConfigurators::~SUnrealMcpAgentConfigurators()
+{
+	if (ViewModel.IsValid() && ConnectionChangedHandle.IsValid())
+		ViewModel->OnConnectionSettingsChanged.Remove(ConnectionChangedHandle);
+}
+
+void SUnrealMcpAgentConfigurators::OnConnectionSettingsChanged()
+{
+	// A connection setting changed. Re-bind the selected configurator to the now-current connection info (BindSelected
+	// calls Initialize, which invalidates the cached STDIO/HTTP configs) and rebuild the panel so the snippet preview,
+	// the per-transport status, and what Configure() will write all reflect the new settings.
+	BindSelected();
+	RebuildAgentPanel();
 }
 
 void SUnrealMcpAgentConfigurators::RefreshSelectedConfigurator()
@@ -204,8 +225,13 @@ void SUnrealMcpAgentConfigurators::RebuildAgentPanel()
 		];
 	}
 
+	// The raw config/snippet text field is noise for built-in agents (their Configure button writes the file
+	// directly); only the snippet-only Custom agent — which has no config path, so the user pastes the snippet by
+	// hand — keeps showing it (§7, issue #56). Computed once here; the panel is rebuilt on every selection change.
+	const bool bShowSnippet = Selected.IsValid() && Selected->GetAgentId() == TEXT("other-custom");
+
 	// A reusable transport section builder (STDIO and HTTP share the same shape).
-	auto BuildTransportSection = [this](const FText& Heading, bool bStdio) -> TSharedRef<SWidget>
+	auto BuildTransportSection = [this, bShowSnippet](const FText& Heading, bool bStdio) -> TSharedRef<SWidget>
 	{
 		return SNew(SVerticalBox)
 			+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)
@@ -233,12 +259,14 @@ void SUnrealMcpAgentConfigurators::RebuildAgentPanel()
 					return FSlateColor(FLinearColor(0.85f, 0.65f, 0.20f));
 				})
 			]
-			// Snippet preview (read-only, token-masked).
+			// Snippet preview (read-only, token-masked) — shown ONLY for the Custom agent (§7, issue #56). Built-in
+			// agents write their config file via Configure, so the raw snippet text is noise and is collapsed.
 			+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
 			[
 				SNew(SMultiLineEditableTextBox)
 				.IsReadOnly(true)
 				.AlwaysShowScrollbars(false)
+				.Visibility(bShowSnippet ? EVisibility::Visible : EVisibility::Collapsed)
 				.Text_Lambda([this, bStdio]()
 				{
 					return FText::FromString(BuildSnippetPreview(bStdio));
@@ -356,6 +384,26 @@ FString SUnrealMcpAgentConfigurators::ResolveSelectedSkillsPath() const
 	return Selected->ResolveAbsoluteSkillsPath(ProjectRoot);
 }
 
+FString SUnrealMcpAgentConfigurators::MakeDisplayPath(const FString& AbsolutePath) const
+{
+	if (AbsolutePath.IsEmpty())
+		return AbsolutePath;
+
+	FString ProjectRoot = ProjectRootProvider ? ProjectRootProvider() : FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
+	ProjectRoot = FPaths::ConvertRelativePathToFull(ProjectRoot);
+	if (ProjectRoot.IsEmpty())
+		return AbsolutePath;
+
+	// MakePathRelativeTo mutates its first arg in place and needs a trailing slash on the base (the pattern used in
+	// Tools/UnrealMcpSourceTools.cpp). When the path is not under the root it leaves a "../"-style result; fall back
+	// to the absolute path in that case rather than show a confusing climb-out.
+	FString Relative = AbsolutePath;
+	FPaths::MakePathRelativeTo(Relative, *(ProjectRoot / TEXT("")));
+	if (Relative.IsEmpty() || Relative.StartsWith(TEXT("..")))
+		return AbsolutePath;
+	return Relative;
+}
+
 void SUnrealMcpAgentConfigurators::GenerateSkillsForSelected()
 {
 	const FString SkillsRoot = ResolveSelectedSkillsPath();
@@ -442,12 +490,15 @@ TSharedRef<SWidget> SUnrealMcpAgentConfigurators::BuildSkillsSection()
 		];
 	}
 
-	// The resolved absolute output path (always shown — read-only).
+	// The resolved output path, shown project-root-relative (e.g. ".claude/skills") for readability (§7, issue #56).
+	// The full absolute path stays available as the tooltip so the user can still see exactly where files land.
+	const FString DisplayPath = MakeDisplayPath(AbsolutePath);
 	Section->AddSlot().AutoHeight().Padding(0, 4, 0, 0)
 	[
 		SNew(STextBlock)
 		.AutoWrapText(true)
-		.Text(FText::Format(LOCTEXT("SkillsOutFmt", "Output: {0}"), FText::FromString(AbsolutePath)))
+		.Text(FText::Format(LOCTEXT("SkillsOutFmt", "Output: {0}"), FText::FromString(DisplayPath)))
+		.ToolTipText(FText::FromString(AbsolutePath))
 	];
 
 	// Generate button (explicit regeneration; idempotent).

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
@@ -228,7 +228,8 @@ void SUnrealMcpAgentConfigurators::RebuildAgentPanel()
 	// The raw config/snippet text field is noise for built-in agents (their Configure button writes the file
 	// directly); only the snippet-only Custom agent — which has no config path, so the user pastes the snippet by
 	// hand — keeps showing it (§7, issue #56). Computed once here; the panel is rebuilt on every selection change.
-	const bool bShowSnippet = Selected.IsValid() && Selected->GetAgentId() == TEXT("other-custom");
+	// Selected is guaranteed valid here — RebuildAgentPanel early-returns above when it is not.
+	const bool bShowSnippet = Selected->GetAgentId() == TEXT("other-custom");
 
 	// A reusable transport section builder (STDIO and HTTP share the same shape).
 	auto BuildTransportSection = [this, bShowSnippet](const FText& Heading, bool bStdio) -> TSharedRef<SWidget>

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.h
@@ -48,11 +48,16 @@ public:
 	SLATE_END_ARGS()
 
 	void Construct(const FArguments& InArgs);
+	virtual ~SUnrealMcpAgentConfigurators() override;
 
 private:
 	TSharedPtr<FUnrealMcpEditorViewModel> ViewModel;
 	TFunction<FAiAgentConnectionInfo()> ConnectionInfoProvider;
 	TFunction<FString()> ProjectRootProvider;
+
+	// Handle for the view-model's OnConnectionSettingsChanged subscription, removed in the destructor so a
+	// connection-setting change after this widget is gone never invokes a dangling handler.
+	FDelegateHandle ConnectionChangedHandle;
 
 	TSharedPtr<FAiAgentConfiguratorRegistry> Registry;
 	// The dropdown's item source (agent display names, registry order).
@@ -70,6 +75,10 @@ private:
 
 	// Re-resolve the selected configurator from the view-model + provider and rebuild its panel.
 	void RefreshSelectedConfigurator();
+	// Handler for FUnrealMcpEditorViewModel::OnConnectionSettingsChanged: invalidate the active configurator's
+	// cached config (re-resolved from fresh connection info) and rebuild the panel, so the shown snippet/status
+	// AND what Configure() writes track the new connection settings without the user reselecting the agent.
+	void OnConnectionSettingsChanged();
 	// (Re)build the per-agent panel for the current Selected configurator into AgentPanelContainer.
 	void RebuildAgentPanel();
 	// Bind the selected configurator to the live connection info + project root.
@@ -86,6 +95,13 @@ private:
 	TSharedRef<SWidget> BuildSkillsSection();
 	/** Resolve the selected agent's absolute skills folder (project-relative resolved under the live project root). */
 	FString ResolveSelectedSkillsPath() const;
+	/**
+	 * Convert an absolute filesystem path to a project-root-relative display string (forward slashes, no leading
+	 * "./"); mirrors Unity's ToDisplayPath and the FPaths::MakePathRelativeTo pattern in UnrealMcpSourceTools.
+	 * A path already outside / not under the project root, or an empty input, is returned unchanged (still useful
+	 * as a fallback display). The full absolute path stays available as the widget's tooltip.
+	 */
+	FString MakeDisplayPath(const FString& AbsolutePath) const;
 	/** Generate the SKILL.md files for the selected agent into its resolved skills folder (idempotent). Logs the result. */
 	void GenerateSkillsForSelected();
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -136,6 +136,11 @@ void FUnrealMcpEditorViewModel::CancelAuth()
 
 void FUnrealMcpEditorViewModel::Revoke()
 {
+	// A no-op Revoke (no bearer stored) must not churn the store / re-push / rebuild the panel — mirror the
+	// no-op guards on SetConnectionMode/SetCustomHost/SetAuthOption/SetCustomToken. Always clear the device-auth
+	// indicator state and tell the sidecar (auth-revoke is idempotent), but only persist/push/notify when a token
+	// was actually dropped.
+	const bool bHadToken = !Config.CloudToken.IsEmpty();
 	Config.CloudToken.Reset();
 	DeviceAuthState = EUnrealMcpDeviceAuthState::Idle;
 	DeviceVerificationUrl.Reset();
@@ -143,10 +148,13 @@ void FUnrealMcpEditorViewModel::Revoke()
 	DeviceAuthError.Reset();
 	if (OnSendAuth)
 		OnSendAuth(TEXT("auth-revoke"));
-	// CloudToken changed — persist (Save restores env/.env overrides) and push the now-anonymous config.
-	PersistAndPush();
-	// The Cloud-mode bearer the configurators inject is now gone — refresh so the snippet drops it.
-	OnConnectionSettingsChanged.Broadcast();
+	if (bHadToken)
+	{
+		// CloudToken changed — persist (Save restores env/.env overrides) and push the now-anonymous config.
+		PersistAndPush();
+		// The Cloud-mode bearer the configurators inject is now gone — refresh so the snippet drops it.
+		OnConnectionSettingsChanged.Broadcast();
+	}
 }
 
 void FUnrealMcpEditorViewModel::ApplyStatus(const TSharedPtr<FJsonObject>& Status)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -33,6 +33,9 @@ void FUnrealMcpEditorViewModel::SetConnectionMode(EUnrealMcpConnectionMode InMod
 		return;
 	Config.ConnectionMode = InMode;
 	PersistAndPush();
+	// The resolved connection facts (auth-required, token source, http url) all hinge on the mode, so the agent
+	// configurators must re-resolve their cached config + rebuild their panel (Unity's InvalidateAndReloadAgentUI).
+	OnConnectionSettingsChanged.Broadcast();
 }
 
 void FUnrealMcpEditorViewModel::SetCustomHost(const FString& InHost)
@@ -42,12 +45,17 @@ void FUnrealMcpEditorViewModel::SetCustomHost(const FString& InHost)
 	// the field, the §8 store, and the dial target stay consistent. Only push a host that validates — pushing a
 	// malformed URL to the sidecar would just make it dial nowhere (§7 validated field).
 	const FString Trimmed = InHost.TrimStartAndEnd();
+	const bool bChanged = Config.CustomHost != Trimmed;
 	Config.CustomHost = Trimmed;
 	FString Error;
 	if (ValidateServerUrl(Trimmed, Error))
 	{
 		PersistAndPush();
 	}
+	// Refresh the configurators on any host change (even before it validates) so the previewed HTTP url tracks
+	// what the user typed; the panel reads the host through the connection-info provider, not the dialed target.
+	if (bChanged)
+		OnConnectionSettingsChanged.Broadcast();
 }
 
 void FUnrealMcpEditorViewModel::SetAuthOption(EUnrealMcpAuthOption InOption)
@@ -56,12 +64,18 @@ void FUnrealMcpEditorViewModel::SetAuthOption(EUnrealMcpAuthOption InOption)
 		return;
 	Config.AuthOption = InOption;
 	PersistAndPush();
+	// Auth-required toggles whether the snippet carries a bearer header/arg — the configurators must re-resolve.
+	OnConnectionSettingsChanged.Broadcast();
 }
 
 void FUnrealMcpEditorViewModel::SetCustomToken(const FString& InToken)
 {
+	if (Config.CustomToken == InToken)
+		return;
 	Config.CustomToken = InToken;
 	PersistAndPush();
+	// The token is injected into the STDIO args / HTTP Authorization header — refresh the configurators.
+	OnConnectionSettingsChanged.Broadcast();
 }
 
 void FUnrealMcpEditorViewModel::GenerateCustomToken()
@@ -72,6 +86,8 @@ void FUnrealMcpEditorViewModel::GenerateCustomToken()
 	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] generated a new Custom-mode token (%s)."),
 		*FUnrealMcpConfig::MaskSecret(Config.CustomToken));
 	PersistAndPush();
+	// New token + auth flipped to required — the configurators' snippet/Configure output must reflect both.
+	OnConnectionSettingsChanged.Broadcast();
 }
 
 void FUnrealMcpEditorViewModel::Connect()
@@ -129,6 +145,8 @@ void FUnrealMcpEditorViewModel::Revoke()
 		OnSendAuth(TEXT("auth-revoke"));
 	// CloudToken changed — persist (Save restores env/.env overrides) and push the now-anonymous config.
 	PersistAndPush();
+	// The Cloud-mode bearer the configurators inject is now gone — refresh so the snippet drops it.
+	OnConnectionSettingsChanged.Broadcast();
 }
 
 void FUnrealMcpEditorViewModel::ApplyStatus(const TSharedPtr<FJsonObject>& Status)
@@ -212,6 +230,8 @@ void FUnrealMcpEditorViewModel::ApplyDeviceAuth(const TSharedPtr<FJsonObject>& D
 			{
 				Config.CloudToken = Token;
 				PersistAndPush();
+				// A fresh Cloud bearer landed — the configurators inject it into the Cloud-mode snippet; refresh.
+				OnConnectionSettingsChanged.Broadcast();
 			}
 		}
 		else if (StateRaw.Equals(TEXT("failed"), ESearchCase::IgnoreCase) || StateRaw.Equals(TEXT("denied"), ESearchCase::IgnoreCase) || StateRaw.Equals(TEXT("expired"), ESearchCase::IgnoreCase))

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
@@ -81,6 +81,17 @@ public:
 	 */
 	TFunction<void(const TArray<FString>& /*DisabledTools*/)> OnToolEnablementChanged;
 
+	/**
+	 * Fires whenever a connection-affecting setting changes — connection mode (Cloud↔Custom), Custom host,
+	 * auth option, the Custom/Cloud token. The AI Agent Configurators panel subscribes to this so it can
+	 * invalidate the active configurator's cached STDIO/HTTP config and rebuild itself, keeping the shown
+	 * snippet/status AND what Configure() writes in sync with the live connection WITHOUT the user reselecting
+	 * the agent (the C++/Slate analog of Unity's InvalidateAndReloadAgentUI). Broadcast-only and side-effect
+	 * free in the view-model; subscribers do the invalidation. Specs can bind a recording lambda to assert the
+	 * notification fires. Subscribers MUST unbind (via the returned handle) before they are destroyed.
+	 */
+	FSimpleMulticastDelegate OnConnectionSettingsChanged;
+
 	// --- Config accessors (the working §8 config the UI edits). ---
 
 	const FUnrealMcpConfig& GetConfig() const { return Config; }

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
@@ -299,6 +299,40 @@ void FUnrealMcpEditorViewModelSpec::Define()
 			TestTrue("auth-revoke sent", Rec->AuthSent.Contains(TEXT("auth-revoke")));
 		});
 
+		It("Revoke notifies + pushes only when a token was actually dropped; a no-op Revoke does neither", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			int32 Notifications = 0;
+			FDelegateHandle Handle = VM->OnConnectionSettingsChanged.AddLambda([&Notifications]() { Notifications++; });
+
+			// No token stored → Revoke is a no-op: clears indicator state + sends idempotent auth-revoke, but must
+			// NOT persist/push or fire a spurious panel rebuild (mirrors the no-op guards on the other setters).
+			TestFalse("no token before no-op revoke", VM->HasCloudToken());
+			VM->Revoke();
+			TestEqual("no-op revoke did not notify", Notifications, 0);
+			TestEqual("no-op revoke did not push", Rec->PushCount, 0);
+			TestTrue("auth-revoke still sent (idempotent)", Rec->AuthSent.Contains(TEXT("auth-revoke")));
+
+			// Now store a real bearer, then Revoke: this DOES drop a token → notify + push exactly once.
+			VM->Authorize();
+			TSharedPtr<FJsonObject> Authorized = MakeShared<FJsonObject>();
+			Authorized->SetStringField(TEXT("state"), TEXT("authorized"));
+			Authorized->SetStringField(TEXT("token"), TEXT("cloud-bearer-xyz"));
+			VM->ApplyDeviceAuth(Authorized);
+			TestTrue("token present before revoke", VM->HasCloudToken());
+			const int32 NotificationsBeforeRevoke = Notifications;
+			const int32 PushesBeforeRevoke = Rec->PushCount;
+
+			VM->Revoke();
+			TestFalse("token cleared after revoke", VM->HasCloudToken());
+			TestEqual("token-dropping revoke notified once", Notifications, NotificationsBeforeRevoke + 1);
+			TestEqual("token-dropping revoke pushed once", Rec->PushCount, PushesBeforeRevoke + 1);
+
+			VM->OnConnectionSettingsChanged.Remove(Handle);
+		});
+
 		It("ignores an authorized device-auth that races in after the user cancelled the flow", [this]()
 		{
 			TSharedRef<FRecording> Rec = MakeShared<FRecording>();

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
@@ -150,6 +150,63 @@ void FUnrealMcpEditorViewModelSpec::Define()
 		});
 	});
 
+	Describe("Connection-settings change notification (§7 — the InvalidateAndReloadAgentUI seam, issue #56)", [this]()
+	{
+		It("fires OnConnectionSettingsChanged when the mode / host / auth / token change so the agent panel can re-resolve", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			int32 Notifications = 0;
+			FDelegateHandle Handle = VM->OnConnectionSettingsChanged.AddLambda([&Notifications]() { Notifications++; });
+
+			// Mode change Cloud (default) -> Custom: one notification.
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			TestEqual("mode change notified", Notifications, 1);
+
+			// A no-op mode set (already Custom) must NOT notify — avoid spurious panel churn.
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			TestEqual("no-op mode change did not notify", Notifications, 1);
+
+			// Host change (even an invalid one) refreshes the previewed url.
+			VM->SetCustomHost(TEXT("http://localhost:9100"));
+			TestEqual("host change notified", Notifications, 2);
+
+			// A no-op host set (same value) must NOT notify.
+			VM->SetCustomHost(TEXT("http://localhost:9100"));
+			TestEqual("no-op host change did not notify", Notifications, 2);
+
+			// Auth option change toggles whether the snippet carries a bearer.
+			VM->SetAuthOption(EUnrealMcpAuthOption::Required);
+			TestEqual("auth change notified", Notifications, 3);
+
+			// Token change is injected into the snippet/Configure output.
+			VM->SetCustomToken(TEXT("fresh-token"));
+			TestEqual("token change notified", Notifications, 4);
+
+			// A no-op token set (same value) must NOT notify.
+			VM->SetCustomToken(TEXT("fresh-token"));
+			TestEqual("no-op token change did not notify", Notifications, 4);
+
+			VM->OnConnectionSettingsChanged.Remove(Handle);
+		});
+
+		It("does NOT notify after the subscriber unbinds (no dangling-handler refresh)", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			int32 Notifications = 0;
+			FDelegateHandle Handle = VM->OnConnectionSettingsChanged.AddLambda([&Notifications]() { Notifications++; });
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			TestEqual("notified while bound", Notifications, 1);
+
+			VM->OnConnectionSettingsChanged.Remove(Handle);
+			VM->SetCustomHost(TEXT("http://localhost:9200"));
+			TestEqual("no notification after unbind", Notifications, 1);
+		});
+	});
+
 	Describe("Cloud device-code auth", [this]()
 	{
 		It("Authorize sends auth-start; device-auth feed opens the browser once and stores the token", [this]()


### PR DESCRIPTION
## Summary
- Hide the raw config snippet for built-in agents (their Configure button writes the file directly); keep it only for the snippet-only Custom agent (`other-custom`), where the user pastes by hand.
- Show the skills "Output:" path project-root-relative (e.g. `.claude/skills`) with the full absolute path as a tooltip, via a new `MakeDisplayPath()` helper.
- Add `FUnrealMcpEditorViewModel::OnConnectionSettingsChanged` (broadcast on mode/host/auth/token changes, all no-op-guarded) and subscribe the configurators panel so it re-resolves its cached config + rebuilds on a connection-method change without the user reselecting the agent (the C++/Slate analog of Unity's `InvalidateAndReloadAgentUI`). Subscription is removed in a new destructor to avoid a dangling-handler refresh.

Token stays masked in the Custom snippet and is never logged.

## Test plan
- [x] Suite 1 — UBT build (`UnrealTestProjectEditor Win64 Development`): exit 0, both plugin modules compiled + linked.
- [x] Suite 2 — headless boot smoke: `[Unreal-MCP] plugin loaded` + `Engine is initialized`. The QUIT_EDITOR teardown crash in `FUnrealMcpRuntime::Shutdown` (file untouched by this PR) is the pre-existing/out-of-scope shutdown quirk; graceful `Quit` path exits 0.
- [x] Suite 3 — Automation specs (`UnrealMcp.` filter): `index.json` failed: 0, succeeded: 221 (+16 warnings). Two new `UnrealMcp.EditorViewModel` connection-notification specs both pass (notify on each change, no-op no-notify, no-notify-after-unbind).

Closes #56