### PR TITLE
feat(cli): auto-clean stale build cache on update + Fab as primary install channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ the plugin spawns and talks to over a localhost IPC channel. The full design liv
 
 - [Requirements](#requirements)
 - [Install](#install)
+- [Updating the plugin](#updating-the-plugin)
 - [First run](#first-run)
 - [Tools](#tools) — all 8 families, 62 tools
 - [Per-tool enable / disable & Settings](#per-tool-enable--disable--settings)
@@ -58,10 +59,31 @@ the plugin spawns and talks to over a localhost IPC channel. The full design liv
 
 ## Install
 
-> No package-registry release exists yet. Until the first GitHub Release / Fab listing, install the
-> plugin from source.
+There are three ways to install the plugin, in order of preference. **Fab / Epic Marketplace is the
+recommended channel for end users** — it ships precompiled, per-engine binaries and the Epic Games
+Launcher keeps them up to date automatically, so there is **zero compile and zero stale-build risk**.
+Source/`unreal-mcp-cli` installs remain the current path for developers and early adopters until the
+Fab listing goes live.
 
-### Option A — `unreal-mcp-cli` (recommended)
+### Option A — Fab / Epic Marketplace (recommended; coming soon)
+
+> **Status: not yet live.** The Fab listing is operator-gated and tracked separately; until it
+> publishes, use Option B or C below. The framing here is what the end-user flow will be.
+
+1. Install **Unreal-MCP** from [Fab](https://www.fab.com/) (the Epic Marketplace successor) into your
+   engine via the Epic Games Launcher.
+2. Enable the plugin for your project from **Edit → Plugins**.
+3. Open the project — UE loads the **precompiled** plugin (no C++ build on your machine). On boot the
+   Output Log prints **`[Unreal-MCP] plugin loaded`**.
+
+Because Fab ships precompiled binaries and the Epic Launcher updates them in place, you never compile
+the plugin and never have to clear a stale build cache — the most robust path for non-developers.
+
+### Option B — `unreal-mcp-cli` (current / advanced)
+
+The CLI is the recommended path **today**, until the Fab listing is live. It copies (or, for dev, junctions)
+the plugin into your project and, on **update**, automatically clears the stale UE build cache so you
+always get a clean recompile of the new code (see [Updating the plugin](#updating-the-plugin)).
 
 ```bash
 # From a clone of this repo (see "unreal-mcp-cli" below for the npm story once published):
@@ -72,7 +94,7 @@ cd cli && npm install && npm run build
 node bin/unreal-mcp-cli.js install-plugin <YourProject> --junction
 ```
 
-### Option B — manual
+### Option C — manual
 
 1. Copy [`UnrealMCP/`](UnrealMCP/) into `<YourProject>/Plugins/UnrealMCP/` (or create a directory
    junction / symlink to it for live development).
@@ -94,6 +116,33 @@ listing), the bundled binary is not present — the plugin then resolves the sid
 `<YourProject>/Intermediate/UnrealMCP/` and set the var to the result. With neither a bundled binary
 nor the env var resolved, the plugin's TCP listener still starts but logs
 `[Unreal-MCP] no sidecar binary resolved for rid <rid> …` and spawns nothing.
+
+## Updating the plugin
+
+Updating in place must always leave you running the **new** code. The risk is UE's incremental
+compiler: if the plugin source changes (new `.cpp` files, a new module) but the old
+`UnrealMCP/Intermediate/` build cache survives, UE can do a partial recompile against a stale module
+file-list and silently leave you on old/partial code. Each channel handles this differently:
+
+- **Fab / Epic Marketplace → automatic.** The Epic Games Launcher replaces the precompiled binaries
+  in place; nothing to compile, no cache to clear. This is why Fab is the recommended channel.
+- **`unreal-mcp-cli update` → automatic clean rebuild.** `update` re-copies the plugin source and,
+  by **default**, deletes the installed plugin's stale `Intermediate/` and the C++ `Binaries/` so UE
+  performs a clean compile on the next editor launch — no manual steps. The bundled sidecar bridge
+  under `Binaries/ThirdParty/UnrealMcpBridge/<rid>/` is **always preserved** (only the C++ module
+  outputs are cleared). Dev **junction** installs are never cleaned (that would wipe your live source
+  tree's outputs). Pass `--no-clean` to opt out of the cache wipe.
+
+  ```bash
+  node bin/unreal-mcp-cli.js update <YourProject>            # default: clean rebuild on version change
+  node bin/unreal-mcp-cli.js update <YourProject> --force    # re-copy even when versions match
+  node bin/unreal-mcp-cli.js update <YourProject> --no-clean # keep the existing build cache
+  ```
+
+- **Manual copy → clear the cache yourself.** If you overwrite `<YourProject>/Plugins/UnrealMCP/`
+  by hand, **close the editor first**, delete `<YourProject>/Plugins/UnrealMCP/Intermediate/` and the
+  C++ `Binaries/` (keep `Binaries/ThirdParty/` if a bundled bridge is present), then relaunch so UE
+  recompiles cleanly.
 
 ## First run
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -29,6 +29,12 @@ Requires Node `^20.19.0 || >=22.12.0`. See the
 [Unreal-MCP repository](https://github.com/IvanMurzak/Unreal-MCP) for the full project docs and the
 [architecture reference](https://github.com/IvanMurzak/Unreal-MCP/blob/main/docs/ARCHITECTURE.md).
 
+> **Plugin distribution.** For end users, the **recommended** way to install the UnrealMCP plugin
+> itself is **Fab / Epic Marketplace** (precompiled per-engine binaries, auto-updated by the Epic
+> Games Launcher — zero compile, zero stale-build risk). This CLI is the current/advanced/dev path
+> until the Fab listing is live; its `install-plugin` / `update` commands copy the plugin into a
+> project and keep its build cache clean on update (see the `update` row below).
+
 ## Commands (docs/ARCHITECTURE.md §9.1)
 
 | Command | What it does |
@@ -46,7 +52,7 @@ Requires Node `^20.19.0 || >=22.12.0`. See the
 | `run-tool <tool>` | Invoke an MCP tool over the local HTTP path |
 | `run-system-tool <tool>` | Invoke a system tool over the local HTTP path |
 | `bootstrap-local [path]` | Build the bridge from source into `Intermediate/UnrealMCP/` (§6) — the MCP server is downloaded from GameDev-MCP-Server releases, not built here |
-| `update [path]` | Re-sync the installed plugin from the repo source |
+| `update [path]` | Re-sync the installed plugin from the repo source. On a version change it **auto-cleans** the stale UE C++ build cache (`Intermediate/` + C++ `Binaries/`) so the editor recompiles cleanly — the bundled sidecar bridge under `Binaries/ThirdParty/` is preserved, junction (dev) installs are never cleaned, and `--no-clean` opts out |
 | `install-engine [version]` | Detect installed engines from `LauncherInstalled.dat`; link to the Epic launcher for missing versions (never installs directly) |
 | `setup-skills` | Write a Claude-Code skill stub that drives the project's MCP server |
 

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -12,24 +12,42 @@ export const updateCommand = new Command('update')
   .argument('[path]', 'Unreal project directory (defaults to cwd)')
   .option('--plugin-source <dir>', 'UnrealMCP plugin source dir (defaults to the repo plugin)')
   .option('--force', 'Re-install even when versions match')
-  .action(async (pathArg: string | undefined, opts: { pluginSource?: string; force?: boolean }) => {
-    const projectDir = pathArg ?? process.cwd();
-    const pluginSourceDir = opts.pluginSource ?? defaultPluginSource(HERE);
-    if (!pluginSourceDir) {
-      ui.error('Could not locate the UnrealMCP plugin source. Pass --plugin-source <dir>.');
-      process.exitCode = 1;
-      return;
-    }
-    const result = await update({ projectDir, pluginSourceDir, force: opts.force });
-    ui.printWarnings(result.warnings);
-    if (result.kind === 'failure') {
-      ui.error(result.error.message);
-      process.exitCode = 1;
-      return;
-    }
-    if (result.updated) {
-      ui.success(`Updated plugin ${result.fromVersion ?? 'none'} -> ${result.toVersion ?? 'unknown'}`);
-    } else {
-      ui.info(`Plugin already up to date (${result.toVersion ?? 'unknown'}).`);
-    }
-  });
+  .option(
+    '--no-clean',
+    'Do not wipe the stale UE C++ build cache after a copy-mode update (cleaning is the default; the bundled sidecar bridge is always preserved)',
+  )
+  .action(
+    async (
+      pathArg: string | undefined,
+      opts: { pluginSource?: string; force?: boolean; clean?: boolean },
+    ) => {
+      const projectDir = pathArg ?? process.cwd();
+      const pluginSourceDir = opts.pluginSource ?? defaultPluginSource(HERE);
+      if (!pluginSourceDir) {
+        ui.error('Could not locate the UnrealMCP plugin source. Pass --plugin-source <dir>.');
+        process.exitCode = 1;
+        return;
+      }
+      // commander maps `--no-clean` to `opts.clean === false`; absent → undefined (clean).
+      const result = await update({
+        projectDir,
+        pluginSourceDir,
+        force: opts.force,
+        noClean: opts.clean === false,
+      });
+      ui.printWarnings(result.warnings);
+      if (result.kind === 'failure') {
+        ui.error(result.error.message);
+        process.exitCode = 1;
+        return;
+      }
+      if (result.updated) {
+        const cleanedNote = result.cleaned ? ' (build cache cleaned)' : '';
+        ui.success(
+          `Updated plugin ${result.fromVersion ?? 'none'} -> ${result.toVersion ?? 'unknown'}${cleanedNote}`,
+        );
+      } else {
+        ui.info(`Plugin already up to date (${result.toVersion ?? 'unknown'}).`);
+      }
+    },
+  );

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -34,6 +34,7 @@ export { getStatus } from './lib/status.js';
 export { waitForReady } from './lib/wait-for-ready.js';
 export { bootstrapLocal, planBuildSteps, ridForPlatform } from './lib/bootstrap-local.js';
 export { update, readPluginVersion } from './lib/update.js';
+export { cleanPluginBuildCache, BUNDLED_BRIDGE_DIRNAME } from './lib/clean-plugin.js';
 export { setupSkills, renderSkill } from './lib/setup-skills.js';
 export {
   detectInstalledEngines,
@@ -124,5 +125,11 @@ export type { UProjectInfo } from './utils/project.js';
 export type { ResolvedConnection } from './utils/config.js';
 export type { LoginOptions, LoginResult } from './lib/login.js';
 export type { UpdateOptions, UpdateResult } from './lib/update.js';
+export type {
+  CleanPluginOptions,
+  CleanPluginResult,
+  CleanPluginSuccess,
+  CleanPluginFailure,
+} from './lib/clean-plugin.js';
 export type { SetupSkillsOptions, SetupSkillsResult } from './lib/setup-skills.js';
 export type { CloseOptions, CloseResult, RunningProcess } from './lib/close.js';

--- a/cli/src/lib/clean-plugin.ts
+++ b/cli/src/lib/clean-plugin.ts
@@ -1,0 +1,131 @@
+// `clean-plugin` — remove the installed plugin's stale UE C++ build cache so
+// the editor performs a clean compile on next launch. Library-safe.
+//
+// Why this exists: on an in-place plugin UPDATE, the editor's cached
+// `Intermediate/` module file-list can miss newly-added `.cpp` files, leaving
+// the user on old/partial code after the new source is copied in (issue #58).
+// Wiping the C++ module build outputs forces UE to recompile from scratch.
+//
+// CRITICAL precision: the bundled, precompiled .NET sidecar bridge ships at
+// `Binaries/ThirdParty/UnrealMcpBridge/<rid>/` (ARCHITECTURE.md §6.1). It is
+// NOT a C++ module output and must SURVIVE the clean — deleting it would strip
+// the plugin's ability to spawn the sidecar with no way to recover it from a
+// dev source tree. So we delete `Intermediate/` wholesale, but inside
+// `Binaries/` we delete every entry EXCEPT the `ThirdParty/` subtree.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { emitProgress } from './progress.js';
+import type { ProgressCallback } from './types.js';
+
+/** Subtree under `Binaries/` that holds the bundled bridge — never deleted. */
+export const BUNDLED_BRIDGE_DIRNAME = 'ThirdParty';
+
+export interface CleanPluginOptions {
+  /** Installed plugin root — `<project>/Plugins/UnrealMCP`. */
+  installedPath: string;
+  onProgress?: ProgressCallback;
+}
+
+export interface CleanPluginSuccess {
+  kind: 'success';
+  success: true;
+  /** Absolute paths actually removed (`Intermediate/` and/or C++ `Binaries/` entries). */
+  removed: string[];
+  /** Absolute paths deliberately preserved (e.g. the bundled bridge subtree). */
+  preserved: string[];
+  warnings: string[];
+}
+
+export interface CleanPluginFailure {
+  kind: 'failure';
+  success: false;
+  removed: string[];
+  preserved: string[];
+  warnings: string[];
+  error: Error;
+}
+
+export type CleanPluginResult = CleanPluginSuccess | CleanPluginFailure;
+
+/** True when `p` is a symlink/junction (vs a real directory). */
+function isLink(p: string): boolean {
+  try {
+    return fs.lstatSync(p).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Delete the C++ module build cache (`Intermediate/` + `Binaries/` minus the
+ * bundled-bridge subtree) inside an installed plugin so UE recompiles cleanly.
+ *
+ * Never throws past the boundary. A junction-mode install must NOT be passed
+ * here — the caller is responsible for that gate (cleaning a junction would
+ * recurse into and wipe the live dev source's outputs). This function does
+ * defend with a junction check on the installed root anyway, refusing to act.
+ */
+export async function cleanPluginBuildCache(opts: CleanPluginOptions): Promise<CleanPluginResult> {
+  const removed: string[] = [];
+  const preserved: string[] = [];
+  const warnings: string[] = [];
+  try {
+    if (!opts?.installedPath) throw new Error('installedPath is required.');
+    const installedPath = path.resolve(opts.installedPath);
+
+    // Defensive: refuse to clean through a junction — removing files via a
+    // junction recurses into the live source the junction points at.
+    if (isLink(installedPath)) {
+      warnings.push(
+        `Refusing to clean ${installedPath}: it is a junction/symlink (dev install). ` +
+          'Skipping build-cache clean to protect the live source outputs.',
+      );
+      return { kind: 'success', success: true, removed, preserved, warnings };
+    }
+
+    emitProgress(opts.onProgress, {
+      phase: 'info',
+      message: `Cleaning stale UE build cache in ${installedPath}`,
+    });
+
+    // 1. Intermediate/ — pure build cache, delete wholesale.
+    const intermediate = path.join(installedPath, 'Intermediate');
+    if (fs.existsSync(intermediate)) {
+      fs.rmSync(intermediate, { recursive: true, force: true });
+      removed.push(intermediate);
+    }
+
+    // 2. Binaries/ — delete every entry EXCEPT the bundled-bridge subtree.
+    const binaries = path.join(installedPath, 'Binaries');
+    if (fs.existsSync(binaries)) {
+      for (const entry of fs.readdirSync(binaries)) {
+        const entryPath = path.join(binaries, entry);
+        if (entry === BUNDLED_BRIDGE_DIRNAME) {
+          preserved.push(entryPath);
+          continue;
+        }
+        fs.rmSync(entryPath, { recursive: true, force: true });
+        removed.push(entryPath);
+      }
+    }
+
+    emitProgress(opts.onProgress, {
+      phase: 'done',
+      message:
+        removed.length > 0
+          ? `Cleaned build cache (${removed.length} path(s) removed; ${preserved.length} preserved).`
+          : 'No stale build cache to clean.',
+    });
+    return { kind: 'success', success: true, removed, preserved, warnings };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      removed,
+      preserved,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}

--- a/cli/src/lib/clean-plugin.ts
+++ b/cli/src/lib/clean-plugin.ts
@@ -101,7 +101,10 @@ export async function cleanPluginBuildCache(opts: CleanPluginOptions): Promise<C
     if (fs.existsSync(binaries)) {
       for (const entry of fs.readdirSync(binaries)) {
         const entryPath = path.join(binaries, entry);
-        if (entry === BUNDLED_BRIDGE_DIRNAME) {
+        // Case-insensitive compare: on a case-insensitive FS (Windows/macOS) an
+        // oddly-cased `thirdparty/` is the SAME dir as the bundled bridge — a
+        // case-sensitive `===` would delete it and destroy the sidecar.
+        if (entry.toLowerCase() === BUNDLED_BRIDGE_DIRNAME.toLowerCase()) {
           preserved.push(entryPath);
           continue;
         }

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -6,6 +6,7 @@
 // plugin source — the same pattern the infra testbed uses.
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { isUnrealProjectDir } from '../utils/project.js';
 import { emitProgress } from './progress.js';
@@ -17,6 +18,8 @@ import type {
 } from './types.js';
 
 const PLUGIN_DIRNAME = 'UnrealMCP';
+/** Subtree under `Binaries/` holding the bundled bridge (ARCHITECTURE §6.1). */
+const BUNDLED_BRIDGE_REL = path.join('Binaries', 'ThirdParty');
 
 /** True when `p` is a symlink/junction (vs a real directory). */
 function isLink(p: string): boolean {
@@ -58,6 +61,27 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
       message: `Installing UnrealMCP plugin into ${installedPath}`,
     });
 
+    const useJunction = opts.junction === true && process.platform === 'win32';
+    if (opts.junction === true && !useJunction) {
+      warnings.push('Junction mode is Windows-only; falling back to copy.');
+    }
+
+    // Preserve the bundled sidecar bridge across a COPY re-install. A prior
+    // (release-packaged) install ships `Binaries/ThirdParty/UnrealMcpBridge/`,
+    // but the plugin SOURCE we copy from (a dev/source checkout) does not — so
+    // a naive rm-then-copy would strip the bridge and leave the plugin unable
+    // to spawn its sidecar (ARCHITECTURE §6). Stash the existing bridge subtree
+    // to a temp dir before clearing, then restore it after the copy IF the new
+    // source did not provide its own. Junction installs never go through this
+    // path (the junction points at the live source — nothing to preserve).
+    let stashedBridge: string | null = null;
+    const priorBridge = path.join(installedPath, BUNDLED_BRIDGE_REL);
+    const installedIsRealDir = fs.existsSync(installedPath) && !isLink(installedPath);
+    if (!useJunction && installedIsRealDir && fs.existsSync(priorBridge)) {
+      stashedBridge = fs.mkdtempSync(path.join(os.tmpdir(), 'unreal-mcp-bridge-stash-'));
+      fs.cpSync(priorBridge, stashedBridge, { recursive: true });
+    }
+
     // Clear any prior install (link or real dir) so the operation is
     // idempotent and never nests a copy inside a stale junction.
     if (fs.existsSync(installedPath) || isLink(installedPath)) {
@@ -68,18 +92,27 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
       }
     }
 
-    const useJunction = opts.junction === true;
     if (useJunction) {
-      if (process.platform !== 'win32') {
-        warnings.push('Junction mode is Windows-only; falling back to copy.');
-      } else {
-        fs.symlinkSync(pluginSourceDir, installedPath, 'junction');
-        emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin junctioned.' });
-        return { kind: 'success', success: true, installedPath, mode: 'junction', warnings };
-      }
+      fs.symlinkSync(pluginSourceDir, installedPath, 'junction');
+      emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin junctioned.' });
+      return { kind: 'success', success: true, installedPath, mode: 'junction', warnings };
     }
 
     fs.cpSync(pluginSourceDir, installedPath, { recursive: true });
+
+    // Restore the stashed bridge if the freshly-copied source did not ship one.
+    if (stashedBridge) {
+      try {
+        if (!fs.existsSync(priorBridge)) {
+          fs.mkdirSync(path.dirname(priorBridge), { recursive: true });
+          fs.cpSync(stashedBridge, priorBridge, { recursive: true });
+          warnings.push('Preserved the previously-bundled sidecar bridge across the re-install.');
+        }
+      } finally {
+        fs.rmSync(stashedBridge, { recursive: true, force: true });
+      }
+    }
+
     emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin copied.' });
     return { kind: 'success', success: true, installedPath, mode: 'copy', warnings };
   } catch (err: unknown) {

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -98,7 +98,28 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
       return { kind: 'success', success: true, installedPath, mode: 'junction', warnings };
     }
 
-    fs.cpSync(pluginSourceDir, installedPath, { recursive: true });
+    // If the copy THROWS after the old install was rm'd and the bridge stashed,
+    // restore the stash before rethrowing — otherwise the only copy of the
+    // (unrecoverable-from-source) bundled bridge is abandoned in os.tmpdir().
+    try {
+      fs.cpSync(pluginSourceDir, installedPath, { recursive: true });
+    } catch (copyErr: unknown) {
+      if (stashedBridge) {
+        try {
+          fs.mkdirSync(path.dirname(priorBridge), { recursive: true });
+          fs.cpSync(stashedBridge, priorBridge, { recursive: true });
+          fs.rmSync(stashedBridge, { recursive: true, force: true });
+          stashedBridge = null;
+        } catch {
+          // Best-effort restore failed — surface the stash path on the error so
+          // the user can recover the bridge manually instead of losing it.
+          const e = copyErr instanceof Error ? copyErr : new Error(String(copyErr));
+          e.message += ` (the bundled sidecar bridge was stashed at ${stashedBridge} — recover it manually)`;
+          throw e;
+        }
+      }
+      throw copyErr;
+    }
 
     // Restore the stashed bridge if the freshly-copied source did not ship one.
     if (stashedBridge) {

--- a/cli/src/lib/update.ts
+++ b/cli/src/lib/update.ts
@@ -137,7 +137,8 @@ export async function update(opts: UpdateOptions): Promise<UpdateResult> {
     // but the post-install path is a real dir only in true copy mode, so gate
     // on the resolved install mode rather than the requested one.
     let cleaned = false;
-    const resolvedMode = installResult.kind === 'success' ? installResult.mode : 'copy';
+    // `installResult` is guaranteed a success here — failure returned above.
+    const resolvedMode = installResult.mode;
     if (!opts.noClean && resolvedMode === 'copy') {
       const cleanResult = await cleanPluginBuildCache({ installedPath, onProgress: opts.onProgress });
       warnings.push(...cleanResult.warnings);

--- a/cli/src/lib/update.ts
+++ b/cli/src/lib/update.ts
@@ -6,6 +6,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { installPlugin } from './install-plugin.js';
+import { cleanPluginBuildCache } from './clean-plugin.js';
 import { emitProgress } from './progress.js';
 import type { ProgressCallback } from './types.js';
 
@@ -15,6 +16,15 @@ export interface UpdateOptions {
   pluginSourceDir: string;
   /** Re-install even when versions match. Default `false`. */
   force?: boolean;
+  /**
+   * Skip wiping the installed plugin's stale UE C++ build cache
+   * (`Intermediate/` + C++ `Binaries/`) after a copy-mode update. Cleaning is
+   * the DEFAULT (`noClean` omitted/false) so the user always gets a clean
+   * recompile of the new code on next editor launch — see issue #58. The
+   * bundled sidecar bridge under `Binaries/ThirdParty/` is preserved either
+   * way. Junction (dev) installs are never cleaned regardless of this flag.
+   */
+  noClean?: boolean;
   onProgress?: ProgressCallback;
 }
 
@@ -27,6 +37,12 @@ export interface UpdateSuccess {
   toVersion: string | null;
   /** `true` when files were re-copied. */
   updated: boolean;
+  /**
+   * `true` when the stale UE build cache was wiped after this update (copy
+   * mode, `noClean` not set). `false` for no-op updates, junction installs,
+   * or when `noClean` was passed.
+   */
+  cleaned: boolean;
   installedPath: string;
   warnings: string[];
 }
@@ -95,16 +111,17 @@ export async function update(opts: UpdateOptions): Promise<UpdateResult> {
     const needsUpdate = opts.force === true || fromVersion === null || fromVersion !== toVersion;
     if (!needsUpdate) {
       emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin already up to date.' });
-      return { kind: 'success', success: true, fromVersion, toVersion, updated: false, installedPath, warnings };
+      return { kind: 'success', success: true, fromVersion, toVersion, updated: false, cleaned: false, installedPath, warnings };
     }
 
     // Preserve the existing install mode: a dev junction install must stay a
     // junction across `update --force` rather than being silently replaced
     // with a copy (which would detach the project from the live source).
+    const installedAsJunction = isJunction(installedPath);
     const installResult = await installPlugin({
       projectDir,
       pluginSourceDir,
-      junction: isJunction(installedPath),
+      junction: installedAsJunction,
       onProgress: opts.onProgress,
     });
     if (installResult.kind === 'failure') {
@@ -112,8 +129,37 @@ export async function update(opts: UpdateOptions): Promise<UpdateResult> {
     }
     warnings.push(...installResult.warnings);
 
+    // Wipe the stale UE C++ build cache so the editor recompiles the new code
+    // on next launch (issue #58). DEFAULT on copy-mode updates; opt out with
+    // `noClean`. NEVER on junction installs — that would recurse through the
+    // junction and destroy the live dev source's build outputs. `installPlugin`
+    // already falls back to copy on non-Windows even when junction is requested,
+    // but the post-install path is a real dir only in true copy mode, so gate
+    // on the resolved install mode rather than the requested one.
+    let cleaned = false;
+    const resolvedMode = installResult.kind === 'success' ? installResult.mode : 'copy';
+    if (!opts.noClean && resolvedMode === 'copy') {
+      const cleanResult = await cleanPluginBuildCache({ installedPath, onProgress: opts.onProgress });
+      warnings.push(...cleanResult.warnings);
+      if (cleanResult.kind === 'failure') {
+        // A failed clean must not fail the whole update — the source is already
+        // copied. Surface it as a warning so the user can clean manually.
+        warnings.push(`Could not clean stale build cache: ${cleanResult.error.message}`);
+      } else {
+        // `cleaned` means "a clean was ensured this update", not "files were
+        // found to delete" — `installPlugin`'s copy-mode rm already strips the
+        // old install (stale cache included; bridge stashed+restored), so the
+        // explicit clean often finds nothing yet still guarantees a clean tree.
+        cleaned = true;
+      }
+    } else if (!opts.noClean && resolvedMode === 'junction') {
+      warnings.push(
+        'Junction (dev) install detected — skipping build-cache clean to protect the live source outputs.',
+      );
+    }
+
     emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin updated.' });
-    return { kind: 'success', success: true, fromVersion, toVersion, updated: true, installedPath, warnings };
+    return { kind: 'success', success: true, fromVersion, toVersion, updated: true, cleaned, installedPath, warnings };
   } catch (err: unknown) {
     return {
       kind: 'failure',

--- a/cli/tests/clean-plugin.test.ts
+++ b/cli/tests/clean-plugin.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { cleanPluginBuildCache, BUNDLED_BRIDGE_DIRNAME } from '../src/lib/clean-plugin.js';
+import { makeTempDir, rmTempDir } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+/**
+ * Build an installed-plugin tree with a stale C++ build cache:
+ *   Intermediate/Build/...                 (C++ module cache — must be removed)
+ *   Binaries/Win64/UnrealEditor-...dll     (C++ module output — must be removed)
+ *   Binaries/ThirdParty/UnrealMcpBridge/win-x64/unreal-mcp-bridge.exe (bundled — must SURVIVE)
+ */
+function makeInstalledPlugin(): string {
+  const installed = tmp();
+  fs.writeFileSync(path.join(installed, 'UnrealMCP.uplugin'), JSON.stringify({ VersionName: '0.2.0' }), 'utf-8');
+
+  const intermediate = path.join(installed, 'Intermediate', 'Build', 'Win64');
+  fs.mkdirSync(intermediate, { recursive: true });
+  fs.writeFileSync(path.join(intermediate, 'stale.obj'), 'stale', 'utf-8');
+
+  const cppBin = path.join(installed, 'Binaries', 'Win64');
+  fs.mkdirSync(cppBin, { recursive: true });
+  fs.writeFileSync(path.join(cppBin, 'UnrealEditor-UnrealMcpEditor.dll'), 'stale-dll', 'utf-8');
+
+  const bridge = path.join(installed, 'Binaries', 'ThirdParty', 'UnrealMcpBridge', 'win-x64');
+  fs.mkdirSync(bridge, { recursive: true });
+  fs.writeFileSync(path.join(bridge, 'unreal-mcp-bridge.exe'), 'BRIDGE-PAYLOAD', 'utf-8');
+
+  return installed;
+}
+
+describe('cleanPluginBuildCache', () => {
+  it('removes Intermediate/ and C++ Binaries/ but PRESERVES the bundled bridge', async () => {
+    const installed = makeInstalledPlugin();
+    const r = await cleanPluginBuildCache({ installedPath: installed });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+
+    // Intermediate gone.
+    expect(fs.existsSync(path.join(installed, 'Intermediate'))).toBe(false);
+    // C++ module output gone.
+    expect(fs.existsSync(path.join(installed, 'Binaries', 'Win64'))).toBe(false);
+    // Bundled bridge SURVIVES with its payload intact.
+    const bridgeExe = path.join(installed, 'Binaries', BUNDLED_BRIDGE_DIRNAME, 'UnrealMcpBridge', 'win-x64', 'unreal-mcp-bridge.exe');
+    expect(fs.existsSync(bridgeExe)).toBe(true);
+    expect(fs.readFileSync(bridgeExe, 'utf-8')).toBe('BRIDGE-PAYLOAD');
+    // Binaries/ itself survives (it still holds ThirdParty/).
+    expect(fs.existsSync(path.join(installed, 'Binaries'))).toBe(true);
+
+    expect(r.removed.some((p) => p.endsWith('Intermediate'))).toBe(true);
+    expect(r.removed.some((p) => p.endsWith('Win64'))).toBe(true);
+    expect(r.preserved.some((p) => p.endsWith(BUNDLED_BRIDGE_DIRNAME))).toBe(true);
+  });
+
+  it('is a no-op (success) when there is nothing to clean', async () => {
+    const installed = tmp();
+    fs.writeFileSync(path.join(installed, 'UnrealMCP.uplugin'), '{}', 'utf-8');
+    const r = await cleanPluginBuildCache({ installedPath: installed });
+    expect(r.kind).toBe('success');
+    if (r.kind === 'success') expect(r.removed).toHaveLength(0);
+  });
+
+  it('refuses to clean a junction/symlink install (protects the live source)', async function () {
+    if (process.platform !== 'win32') {
+      // junction is Windows; on other platforms a regular symlink exercises the same guard.
+    }
+    const source = makeInstalledPlugin();
+    const project = tmp();
+    const link = path.join(project, 'UnrealMCP');
+    try {
+      fs.symlinkSync(source, link, 'junction');
+    } catch {
+      // Some CI shells can't create symlinks without privilege — skip gracefully.
+      return;
+    }
+    const r = await cleanPluginBuildCache({ installedPath: link });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    // Nothing removed; a warning explains why.
+    expect(r.removed).toHaveLength(0);
+    expect(r.warnings.some((w) => /junction|symlink/i.test(w))).toBe(true);
+    // The live source's build cache is untouched.
+    expect(fs.existsSync(path.join(source, 'Intermediate'))).toBe(true);
+    expect(fs.existsSync(path.join(source, 'Binaries', 'Win64'))).toBe(true);
+  });
+
+  it('fails (no throw) when installedPath is missing', async () => {
+    const r = await cleanPluginBuildCache({ installedPath: '' });
+    expect(r.kind).toBe('failure');
+  });
+});

--- a/cli/tests/install-plugin.test.ts
+++ b/cli/tests/install-plugin.test.ts
@@ -47,6 +47,25 @@ describe('installPlugin (copy)', () => {
     const r = await installPlugin({ projectDir: project, pluginSourceDir: path.join(tmp(), 'nope') });
     expect(r.kind).toBe('failure');
   });
+
+  it('preserves a previously-bundled sidecar bridge across a copy re-install (issue #58)', async () => {
+    // First install ships a release plugin WITH the bundled bridge.
+    const project = tmp();
+    const released = makePluginSource();
+    const bridge = path.join(released, 'Binaries', 'ThirdParty', 'UnrealMcpBridge', 'win-x64');
+    fs.mkdirSync(bridge, { recursive: true });
+    fs.writeFileSync(path.join(bridge, 'unreal-mcp-bridge.exe'), 'BRIDGE-PAYLOAD', 'utf-8');
+    await installPlugin({ projectDir: project, pluginSourceDir: released });
+
+    // Re-install from a SOURCE checkout that has NO bundled bridge.
+    const sourceCheckout = makePluginSource();
+    const r = await installPlugin({ projectDir: project, pluginSourceDir: sourceCheckout });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    const installedBridge = path.join(r.installedPath, 'Binaries', 'ThirdParty', 'UnrealMcpBridge', 'win-x64', 'unreal-mcp-bridge.exe');
+    expect(fs.existsSync(installedBridge)).toBe(true);
+    expect(fs.readFileSync(installedBridge, 'utf-8')).toBe('BRIDGE-PAYLOAD');
+  });
 });
 
 describe('removePlugin', () => {

--- a/cli/tests/update.test.ts
+++ b/cli/tests/update.test.ts
@@ -20,6 +20,26 @@ function makeSource(version: string): string {
   return dir;
 }
 
+/**
+ * Seed an already-installed plugin under `<project>/Plugins/UnrealMCP` carrying
+ * a stale build cache (Intermediate/ + C++ Binaries/) AND a bundled bridge
+ * under Binaries/ThirdParty/ — the post-compile state a real release install
+ * reaches before an `update`.
+ */
+function seedInstalledWithCache(project: string, version: string): string {
+  const installed = path.join(project, 'Plugins', 'UnrealMCP');
+  fs.mkdirSync(installed, { recursive: true });
+  fs.writeFileSync(path.join(installed, 'UnrealMCP.uplugin'), JSON.stringify({ VersionName: version }), 'utf-8');
+  fs.mkdirSync(path.join(installed, 'Intermediate', 'Build'), { recursive: true });
+  fs.writeFileSync(path.join(installed, 'Intermediate', 'Build', 'stale.obj'), 'stale', 'utf-8');
+  fs.mkdirSync(path.join(installed, 'Binaries', 'Win64'), { recursive: true });
+  fs.writeFileSync(path.join(installed, 'Binaries', 'Win64', 'UnrealEditor-UnrealMcpEditor.dll'), 'stale', 'utf-8');
+  const bridge = path.join(installed, 'Binaries', 'ThirdParty', 'UnrealMcpBridge', 'win-x64');
+  fs.mkdirSync(bridge, { recursive: true });
+  fs.writeFileSync(path.join(bridge, 'unreal-mcp-bridge.exe'), 'BRIDGE-PAYLOAD', 'utf-8');
+  return installed;
+}
+
 describe('readPluginVersion', () => {
   it('reads VersionName, null on miss', () => {
     const dir = makeSource('0.2.0');
@@ -78,5 +98,70 @@ describe('update', () => {
       expect(r.toVersion).toBe('0.2.0');
       expect(r.updated).toBe(true);
     }
+  });
+
+  // --- issue #58: auto-clean stale build cache on update -------------------
+
+  it('on a version-change copy update, wipes Intermediate/+C++ Binaries/ and preserves the bundled bridge', async () => {
+    const project = tmp();
+    const installed = seedInstalledWithCache(project, '0.1.0');
+    const r = await update({ projectDir: project, pluginSourceDir: makeSource('0.2.0') });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.updated).toBe(true);
+    expect(r.cleaned).toBe(true);
+    // New source landed.
+    expect(readPluginVersion(path.join(installed, 'UnrealMCP.uplugin'))).toBe('0.2.0');
+    // Stale C++ cache gone.
+    expect(fs.existsSync(path.join(installed, 'Intermediate'))).toBe(false);
+    expect(fs.existsSync(path.join(installed, 'Binaries', 'Win64'))).toBe(false);
+    // Bundled bridge SURVIVED both the re-copy and the clean, payload intact.
+    const bridgeExe = path.join(installed, 'Binaries', 'ThirdParty', 'UnrealMcpBridge', 'win-x64', 'unreal-mcp-bridge.exe');
+    expect(fs.existsSync(bridgeExe)).toBe(true);
+    expect(fs.readFileSync(bridgeExe, 'utf-8')).toBe('BRIDGE-PAYLOAD');
+  });
+
+  it('--no-clean (noClean) skips the explicit clean step but still preserves the bridge', async () => {
+    const project = tmp();
+    const installed = seedInstalledWithCache(project, '0.1.0');
+    const r = await update({ projectDir: project, pluginSourceDir: makeSource('0.2.0'), noClean: true });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.updated).toBe(true);
+    // The opt-out: no explicit clean was performed this update.
+    expect(r.cleaned).toBe(false);
+    // The bundled bridge is preserved across the re-copy regardless of noClean
+    // (installPlugin stashes+restores it; only the explicit clean is gated).
+    const bridgeExe = path.join(installed, 'Binaries', 'ThirdParty', 'UnrealMcpBridge', 'win-x64', 'unreal-mcp-bridge.exe');
+    expect(fs.existsSync(bridgeExe)).toBe(true);
+    expect(fs.readFileSync(bridgeExe, 'utf-8')).toBe('BRIDGE-PAYLOAD');
+  });
+
+  it('junction (dev) install is NOT cleaned — the live source build outputs survive', async () => {
+    if (process.platform !== 'win32') return; // junction install path is Windows-only
+    const project = tmp();
+    fs.mkdirSync(path.join(project, 'Plugins'), { recursive: true });
+    // Live dev source carrying its own build cache.
+    const source = tmp();
+    fs.writeFileSync(path.join(source, 'UnrealMCP.uplugin'), JSON.stringify({ VersionName: '0.1.0' }), 'utf-8');
+    fs.mkdirSync(path.join(source, 'Intermediate'), { recursive: true });
+    fs.writeFileSync(path.join(source, 'Intermediate', 'live.obj'), 'live', 'utf-8');
+    fs.mkdirSync(path.join(source, 'Binaries', 'Win64'), { recursive: true });
+    fs.writeFileSync(path.join(source, 'Binaries', 'Win64', 'live.dll'), 'live', 'utf-8');
+    const link = path.join(project, 'Plugins', 'UnrealMCP');
+    try {
+      fs.symlinkSync(source, link, 'junction');
+    } catch {
+      return; // privilege-gated symlink creation — skip gracefully
+    }
+    // force an update against a 0.2.0 source while the install is a junction.
+    const newSource = makeSource('0.2.0');
+    const r = await update({ projectDir: project, pluginSourceDir: newSource, force: true });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.cleaned).toBe(false);
+    // The dev source's build outputs are untouched.
+    expect(fs.existsSync(path.join(source, 'Intermediate', 'live.obj'))).toBe(true);
+    expect(fs.existsSync(path.join(source, 'Binaries', 'Win64', 'live.dll'))).toBe(true);
   });
 });

--- a/cli/tests/update.test.ts
+++ b/cli/tests/update.test.ts
@@ -21,6 +21,21 @@ function makeSource(version: string): string {
 }
 
 /**
+ * A plugin SOURCE that itself ships a stale C++ build cache (Intermediate/ +
+ * Binaries/Win64). Copying this into the install reproduces the cache there, so
+ * only the EXPLICIT clean step (not installPlugin's rm-then-copy) can remove it
+ * — this makes the "clean wiped the cache" assertion non-vacuous.
+ */
+function makeSourceWithCache(version: string): string {
+  const dir = makeSource(version);
+  fs.mkdirSync(path.join(dir, 'Intermediate', 'Build'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'Intermediate', 'Build', 'stale.obj'), 'stale', 'utf-8');
+  fs.mkdirSync(path.join(dir, 'Binaries', 'Win64'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'Binaries', 'Win64', 'UnrealEditor-UnrealMcpEditor.dll'), 'stale', 'utf-8');
+  return dir;
+}
+
+/**
  * Seed an already-installed plugin under `<project>/Plugins/UnrealMCP` carrying
  * a stale build cache (Intermediate/ + C++ Binaries/) AND a bundled bridge
  * under Binaries/ThirdParty/ — the post-compile state a real release install
@@ -119,6 +134,39 @@ describe('update', () => {
     const bridgeExe = path.join(installed, 'Binaries', 'ThirdParty', 'UnrealMcpBridge', 'win-x64', 'unreal-mcp-bridge.exe');
     expect(fs.existsSync(bridgeExe)).toBe(true);
     expect(fs.readFileSync(bridgeExe, 'utf-8')).toBe('BRIDGE-PAYLOAD');
+  });
+
+  it('clean removes cache that the COPIED SOURCE itself shipped (non-vacuous: only the explicit clean can remove it)', async () => {
+    // Distinct from the test above: here the NEW SOURCE ships the stale cache,
+    // so installPlugin's rm-then-copy RE-CREATES Intermediate/+Binaries/Win64 in
+    // the install. Only the explicit cleanPluginBuildCache step can remove them —
+    // if the clean call were deleted, these assertions would FAIL.
+    const project = tmp();
+    seedInstalledWithCache(project, '0.1.0');
+    const installed = path.join(project, 'Plugins', 'UnrealMCP');
+    const r = await update({ projectDir: project, pluginSourceDir: makeSourceWithCache('0.2.0') });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.cleaned).toBe(true);
+    // The source-shipped stale cache was copied in, then wiped by the clean.
+    expect(fs.existsSync(path.join(installed, 'Intermediate'))).toBe(false);
+    expect(fs.existsSync(path.join(installed, 'Binaries', 'Win64'))).toBe(false);
+  });
+
+  it('--no-clean leaves the source-shipped cache in place (proves the copy lands it; only clean removes it)', async () => {
+    // The mirror of the test above: with noClean, the cache the source shipped
+    // SURVIVES the update — proving installPlugin copied it in and that it is the
+    // explicit clean (not the rm-then-copy) that removes it in the default path.
+    const project = tmp();
+    seedInstalledWithCache(project, '0.1.0');
+    const installed = path.join(project, 'Plugins', 'UnrealMCP');
+    const r = await update({ projectDir: project, pluginSourceDir: makeSourceWithCache('0.2.0'), noClean: true });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.cleaned).toBe(false);
+    // The copied-in cache is still present because no explicit clean ran.
+    expect(fs.existsSync(path.join(installed, 'Intermediate'))).toBe(true);
+    expect(fs.existsSync(path.join(installed, 'Binaries', 'Win64'))).toBe(true);
   });
 
   it('--no-clean (noClean) skips the explicit clean step but still preserves the bridge', async () => {


### PR DESCRIPTION
## Summary
- **Part A (cli):** `unreal-mcp-cli update` now auto-cleans the installed plugin's stale UE C++ build cache (`Intermediate/` + C++ `Binaries/`) by default on a version-change copy update, so UE recompiles cleanly and the user never runs old/partial code from a stale incremental build. The bundled .NET sidecar bridge under `Binaries/ThirdParty/UnrealMcpBridge/<rid>/` is always preserved; dev junction installs are never cleaned; `--no-clean` opts out. `installPlugin` copy-mode re-install now stashes+restores an existing bundled bridge across the rm-then-copy.
- **Part B (docs):** README + cli/README reframed so **Fab / Epic Marketplace** is the recommended primary channel (precompiled, auto-updated, zero stale-build risk); source/`unreal-mcp-cli` is the current/advanced/dev path. New "Updating the plugin" section (Fab auto / cli auto clean rebuild / manual close+delete).

## Test plan
- [x] cli build (`tsc`) + tests (`vitest run`) green — 152 passed, 1 skipped (Node 22 local).
- [x] New `clean-plugin.test.ts` (clean removes cache + preserves bridge; junction-safe; missing-path failure) and extended `update.test.ts` / `install-plugin.test.ts` (clean-on-update, `--no-clean`, bridge preservation across copy re-install).

The Fab submission itself is operator-gated and out of scope (docs framing only).

Closes #58