### PR TITLE
fix(bridge): Cloud mode never connects — suffix the SignalR host with the /mcp hub prefix

### DIFF
--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -36,6 +36,18 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
     /// </summary>
     public sealed class SidecarHost : IDisposable
     {
+        /// <summary>
+        /// The URL-prefix the cloud serves the MCP server + SignalR hub behind (nginx routes
+        /// <c>^/mcp(/|$)</c> → the mcp-server container, rewriting <c>/mcp/hub/... → /hub/...</c>). The
+        /// McpPlugin SignalR client appends <c>Consts.Hub.RemoteApp</c> (<c>/hub/mcp-server</c>) to
+        /// <see cref="ConnectionConfig.Host"/>, so in Cloud mode the host MUST carry this prefix — otherwise
+        /// the client dials <c>https://ai-game.dev/hub/mcp-server</c>, which nginx routes to the frontend SPA
+        /// (404) and the sidecar never connects. Mirrors Unity-MCP's <c>CloudServerUrl => base + "/mcp"</c> and
+        /// Godot-MCP's <c>CloudHubPath = "/mcp"</c>. Device-code auth hits the BACKEND (<c>/api/auth/...</c>),
+        /// which is NOT behind this prefix, so it must use the stripped base (see <see cref="StripCloudHubPath"/>).
+        /// </summary>
+        internal const string CloudHubPath = "/mcp";
+
         private readonly IpcClient _ipc;
         private readonly string _sidecarVersion;
         private readonly ILoggerProvider? _loggerProvider;
@@ -269,7 +281,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             if (string.IsNullOrWhiteSpace(selected))
                 selected = isCloud ? host : cloudUrl;
             if (!string.IsNullOrWhiteSpace(selected))
-                _config.Host = selected!;
+                // Cloud mode: suffix the SignalR host with the /mcp prefix the cloud serves the hub behind
+                // (idempotent — never /mcp/mcp). Custom mode: use the host verbatim (a local/self-hosted
+                // server exposes the hub at the root, like Unity/Godot Custom). Device-auth strips this back
+                // off in StartDeviceAuth (the backend /api/auth/... is NOT behind /mcp).
+                _config.Host = isCloud ? AppendCloudHubPath(selected!) : selected!;
 
             // Token: the plugin already applied mode+auth resolution (empty in Custom+None). An absent key
             // leaves the existing token; an explicit empty value clears it (anonymous connection).
@@ -278,6 +294,36 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
             if (config["keepConnected"] is JsonValue keepNode && keepNode.TryGetValue<bool>(out var keepConnected))
                 _config.KeepConnected = keepConnected;
+        }
+
+        /// <summary>
+        /// Append the <see cref="CloudHubPath"/> (<c>/mcp</c>) prefix to a cloud host so the McpPlugin SignalR
+        /// client dials <c>…/mcp/hub/mcp-server</c> (the cloud serves the hub behind <c>/mcp</c>). Idempotent —
+        /// a host that already ends in <c>/mcp</c> (with or without a trailing slash) is returned with a single
+        /// suffix, never <c>/mcp/mcp</c>. Trailing slashes on the base are trimmed first. Pure so the bridge
+        /// xUnit suite can lock the round-trip/idempotency/trailing-slash matrix without a live plugin. Mirrors
+        /// Unity-MCP's <c>CloudServerUrl</c> and Godot-MCP's <c>ResolveCloudUrl</c>.
+        /// </summary>
+        internal static string AppendCloudHubPath(string host)
+        {
+            var trimmed = (host ?? string.Empty).TrimEnd('/');
+            if (trimmed.EndsWith(CloudHubPath, StringComparison.OrdinalIgnoreCase))
+                return trimmed;
+            return trimmed + CloudHubPath;
+        }
+
+        /// <summary>
+        /// Strip a trailing <see cref="CloudHubPath"/> (<c>/mcp</c>) from a cloud host to recover the BASE URL
+        /// the cloud backend lives at (<c>https://ai-game.dev</c>) — device-code auth targets
+        /// <c>{base}/api/auth/device/…</c>, which is NOT behind the <c>/mcp</c> nginx prefix. The inverse of
+        /// <see cref="AppendCloudHubPath"/>; idempotent for a host with no suffix. Pure (unit-testable).
+        /// </summary>
+        internal static string StripCloudHubPath(string host)
+        {
+            var trimmed = (host ?? string.Empty).TrimEnd('/');
+            if (trimmed.EndsWith(CloudHubPath, StringComparison.OrdinalIgnoreCase))
+                return trimmed[..^CloudHubPath.Length];
+            return trimmed;
         }
 
         /// <summary>
@@ -316,7 +362,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _authCts?.Dispose();
             var cts = new CancellationTokenSource();
             _authCts = cts;
-            var cloudUrl = _config.Host; // Cloud mode resolved Host to cloudUrl (ApplyConnectionConfig).
+            // ApplyConnectionConfig suffixed the Cloud host with /mcp for the SignalR hub; the device-code flow
+            // hits the BACKEND ({base}/api/auth/device/…), which is NOT behind the /mcp nginx prefix, so strip
+            // it back off to recover the base (https://ai-game.dev). A no-op for a host without the suffix.
+            var cloudUrl = StripCloudHubPath(_config.Host);
             _logger?.LogInformation("auth-start received; beginning device-code flow against {Host}.", cloudUrl);
             _ = RunDeviceAuthAsync(cloudUrl, cts.Token);
         }

--- a/bridge/tests/ConnectionConfigTests.cs
+++ b/bridge/tests/ConnectionConfigTests.cs
@@ -43,13 +43,52 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         }
 
         [Fact]
-        public void CloudMode_RoutesToCloudUrlWithToken()
+        public void CloudMode_RoutesToCloudUrlWithToken_AndSuffixesHubPath()
         {
             using var host = BuildHost();
             host.ApplyConnectionConfig(Config("Cloud", host: "http://localhost:5200", cloudUrl: "https://ai-game.dev", token: "cloud-bearer"));
 
-            Assert.Equal("https://ai-game.dev", host.Config.Host);
+            // The cloud serves the SignalR hub behind the /mcp nginx prefix, so the McpPlugin connection host
+            // MUST carry it (the client appends /hub/mcp-server) — otherwise it dials the frontend SPA → 404.
+            Assert.Equal("https://ai-game.dev/mcp", host.Config.Host);
             Assert.Equal("cloud-bearer", host.Config.Token);
+        }
+
+        [Fact]
+        public void CloudMode_CloudUrlAlreadyHasMcp_IsNotDoubleSuffixed()
+        {
+            using var host = BuildHost();
+            host.ApplyConnectionConfig(Config("Cloud", host: null, cloudUrl: "https://ai-game.dev/mcp", token: "cloud-bearer"));
+
+            Assert.Equal("https://ai-game.dev/mcp", host.Config.Host); // idempotent — never /mcp/mcp
+        }
+
+        [Fact]
+        public void CloudMode_CloudUrlHasMcpWithTrailingSlash_IsNormalized()
+        {
+            using var host = BuildHost();
+            host.ApplyConnectionConfig(Config("Cloud", host: null, cloudUrl: "https://ai-game.dev/mcp/", token: "cloud-bearer"));
+
+            Assert.Equal("https://ai-game.dev/mcp", host.Config.Host);
+        }
+
+        [Fact]
+        public void CloudMode_CloudUrlWithTrailingSlash_GetsSingleSuffix()
+        {
+            using var host = BuildHost();
+            host.ApplyConnectionConfig(Config("Cloud", host: null, cloudUrl: "https://ai-game.dev/", token: "cloud-bearer"));
+
+            Assert.Equal("https://ai-game.dev/mcp", host.Config.Host);
+        }
+
+        [Fact]
+        public void CloudMode_FallsBackToHostField_AlsoSuffixesHubPath()
+        {
+            // A partial Cloud config (cloudUrl blank, only `host` present) still gets the /mcp hub suffix.
+            using var host = BuildHost();
+            host.ApplyConnectionConfig(new JsonObject { ["mode"] = "Cloud", ["host"] = "https://ai-game.dev" });
+
+            Assert.Equal("https://ai-game.dev/mcp", host.Config.Host);
         }
 
         [Fact]
@@ -58,6 +97,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             using var host = BuildHost();
             host.ApplyConnectionConfig(Config("Custom", host: "http://localhost:5200", cloudUrl: "https://ai-game.dev", token: "custom-bearer"));
 
+            // Custom mode uses the host VERBATIM — no /mcp hub suffix (a local/self-hosted server exposes the
+            // hub at the root, mirroring Unity/Godot Custom mode).
             Assert.Equal("http://localhost:5200", host.Config.Host);
             Assert.Equal("custom-bearer", host.Config.Token);
         }
@@ -104,11 +145,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         [Fact]
         public void CloudMode_MissingCloudUrl_FallsBackToHostField()
         {
-            // A partial config (mode=Cloud but only `host` present) still resolves a host rather than blanking it.
+            // A partial config (mode=Cloud but only `host` present) still resolves a host rather than blanking it
+            // — and (Cloud mode) suffixes the /mcp hub path onto whatever cloud host was selected.
             using var host = BuildHost();
             host.ApplyConnectionConfig(new JsonObject { ["mode"] = "Cloud", ["host"] = "http://localhost:5200" });
 
-            Assert.Equal("http://localhost:5200", host.Config.Host);
+            Assert.Equal("http://localhost:5200/mcp", host.Config.Host);
         }
 
         [Fact]
@@ -132,6 +174,54 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
 
             host.HandleAuthMessage(type); // must not throw and must not touch the bearer
             Assert.Equal("keep", host.Config.Token);
+        }
+
+        // --- AppendCloudHubPath / StripCloudHubPath helper specs (the /mcp hub-prefix round-trip) -----------
+
+        [Theory]
+        [InlineData("https://ai-game.dev", "https://ai-game.dev/mcp")]
+        [InlineData("https://ai-game.dev/", "https://ai-game.dev/mcp")]
+        [InlineData("https://ai-game.dev/mcp", "https://ai-game.dev/mcp")]   // idempotent — never /mcp/mcp
+        [InlineData("https://ai-game.dev/mcp/", "https://ai-game.dev/mcp")]  // trailing slash normalized
+        [InlineData("https://ai-game.dev/MCP", "https://ai-game.dev/MCP")]   // case-insensitive suffix match
+        [InlineData("http://localhost:5200", "http://localhost:5200/mcp")]
+        public void AppendCloudHubPath_SuffixesIdempotently(string input, string expected)
+        {
+            Assert.Equal(expected, SidecarHost.AppendCloudHubPath(input));
+        }
+
+        [Theory]
+        [InlineData("https://ai-game.dev/mcp", "https://ai-game.dev")]
+        [InlineData("https://ai-game.dev/mcp/", "https://ai-game.dev")]
+        [InlineData("https://ai-game.dev", "https://ai-game.dev")]   // no suffix → unchanged (idempotent)
+        [InlineData("https://ai-game.dev/", "https://ai-game.dev")]  // trailing slash trimmed
+        [InlineData("http://localhost:5200/mcp", "http://localhost:5200")]
+        public void StripCloudHubPath_RemovesHubSuffix(string input, string expected)
+        {
+            Assert.Equal(expected, SidecarHost.StripCloudHubPath(input));
+        }
+
+        [Theory]
+        [InlineData("https://ai-game.dev")]
+        [InlineData("https://ai-game.dev/")]
+        [InlineData("https://ai-game.dev/mcp")]
+        public void AppendThenStrip_RoundTripsToBase(string baseUrl)
+        {
+            // Append (for the SignalR hub) then Strip (for device-auth) recovers the canonical base every time.
+            var hubHost = SidecarHost.AppendCloudHubPath(baseUrl);
+            Assert.Equal("https://ai-game.dev", SidecarHost.StripCloudHubPath(hubHost));
+        }
+
+        [Fact]
+        public void DeviceAuthBase_HasNoMcpSuffix_AfterCloudApply()
+        {
+            // After a Cloud ApplyConnectionConfig the SignalR Host carries /mcp; device-auth must derive the
+            // backend BASE (no /mcp) because {base}/api/auth/device/… is NOT behind the /mcp nginx prefix.
+            using var host = BuildHost();
+            host.ApplyConnectionConfig(Config("Cloud", host: null, cloudUrl: "https://ai-game.dev", token: "cloud-bearer"));
+
+            Assert.Equal("https://ai-game.dev/mcp", host.Config.Host);          // SignalR hub host
+            Assert.Equal("https://ai-game.dev", SidecarHost.StripCloudHubPath(host.Config.Host)); // device-auth base
         }
     }
 }


### PR DESCRIPTION
## Problem
Cloud mode is stuck on **"Connecting…"** forever; the plugin never registers with the cloud MCP server, so no MCP client (Claude Code, etc.) can pair with Unreal.

## Root cause (proven live)
The cloud serves the MCP server + SignalR hub **behind the `/mcp` prefix** (nginx `location ~ ^/mcp(/|$)` → `mcp-server:9090`, rewrites `/mcp/hub/... → /hub/...`). The bridge built the McpPlugin connection host from `cloudUrl` **as-is** (`https://ai-game.dev`), so the client dialed `https://ai-game.dev/hub/mcp-server` → nginx sent it to the **frontend SPA → 404** → SignalR negotiate never reached the server.

- `POST https://ai-game.dev/hub/mcp-server/negotiate` → **404 (html)**
- `POST https://ai-game.dev/mcp/hub/mcp-server/negotiate` → **200 (json)** real negotiate

Unity (`CloudServerUrl => base + "/mcp"`) and Godot (`CloudHubPath = "/mcp"`) already suffix the connection host; Unreal didn't.

## Fix (`bridge/src/Host/SidecarHost.cs`)
`_config.Host` is read by two consumers with different needs:
- **SignalR connection** (`McpPluginBuilder.SetConfig`) → needs `base + /mcp`.
- **Device-code auth** (`{base}/api/auth/device/*` → backend, NOT behind `/mcp`) → needs the bare base.

Added `CloudHubPath = "/mcp"` + idempotent pure helpers `AppendCloudHubPath` / `StripCloudHubPath`:
- `ApplyConnectionConfig`: Cloud host → `AppendCloudHubPath(selected)`; Custom verbatim.
- `StartDeviceAuth`: derives the base via `StripCloudHubPath(_config.Host)`.

Idempotent (never `/mcp/mcp`), trailing-slash-normalized, case-insensitive. Custom mode unchanged.

## Tests
`bridge/tests/ConnectionConfigTests.cs` — updated the prior Cloud assertions and added 12 cases (Cloud-suffix, idempotency, trailing-slash, Custom-verbatim, device-auth-base, Append/Strip round-trip). **109 passed / 0 failed.**

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)