### PR TITLE
fix(cli): exclude stale Win64/Intermediate build cache from install-plugin copy

### DIFF
--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -20,6 +20,34 @@ import type {
 const PLUGIN_DIRNAME = 'UnrealMCP';
 /** Subtree under `Binaries/` holding the bundled bridge (ARCHITECTURE §6.1). */
 const BUNDLED_BRIDGE_REL = path.join('Binaries', 'ThirdParty');
+/** `Binaries/ThirdParty` with forward slashes, for the copy filter's keep-check. */
+const BUNDLED_BRIDGE_REL_POSIX = BUNDLED_BRIDGE_REL.split(path.sep).join('/');
+
+/**
+ * Decide whether `srcAbs` (an absolute path inside `pluginSourceDir`) should be
+ * copied into the target project. Excludes the plugin SOURCE checkout's local
+ * dev build cache so we never ship stale/mismatched compiled modules (issue
+ * #73 — the inverse of #60's update-time auto-clean):
+ *   - `Intermediate/` and everything under it (UBT build artifacts).
+ *   - compiled-module dirs directly under `Binaries/` (e.g. `Binaries/Win64`),
+ *     i.e. anything under `Binaries/` that is NOT the bundled-bridge subtree.
+ * Keeps everything else — `Source/`, `Resources/`, `Config/`, `*.uplugin`, the
+ * plugin root, `Binaries/` itself (needed to reach ThirdParty), and the bundled
+ * sidecar under `Binaries/ThirdParty/**` (ARCHITECTURE §6.1).
+ */
+function copyFilter(srcAbs: string, pluginSourceDir: string): boolean {
+  const rel = path.relative(pluginSourceDir, srcAbs).split(path.sep).join('/');
+  if (rel === '' || rel === '.') return true; // the plugin root itself
+  // Skip Intermediate and its subtree.
+  if (rel === 'Intermediate' || rel.startsWith('Intermediate/')) return false;
+  // Under Binaries/: allow `Binaries` itself and the ThirdParty subtree; skip
+  // every other child (compiled-module platform dirs like Binaries/Win64).
+  if (rel === 'Binaries') return true;
+  if (rel.startsWith('Binaries/')) {
+    return rel === BUNDLED_BRIDGE_REL_POSIX || rel.startsWith(BUNDLED_BRIDGE_REL_POSIX + '/');
+  }
+  return true;
+}
 
 /** True when `p` is a symlink/junction (vs a real directory). */
 function isLink(p: string): boolean {
@@ -102,7 +130,10 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     // restore the stash before rethrowing — otherwise the only copy of the
     // (unrecoverable-from-source) bundled bridge is abandoned in os.tmpdir().
     try {
-      fs.cpSync(pluginSourceDir, installedPath, { recursive: true });
+      fs.cpSync(pluginSourceDir, installedPath, {
+        recursive: true,
+        filter: (src) => copyFilter(src, pluginSourceDir),
+      });
     } catch (copyErr: unknown) {
       if (stashedBridge) {
         try {

--- a/cli/tests/install-plugin.test.ts
+++ b/cli/tests/install-plugin.test.ts
@@ -48,6 +48,41 @@ describe('installPlugin (copy)', () => {
     expect(r.kind).toBe('failure');
   });
 
+  it('excludes the source checkout\'s stale Win64/Intermediate build cache but keeps the sidecar (issue #73)', async () => {
+    const project = tmp();
+    const source = makePluginSource();
+    // Extra kept content alongside the .uplugin / Source.
+    fs.mkdirSync(path.join(source, 'Resources'), { recursive: true });
+    fs.writeFileSync(path.join(source, 'Resources', 'Icon.png'), 'PNG', 'utf-8');
+    // The bundled sidecar — SHOULD be copied.
+    const bridge = path.join(source, 'Binaries', 'ThirdParty', 'UnrealMcpBridge', 'win-x64');
+    fs.mkdirSync(bridge, { recursive: true });
+    fs.writeFileSync(path.join(bridge, 'unreal-mcp-bridge.exe'), 'BRIDGE', 'utf-8');
+    // Stale dev build cache — should NOT be copied.
+    const win64 = path.join(source, 'Binaries', 'Win64');
+    fs.mkdirSync(win64, { recursive: true });
+    fs.writeFileSync(path.join(win64, 'UnrealEditor-UnrealMcpEditor.dll'), 'DLL', 'utf-8');
+    fs.writeFileSync(path.join(win64, 'UnrealEditor.modules'), '{}', 'utf-8');
+    const inter = path.join(source, 'Intermediate', 'Build', 'Win64');
+    fs.mkdirSync(inter, { recursive: true });
+    fs.writeFileSync(path.join(inter, 'x.obj'), 'OBJ', 'utf-8');
+
+    const r = await installPlugin({ projectDir: project, pluginSourceDir: source });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    const p = r.installedPath;
+    // Kept:
+    expect(fs.existsSync(path.join(p, 'UnrealMCP.uplugin'))).toBe(true);
+    expect(fs.existsSync(path.join(p, 'Source', 'marker.txt'))).toBe(true);
+    expect(fs.existsSync(path.join(p, 'Resources', 'Icon.png'))).toBe(true);
+    expect(
+      fs.existsSync(path.join(p, 'Binaries', 'ThirdParty', 'UnrealMcpBridge', 'win-x64', 'unreal-mcp-bridge.exe')),
+    ).toBe(true);
+    // Excluded:
+    expect(fs.existsSync(path.join(p, 'Binaries', 'Win64'))).toBe(false);
+    expect(fs.existsSync(path.join(p, 'Intermediate'))).toBe(false);
+  });
+
   it('preserves a previously-bundled sidecar bridge across a copy re-install (issue #58)', async () => {
     // First install ships a release plugin WITH the bundled bridge.
     const project = tmp();

--- a/cli/tests/update.test.ts
+++ b/cli/tests/update.test.ts
@@ -136,11 +136,11 @@ describe('update', () => {
     expect(fs.readFileSync(bridgeExe, 'utf-8')).toBe('BRIDGE-PAYLOAD');
   });
 
-  it('clean removes cache that the COPIED SOURCE itself shipped (non-vacuous: only the explicit clean can remove it)', async () => {
-    // Distinct from the test above: here the NEW SOURCE ships the stale cache,
-    // so installPlugin's rm-then-copy RE-CREATES Intermediate/+Binaries/Win64 in
-    // the install. Only the explicit cleanPluginBuildCache step can remove them —
-    // if the clean call were deleted, these assertions would FAIL.
+  it('a SOURCE that ships a stale cache never lands it in the install (issue #73 copy filter)', async () => {
+    // Since #73, installPlugin's copy EXCLUDES Intermediate/+Binaries/<platform>
+    // (keeping only Binaries/ThirdParty), so even a NEW SOURCE that ships the
+    // stale cache cannot reintroduce it into the install. The explicit clean on
+    // top then has nothing left to do — the cache is gone either way.
     const project = tmp();
     seedInstalledWithCache(project, '0.1.0');
     const installed = path.join(project, 'Plugins', 'UnrealMCP');
@@ -148,15 +148,15 @@ describe('update', () => {
     expect(r.kind).toBe('success');
     if (r.kind !== 'success') return;
     expect(r.cleaned).toBe(true);
-    // The source-shipped stale cache was copied in, then wiped by the clean.
+    // No stale cache in the install: the copy filter dropped it before any clean.
     expect(fs.existsSync(path.join(installed, 'Intermediate'))).toBe(false);
     expect(fs.existsSync(path.join(installed, 'Binaries', 'Win64'))).toBe(false);
   });
 
-  it('--no-clean leaves the source-shipped cache in place (proves the copy lands it; only clean removes it)', async () => {
-    // The mirror of the test above: with noClean, the cache the source shipped
-    // SURVIVES the update — proving installPlugin copied it in and that it is the
-    // explicit clean (not the rm-then-copy) that removes it in the default path.
+  it('--no-clean still keeps the source-shipped cache out (the copy filter, not the clean, removes it since #73)', async () => {
+    // Before #73 the copy landed the source's cache and only the explicit clean
+    // removed it. Now the copy filter excludes it up front, so even with noClean
+    // (no explicit clean step) the install has no stale Intermediate/+Binaries/Win64.
     const project = tmp();
     seedInstalledWithCache(project, '0.1.0');
     const installed = path.join(project, 'Plugins', 'UnrealMCP');
@@ -164,9 +164,9 @@ describe('update', () => {
     expect(r.kind).toBe('success');
     if (r.kind !== 'success') return;
     expect(r.cleaned).toBe(false);
-    // The copied-in cache is still present because no explicit clean ran.
-    expect(fs.existsSync(path.join(installed, 'Intermediate'))).toBe(true);
-    expect(fs.existsSync(path.join(installed, 'Binaries', 'Win64'))).toBe(true);
+    // The copy filter kept the cache out even though no explicit clean ran.
+    expect(fs.existsSync(path.join(installed, 'Intermediate'))).toBe(false);
+    expect(fs.existsSync(path.join(installed, 'Binaries', 'Win64'))).toBe(false);
   });
 
   it('--no-clean (noClean) skips the explicit clean step but still preserves the bridge', async () => {


### PR DESCRIPTION
## Problem (verified live)
`install-plugin <project>` (copy) dragged the plugin source checkout's local build cache into the target: `Binaries/Win64/*.dll/.pdb` + `UnrealEditor.modules` and `Intermediate/Build/Win64/**` (~30 files). Those modules were built against a different project/engine context → stale/mismatched in the target ("modules out of date" / stale load). It's the inverse of #60 (clean refresh on update); install must not ship the dev cache.

## Fix
`cli/src/lib/install-plugin.ts`: added `copyFilter(srcAbs, pluginSourceDir)` wired into the existing `fs.cpSync` as `filter`. Per path (relative to the source, normalized to `/`):
- skip `Intermediate` / `Intermediate/**`
- allow `Binaries` itself, but under it allow only `Binaries/ThirdParty` + subtree (the bundled sidecar, reusing `BUNDLED_BRIDGE_REL`); skip `Binaries/Win64`/`Mac`/`Linux`/...
- keep everything else (`Source/`, `Resources/`, `Config/`, `*.uplugin`)

Stash/restore-bridge flow and throw/rollback are intact (filter is additive). Junction mode unchanged.

## Tests
- New `install-plugin.test.ts` case: a fixture source with `Source/`, `Binaries/ThirdParty/...`, `Binaries/Win64/...`, `Intermediate/...` → installed has Source + `Binaries/ThirdParty` + `.uplugin`, and NOT `Binaries/Win64` / `Intermediate`.
- Rewrote two `update.test.ts` cases whose premise (copy lands the cache; only the explicit clean removes it) is now false — they assert the copy filter keeps the cache out even with `--no-clean`; the #58 clean stays as defense-in-depth.

`npm test`: **178 passed**, 1 skipped, build clean.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)