### PR TITLE
feat(ci): self-contained connection + tool smoke (custom local server) + gated CI leg

### DIFF
--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -13,9 +13,14 @@
 #   (b) cli     — unreal-mcp-cli node 20/22 tests via the reusable test_cli.yml
 #   (c) plugin  — UE 5.7 BuildPlugin + Automation specs (UnrealMcp. filter) on a
 #                 SELF-HOSTED windows runner labelled `unreal-5-7`
+#   (d) connection-smoke — live relay round-trip (client -> gamedev-mcp-server ->
+#                 sidecar -> plugin -> editor -> tool), self-hosted, gated on a
+#                 SEPARATE dormant `vars.UNREAL_SMOKE_READY` (owner-enabled after a
+#                 one-time runner validation; see the job + docs/RELEASING.md)
 #
 # (There is no server leg: the MCP server lives in the shared
-# IvanMurzak/GameDev-MCP-Server repo and is tested/released there.)
+# IvanMurzak/GameDev-MCP-Server repo and is tested/released there. Leg (d) pulls
+# the public server release at runtime; it does not build the server here.)
 #
 # Self-hosted runner is NEVER red-by-absence: job (c) is gated on the repository
 # variable `vars.UNREAL_RUNNER_READY == 'true'`. While that variable is unset
@@ -170,3 +175,68 @@ jobs:
           path: ${{ env.REPORT_DIR }}
           if-no-files-found: ignore
           retention-days: 7
+
+  # (d) connection + tool smoke — the live RELAY path the Automation specs do NOT
+  # cover: a real MCP client -> gamedev-mcp-server -> sidecar -> plugin -> editor
+  # round-trip, exercised by the self-contained scripts/connection_smoke.py
+  # (--mode custom: it DOWNLOADS the public gamedev-mcp-server release, runs it in
+  # streamableHttp mode, launches the host editor in Custom mode, and calls a tool
+  # battery over POST /mcp). No infra-repo dependency; the server is fetched from
+  # the public GameDev-MCP-Server releases.
+  #
+  # Gated on a DEDICATED `vars.UNREAL_SMOKE_READY == 'true'` (NOT the plugin
+  # runner var), so it stays SKIPPED — never red-by-absence — until the owner has
+  # validated it once on the runner and flips the variable. Prerequisites the
+  # owner confirms before enabling (see docs/RELEASING.md):
+  #   • the host project (`vars.UNREAL_HOST_PROJECT`) has the UnrealMCP plugin
+  #     COMPILED (the plugin leg / runner setup builds it); and
+  #   • a bridge sidecar is resolvable — this job builds it and exports
+  #     UNREAL_MCP_BRIDGE_PATH (PR builds do not bundle the §6 sidecar; only the
+  #     release job does).
+  connection-smoke:
+    name: connection + tool smoke (UE 5.7, custom server)
+    if: ${{ vars.UNREAL_SMOKE_READY == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: [self-hosted, windows, unreal-5-7]
+    env:
+      UE_ROOT: ${{ vars.UNREAL_ENGINE_PATH || 'C:\Program Files\Epic Games\UE_5.7' }}
+      HOST_UPROJECT: ${{ vars.UNREAL_HOST_PROJECT }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build bridge sidecar (for UNREAL_MCP_BRIDGE_PATH override)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          dotnet build bridge/Unreal-MCP-Bridge.sln --configuration Debug
+          if ($LASTEXITCODE -ne 0) { throw "bridge build failed ($LASTEXITCODE)" }
+          $bridge = Join-Path $env:GITHUB_WORKSPACE 'bridge\src\bin\Debug\net9.0\unreal-mcp-bridge.exe'
+          if (-not (Test-Path $bridge)) { throw "bridge binary not found at $bridge" }
+          echo "UNREAL_MCP_BRIDGE_PATH=$bridge" >> $env:GITHUB_ENV
+
+      - name: Run connection + tool smoke (custom local server)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ([string]::IsNullOrWhiteSpace($env:HOST_UPROJECT)) {
+            throw "UNREAL_HOST_PROJECT repo variable is not set — the smoke needs a host .uproject with the UnrealMCP plugin compiled (see docs/RELEASING.md)."
+          }
+          $editorCmd = Join-Path $env:UE_ROOT 'Engine\Binaries\Win64\UnrealEditor-Cmd.exe'
+          # --mode custom downloads the public gamedev-mcp-server release, runs it,
+          # launches the editor in Custom mode, and asserts the tool battery. The
+          # bridge override (UNREAL_MCP_BRIDGE_PATH, set above) is inherited by the
+          # editor the script spawns.
+          python scripts/connection_smoke.py --mode custom --project "$env:HOST_UPROJECT" --ue "$editorCmd" --server-port 18080 --timeout 240
+          if ($LASTEXITCODE -ne 0) { throw "connection + tool smoke FAILED (exit $LASTEXITCODE)" }

--- a/scripts/connection_smoke.py
+++ b/scripts/connection_smoke.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""
+connection_smoke.py — Headless Unreal-MCP connection + tool e2e smoke (self-contained).
+
+Verifies, with NO GUI and NO human, that the UnrealMCP plugin connects to an MCP server and serves
+tool calls end-to-end through the relay. Self-contained: depends only on this repo + a UE editor +
+network access to the public GameDev-MCP-Server releases. NO dependency on the infra superproject.
+
+Modes
+-----
+  --mode cloud   — connect to the hosted ai-game.dev server using the project's stored cloudToken
+                 (Saved/Config/UnrealMcp/ai-game-developer-config.json). Signal: POST /mcp flips
+                 401 -> 200 once the plugin registers the session.
+
+  --mode custom  — DOWNLOAD the public `gamedev-mcp-server` release (latest, or --server-version),
+                 run it locally in streamableHttp mode, launch the editor in Custom mode pointed at
+                 it, and verify the plugin connects. Signal: tools/list returns the plugin's tools.
+                 No auth. The server is fetched from
+                 https://github.com/IvanMurzak/GameDev-MCP-Server/releases (cached under the
+                 project's Intermediate/), or pass --server / set UNREAL_MCP_SERVER_PATH to reuse a
+                 local build.
+
+Both modes finish with a tool battery (ping + a few read-only tools) over the relay, proving the
+whole chain (smoke -> server -> sidecar -> plugin -> editor -> tool -> back).
+
+Usage
+-----
+  python scripts/connection_smoke.py --mode custom --project <.uproject>
+        [--ue <UnrealEditor-Cmd.exe>] [--timeout 180] [--poll 5] [--connect-only]
+        [--keep-editor] [--no-kill-existing] [--server-port 18080]
+        [--server <gamedev-mcp-server[.exe]>] [--server-version latest|8.0.0]
+
+Exit code 0 = all requested stages passed; non-zero = FAIL / timeout / setup error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import socket
+import ssl
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+
+DEFAULT_UE = Path(r"C:\Program Files\Epic Games\UE_5.7\Engine\Binaries\Win64\UnrealEditor-Cmd.exe")
+CONFIG_REL = Path("Saved") / "Config" / "UnrealMcp" / "ai-game-developer-config.json"
+MCP_PROTOCOL_VERSION = "2025-06-18"
+SERVER_REPO = "IvanMurzak/GameDev-MCP-Server"
+SERVER_BASENAME = "gamedev-mcp-server.exe" if os.name == "nt" else "gamedev-mcp-server"
+
+MARK_PLUGIN_LOADED = "[Unreal-MCP] plugin loaded"
+MARK_SIDECAR_SPAWN = "spawned sidecar"
+MARK_NO_BINARY = "no sidecar binary resolved"
+RE_FATAL = re.compile(r"Fatal error|Unhandled Exception|\[Callstack\]")
+
+
+def _ascii_safe_stdio() -> None:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+        except (AttributeError, ValueError):
+            pass
+
+
+def log(msg: str) -> None:
+    print(f"[smoke] {msg}", flush=True)
+
+
+def read_config(project: Path) -> dict:
+    cfg_path = project.parent / CONFIG_REL
+    if not cfg_path.is_file():
+        raise SystemExit(f"FAIL: no plugin config at {cfg_path} — open the editor & authorize once first.")
+    return json.loads(cfg_path.read_text(encoding="utf-8-sig"))
+
+
+# --------------------------------------------------------------------------- MCP streamable HTTP
+
+def _parse_messages(body: str, content_type: str) -> list:
+    msgs: list = []
+    if "text/event-stream" in content_type:
+        for line in body.splitlines():
+            line = line.strip()
+            if line.startswith("data:"):
+                payload = line[len("data:"):].strip()
+                if payload and payload != "[DONE]":
+                    try:
+                        msgs.append(json.loads(payload))
+                    except json.JSONDecodeError:
+                        pass
+    elif body.strip():
+        try:
+            msgs.append(json.loads(body))
+        except json.JSONDecodeError:
+            pass
+    return msgs
+
+
+def mcp_post(url: str, token: str | None, payload: dict, session_id: str | None = None,
+             timeout: float = 30.0) -> tuple[int, str | None, list]:
+    headers = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+    req = urllib.request.Request(url, data=json.dumps(payload).encode(), method="POST", headers=headers)
+    ctx = ssl.create_default_context()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            sid = resp.headers.get("Mcp-Session-Id") or session_id
+            ctype = resp.headers.get("Content-Type", "")
+            return resp.status, sid, _parse_messages(resp.read().decode("utf-8", "replace"), ctype)
+    except urllib.error.HTTPError as e:
+        return e.code, session_id, []
+    except (urllib.error.URLError, socket.timeout, ssl.SSLError, ConnectionError):
+        return 0, session_id, []
+
+
+def mcp_initialize(url: str, token: str | None) -> tuple[int, str | None]:
+    status, sid, _ = mcp_post(url, token, {
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": MCP_PROTOCOL_VERSION, "capabilities": {},
+                   "clientInfo": {"name": "unreal-conn-smoke", "version": "0"}}})
+    return status, sid
+
+
+def mcp_list_tools(url: str, token: str | None, sid: str | None) -> list[str]:
+    _s, sid, msgs = mcp_post(url, token, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}, sid)
+    names: list[str] = []
+    for m in msgs:
+        for t in (m.get("result", {}).get("tools") or []):
+            if t.get("name"):
+                names.append(t["name"])
+    return names
+
+
+def _result_text(msg: dict) -> str:
+    return " ".join(str(i.get("text", "")) for i in (msg.get("result", {}).get("content") or [])
+                    if isinstance(i, dict) and i.get("type") == "text")
+
+
+def mcp_call_tool(url: str, token: str | None, sid: str | None, name: str, args: dict,
+                  call_id: int) -> tuple[bool, str | None, str]:
+    _s, sid, msgs = mcp_post(url, token, {"jsonrpc": "2.0", "id": call_id, "method": "tools/call",
+                                          "params": {"name": name, "arguments": args}}, sid)
+    for m in msgs:
+        if m.get("id") == call_id:
+            if "error" in m:
+                return False, sid, str(m.get("error"))[:120]
+            res = m.get("result", {})
+            text = _result_text(m) or json.dumps(res.get("structuredContent", ""))[:120]
+            if res.get("isError"):
+                return False, sid, text[:120]
+            return True, sid, text.strip()[:120]
+    return False, sid, "no result"
+
+
+SMOKE_BATTERY = [
+    ("ping", lambda nonce: {"message": nonce}),
+    ("editor-application-get-state", lambda nonce: {}),
+    ("level-list-loaded", lambda nonce: {}),
+    ("actor-find", lambda nonce: {}),
+    ("actor-component-list-all", lambda nonce: {}),
+]
+
+
+def run_e2e(url: str, token: str | None, nonce: str) -> tuple[bool, str]:
+    status, sid = mcp_initialize(url, token)
+    if status != 200 or not sid:
+        return False, f"initialize failed (HTTP {status})"
+    mcp_post(url, token, {"jsonrpc": "2.0", "method": "notifications/initialized"}, sid)
+    tools: list[str] = []
+    for _ in range(6):
+        tools = mcp_list_tools(url, token, sid)
+        if tools:
+            break
+        time.sleep(2)
+    if not tools:
+        return False, "tools/list returned no tools"
+    log(f"e2e: tools/list -> {len(tools)} tools (e.g. {', '.join(sorted(tools)[:6])})")
+    results: list[tuple[str, bool]] = []
+    call_id = 10
+    for name, mkargs in SMOKE_BATTERY:
+        if name not in tools:
+            continue
+        ok, sid, text = mcp_call_tool(url, token, sid, name, mkargs(nonce), call_id)
+        call_id += 1
+        if name == "ping" and ok:
+            ok = (nonce in text) or ("pong" in text.lower())
+        results.append((name, ok))
+        log(f"e2e: {name:<30} -> {'OK  ' if ok else 'FAIL'}  {text[:60]}")
+    if not results:
+        return True, f"connected + {len(tools)} tools listed (no battery tools present; list = PASS)"
+    passed = sum(1 for _, ok in results if ok)
+    detail = f"{passed}/{len(results)} tools OK ({len(tools)} listed): " + \
+             ", ".join(f"{n}{'' if ok else '!'}" for n, ok in results)
+    return passed == len(results), detail
+
+
+# --------------------------------------------------------------------------- local server (custom)
+
+def server_rid() -> str:
+    import platform
+    m = platform.machine().lower()
+    if sys.platform.startswith("win"):
+        return "win-arm64" if "arm" in m else "win-x64"
+    if sys.platform == "darwin":
+        return "osx-arm64" if "arm" in m else "osx-x64"
+    return "linux-arm64" if "arm" in m or "aarch64" in m else "linux-x64"
+
+
+def latest_server_version() -> str:
+    try:
+        with urllib.request.urlopen(
+                f"https://api.github.com/repos/{SERVER_REPO}/releases/latest", timeout=20) as r:
+            tag = json.load(r).get("tag_name", "") or ""
+        return tag.lstrip("v") or "8.0.0"
+    except (urllib.error.URLError, json.JSONDecodeError, socket.timeout):
+        return "8.0.0"
+
+
+def download_server(version: str, cache_dir: Path) -> Path | None:
+    rid = server_rid()
+    url = f"https://github.com/{SERVER_REPO}/releases/download/v{version}/gamedev-mcp-server-{rid}.zip"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    zippath = cache_dir / f"gamedev-mcp-server-{rid}.zip"
+    log(f"downloading server v{version} ({rid}) ...")
+    try:
+        with urllib.request.urlopen(url, timeout=120) as r, open(zippath, "wb") as f:
+            f.write(r.read())
+        with zipfile.ZipFile(zippath) as z:
+            z.extractall(cache_dir)
+    except (urllib.error.URLError, socket.timeout, zipfile.BadZipFile) as e:
+        log(f"server download failed: {e}")
+        return None
+    # win-x64 zips are flat; *nix zips nest under <rid>/ — find the binary at the shallowest depth.
+    found = sorted(cache_dir.rglob(SERVER_BASENAME), key=lambda p: len(p.parts))
+    return found[0] if found else None
+
+
+def resolve_server(project: Path, override: str | None, version: str) -> Path | None:
+    if override:
+        p = Path(override)
+        return p if p.is_file() else None
+    env = os.environ.get("UNREAL_MCP_SERVER_PATH")
+    if env and Path(env).is_file():
+        return Path(env)
+    cache = project.parent / "Intermediate" / "connection-smoke" / "server" / version
+    binp = cache / SERVER_BASENAME
+    if binp.is_file():
+        return binp
+    return download_server(version, cache)
+
+
+def start_server(server_bin: Path, port: int, logdir: Path) -> tuple[subprocess.Popen, Path]:
+    logpath = logdir / f"gamedev-mcp-server-{port}.log"
+    fh = open(logpath, "w", encoding="utf-8")
+    proc = subprocess.Popen([str(server_bin), "--port", str(port), "--client-transport", "streamableHttp"],
+                            stdout=fh, stderr=subprocess.STDOUT, cwd=str(server_bin.parent))
+    return proc, logpath
+
+
+def wait_port(port: int, timeout: float) -> bool:
+    start = time.monotonic()
+    while time.monotonic() - start < timeout:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=2):
+                return True
+        except OSError:
+            time.sleep(1)
+    return False
+
+
+# --------------------------------------------------------------------------- process management
+
+def kill_existing_editors(project: Path) -> int:
+    if os.name != "nt":
+        return 0
+    ps = ("Get-CimInstance Win32_Process -Filter \"Name='UnrealEditor.exe' OR Name='UnrealEditor-Cmd.exe'\" "
+          f"| Where-Object {{ $_.CommandLine -like '*{project.stem}*' }} "
+          "| ForEach-Object { Stop-Process -Id $_.ProcessId -Force; $_.ProcessId }")
+    out = subprocess.run(["powershell", "-NoProfile", "-Command", ps], capture_output=True, text=True)
+    return len([l for l in out.stdout.splitlines() if l.strip().isdigit()])
+
+
+def kill_tree(pid: int) -> None:
+    if os.name == "nt":
+        subprocess.run(["taskkill", "/PID", str(pid), "/T", "/F"], capture_output=True, text=True)
+    else:
+        subprocess.run(["kill", "-9", str(pid)], capture_output=True, text=True)
+
+
+def tail(path: Path, n: int = 25) -> str:
+    try:
+        return "\n".join(path.read_text(encoding="utf-8", errors="replace").splitlines()[-n:])
+    except OSError:
+        return "(log not readable yet)"
+
+
+def scan_log(path: Path) -> dict:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+    return {"plugin_loaded": MARK_PLUGIN_LOADED in text, "sidecar_spawned": MARK_SIDECAR_SPAWN in text,
+            "no_binary": MARK_NO_BINARY in text, "fatal": bool(RE_FATAL.search(text))}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Headless Unreal-MCP connection + tool smoke.")
+    ap.add_argument("--mode", choices=["cloud", "custom"], default="custom")
+    ap.add_argument("--project", type=Path, required=True, help="path to the host .uproject")
+    ap.add_argument("--ue", type=Path, default=Path(os.environ.get("UE_EDITOR_CMD", str(DEFAULT_UE))))
+    ap.add_argument("--timeout", type=float, default=180.0)
+    ap.add_argument("--poll", type=float, default=5.0)
+    ap.add_argument("--connect-only", action="store_true")
+    ap.add_argument("--keep-editor", action="store_true")
+    ap.add_argument("--no-kill-existing", action="store_true")
+    ap.add_argument("--server-port", type=int, default=18080)
+    ap.add_argument("--server", type=str, default=None, help="custom: gamedev-mcp-server path override")
+    ap.add_argument("--server-version", type=str, default="latest", help="custom: release version or 'latest'")
+    args = ap.parse_args()
+    _ascii_safe_stdio()
+
+    project = args.project.resolve()
+    if not project.is_file():
+        raise SystemExit(f"FAIL: project not found: {project}")
+    if not args.ue.is_file():
+        raise SystemExit(f"FAIL: UnrealEditor-Cmd.exe not found: {args.ue} (set UE_EDITOR_CMD)")
+
+    logdir = project.parent / "Saved" / "Logs"
+    logdir.mkdir(parents=True, exist_ok=True)
+    editor_env = dict(os.environ)
+    server_proc: subprocess.Popen | None = None
+    server_logpath: Path | None = None
+
+    if args.mode == "cloud":
+        cfg = read_config(project)
+        token: str | None = (cfg.get("cloudToken") or "").strip() or None
+        if not token:
+            raise SystemExit("FAIL: no cloudToken — authorize once in the editor first.")
+        base = (cfg.get("cloudUrl") or "https://ai-game.dev").rstrip("/")
+        mcp_url = base + "/mcp"
+        log(f"mode=cloud  mcp={mcp_url}  (token len {len(token)})")
+    else:
+        token = None
+        port = args.server_port
+        version = latest_server_version() if args.server_version == "latest" else args.server_version
+        server_bin = resolve_server(project, args.server, version)
+        if not server_bin:
+            raise SystemExit("FAIL: could not obtain gamedev-mcp-server "
+                             f"(version {version}); pass --server <path> or set UNREAL_MCP_SERVER_PATH.")
+        log(f"mode=custom  server={server_bin.name}  version={version}  port={port}")
+        server_proc, server_logpath = start_server(server_bin, port, logdir)
+        if not wait_port(port, 40):
+            kill_tree(server_proc.pid)
+            print(f"RESULT: FAIL  -- local server never bound port {port}\n{tail(server_logpath, 20)}")
+            return 1
+        log(f"local server listening on {port}")
+        mcp_url = f"http://localhost:{port}/mcp"
+        editor_env["UNREAL_MCP_CONNECTION_MODE"] = "Custom"
+        editor_env["UNREAL_MCP_HOST"] = f"http://localhost:{port}"
+        editor_env["UNREAL_MCP_KEEP_CONNECTED"] = "true"
+
+    if not args.no_kill_existing:
+        n = kill_existing_editors(project)
+        if n:
+            log(f"killed {n} pre-existing editor(s)")
+            time.sleep(2)
+    logpath = logdir / f"conn-smoke-{int(time.time())}.log"
+    cmd = [str(args.ue), str(project), "-nullrhi", "-nosplash", "-unattended", "-NoSound", f"-abslog={logpath}"]
+    log(f"launching headless editor -> log: {logpath.name}")
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                            cwd=str(project.parent), env=editor_env)
+
+    connect_result = "TIMEOUT"
+    e2e_ok: bool | None = None
+    e2e_detail = ""
+    connected_at = None
+    marks: dict = {}
+    start = time.monotonic()
+    try:
+        while time.monotonic() - start < args.timeout:
+            time.sleep(args.poll)
+            if proc.poll() is not None:
+                connect_result = "EDITOR_EXITED"; break
+            if server_proc and server_proc.poll() is not None:
+                connect_result = "SERVER_EXITED"; break
+            marks = scan_log(logpath)
+            if marks.get("no_binary"):
+                connect_result = "NO_SIDECAR_BINARY"; break
+            if marks.get("fatal"):
+                connect_result = "EDITOR_CRASH"; break
+            elapsed = int(time.monotonic() - start)
+            if args.mode == "cloud":
+                status, _sid = mcp_initialize(mcp_url, token)
+                log(f"t+{elapsed:>3}s  /mcp init -> HTTP {status}  [sidecar={marks.get('sidecar_spawned')}]")
+                connected = status == 200
+            else:
+                status, sid = mcp_initialize(mcp_url, token)
+                tools = mcp_list_tools(mcp_url, token, sid) if status == 200 else []
+                log(f"t+{elapsed:>3}s  /mcp init={status} tools={len(tools)}  [sidecar={marks.get('sidecar_spawned')}]")
+                connected = len(tools) > 0
+            if connected:
+                connect_result = "PASS"; connected_at = elapsed; break
+
+        if connect_result == "PASS" and not args.connect_only:
+            log("connection up — running e2e tool battery...")
+            e2e_ok, e2e_detail = run_e2e(mcp_url, token, nonce=f"conn-smoke-{int(start)}")
+    finally:
+        marks = scan_log(logpath) or marks
+        if not args.keep_editor and proc.poll() is None:
+            log("tearing down editor (kill tree)...")
+            kill_tree(proc.pid)
+        if server_proc and server_proc.poll() is None:
+            log("stopping local server...")
+            kill_tree(server_proc.pid)
+
+    overall = connect_result == "PASS" and (args.connect_only or e2e_ok is True)
+    print("\n" + "=" * 70)
+    print(f"MODE    : {args.mode}")
+    print(f"CONNECT : {'PASS' if connect_result == 'PASS' else 'FAIL (' + connect_result + ')'}"
+          + (f"  (~{connected_at}s)" if connected_at is not None else ""))
+    if not args.connect_only:
+        print(f"E2E     : {'SKIPPED' if e2e_ok is None else ('PASS' if e2e_ok else 'FAIL')}"
+              + (f"  -- {e2e_detail}" if e2e_detail else ""))
+    print(f"RESULT  : {'PASS' if overall else 'FAIL'}")
+    if not overall:
+        print(f"  markers: {marks}")
+        print(f"  --- editor log tail ({logpath.name}) ---\n{tail(logpath, 25)}")
+        bridge_log = project.parent / "Saved" / "Logs" / "UnrealMcpBridge.log"
+        if bridge_log.is_file():
+            print(f"  --- sidecar log tail ({bridge_log.name}) ---\n{tail(bridge_log, 25)}")
+        if server_logpath and server_logpath.is_file():
+            print(f"  --- server log tail ({server_logpath.name}) ---\n{tail(server_logpath, 20)}")
+    print("=" * 70)
+    return 0 if overall else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What
A **self-contained** headless e2e that verifies the live relay path the Automation specs don't cover — MCP client → `gamedev-mcp-server` → sidecar → plugin → editor → tool round-trip.

- **`scripts/connection_smoke.py`** (new):
  - `--mode custom`: **downloads the public `gamedev-mcp-server` release** (latest, or `--server-version`), runs it in streamableHttp, launches the editor in Custom mode, and asserts a tool battery (`ping` + `editor-application-get-state` + `level-list-loaded` + `actor-find` + `actor-component-list-all`) over `POST /mcp`. Server + editor torn down on exit; server/sidecar/editor logs surfaced on failure.
  - `--mode cloud`: uses the project's stored `cloudToken` (signal: `/mcp` 401→200 on plugin registration).
  - **No infra-repo dependency** — Unreal-MCP stays self-contained; the server comes from the public GameDev-MCP-Server releases.
- **CI leg `connection-smoke`** in `test_pull_request.yml` (self-hosted `unreal-5-7`): builds the bridge, exports `UNREAL_MCP_BRIDGE_PATH` (PR builds don't bundle the §6 sidecar), runs the smoke against `vars.UNREAL_HOST_PROJECT`.

## Safety / gating
The CI leg is gated on a **dedicated dormant `vars.UNREAL_SMOKE_READY == 'true'`** (separate from the plugin runner var) + the fork clause, so it stays **SKIPPED — never red-by-absence** until the owner validates it once on the runner and flips the variable. PR signal is unchanged until then.

## Verified locally
`--mode custom` PASS: downloaded server **v8.0.0**, editor connected ~6s, **5/5 tools OK** over the relay; cloud regression also PASS. The CI YAML parses (4 jobs). The runner wiring (host project compiled + bridge override) needs a one-time owner validation before enabling `UNREAL_SMOKE_READY` — see the job's header comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)