### PR TITLE
fix(cli): resolve Cloud-mode connection from the plugin config

### DIFF
--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -2,11 +2,17 @@
 // `run-system-tool`, `status`, `wait-for-ready`).
 //
 // Precedence mirrors docs/ARCHITECTURE.md §8 (highest wins):
-//   explicit override -> process env -> project `.env` -> deterministic
-//   localhost port. Only the plugin owns the on-disk JSON config under
-//   `Saved/Config/UnrealMcp/`, so the CLI never reads it — the `.env`
-//   layer plus the deterministic port are the CLI's whole picture.
+//   explicit override -> process env -> project `.env` -> plugin JSON
+//   config -> deterministic localhost port.
+//
+// The plugin owns the on-disk JSON config under `Saved/Config/UnrealMcp/`
+// (FUnrealMcpConfig::DefaultConfigFilePath). It is the ONLY place a Cloud-mode
+// project records its connection — Cloud mode writes no `.env`, so without
+// reading this file the CLI falls through to the deterministic localhost port
+// where no server runs (issue #71). We mirror Unity's CLI, which reads its own
+// plugin config in the same precedence slot.
 
+import * as fs from 'fs';
 import * as path from 'path';
 import { readEnvFile } from './env-file.js';
 import { generatePortFromDirectory } from './port.js';
@@ -17,7 +23,7 @@ export interface ResolvedConnection {
   /** Bearer token, when one is configured. */
   token: string | undefined;
   /** Where the URL came from — for diagnostics / `status`. */
-  source: 'override' | 'process-env' | 'env-file' | 'deterministic-port';
+  source: 'override' | 'process-env' | 'env-file' | 'plugin-config' | 'deterministic-port';
 }
 
 export interface ResolveConnectionOptions {
@@ -71,6 +77,18 @@ export function resolveConnection(opts: ResolveConnectionOptions): ResolvedConne
     return { url: stripTrailingSlash(fileHost), token, source: 'env-file' };
   }
 
+  // Plugin JSON config — the only record of a Cloud-mode connection (issue #71).
+  // The `.env` token layer still wins over the config's token (it sits higher in
+  // §8 precedence); the config supplies a token only when no `.env`/process-env
+  // token is present.
+  const pluginConfig = readPluginConfig(projectDir);
+  if (pluginConfig) {
+    const fromConfig = resolveConnectionFromPluginConfig(pluginConfig);
+    if (fromConfig.url) {
+      return { url: stripTrailingSlash(fromConfig.url), token: token ?? fromConfig.token, source: 'plugin-config' };
+    }
+  }
+
   const port = generatePortFromDirectory(projectDir);
   return { url: `http://localhost:${port}`, token, source: 'deterministic-port' };
 }
@@ -84,4 +102,117 @@ function nonEmpty(value: string | undefined): string | undefined {
 
 export function stripTrailingSlash(url: string): string {
   return url.trim().replace(/\/+$/, '');
+}
+
+// --- Plugin on-disk JSON config (issue #71) -------------------------------
+//
+// Path + field names mirror the plugin's FUnrealMcpConfig
+// (UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp): the
+// file lives at `<project>/Saved/Config/UnrealMcp/ai-game-developer-config.json`
+// and uses camelCase keys. We read only the connection-relevant subset.
+
+/** Project-relative path to the plugin's persisted JSON config. */
+export const PLUGIN_CONFIG_RELATIVE_PATH = path.join(
+  'Saved',
+  'Config',
+  'UnrealMcp',
+  'ai-game-developer-config.json',
+);
+
+/** The connection-relevant subset of the plugin's JSON config. */
+export interface PluginConnectionConfig {
+  /** "Cloud" | "Custom" (case-insensitive; anything else is treated as Custom). */
+  connectionMode?: string;
+  /** Cloud base URL (e.g. `https://ai-game.dev`); the `/mcp` prefix is appended. */
+  cloudUrl?: string;
+  /** Bearer token for Cloud mode. */
+  cloudToken?: string;
+  /** Custom-mode host (full base URL). */
+  host?: string;
+  /** Bearer token for Custom mode (only on the wire when authOption is Required). */
+  token?: string;
+  /** "Required" | "None" — Custom-mode auth gate for `token`. */
+  authOption?: string;
+}
+
+/**
+ * Read `<projectDir>/Saved/Config/UnrealMcp/ai-game-developer-config.json`.
+ * Returns `undefined` when the file is absent, unreadable, or not valid JSON —
+ * never throws (library-safe). Tolerates a UTF-8 BOM.
+ */
+export function readPluginConfig(projectDir: string): PluginConnectionConfig | undefined {
+  const configPath = path.join(path.resolve(projectDir), PLUGIN_CONFIG_RELATIVE_PATH);
+  let raw: string;
+  try {
+    if (!fs.existsSync(configPath)) return undefined;
+    raw = fs.readFileSync(configPath, 'utf-8');
+  } catch {
+    return undefined;
+  }
+  // Strip a leading UTF-8 BOM (FFileHelper::SaveStringToFile may emit one).
+  if (raw.charCodeAt(0) === 0xfeff) raw = raw.slice(1);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (parsed === null || typeof parsed !== 'object') return undefined;
+  const obj = parsed as Record<string, unknown>;
+  return {
+    connectionMode: asString(obj.connectionMode),
+    cloudUrl: asString(obj.cloudUrl),
+    cloudToken: asString(obj.cloudToken),
+    host: asString(obj.host),
+    token: asString(obj.token),
+    authOption: asString(obj.authOption),
+  };
+}
+
+/** True when the config selects Cloud mode (case-insensitive). */
+export function isCloudMode(config: PluginConnectionConfig): boolean {
+  return (config.connectionMode ?? '').trim().toLowerCase() === 'cloud';
+}
+
+/**
+ * Resolve a `{ url, token }` from a plugin config, mirroring the plugin's
+ * routing (FUnrealMcpConfig):
+ *   - Cloud  -> url = appendMcp(cloudUrl), token = cloudToken
+ *   - Custom -> url = host,                token = (authOption Required ? token : undefined)
+ * `url` may be undefined when the relevant field is blank.
+ */
+export function resolveConnectionFromPluginConfig(config: PluginConnectionConfig): {
+  url: string | undefined;
+  token: string | undefined;
+} {
+  if (isCloudMode(config)) {
+    const cloudUrl = nonEmpty(config.cloudUrl);
+    return {
+      url: cloudUrl ? appendMcp(cloudUrl) : undefined,
+      token: nonEmpty(config.cloudToken),
+    };
+  }
+  // Custom mode: the token only goes on the wire when auth is Required (mirrors
+  // FUnrealMcpConfig::ResolveEffectiveToken).
+  const authRequired = (config.authOption ?? '').trim().toLowerCase() === 'required';
+  return {
+    url: nonEmpty(config.host),
+    token: authRequired ? nonEmpty(config.token) : undefined,
+  };
+}
+
+/**
+ * Idempotently ensure a URL ends with exactly one `/mcp` segment: strip a
+ * trailing `/mcp` (case-insensitive, trailing-slash tolerant) then re-append
+ * `/mcp`. `https://ai-game.dev` -> `https://ai-game.dev/mcp`;
+ * `https://ai-game.dev/mcp/` -> `https://ai-game.dev/mcp` (never `/mcp/mcp`).
+ */
+export function appendMcp(url: string): string {
+  const base = stripTrailingSlash(url).replace(/\/mcp$/i, '');
+  return `${base}/mcp`;
+}
+
+/** Coerce an unknown JSON field to a trimmed non-empty string, else undefined. */
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? nonEmpty(value) : undefined;
 }

--- a/cli/tests/config.test.ts
+++ b/cli/tests/config.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  resolveConnection,
+  readPluginConfig,
+  resolveConnectionFromPluginConfig,
+  appendMcp,
+  isCloudMode,
+  PLUGIN_CONFIG_RELATIVE_PATH,
+} from '../src/utils/config.js';
+import { generatePortFromDirectory } from '../src/utils/port.js';
+import { makeTempDir, rmTempDir } from './helpers.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length) rmTempDir(tempDirs.pop()!);
+});
+
+/** Make a temp project dir; optionally drop a plugin JSON config and/or `.env`. */
+function makeProject(opts: { config?: object | string; env?: string } = {}): string {
+  const dir = makeTempDir();
+  tempDirs.push(dir);
+  if (opts.config !== undefined) {
+    const configPath = path.join(dir, PLUGIN_CONFIG_RELATIVE_PATH);
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    const text = typeof opts.config === 'string' ? opts.config : JSON.stringify(opts.config, null, 2);
+    fs.writeFileSync(configPath, text, 'utf-8');
+  }
+  if (opts.env !== undefined) {
+    fs.writeFileSync(path.join(dir, '.env'), opts.env, 'utf-8');
+  }
+  return dir;
+}
+
+describe('appendMcp', () => {
+  it('appends /mcp to a bare base URL', () => {
+    expect(appendMcp('https://ai-game.dev')).toBe('https://ai-game.dev/mcp');
+  });
+  it('is idempotent when the URL already ends with /mcp', () => {
+    expect(appendMcp('https://ai-game.dev/mcp')).toBe('https://ai-game.dev/mcp');
+  });
+  it('handles a trailing slash after /mcp (no /mcp/mcp)', () => {
+    expect(appendMcp('https://ai-game.dev/mcp/')).toBe('https://ai-game.dev/mcp');
+  });
+  it('is case-insensitive on the existing /mcp segment', () => {
+    expect(appendMcp('https://ai-game.dev/MCP')).toBe('https://ai-game.dev/mcp');
+  });
+  it('strips trailing slashes on a bare base URL', () => {
+    expect(appendMcp('https://ai-game.dev/')).toBe('https://ai-game.dev/mcp');
+  });
+});
+
+describe('readPluginConfig', () => {
+  it('returns undefined when the file is absent', () => {
+    const dir = makeProject();
+    expect(readPluginConfig(dir)).toBeUndefined();
+  });
+  it('returns undefined for malformed JSON (does not throw)', () => {
+    const dir = makeProject({ config: '{ not json' });
+    expect(readPluginConfig(dir)).toBeUndefined();
+  });
+  it('tolerates a UTF-8 BOM', () => {
+    const dir = makeProject({ config: '﻿' + JSON.stringify({ connectionMode: 'Cloud', cloudUrl: 'https://ai-game.dev' }) });
+    const cfg = readPluginConfig(dir);
+    expect(cfg?.connectionMode).toBe('Cloud');
+    expect(cfg?.cloudUrl).toBe('https://ai-game.dev');
+  });
+});
+
+describe('resolveConnectionFromPluginConfig', () => {
+  it('Cloud → appendMcp(cloudUrl) + cloudToken', () => {
+    const r = resolveConnectionFromPluginConfig({ connectionMode: 'Cloud', cloudUrl: 'https://ai-game.dev', cloudToken: 'ct' });
+    expect(r.url).toBe('https://ai-game.dev/mcp');
+    expect(r.token).toBe('ct');
+  });
+  it('Custom + authOption Required → host + token', () => {
+    const r = resolveConnectionFromPluginConfig({ connectionMode: 'Custom', host: 'http://localhost:9001', authOption: 'Required', token: 'tk' });
+    expect(r.url).toBe('http://localhost:9001');
+    expect(r.token).toBe('tk');
+  });
+  it('Custom + authOption None → token undefined', () => {
+    const r = resolveConnectionFromPluginConfig({ connectionMode: 'Custom', host: 'http://localhost:9001', authOption: 'None', token: 'tk' });
+    expect(r.url).toBe('http://localhost:9001');
+    expect(r.token).toBeUndefined();
+  });
+
+  it('isCloudMode is case-insensitive', () => {
+    expect(isCloudMode({ connectionMode: 'cloud' })).toBe(true);
+    expect(isCloudMode({ connectionMode: 'Custom' })).toBe(false);
+    expect(isCloudMode({})).toBe(false);
+  });
+});
+
+describe('resolveConnection — plugin-config layer (issue #71)', () => {
+  it('Cloud config → url ends with /mcp, token = cloudToken, source plugin-config', () => {
+    const dir = makeProject({ config: { connectionMode: 'Cloud', cloudUrl: 'https://ai-game.dev', cloudToken: 'cloud-secret' } });
+    const r = resolveConnection({ projectDir: dir });
+    expect(r.url).toBe('https://ai-game.dev/mcp');
+    expect(r.token).toBe('cloud-secret');
+    expect(r.source).toBe('plugin-config');
+  });
+
+  it('Cloud config whose cloudUrl already ends /mcp → single /mcp', () => {
+    const dir = makeProject({ config: { connectionMode: 'Cloud', cloudUrl: 'https://ai-game.dev/mcp', cloudToken: 't' } });
+    expect(resolveConnection({ projectDir: dir }).url).toBe('https://ai-game.dev/mcp');
+  });
+
+  it('Cloud config whose cloudUrl ends /mcp/ → single /mcp', () => {
+    const dir = makeProject({ config: { connectionMode: 'Cloud', cloudUrl: 'https://ai-game.dev/mcp/', cloudToken: 't' } });
+    expect(resolveConnection({ projectDir: dir }).url).toBe('https://ai-game.dev/mcp');
+  });
+
+  it('Custom config + authOption Required → host + token', () => {
+    const dir = makeProject({ config: { connectionMode: 'Custom', host: 'http://localhost:9100', authOption: 'Required', token: 'tk' } });
+    const r = resolveConnection({ projectDir: dir });
+    expect(r.url).toBe('http://localhost:9100');
+    expect(r.token).toBe('tk');
+    expect(r.source).toBe('plugin-config');
+  });
+
+  it('Custom config + authOption None → token undefined', () => {
+    const dir = makeProject({ config: { connectionMode: 'Custom', host: 'http://localhost:9100', authOption: 'None', token: 'tk' } });
+    const r = resolveConnection({ projectDir: dir });
+    expect(r.url).toBe('http://localhost:9100');
+    expect(r.token).toBeUndefined();
+  });
+
+  it('explicit --url override still wins over a Cloud config', () => {
+    const dir = makeProject({ config: { connectionMode: 'Cloud', cloudUrl: 'https://ai-game.dev', cloudToken: 'cloud-secret' } });
+    const r = resolveConnection({ projectDir: dir, url: 'http://localhost:5220/', token: 'explicit' });
+    expect(r.url).toBe('http://localhost:5220');
+    expect(r.token).toBe('explicit');
+    expect(r.source).toBe('override');
+  });
+
+  it('process-env HOST wins over a Cloud config', () => {
+    const dir = makeProject({ config: { connectionMode: 'Cloud', cloudUrl: 'https://ai-game.dev', cloudToken: 'cloud-secret' } });
+    const r = resolveConnection({ projectDir: dir, processEnv: { UNREAL_MCP_HOST: 'http://localhost:7000' } });
+    expect(r.url).toBe('http://localhost:7000');
+    expect(r.source).toBe('process-env');
+  });
+
+  it('project .env HOST wins over a Cloud config', () => {
+    const dir = makeProject({
+      config: { connectionMode: 'Cloud', cloudUrl: 'https://ai-game.dev', cloudToken: 'cloud-secret' },
+      env: 'UNREAL_MCP_HOST=http://localhost:7001\n',
+    });
+    const r = resolveConnection({ projectDir: dir, processEnv: {} });
+    expect(r.url).toBe('http://localhost:7001');
+    expect(r.source).toBe('env-file');
+  });
+
+  it('an env token still wins over the config token while the config supplies the URL', () => {
+    const dir = makeProject({
+      config: { connectionMode: 'Cloud', cloudUrl: 'https://ai-game.dev', cloudToken: 'cloud-secret' },
+      env: 'UNREAL_MCP_TOKEN=env-token\n',
+    });
+    const r = resolveConnection({ projectDir: dir, processEnv: {} });
+    expect(r.url).toBe('https://ai-game.dev/mcp');
+    expect(r.token).toBe('env-token');
+    expect(r.source).toBe('plugin-config');
+  });
+
+  it('no config file and no .env → unchanged localhost:<port> fallback', () => {
+    const dir = makeProject();
+    const r = resolveConnection({ projectDir: dir, processEnv: {} });
+    expect(r.url).toBe(`http://localhost:${generatePortFromDirectory(dir)}`);
+    expect(r.token).toBeUndefined();
+    expect(r.source).toBe('deterministic-port');
+  });
+
+  it('a config with no usable connection fields falls through to localhost', () => {
+    const dir = makeProject({ config: { connectionMode: 'Custom' } });
+    const r = resolveConnection({ projectDir: dir, processEnv: {} });
+    expect(r.url).toBe(`http://localhost:${generatePortFromDirectory(dir)}`);
+    expect(r.source).toBe('deterministic-port');
+  });
+});


### PR DESCRIPTION
## Problem (verified live)
`unreal-mcp-cli run-tool ping -p <project>` fails with `connection-refused` in Cloud mode — `resolveConnection` never read the plugin's JSON config, so it fell through to `localhost:<port>` where no server runs. Worked only with explicit `--url https://ai-game.dev/mcp --token <cloudToken>`.

## Fix
`cli/src/utils/config.ts`: new precedence (mirrors Unity / ARCHITECTURE §8) `override → process-env → .env → plugin-config → deterministic-port`. Added `readPluginConfig` (reads `<project>/Saved/Config/UnrealMcp/ai-game-developer-config.json`, BOM-tolerant, never throws) + `resolveConnectionFromPluginConfig` (Cloud → `appendMcp(cloudUrl)` + `cloudToken`; Custom → `host` + token when `authOption=Required`). `appendMcp` is idempotent (never `/mcp/mcp`). Field names verified against `UnrealMcpConfig.cpp`. All four consumers (`run-tool`/`run-system-tool`/`status`/`wait-for-ready`) benefit; no signature change.

## Tests
`cli/tests/config.test.ts` (+23 cases): Cloud→/mcp, idempotency, Custom path + authOption gate, override precedence, localhost fallback intact. **npm test: 177 passed**, build clean.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)