### PR TITLE
feat(ui): agent-configurator transport/connection UI rework + Unity rich-text parity

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.cpp
@@ -177,6 +177,42 @@ bool FAiAgentConfigurator::Configure(bool bStdio)
 	return bResult;
 }
 
+TArray<FAiAgentRichContentSection> FAiAgentConfigurator::BuildRichContent(bool bStdio) const
+{
+	// Generic default (issue #59): a single "Configuration details" foldout so every built-in agent shows
+	// richer-than-bare content even without a bespoke override. Describes which transport the config targets, the
+	// resolved endpoint (HTTP url or the stdio server command + port), and whether a bearer is included. The token
+	// is NEVER inlined here — the snippet preview is the single place a (masked/revealed) token surfaces (§8).
+	using FItem = FAiAgentRichContentItem;
+
+	FAiAgentRichContentSection Section;
+	Section.Heading = TEXT("Configuration details");
+	Section.bExpandedFirst = true;
+
+	if (bStdio)
+	{
+		Section.Items.Add(FItem::Description(TEXT("This agent launches the MCP server over stdio. The config writes the server command and arguments below.")));
+		const FString Command = Connection.ServerPath.IsEmpty()
+			? TEXT("<gamedev-mcp-server>")
+			: Connection.ServerPath.Replace(TEXT("\\"), TEXT("/"));
+		Section.Items.Add(FItem::ReadOnlyField(FString::Printf(TEXT("%s port=%d client-transport=stdio"), *Command, Connection.Port)));
+		if (Connection.ServerPath.IsEmpty())
+			Section.Items.Add(FItem::Warning(TEXT("The local MCP server binary is not present yet; the snippet is still a valid template and will resolve once the server is installed.")));
+	}
+	else
+	{
+		Section.Items.Add(FItem::Description(TEXT("This agent connects to a running MCP server over HTTP at the URL below.")));
+		Section.Items.Add(FItem::ReadOnlyField(Connection.HttpUrl));
+	}
+
+	if (Connection.bAuthRequired)
+		Section.Items.Add(FItem::Description(TEXT("Authorization is required — a bearer token is included in the snippet (masked above unless revealed).")));
+	else
+		Section.Items.Add(FItem::Description(TEXT("Authorization is not required — no bearer token is sent.")));
+
+	return { MoveTemp(Section) };
+}
+
 bool FAiAgentConfigurator::RemoveAll()
 {
 	// Remove via either transport's config — both share the same file/body/identity, and Remove() clears the

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/AiAgentConfigurator.h
@@ -42,6 +42,45 @@ struct FAiAgentConnectionInfo
 };
 
 /**
+ * One element inside a per-agent rich-content section (docs/ARCHITECTURE.md §7) — the data model the Slate panel
+ * renders with the reusable widget templates (SUnrealMcpAgentWidgets). The Agents layer stays Slate-free and fully
+ * spec-testable: a configurator returns these structs, the view (SUnrealMcpAgentConfigurators) maps each Kind to a
+ * widget (Description→label, Warning→orange label, Alert→red label, ReadOnlyField→read-only copy field). This is the
+ * data analog of Unity's TemplateLabelDescription / TemplateWarningLabel / TemplateAlertLabel / TemplateTextFieldReadOnly
+ * calls inside a configurator's OnUICreated.
+ */
+struct FAiAgentRichContentItem
+{
+	enum class EKind : uint8
+	{
+		Description,    // a dimmed wrapped description line (Unity TemplateLabelDescription)
+		Warning,        // an orange wrapped warning line (Unity TemplateWarningLabel)
+		Alert,          // a red wrapped alert line (Unity TemplateAlertLabel)
+		ReadOnlyField   // a read-only, copyable command field (Unity TemplateTextFieldReadOnly)
+	};
+
+	EKind Kind = EKind::Description;
+	FString Text;
+
+	static FAiAgentRichContentItem Description(const FString& InText) { return { EKind::Description, InText }; }
+	static FAiAgentRichContentItem Warning(const FString& InText)     { return { EKind::Warning, InText }; }
+	static FAiAgentRichContentItem Alert(const FString& InText)       { return { EKind::Alert, InText }; }
+	static FAiAgentRichContentItem ReadOnlyField(const FString& InText) { return { EKind::ReadOnlyField, InText }; }
+};
+
+/**
+ * A collapsible per-agent rich-content section (Unity's TemplateFoldout / TemplateFoldoutFirst). bExpandedFirst marks
+ * the section that should open by default (Unity's "first" foldout, e.g. "Start"). The Slate panel wraps these in an
+ * SExpandableArea; the items render in order with the matching widget template.
+ */
+struct FAiAgentRichContentSection
+{
+	FString Heading;
+	bool bExpandedFirst = false;
+	TArray<FAiAgentRichContentItem> Items;
+};
+
+/**
  * Abstract base for an AI-agent configurator (docs/ARCHITECTURE.md §7/§8) — the C++/Slate analog of Unity's
  * AiAgentConfigurator and Godot's GodotAgentConfigurator. Unlike Godot (HTTP-only, no server shipped), Unreal
  * ships a server, so — like Unity — every configurator emits BOTH a STDIO (launch-the-server) and an HTTP
@@ -118,6 +157,19 @@ public:
 	UNREALMCPEDITOR_API bool Configure(bool bStdio);
 	/** Remove BOTH transports' entries from the file (a single Remove clears the agent regardless of transport). */
 	UNREALMCPEDITOR_API bool RemoveAll();
+
+	// --- Rich per-agent content (docs/ARCHITECTURE.md §7 — the data analog of Unity's per-agent OnUICreated). ---
+
+	/**
+	 * The collapsible rich-content sections shown for this agent under @p bStdio's transport (foldouts of
+	 * descriptions / warnings / alerts / read-only command fields). The base supplies a GENERIC default (a
+	 * "Configuration details" foldout describing where the config lands + the resolved server endpoint), so every
+	 * agent gets richer-than-bare content; an agent with a bespoke flow (e.g. Claude Code's `claude mcp add` steps)
+	 * overrides this to add the equivalent of Unity's per-agent "Start" / "Manual Configuration Steps" /
+	 * "Troubleshooting" foldouts. Pure data + connection facts (no Slate, no disk) so the specs drive it directly.
+	 * Initialize() must have been called so GetConnection()/GetProjectRoot() are current.
+	 */
+	UNREALMCPEDITOR_API virtual TArray<FAiAgentRichContentSection> BuildRichContent(bool bStdio) const;
 
 protected:
 	FAiAgentConnectionInfo Connection;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ClaudeCodeConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ClaudeCodeConfigurator.h
@@ -65,10 +65,16 @@ public:
 			const FString AuthArgs = Conn.bAuthRequired
 				? FString::Printf(TEXT(" authorization=required token=%s"), *Token)
 				: FString();
-			const FString Command = Conn.ServerPath.Replace(TEXT("\\"), TEXT("/"));
+			// Match the generic base BuildRichContent: when the local server binary is not present yet, render a
+			// "<gamedev-mcp-server>" placeholder + a Warning rather than an empty quoted path with no feedback.
+			const FString Command = Conn.ServerPath.IsEmpty()
+				? TEXT("<gamedev-mcp-server>")
+				: Conn.ServerPath.Replace(TEXT("\\"), TEXT("/"));
 			Manual.Items.Add(FItem::ReadOnlyField(FString::Printf(
 				TEXT("claude mcp add %s \"%s\" port=%d client-transport=stdio%s"),
 				*ServerName, *Command, Conn.Port, *AuthArgs)));
+			if (Conn.ServerPath.IsEmpty())
+				Manual.Items.Add(FItem::Warning(TEXT("The local MCP server binary is not present yet; the command is still a valid template and will resolve once the server is installed.")));
 		}
 		else
 		{

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ClaudeCodeConfigurator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Agents/Impl/ClaudeCodeConfigurator.h
@@ -25,6 +25,74 @@ public:
 		return FPaths::ConvertRelativePathToFull(FPaths::Combine(InProjectRoot, TEXT(".mcp.json")));
 	}
 	virtual FString GetBodyPath() const override { return TEXT("mcpServers"); }
+	virtual FString GetTutorialUrl() const override { return TEXT("https://youtu.be/Sknh2p12W8c"); }
 	// Per-agent skills folder (Phase C, issue #53) — mirrors Unity's ClaudeCodeConfigurator.SkillsPath.
 	virtual FString GetSkillsPath(const FString& /*InProjectRoot*/) const override { return TEXT(".claude/skills"); }
+
+	/**
+	 * Per-agent rich content (issue #59) — the 1:1 Slate-data port of Unity's ClaudeCodeConfigurator.OnUICreated:
+	 * a "Start" foldout (cd to project root + `claude`), a "Manual Configuration Steps" foldout (the `claude mcp add`
+	 * command for the active transport, with the bearer only when auth is required), and a "Troubleshooting" foldout.
+	 * The view renders these with the reusable widget templates. Pure data — no Slate, no disk — so it is spec-driven.
+	 */
+	virtual TArray<FAiAgentRichContentSection> BuildRichContent(bool bStdio) const override
+	{
+		using FItem = FAiAgentRichContentItem;
+		const FAiAgentConnectionInfo& Conn = GetConnection();
+		const FString Root = GetProjectRoot();
+		const FString ServerName = TEXT("Unreal-MCP");
+		// Match Unity: show the real token when present + auth required, else a "<token>" placeholder.
+		const FString Token = (Conn.bAuthRequired && !Conn.Token.IsEmpty()) ? Conn.Token : TEXT("<token>");
+
+		TArray<FAiAgentRichContentSection> Sections;
+
+		// "Start" foldout (opens first) — identical to Unity for both transports.
+		FAiAgentRichContentSection Start;
+		Start.Heading = TEXT("Start");
+		Start.bExpandedFirst = true;
+		Start.Items.Add(FItem::Description(TEXT("Navigate to project root")));
+		Start.Items.Add(FItem::ReadOnlyField(FString::Printf(TEXT("cd \"%s\""), *Root)));
+		Start.Items.Add(FItem::Description(TEXT("Launch Claude Code")));
+		Start.Items.Add(FItem::ReadOnlyField(TEXT("claude")));
+		Sections.Add(MoveTemp(Start));
+
+		// "Manual Configuration Steps" foldout — the add-mcp-server command for the active transport.
+		FAiAgentRichContentSection Manual;
+		Manual.Heading = TEXT("Manual Configuration Steps");
+		Manual.Items.Add(FItem::Description(TEXT("Run the following command in the folder of the Unreal project to configure Claude Code")));
+		if (bStdio)
+		{
+			const FString AuthArgs = Conn.bAuthRequired
+				? FString::Printf(TEXT(" authorization=required token=%s"), *Token)
+				: FString();
+			const FString Command = Conn.ServerPath.Replace(TEXT("\\"), TEXT("/"));
+			Manual.Items.Add(FItem::ReadOnlyField(FString::Printf(
+				TEXT("claude mcp add %s \"%s\" port=%d client-transport=stdio%s"),
+				*ServerName, *Command, Conn.Port, *AuthArgs)));
+		}
+		else
+		{
+			const FString AuthHeader = Conn.bAuthRequired
+				? FString::Printf(TEXT(" --header \"Authorization: Bearer %s\""), *Token)
+				: FString();
+			Manual.Items.Add(FItem::ReadOnlyField(FString::Printf(
+				TEXT("claude mcp add --transport http %s %s%s"),
+				*ServerName, *Conn.HttpUrl, *AuthHeader)));
+		}
+		Manual.Items.Add(FItem::Description(TEXT("Restart or start Claude Code to apply the configuration")));
+		Manual.Items.Add(FItem::ReadOnlyField(TEXT("claude")));
+		Sections.Add(MoveTemp(Manual));
+
+		// "Troubleshooting" foldout — same hints as Unity.
+		FAiAgentRichContentSection Trouble;
+		Trouble.Heading = TEXT("Troubleshooting");
+		Trouble.Items.Add(FItem::Description(TEXT("- Ensure Claude Code CLI is installed and accessible from the terminal")));
+		Trouble.Items.Add(FItem::Description(TEXT("- Ensure Claude Code CLI is started in the folder where the Unreal project is located")));
+		Trouble.Items.Add(FItem::Description(TEXT("- Ensure Claude Code is configured with the same port as the plugin shows right now")));
+		Trouble.Items.Add(FItem::Description(TEXT("- Check that the configuration file .mcp.json exists")));
+		Trouble.Items.Add(FItem::Description(TEXT("- Restart Claude Code after configuration changes")));
+		Sections.Add(MoveTemp(Trouble));
+
+		return Sections;
+	}
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
@@ -388,6 +388,37 @@ bool FUnrealMcpConfig::Save(const FString& Path) const
 	return FFileHelper::SaveStringToFile(Serialized, *Path);
 }
 
+EUnrealMcpTransportMethod FUnrealMcpConfig::GetTransportMethod() const
+{
+	return ParseTransport(Transport);
+}
+
+void FUnrealMcpConfig::SetTransportMethod(EUnrealMcpTransportMethod InMethod)
+{
+	Transport = TransportToString(InMethod);
+}
+
+EUnrealMcpTransportMethod FUnrealMcpConfig::ResolveEffectiveTransport() const
+{
+	// Cloud is HTTP-only (the cloud server enforces streamable HTTP); stdio is never offered there. In Custom
+	// mode the user's stored choice stands. Mirrors Unity's SetupConnectionModeToggle forcing streamableHttp.
+	if (ConnectionMode == EUnrealMcpConnectionMode::Cloud)
+		return EUnrealMcpTransportMethod::Http;
+	return GetTransportMethod();
+}
+
+EUnrealMcpTransportMethod FUnrealMcpConfig::ParseTransport(const FString& Raw)
+{
+	return Raw.Equals(TEXT("stdio"), ESearchCase::IgnoreCase)
+		? EUnrealMcpTransportMethod::Stdio
+		: EUnrealMcpTransportMethod::Http; // default + unknown → Http
+}
+
+const TCHAR* FUnrealMcpConfig::TransportToString(EUnrealMcpTransportMethod Method)
+{
+	return Method == EUnrealMcpTransportMethod::Stdio ? TEXT("stdio") : TEXT("http");
+}
+
 FString FUnrealMcpConfig::ResolveCloudBaseUrl() const
 {
 	const FString Trimmed = TrimSlash(CloudUrl.TrimStartAndEnd());

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
@@ -28,6 +28,21 @@ enum class EUnrealMcpAuthOption : uint8
 };
 
 /**
+ * The client transport an AI agent uses to reach the MCP server (docs/ARCHITECTURE.md §7/§8) — the C++ analog
+ * of Unity's TransportMethod (stdio / streamableHttp). The user picks it in the AI Game Developer window under
+ * the Custom connection method; in Cloud mode it is LOCKED to Http (the cloud is HTTP-only — mirrors Unity's
+ * "Cloud forces streamableHttp"). It is the typed view of the existing FUnrealMcpConfig::Transport string field
+ * ("stdio" / "http"), so it persists + env-overrides through the same §8 layer with no extra storage.
+ */
+enum class EUnrealMcpTransportMethod : uint8
+{
+	/** The agent launches the MCP server itself over stdio (config carries command + args). */
+	Stdio,
+	/** The agent connects to a running MCP server over streamable HTTP (config carries url + headers). */
+	Http
+};
+
+/**
  * Connection + environment configuration for the UnrealMCP plugin (docs/ARCHITECTURE.md §8). The C++
  * analog of Godot's GodotMcpConfig + GodotMcpEnvFile + Unity's EnvironmentUtils.OverrideRecord:
  *
@@ -157,6 +172,29 @@ public:
 	 * The token is the resolved bearer (empty in Custom+None) — the sidecar sends it verbatim, never re-resolves.
 	 */
 	UNREALMCPEDITOR_API TSharedPtr<FJsonObject> BuildEffectiveConnectionConfig() const;
+
+	// --- Transport (the typed view of the Transport string field, §7/§8). ---
+
+	/**
+	 * The persisted transport as a typed enum (the typed view of the Transport string). An unrecognized/blank
+	 * stored value falls back to Http (the default the snippet/connection prefer). NOTE: this is the RAW stored
+	 * intent — it does NOT apply the Cloud→Http lock; use ResolveEffectiveTransport() for the connection-aware
+	 * value the UI/snippets must honour.
+	 */
+	UNREALMCPEDITOR_API EUnrealMcpTransportMethod GetTransportMethod() const;
+	/** Set the transport from the typed enum (writes the matching "stdio"/"http" string into Transport). */
+	UNREALMCPEDITOR_API void SetTransportMethod(EUnrealMcpTransportMethod InMethod);
+	/**
+	 * The connection-aware transport the UI offers and the snippets reflect: in Cloud mode this is ALWAYS Http
+	 * (the cloud is HTTP-only — mirrors Unity's "Cloud forces streamableHttp"); in Custom mode it is the stored
+	 * GetTransportMethod(). This is the value the agent configurators render a single transport for.
+	 */
+	UNREALMCPEDITOR_API EUnrealMcpTransportMethod ResolveEffectiveTransport() const;
+
+	/** Parse a transport string ("stdio"/"http", case-insensitive) into the enum; unknown → Http. */
+	static UNREALMCPEDITOR_API EUnrealMcpTransportMethod ParseTransport(const FString& Raw);
+	/** The canonical lowercase string ("stdio"/"http") for a transport enum (the persisted form). */
+	static UNREALMCPEDITOR_API const TCHAR* TransportToString(EUnrealMcpTransportMethod Method);
 
 	/** The resolved cloud base URL (CloudUrl override or DefaultCloudBaseUrl), trailing slash trimmed. */
 	UNREALMCPEDITOR_API FString ResolveCloudBaseUrl() const;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
@@ -427,6 +427,9 @@ TSharedRef<SWidget> SUnrealMcpAgentConfigurators::MakeRichContentFoldout(const F
 			case FAiAgentRichContentItem::EKind::ReadOnlyField:
 				ItemWidget = UnrealMcpAgentWidgets::TemplateTextFieldReadOnly(Item.Text);
 				break;
+			default:
+				checkNoEntry(); // Exhaustive over EKind — a new kind must add a case here, not silently render NullWidget.
+				break;
 		}
 		Body->AddSlot().AutoHeight().Padding(0, 2, 0, 0)[ ItemWidget ];
 	}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
@@ -3,6 +3,7 @@
 
 #include "UI/SUnrealMcpAgentConfigurators.h"
 #include "UI/UnrealMcpEditorViewModel.h"
+#include "UI/SUnrealMcpAgentWidgets.h"
 #include "Agents/AiAgentConfiguratorRegistry.h"
 #include "Agents/JsonAiAgentConfig.h"
 #include "Agents/UnrealMcpSkillFileGenerator.h"
@@ -13,6 +14,7 @@
 #include "Widgets/SBoxPanel.h"
 #include "Widgets/Layout/SBorder.h"
 #include "Widgets/Layout/SSeparator.h"
+#include "Widgets/Layout/SExpandableArea.h"
 #include "Widgets/Text/STextBlock.h"
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Input/SComboBox.h"
@@ -231,102 +233,29 @@ void SUnrealMcpAgentConfigurators::RebuildAgentPanel()
 	// Selected is guaranteed valid here — RebuildAgentPanel early-returns above when it is not.
 	const bool bShowSnippet = Selected->GetAgentId() == TEXT("other-custom");
 
-	// A reusable transport section builder (STDIO and HTTP share the same shape).
-	auto BuildTransportSection = [this, bShowSnippet](const FText& Heading, bool bStdio) -> TSharedRef<SWidget>
-	{
-		return SNew(SVerticalBox)
-			+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)
-			[
-				SNew(STextBlock).Text(Heading).Font(FCoreStyle::GetDefaultFontStyle("Bold", 10))
-			]
-			// Status line.
-			+ SVerticalBox::Slot().AutoHeight().Padding(0, 2, 0, 0)
-			[
-				SNew(STextBlock)
-				.Text_Lambda([this, bStdio]()
-				{
-					if (!Selected.IsValid())
-						return FText::GetEmpty();
-					return Selected->IsConfigured(bStdio)
-						? LOCTEXT("StatusConfigured", "Status: configured")
-						: (Selected->IsAnyDetected()
-							? LOCTEXT("StatusDetectedOutdated", "Status: detected (needs reconfigure)")
-							: LOCTEXT("StatusNotConfigured", "Status: not configured"));
-				})
-				.ColorAndOpacity_Lambda([this, bStdio]()
-				{
-					if (Selected.IsValid() && Selected->IsConfigured(bStdio))
-						return FSlateColor(FLinearColor(0.16f, 0.74f, 0.30f));
-					return FSlateColor(FLinearColor(0.85f, 0.65f, 0.20f));
-				})
-			]
-			// Snippet preview (read-only, token-masked) — shown ONLY for the Custom agent (§7, issue #56). Built-in
-			// agents write their config file via Configure, so the raw snippet text is noise and is collapsed.
-			+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
-			[
-				SNew(SMultiLineEditableTextBox)
-				.IsReadOnly(true)
-				.AlwaysShowScrollbars(false)
-				.Visibility(bShowSnippet ? EVisibility::Visible : EVisibility::Collapsed)
-				.Text_Lambda([this, bStdio]()
-				{
-					return FText::FromString(BuildSnippetPreview(bStdio));
-				})
-			]
-			// Action buttons.
-			+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
-			[
-				SNew(SHorizontalBox)
-				+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 6, 0)
-				[
-					SNew(SButton)
-					.Text_Lambda([this, bStdio]()
-					{
-						return (Selected.IsValid() && Selected->IsConfigured(bStdio))
-							? LOCTEXT("Reconfigure", "Reconfigure")
-							: LOCTEXT("Configure", "Configure");
-					})
-					.OnClicked_Lambda([this, bStdio]()
-					{
-						if (Selected.IsValid())
-						{
-							const bool bOk = Selected->Configure(bStdio);
-							UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] agent '%s' %s configure %s."),
-								*Selected->GetAgentName(), bStdio ? TEXT("STDIO") : TEXT("HTTP"),
-								bOk ? TEXT("succeeded") : TEXT("failed"));
-							BindSelected(); // rebuild configs after the write
-						}
-						return FReply::Handled();
-					})
-				]
-				+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 6, 0)
-				[
-					SNew(SButton)
-					.Text(LOCTEXT("CopySnippet", "Copy"))
-					.ToolTipText(LOCTEXT("CopySnippetHint", "Copy the config snippet (with the real token) to the clipboard."))
-					.OnClicked_Lambda([this, bStdio]()
-					{
-						if (Selected.IsValid())
-						{
-							// Copy the REAL snippet (unmasked) — the user is pasting it into their own config.
-							FAiAgentConfig& Config = bStdio ? Selected->GetConfigStdio() : Selected->GetConfigHttp();
-							FPlatformApplicationMisc::ClipboardCopy(*Config.GetExpectedFileContent());
-						}
-						return FReply::Handled();
-					})
-				]
-			];
-	};
+	// Issue #59: render ONLY the user-selected (effective) transport, not both. Cloud locks this to Http; Custom uses
+	// the stored stdio/http choice. The whole panel rebuilds via OnConnectionSettingsChanged when the user flips the
+	// transport selector in the main window, so this single-transport view always tracks the live selection.
+	const EUnrealMcpTransportMethod EffectiveTransport = IsViewModelValid()
+		? ViewModel->GetEffectiveTransport()
+		: EUnrealMcpTransportMethod::Http;
+	const bool bStdio = EffectiveTransport == EUnrealMcpTransportMethod::Stdio;
+	const FText TransportHeading = bStdio
+		? LOCTEXT("StdioHeader", "STDIO (launch the server)")
+		: LOCTEXT("HttpHeader", "HTTP (connect to URL)");
 
 	AgentPanelContainer->AddSlot().AutoHeight()[ LinksRow ];
 
-	// Config path line.
-	AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 6, 0, 0)
-	[
-		SNew(STextBlock)
-		.AutoWrapText(true)
-		.Text(FText::Format(LOCTEXT("ConfigPathFmt", "Config file: {0}"), FText::FromString(ConfigPath)))
-	];
+	// Config path line (skip for the snippet-only Custom agent, which has no on-disk file).
+	if (!ConfigPath.IsEmpty())
+	{
+		AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 6, 0, 0)
+		[
+			SNew(STextBlock)
+			.AutoWrapText(true)
+			.Text(FText::Format(LOCTEXT("ConfigPathFmt", "Config file: {0}"), FText::FromString(ConfigPath)))
+		];
+	}
 
 	// Reveal-token toggle (per-agent; default masked, §8).
 	AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 6, 0, 0)
@@ -342,10 +271,51 @@ void SUnrealMcpAgentConfigurators::RebuildAgentPanel()
 		]
 	];
 
-	// STDIO + HTTP sections.
-	AgentPanelContainer->AddSlot().AutoHeight()[ BuildTransportSection(LOCTEXT("StdioHeader", "STDIO (launch the server)"), /*bStdio*/ true) ];
-	AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 4, 0, 0)[ SNew(SSeparator) ];
-	AgentPanelContainer->AddSlot().AutoHeight()[ BuildTransportSection(LOCTEXT("HttpHeader", "HTTP (connect to URL)"), /*bStdio*/ false) ];
+	// Active-transport heading.
+	AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 8, 0, 0)
+	[
+		SNew(STextBlock).Text(TransportHeading).Font(FCoreStyle::GetDefaultFontStyle("Bold", 10))
+	];
+
+	// Configuration-status row (Unity's ConfigurationElements): "Configured (transport)" / "Not configured" +
+	// Configure/Reconfigure + Remove, shown only for agents with an on-disk config file. The snippet-only Custom
+	// agent has no file to detect, so its status row is meaningless — it relies on the snippet preview + Copy below.
+	if (!bShowSnippet)
+		AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 4, 0, 0)[ MakeConfigurationStatusRow(bStdio) ];
+
+	// Per-agent rich content (issue #59): the configurator's foldout sections for the active transport (the 1:1
+	// data port of Unity's per-agent OnUICreated foldouts). Rendered with the reusable widget templates.
+	for (const FAiAgentRichContentSection& RichSection : Selected->BuildRichContent(bStdio))
+		AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 4, 0, 0)[ MakeRichContentFoldout(RichSection) ];
+
+	// Snippet preview (read-only, token-masked) + Copy — shown ONLY for the Custom agent (§7, issue #56). Built-in
+	// agents write their config file via the status-row Configure button, so the raw snippet text is noise there.
+	if (bShowSnippet)
+	{
+		AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 6, 0, 0)
+		[
+			SNew(SMultiLineEditableTextBox)
+			.IsReadOnly(true)
+			.AlwaysShowScrollbars(false)
+			.Text_Lambda([this, bStdio]() { return FText::FromString(BuildSnippetPreview(bStdio)); })
+		];
+		AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 4, 0, 0)
+		[
+			SNew(SButton)
+			.Text(LOCTEXT("CopySnippet", "Copy snippet"))
+			.ToolTipText(LOCTEXT("CopySnippetHint", "Copy the config snippet (with the real token) to the clipboard."))
+			.OnClicked_Lambda([this, bStdio]()
+			{
+				if (Selected.IsValid())
+				{
+					// Copy the REAL snippet (unmasked) — the user is pasting it into their own config.
+					FAiAgentConfig& Config = bStdio ? Selected->GetConfigStdio() : Selected->GetConfigHttp();
+					FPlatformApplicationMisc::ClipboardCopy(*Config.GetExpectedFileContent());
+				}
+				return FReply::Handled();
+			})
+		];
+	}
 
 	// Skills section (§7/§53 Phase C) — shown ONLY when the selected agent supports skills.
 	{
@@ -356,25 +326,113 @@ void SUnrealMcpAgentConfigurators::RebuildAgentPanel()
 			AgentPanelContainer->AddSlot().AutoHeight()[ BuildSkillsSection() ];
 		}
 	}
+	// NOTE: Remove now lives inside the configuration-status row (MakeConfigurationStatusRow) for built-in agents
+	// (Unity's ConfigurationElements). The snippet-only Custom agent has no on-disk file to remove, so no extra
+	// bottom Remove button is added.
+}
 
-	// Remove (clears both transports).
-	AgentPanelContainer->AddSlot().AutoHeight().Padding(0, 8, 0, 0)
-	[
-		SNew(SButton)
-		.Text(LOCTEXT("RemoveAgent", "Remove"))
-		.IsEnabled_Lambda([this]() { return Selected.IsValid() && Selected->IsAnyDetected(); })
-		.OnClicked_Lambda([this]()
-		{
-			if (Selected.IsValid())
+TSharedRef<SWidget> SUnrealMcpAgentConfigurators::MakeConfigurationStatusRow(bool bStdio)
+{
+	// The Slate analog of Unity's ConfigurationElements: a status label ("Configured (transport)" / "Not
+	// configured") + a Configure/Reconfigure button + a Remove button (shown only when something is detected). The
+	// transport word matches the active transport. After any write, BindSelected() rebuilds the cached configs so
+	// the next status read reflects the file (the lambdas re-read Selected on each paint, so the row self-updates).
+	const FString TransportWord = bStdio ? TEXT("stdio") : TEXT("http");
+
+	return SNew(SHorizontalBox)
+		// Status label.
+		+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
+		[
+			SNew(STextBlock)
+			.Text_Lambda([this, bStdio, TransportWord]()
 			{
-				const bool bOk = Selected->RemoveAll();
-				UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] agent '%s' remove %s."),
-					*Selected->GetAgentName(), bOk ? TEXT("succeeded") : TEXT("(nothing to remove)"));
-				BindSelected();
-			}
-			return FReply::Handled();
-		})
-	];
+				if (!Selected.IsValid())
+					return FText::GetEmpty();
+				return Selected->IsConfigured(bStdio)
+					? FText::Format(LOCTEXT("StatusConfiguredFmt", "Configured ({0})"), FText::FromString(TransportWord))
+					: LOCTEXT("StatusNotConfigured", "Not configured");
+			})
+			.ColorAndOpacity_Lambda([this, bStdio]()
+			{
+				return (Selected.IsValid() && Selected->IsConfigured(bStdio))
+					? FSlateColor(UnrealMcpAgentWidgets::ConfiguredColor())
+					: FSlateColor(UnrealMcpAgentWidgets::PendingColor());
+			})
+		]
+		// Configure / Reconfigure.
+		+ SHorizontalBox::Slot().AutoWidth().Padding(6, 0, 0, 0).VAlign(VAlign_Center)
+		[
+			SNew(SButton)
+			.Text_Lambda([this, bStdio]()
+			{
+				return (Selected.IsValid() && Selected->IsConfigured(bStdio))
+					? LOCTEXT("Reconfigure", "Reconfigure")
+					: LOCTEXT("Configure", "Configure");
+			})
+			.OnClicked_Lambda([this, bStdio]()
+			{
+				if (Selected.IsValid())
+				{
+					const bool bOk = Selected->Configure(bStdio);
+					UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] agent '%s' %s configure %s."),
+						*Selected->GetAgentName(), bStdio ? TEXT("STDIO") : TEXT("HTTP"),
+						bOk ? TEXT("succeeded") : TEXT("failed"));
+					BindSelected(); // rebuild configs after the write so the status row re-reads the file
+				}
+				return FReply::Handled();
+			})
+		]
+		// Remove (clears BOTH transports' entries; visible only when something is detected, per Unity).
+		+ SHorizontalBox::Slot().AutoWidth().Padding(6, 0, 0, 0).VAlign(VAlign_Center)
+		[
+			SNew(SButton)
+			.Text(LOCTEXT("RemoveAgent", "Remove"))
+			.Visibility_Lambda([this]()
+			{
+				return (Selected.IsValid() && Selected->IsAnyDetected()) ? EVisibility::Visible : EVisibility::Collapsed;
+			})
+			.OnClicked_Lambda([this]()
+			{
+				if (Selected.IsValid())
+				{
+					const bool bOk = Selected->RemoveAll();
+					UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] agent '%s' remove %s."),
+						*Selected->GetAgentName(), bOk ? TEXT("succeeded") : TEXT("(nothing to remove)"));
+					BindSelected();
+				}
+				return FReply::Handled();
+			})
+		];
+}
+
+TSharedRef<SWidget> SUnrealMcpAgentConfigurators::MakeRichContentFoldout(const FAiAgentRichContentSection& Section)
+{
+	// Build the foldout body from the section's items, each mapped to its widget template (the data→view mapping
+	// described on FAiAgentRichContentItem). Then wrap in a collapsible area (expanded if the section is the "first").
+	TSharedRef<SVerticalBox> Body = SNew(SVerticalBox);
+	for (const FAiAgentRichContentItem& Item : Section.Items)
+	{
+		TSharedRef<SWidget> ItemWidget = SNullWidget::NullWidget;
+		switch (Item.Kind)
+		{
+			case FAiAgentRichContentItem::EKind::Description:
+				ItemWidget = UnrealMcpAgentWidgets::TemplateLabelDescription(FText::FromString(Item.Text));
+				break;
+			case FAiAgentRichContentItem::EKind::Warning:
+				ItemWidget = UnrealMcpAgentWidgets::TemplateWarningLabel(FText::FromString(Item.Text));
+				break;
+			case FAiAgentRichContentItem::EKind::Alert:
+				ItemWidget = UnrealMcpAgentWidgets::TemplateAlertLabel(FText::FromString(Item.Text));
+				break;
+			case FAiAgentRichContentItem::EKind::ReadOnlyField:
+				ItemWidget = UnrealMcpAgentWidgets::TemplateTextFieldReadOnly(Item.Text);
+				break;
+		}
+		Body->AddSlot().AutoHeight().Padding(0, 2, 0, 0)[ ItemWidget ];
+	}
+
+	return UnrealMcpAgentWidgets::TemplateFoldout(
+		FText::FromString(Section.Heading), Body, Section.bExpandedFirst);
 }
 
 FString SUnrealMcpAgentConfigurators::ResolveSelectedSkillsPath() const

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.h
@@ -84,6 +84,12 @@ private:
 	// Bind the selected configurator to the live connection info + project root.
 	void BindSelected();
 
+	// The configuration-status row for the active transport (Unity's ConfigurationElements): a
+	// "Configured (transport)" / "Not configured" label + Configure/Reconfigure + Remove (#59).
+	TSharedRef<SWidget> MakeConfigurationStatusRow(bool bStdio);
+	// A collapsible foldout rendering one per-agent rich-content section with the reusable widget templates (#59).
+	TSharedRef<SWidget> MakeRichContentFoldout(const struct FAiAgentRichContentSection& Section);
+
 	// The snippet preview text for a transport, masking the token unless bRevealToken (§8).
 	FString BuildSnippetPreview(bool bStdio) const;
 	// Mask the bearer token inside an assembled snippet string unless revealed.

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentWidgets.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentWidgets.h
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SWidget.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SExpandableArea.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SMultiLineEditableTextBox.h"
+#include "Styling/AppStyle.h"
+#include "Styling/CoreStyle.h"
+#include "HAL/PlatformApplicationMisc.h"
+
+/**
+ * Reusable Slate equivalents of Unity's AI-agent-configurator UI templates (docs/ARCHITECTURE.md §7) — the
+ * Slate analog of Unity's UI/AiAgentConfigurators/AiAgentConfigurator.cs `Template*` helpers + the
+ * UI/Components/AlertPanel.cs widget + the UI/AiAgentConfigurators/ConfigurationElements.cs status row.
+ *
+ * Unity uses UXML+USS templates loaded by name; Unreal has no UMG/asset dependency in this pure-Slate window, so
+ * these are plain static factory functions (and one compound widget) that build the equivalent Slate trees with the
+ * matching styling intent:
+ *   - TemplateLabelDescription  → a wrapped, slightly-dimmed description label.
+ *   - TemplateWarningLabel       → an ORANGE wrapped label (Unity's .warning-label).
+ *   - TemplateAlertLabel         → a RED wrapped label (Unity's .alert-label).
+ *   - TemplateTextFieldReadOnly  → a read-only, selectable command field WITH a Copy button (Unity's read-only
+ *                                  TextField the user copies a command out of).
+ *   - TemplateFoldout / First    → an SExpandableArea (Unity's Foldout); "First" starts expanded.
+ *   - SUnrealMcpAlertPanel       → title + message + bullet items + optional action button (Unity's AlertPanel).
+ *   - MakeConfigurationStatusRow → "Configured (transport)" / "Not configured" + Configure/Reconfigure + Remove
+ *                                  (Unity's ConfigurationElements).
+ *
+ * These are header-only (factory functions + a small SCompoundWidget) so any §7 widget can reuse them without a
+ * link-time dependency. Colours match the existing window palette (green/orange/red constants already used in
+ * SUnrealMcpMainWindow / SUnrealMcpAgentConfigurators) so the rich content blends with the rest of the UI.
+ */
+namespace UnrealMcpAgentWidgets
+{
+	/** Shared palette (kept in lockstep with the inline constants already used by the §7 window widgets). */
+	inline FLinearColor DescriptionColor() { return FLinearColor(0.70f, 0.70f, 0.70f); }   // dimmed grey
+	inline FLinearColor WarningColor()     { return FLinearColor(0.95f, 0.60f, 0.13f); }   // orange
+	inline FLinearColor AlertColor()       { return FLinearColor(0.95f, 0.40f, 0.40f); }   // red
+	inline FLinearColor ConfiguredColor()  { return FLinearColor(0.16f, 0.74f, 0.30f); }   // green
+	inline FLinearColor PendingColor()     { return FLinearColor(0.85f, 0.65f, 0.20f); }   // amber
+
+	/** Unity's TemplateLabelDescription — a wrapped, dimmed description line. */
+	inline TSharedRef<SWidget> TemplateLabelDescription(const FText& Text)
+	{
+		return SNew(STextBlock)
+			.AutoWrapText(true)
+			.ColorAndOpacity(FSlateColor(DescriptionColor()))
+			.Text(Text);
+	}
+
+	/** Unity's TemplateWarningLabel — an ORANGE wrapped warning line. */
+	inline TSharedRef<SWidget> TemplateWarningLabel(const FText& Text)
+	{
+		return SNew(STextBlock)
+			.AutoWrapText(true)
+			.ColorAndOpacity(FSlateColor(WarningColor()))
+			.Text(Text);
+	}
+
+	/** Unity's TemplateAlertLabel — a RED wrapped alert line. */
+	inline TSharedRef<SWidget> TemplateAlertLabel(const FText& Text)
+	{
+		return SNew(STextBlock)
+			.AutoWrapText(true)
+			.ColorAndOpacity(FSlateColor(AlertColor()))
+			.Text(Text);
+	}
+
+	/**
+	 * Unity's read-only TextField the user copies a command out of. Slate's SEditableText/SMultiLineEditableTextBox
+	 * is read-only + selectable; we pair it with a Copy button (Unreal has no implicit Ctrl+C affordance hint), so
+	 * the user can both select-copy and one-click-copy. The value is shown verbatim (these are command snippets, not
+	 * secrets — token masking happens at the snippet-assembly layer, never here).
+	 */
+	inline TSharedRef<SWidget> TemplateTextFieldReadOnly(const FString& Value)
+	{
+		return SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
+			[
+				SNew(SMultiLineEditableTextBox)
+				.IsReadOnly(true)
+				.AllowMultiLine(false)
+				.AlwaysShowScrollbars(false)
+				.Text(FText::FromString(Value))
+			]
+			+ SHorizontalBox::Slot().AutoWidth().Padding(4, 0, 0, 0).VAlign(VAlign_Center)
+			[
+				SNew(SButton)
+				.Text(NSLOCTEXT("UnrealMcp", "CopyField", "Copy"))
+				.ToolTipText(NSLOCTEXT("UnrealMcp", "CopyFieldHint", "Copy this value to the clipboard."))
+				.OnClicked_Lambda([Value]()
+				{
+					FPlatformApplicationMisc::ClipboardCopy(*Value);
+					return FReply::Handled();
+				})
+			];
+	}
+
+	/** Unity's TemplateFoldout — a collapsible section (collapsed by default). */
+	inline TSharedRef<SExpandableArea> TemplateFoldout(const FText& Heading, const TSharedRef<SWidget>& Body, bool bInitiallyExpanded = false)
+	{
+		return SNew(SExpandableArea)
+			.InitiallyCollapsed(!bInitiallyExpanded)
+			.BorderImage(FAppStyle::GetBrush("NoBorder"))
+			.HeaderContent()
+			[
+				SNew(STextBlock)
+				.Text(Heading)
+				.Font(FCoreStyle::GetDefaultFontStyle("Bold", 10))
+			]
+			.BodyContent()
+			[
+				Body
+			];
+	}
+
+	/** Unity's TemplateFoldoutFirst — the first foldout, which starts EXPANDED. */
+	inline TSharedRef<SExpandableArea> TemplateFoldoutFirst(const FText& Heading, const TSharedRef<SWidget>& Body)
+	{
+		return TemplateFoldout(Heading, Body, /*bInitiallyExpanded*/ true);
+	}
+}
+
+/**
+ * Unity's AlertPanel.cs as a Slate compound widget (docs/ARCHITECTURE.md §7): a bordered notice with a bold title,
+ * a wrapped message, an optional bulleted item list, and an optional action button. SetVisible toggles the whole
+ * panel. Used for the §7 "Setup Required" / "Reconfiguration Required" / Cloud-auth alerts. Fluent AddItem/SetButton
+ * mirror the Unity API 1:1 so callers read the same.
+ */
+class SUnrealMcpAlertPanel : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SUnrealMcpAlertPanel) {}
+		SLATE_ARGUMENT(FText, Title)
+		SLATE_ARGUMENT(FText, Message)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs)
+	{
+		ItemsBox = SNew(SVerticalBox);
+
+		ButtonBox = SNew(SHorizontalBox);
+
+		ChildSlot
+		[
+			SAssignNew(RootBorder, SBorder)
+			.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+			.Padding(8.0f)
+			[
+				SNew(SVerticalBox)
+				+ SVerticalBox::Slot().AutoHeight()
+				[
+					SNew(STextBlock)
+					.Text(InArgs._Title)
+					.ColorAndOpacity(FSlateColor(UnrealMcpAgentWidgets::WarningColor()))
+					.Font(FCoreStyle::GetDefaultFontStyle("Bold", 11))
+				]
+				+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
+				[
+					SNew(STextBlock)
+					.AutoWrapText(true)
+					.Text(InArgs._Message)
+				]
+				+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
+				[
+					ItemsBox.ToSharedRef()
+				]
+				+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+				[
+					ButtonBox.ToSharedRef()
+				]
+			]
+		];
+	}
+
+	/** Add a bulleted item line; bRecommended renders it green (Unity's "alert-frame-item-recommended"). */
+	SUnrealMcpAlertPanel& AddItem(const FText& Text, bool bRecommended = false)
+	{
+		ItemsBox->AddSlot().AutoHeight().Padding(0, 1, 0, 0)
+		[
+			SNew(STextBlock)
+			.AutoWrapText(true)
+			.ColorAndOpacity(FSlateColor(bRecommended ? UnrealMcpAgentWidgets::ConfiguredColor() : UnrealMcpAgentWidgets::DescriptionColor()))
+			.Text(Text)
+		];
+		return *this;
+	}
+
+	/** Configure the (single) action button. Calling again replaces the previous button. */
+	SUnrealMcpAlertPanel& SetButton(const FText& Text, FSimpleDelegate OnClick)
+	{
+		ButtonBox->ClearChildren();
+		ButtonBox->AddSlot().AutoWidth()
+		[
+			SNew(SButton)
+			.Text(Text)
+			.OnClicked_Lambda([OnClick]()
+			{
+				OnClick.ExecuteIfBound();
+				return FReply::Handled();
+			})
+		];
+		return *this;
+	}
+
+	/** Show / hide the whole panel (Unity's SetVisible). */
+	void SetVisible(bool bVisible)
+	{
+		if (RootBorder.IsValid())
+			RootBorder->SetVisibility(bVisible ? EVisibility::Visible : EVisibility::Collapsed);
+	}
+
+private:
+	TSharedPtr<SBorder> RootBorder;
+	TSharedPtr<SVerticalBox> ItemsBox;
+	TSharedPtr<SHorizontalBox> ButtonBox;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -392,7 +392,16 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCustomAuthSection()
 		.Padding(8.0f)
 		[
 			SNew(SVerticalBox)
-			+ SVerticalBox::Slot().AutoHeight()[ SectionHeader(LOCTEXT("CustomAuthHeader", "Server authorization")) ]
+			+ SVerticalBox::Slot().AutoHeight()[ SectionHeader(LOCTEXT("CustomAuthHeader", "Custom connection settings")) ]
+			// Transport selector (stdio / http) — shown directly under the connection-method section (#59).
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)[ BuildTransportSelector() ]
+			// Authorization sub-header.
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 10, 0, 0)
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("CustomAuthSubHeader", "Authorization"))
+				.Font(FCoreStyle::GetDefaultFontStyle("Bold", 10))
+			]
 			// none / required toggle.
 			+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
 			[
@@ -465,6 +474,56 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCustomAuthSection()
 			? EVisibility::Visible : EVisibility::Collapsed;
 	}));
 	return Section;
+}
+
+TSharedRef<SWidget> SUnrealMcpMainWindow::BuildTransportSelector()
+{
+	// A stdio/http segmented control — the Slate analog of Unity's SetupAiAgentSection segmented control. Each is a
+	// toggle-button checkbox bound to the view-model's transport (mirrors the connection-mode toggle pattern above).
+	// Only meaningful in Custom mode (Cloud locks transport to Http); the whole BuildCustomAuthSection that hosts this
+	// is already Custom-only, so no extra visibility guard is needed here.
+	auto MakeTransportButton = [this](const FText& Label, EUnrealMcpTransportMethod Method)
+	{
+		return SNew(SCheckBox)
+			.Style(FAppStyle::Get(), "ToggleButtonCheckbox")
+			.IsChecked_Lambda([this, Method]()
+			{
+				return IsViewModelValid() && ViewModel->GetEffectiveTransport() == Method
+					? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+			})
+			.OnCheckStateChanged_Lambda([this, Method](ECheckBoxState NewState)
+			{
+				if (NewState == ECheckBoxState::Checked && IsViewModelValid())
+					ViewModel->SetTransportMethod(Method);
+			})
+			.Padding(FMargin(12, 4))
+			[
+				SNew(STextBlock).Text(Label)
+			];
+	};
+
+	return SNew(SVerticalBox)
+		+ SVerticalBox::Slot().AutoHeight()
+		[
+			SNew(STextBlock)
+			.Text(LOCTEXT("TransportLabel", "Transport"))
+			.Font(FCoreStyle::GetDefaultFontStyle("Bold", 10))
+		]
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 6, 0)
+			[ MakeTransportButton(LOCTEXT("TransportStdio", "stdio"), EUnrealMcpTransportMethod::Stdio) ]
+			+ SHorizontalBox::Slot().AutoWidth()
+			[ MakeTransportButton(LOCTEXT("TransportHttp", "http"), EUnrealMcpTransportMethod::Http) ]
+		]
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
+		[
+			SNew(STextBlock)
+			.AutoWrapText(true)
+			.ColorAndOpacity(FSlateColor(FLinearColor(0.70f, 0.70f, 0.70f)))
+			.Text(LOCTEXT("TransportHint", "stdio: the AI agent launches the MCP server itself. http: the agent connects to a running server over HTTP."))
+		];
 }
 
 TSharedRef<SWidget> SUnrealMcpMainWindow::BuildBridgeStatusSection()

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
@@ -54,6 +54,8 @@ private:
 	TSharedRef<SWidget> BuildModeToggleSection();
 	TSharedRef<SWidget> BuildCloudAuthSection();
 	TSharedRef<SWidget> BuildCustomAuthSection();
+	// The Custom-mode transport selector (stdio/http), shown directly under the connection-method section (§7, #59).
+	TSharedRef<SWidget> BuildTransportSelector();
 	TSharedRef<SWidget> BuildBridgeStatusSection();
 	TSharedRef<SWidget> BuildAiAgentsSection();
 	TSharedRef<SWidget> BuildAgentConfiguratorsSection();

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -32,9 +32,36 @@ void FUnrealMcpEditorViewModel::SetConnectionMode(EUnrealMcpConnectionMode InMod
 	if (Config.ConnectionMode == InMode)
 		return;
 	Config.ConnectionMode = InMode;
+	// Cloud is HTTP-only AND always authenticated (the cloud server enforces both): switching INTO Cloud forces
+	// transport→Http and auth→Required so the locked-in connection facts are consistent the moment the mode flips
+	// (mirrors Unity's SetupConnectionModeToggle: `TransportMethod = streamableHttp; AuthOption = required`). The
+	// stored Custom transport string is left as-is — ResolveEffectiveTransport already returns Http while in Cloud,
+	// and forcing it here keeps the persisted value coherent so a later switch back to Custom restores intent.
+	if (InMode == EUnrealMcpConnectionMode::Cloud)
+	{
+		Config.SetTransportMethod(EUnrealMcpTransportMethod::Http);
+		Config.AuthOption = EUnrealMcpAuthOption::Required;
+	}
 	PersistAndPush();
-	// The resolved connection facts (auth-required, token source, http url) all hinge on the mode, so the agent
-	// configurators must re-resolve their cached config + rebuild their panel (Unity's InvalidateAndReloadAgentUI).
+	// The resolved connection facts (auth-required, token source, http url, transport) all hinge on the mode, so the
+	// agent configurators must re-resolve their cached config + rebuild their panel (Unity's InvalidateAndReloadAgentUI).
+	OnConnectionSettingsChanged.Broadcast();
+}
+
+void FUnrealMcpEditorViewModel::SetTransportMethod(EUnrealMcpTransportMethod InMethod)
+{
+	// Cloud locks the transport to Http (the cloud is HTTP-only) — ignore a stray set so the selector cannot
+	// desync the effective transport. Only Custom mode honours the user's stdio/http choice.
+	if (Config.ConnectionMode == EUnrealMcpConnectionMode::Cloud)
+		return;
+	if (Config.GetTransportMethod() == InMethod)
+		return; // no-op — no persist / no panel churn (mirrors the other setters' no-op guards).
+	Config.SetTransportMethod(InMethod);
+	// Transport selection is UI/snippet presentation state (which transport's snippet the agent panel shows + what
+	// Configure writes); it does NOT change the live SignalR connection, so — like SetSelectedAgentId — persist only,
+	// never OnPushConfig. But it DOES change the agent snippet/status, so fire OnConnectionSettingsChanged to rebuild.
+	if (OnPersistConfig)
+		OnPersistConfig(Config);
 	OnConnectionSettingsChanged.Broadcast();
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
@@ -107,6 +107,25 @@ public:
 	EUnrealMcpAuthOption GetAuthOption() const { return Config.AuthOption; }
 	UNREALMCPEDITOR_API void SetAuthOption(EUnrealMcpAuthOption InOption);
 
+	// --- Transport selector (§7 — the C++ analog of Unity's SetupAiAgentSection segmented control). ---
+
+	/** The persisted (raw) transport intent. NOT connection-aware — see GetEffectiveTransport for the locked value. */
+	EUnrealMcpTransportMethod GetTransportMethod() const { return Config.GetTransportMethod(); }
+	/**
+	 * The connection-aware transport the UI offers + the snippets reflect: Cloud is LOCKED to Http (the cloud is
+	 * HTTP-only); Custom uses the stored choice. This is the value the agent configurators render a single transport
+	 * for (mirrors Unity's "Cloud forces streamableHttp" + the agent panel reading the active transport).
+	 */
+	EUnrealMcpTransportMethod GetEffectiveTransport() const { return Config.ResolveEffectiveTransport(); }
+	/** Whether the transport selector is user-editable (only in Custom mode; Cloud locks it to Http). */
+	bool IsTransportSelectable() const { return Config.ConnectionMode == EUnrealMcpConnectionMode::Custom; }
+	/**
+	 * Set the Custom-mode transport (the §7 stdio/http selector). Persists + fires OnConnectionSettingsChanged so
+	 * the agent panel re-resolves the now-selected transport's snippet/status. A no-op change does nothing. In Cloud
+	 * mode the selector is locked, so a stray set is ignored (the effective transport stays Http). Game-thread only.
+	 */
+	UNREALMCPEDITOR_API void SetTransportMethod(EUnrealMcpTransportMethod InMethod);
+
 	const FString& GetCustomToken() const { return Config.CustomToken; }
 	UNREALMCPEDITOR_API void SetCustomToken(const FString& InToken);
 	/** Replace the Custom-mode token with a fresh CSPRNG value (§7 Generate button), then persist + push. */

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfiguratorSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfiguratorSpec.cpp
@@ -937,6 +937,71 @@ void FUnrealMcpAgentConfiguratorSpec::Define()
 			TestEqual(TEXT("blank keeps default"), Loaded.SelectedAgentId, FString(TEXT("claude-code")));
 		});
 	});
+
+	Describe("Per-agent rich content (§7 templates — issue #59)", [this]()
+	{
+		It("Claude Code emits Start / Manual / Troubleshooting foldouts with transport-specific commands", [this]()
+		{
+			FClaudeCodeConfigurator Agent;
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.AuthOption = EUnrealMcpAuthOption::Required;
+			Config.CustomToken = TEXT("rich-token-xyz");
+			const FAiAgentConnectionInfo Conn = FAiAgentConnectionInfo::FromPluginConfig(Config, TEXT("C:/srv/gamedev-mcp-server.exe"), 5123);
+			Agent.Initialize(Conn, TEXT("C:/proj"));
+
+			// STDIO rich content: a `claude mcp add ... client-transport=stdio` command with the bearer.
+			const TArray<FAiAgentRichContentSection> Stdio = Agent.BuildRichContent(/*bStdio*/ true);
+			TestEqual(TEXT("three stdio foldouts"), Stdio.Num(), 3);
+			TestEqual(TEXT("first foldout is Start"), Stdio[0].Heading, FString(TEXT("Start")));
+			TestTrue(TEXT("Start opens first"), Stdio[0].bExpandedFirst);
+
+			FString StdioCommand;
+			for (const FAiAgentRichContentItem& Item : Stdio[1].Items)
+				if (Item.Kind == FAiAgentRichContentItem::EKind::ReadOnlyField && Item.Text.Contains(TEXT("claude mcp add")))
+					StdioCommand = Item.Text;
+			TestTrue(TEXT("stdio command present"), StdioCommand.Contains(TEXT("client-transport=stdio")));
+			TestTrue(TEXT("stdio command carries the token when auth required"), StdioCommand.Contains(TEXT("rich-token-xyz")));
+
+			// HTTP rich content: a `claude mcp add --transport http` command with the Bearer header.
+			const TArray<FAiAgentRichContentSection> Http = Agent.BuildRichContent(/*bStdio*/ false);
+			FString HttpCommand;
+			for (const FAiAgentRichContentItem& Item : Http[1].Items)
+				if (Item.Kind == FAiAgentRichContentItem::EKind::ReadOnlyField && Item.Text.Contains(TEXT("claude mcp add")))
+					HttpCommand = Item.Text;
+			TestTrue(TEXT("http command uses --transport http"), HttpCommand.Contains(TEXT("--transport http")));
+			TestTrue(TEXT("http command carries the Bearer header"), HttpCommand.Contains(TEXT("Authorization: Bearer rich-token-xyz")));
+		});
+
+		It("Claude Code omits the bearer from commands when auth is not required", [this]()
+		{
+			FClaudeCodeConfigurator Agent;
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.AuthOption = EUnrealMcpAuthOption::None;
+			Config.CustomToken = TEXT("should-not-appear");
+			const FAiAgentConnectionInfo Conn = FAiAgentConnectionInfo::FromPluginConfig(Config, TEXT("C:/srv/server.exe"), 5123);
+			Agent.Initialize(Conn, TEXT("C:/proj"));
+
+			for (const FAiAgentRichContentSection& Section : Agent.BuildRichContent(/*bStdio*/ true))
+				for (const FAiAgentRichContentItem& Item : Section.Items)
+					TestFalse(TEXT("no token leaks when auth is None"), Item.Text.Contains(TEXT("should-not-appear")));
+		});
+
+		It("the generic base configurator supplies a Configuration-details foldout for plain agents", [this]()
+		{
+			FCursorConfigurator Agent; // Cursor uses the base BuildRichContent (no override).
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			const FAiAgentConnectionInfo Conn = FAiAgentConnectionInfo::FromPluginConfig(Config, TEXT("C:/srv/server.exe"), 5123);
+			Agent.Initialize(Conn, TEXT("C:/proj"));
+
+			const TArray<FAiAgentRichContentSection> Sections = Agent.BuildRichContent(/*bStdio*/ false);
+			TestEqual(TEXT("one generic section"), Sections.Num(), 1);
+			TestEqual(TEXT("generic heading"), Sections[0].Heading, FString(TEXT("Configuration details")));
+			TestTrue(TEXT("generic section has items"), Sections[0].Items.Num() > 0);
+		});
+	});
 }
 
 #endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConfigSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConfigSpec.cpp
@@ -281,6 +281,61 @@ void FUnrealMcpConfigSpec::Define()
 			TestFalse(TEXT("raw token never reached the log"), Capture.Captured.Contains(RawToken));
 		});
 	});
+
+	Describe("Transport method typed view (§7, issue #59)", [this]()
+	{
+		It("round-trips the typed transport through the Transport string field", [this]()
+		{
+			FUnrealMcpConfig Config;
+			// Default Transport is "http" (see DefaultTransport) → Http.
+			TestEqual(TEXT("default transport is Http"),
+				static_cast<int32>(Config.GetTransportMethod()), static_cast<int32>(EUnrealMcpTransportMethod::Http));
+
+			Config.SetTransportMethod(EUnrealMcpTransportMethod::Stdio);
+			TestEqual(TEXT("stored string is stdio"), Config.Transport, FString(TEXT("stdio")));
+			TestEqual(TEXT("typed read is Stdio"),
+				static_cast<int32>(Config.GetTransportMethod()), static_cast<int32>(EUnrealMcpTransportMethod::Stdio));
+
+			Config.SetTransportMethod(EUnrealMcpTransportMethod::Http);
+			TestEqual(TEXT("stored string is http"), Config.Transport, FString(TEXT("http")));
+		});
+
+		It("ParseTransport is case-insensitive and defaults unknown to Http", [this]()
+		{
+			TestEqual(TEXT("STDIO -> Stdio"),
+				static_cast<int32>(FUnrealMcpConfig::ParseTransport(TEXT("StDiO"))), static_cast<int32>(EUnrealMcpTransportMethod::Stdio));
+			TestEqual(TEXT("http -> Http"),
+				static_cast<int32>(FUnrealMcpConfig::ParseTransport(TEXT("http"))), static_cast<int32>(EUnrealMcpTransportMethod::Http));
+			TestEqual(TEXT("garbage -> Http"),
+				static_cast<int32>(FUnrealMcpConfig::ParseTransport(TEXT("websocket"))), static_cast<int32>(EUnrealMcpTransportMethod::Http));
+			TestEqual(TEXT("empty -> Http"),
+				static_cast<int32>(FUnrealMcpConfig::ParseTransport(TEXT(""))), static_cast<int32>(EUnrealMcpTransportMethod::Http));
+		});
+
+		It("ResolveEffectiveTransport locks Cloud to Http but honours the stored choice in Custom", [this]()
+		{
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.SetTransportMethod(EUnrealMcpTransportMethod::Stdio);
+			TestEqual(TEXT("Custom honours stored stdio"),
+				static_cast<int32>(Config.ResolveEffectiveTransport()), static_cast<int32>(EUnrealMcpTransportMethod::Stdio));
+
+			// Cloud is HTTP-only regardless of the stored Transport string.
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Cloud;
+			TestEqual(TEXT("Cloud forces Http even with stored stdio"),
+				static_cast<int32>(Config.ResolveEffectiveTransport()), static_cast<int32>(EUnrealMcpTransportMethod::Http));
+		});
+
+		It("honours the UNREAL_MCP_TRANSPORT env override through the typed view", [this]()
+		{
+			FUnrealMcpConfig Config;
+			Config.ApplyOverrides({}, MakeEnvReader({
+				{ TEXT("UNREAL_MCP_TRANSPORT"), TEXT("stdio") },
+			}));
+			TestEqual(TEXT("env override drives the typed transport"),
+				static_cast<int32>(Config.GetTransportMethod()), static_cast<int32>(EUnrealMcpTransportMethod::Stdio));
+		});
+	});
 }
 
 #endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
@@ -397,6 +397,59 @@ void FUnrealMcpEditorViewModelSpec::Define()
 		});
 	});
 
+	Describe("Transport selector (§7 stdio/http — issue #59)", [this]()
+	{
+		It("Custom mode honours the stored transport and notifies on change", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			int32 Notifications = 0;
+			FDelegateHandle Handle = VM->OnConnectionSettingsChanged.AddLambda([&Notifications]() { Notifications++; });
+
+			// Enter Custom so the selector is live (mode change also notifies once).
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			const int32 NotificationsAfterMode = Notifications;
+			TestTrue("transport selectable in Custom", VM->IsTransportSelectable());
+
+			VM->SetTransportMethod(EUnrealMcpTransportMethod::Stdio);
+			TestEqual("effective transport is stdio", static_cast<int32>(VM->GetEffectiveTransport()), static_cast<int32>(EUnrealMcpTransportMethod::Stdio));
+			TestEqual("transport change notified once", Notifications, NotificationsAfterMode + 1);
+
+			// A no-op transport set must NOT notify.
+			VM->SetTransportMethod(EUnrealMcpTransportMethod::Stdio);
+			TestEqual("no-op transport change did not notify", Notifications, NotificationsAfterMode + 1);
+
+			// Transport selection persists but does NOT push the connection config (it is presentation state).
+			const int32 PushBefore = Rec->PushCount;
+			VM->SetTransportMethod(EUnrealMcpTransportMethod::Http);
+			TestEqual("transport change did not push the connection config", Rec->PushCount, PushBefore);
+			TestEqual("effective transport is http", static_cast<int32>(VM->GetEffectiveTransport()), static_cast<int32>(EUnrealMcpTransportMethod::Http));
+
+			VM->OnConnectionSettingsChanged.Remove(Handle);
+		});
+
+		It("Cloud locks the transport to Http and forces auth Required (mirrors Unity)", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			// Start in Custom with stdio + no auth, then switch to Cloud.
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			VM->SetTransportMethod(EUnrealMcpTransportMethod::Stdio);
+			VM->SetAuthOption(EUnrealMcpAuthOption::None);
+
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Cloud);
+			TestFalse("transport not selectable in Cloud", VM->IsTransportSelectable());
+			TestEqual("Cloud effective transport is Http", static_cast<int32>(VM->GetEffectiveTransport()), static_cast<int32>(EUnrealMcpTransportMethod::Http));
+			TestEqual("Cloud forces auth Required", static_cast<int32>(VM->GetAuthOption()), static_cast<int32>(EUnrealMcpAuthOption::Required));
+
+			// A stray SetTransportMethod in Cloud is ignored (selector is locked).
+			VM->SetTransportMethod(EUnrealMcpTransportMethod::Stdio);
+			TestEqual("Cloud transport stays Http after stray set", static_cast<int32>(VM->GetEffectiveTransport()), static_cast<int32>(EUnrealMcpTransportMethod::Http));
+		});
+	});
+
 	Describe("Status feed application", [this]()
 	{
 		It("applies connectionState and aiAgents from a status message", [this]()


### PR DESCRIPTION
## Summary
- Add a typed stdio/http transport view over the existing config, with Cloud locked to HTTP, plus a transport selector under the Custom connection method (view-model ignores it in Cloud and forces Cloud→Http + auth Required).
- Agent panel now renders only the effective transport with a Configured(transport)/Not configured status row (Configure/Reconfigure/Remove), and per-agent rich content (description/warning/alert/read-only-command foldouts via reusable Slate templates); Claude Code gets a bespoke Start / Manual Configuration Steps / Troubleshooting override with transport-specific `claude mcp add` commands.
- Token stays masked in the snippet preview and out of logs; display/selection UI only — no auth-mechanism/storage changes. Extended config / view-model / agent-configurator specs.

## Test plan
- [x] Suite 1 — UBT build (`UnrealTestProjectEditor Win64 Development`): `Result: Succeeded`, exit 0.
- [x] Suite 2 — headless boot smoke: `[Unreal-MCP] plugin loaded` + `Engine is initialized` (the exit-3 was the documented `QUIT_EDITOR` teardown crash in `FUnrealMcpRuntime::Shutdown`→Slate, not a load failure; re-verified clean via the graceful-`Quit` Suite-3 run, exit 0).
- [x] Suite 3 — Automation `UnrealMcp.` specs: `index.json` `failed: 0`, `succeeded: 231` (+16 with warnings).
- Self-hosted UE CI leg is gated on `UNREAL_RUNNER_READY`; hosted bridge/cli legs are N/A (only `UnrealMCP/**` touched).

Closes #59