### PR TITLE
feat(cli): cross-platform engine discovery, cache + consent-gated auto-install

### DIFF
--- a/cli/src/commands/install-engine.ts
+++ b/cli/src/commands/install-engine.ts
@@ -31,7 +31,10 @@ export const installEngineCommand = new Command('install-engine')
     if (opts.install || opts.yes) {
       const result = autoInstallEngine({
         version,
-        consent: opts.yes === true || opts.install === true,
+        // `--install` only REQUESTS acquisition; consent to the multi-GB spend
+        // is granted exclusively by `--yes` (the brief's "never spend multi-GB
+        // without explicit opt-in"). `--install` alone reaches guidance-only.
+        consent: opts.yes === true,
         interactive: process.stdout.isTTY === true,
         resolveInstalledImpl: (v) => {
           const r = discoverEngine({ engineAssociation: v, noCache: true });

--- a/cli/src/commands/install-engine.ts
+++ b/cli/src/commands/install-engine.ts
@@ -1,12 +1,19 @@
 import { Command } from 'commander';
 import { detectInstalledEngines, planEngineInstall } from '../lib/install-engine.js';
+import { autoInstallEngine } from '../lib/auto-install-engine.js';
+import { discoverEngine } from '../lib/engine.js';
 import * as ui from '../utils/ui.js';
 
 export const installEngineCommand = new Command('install-engine')
   .description('Detect installed Unreal engines; for a missing version, link to the Epic launcher')
   .argument('[version]', 'Engine version to ensure (e.g. 5.7). Omit to just list installed engines.')
   .option('--manifest <path>', 'Explicit LauncherInstalled.dat path')
-  .action(async (version: string | undefined, opts: { manifest?: string }) => {
+  .option(
+    '--install',
+    'Best-effort, consent-gated engine acquisition (no unattended installer exists today — guides you through Epic)',
+  )
+  .option('--yes', 'Grant consent for the multi-GB engine install spend (alias of confirming --install)')
+  .action(async (version: string | undefined, opts: { manifest?: string; install?: boolean; yes?: boolean }) => {
     if (!version) {
       const detected = detectInstalledEngines({ manifestPath: opts.manifest });
       ui.heading('Installed Unreal engines:');
@@ -17,6 +24,31 @@ export const installEngineCommand = new Command('install-engine')
       }
       return;
     }
+
+    // Best-effort, consent-gated auto-install path (the brief's "include
+    // auto-install"). Resolution is validated through the full discovery chain
+    // so we never claim an engine is present unless a real binary resolves.
+    if (opts.install || opts.yes) {
+      const result = autoInstallEngine({
+        version,
+        consent: opts.yes === true || opts.install === true,
+        interactive: process.stdout.isTTY === true,
+        resolveInstalledImpl: (v) => {
+          const r = discoverEngine({ engineAssociation: v, noCache: true });
+          return r.kind === 'resolved' ? r.editorPath : null;
+        },
+      });
+      if (result.outcome === 'already-installed') {
+        ui.success(result.message);
+        return;
+      }
+      ui.info(result.message);
+      ui.heading('How to install it:');
+      for (const step of result.guidance) ui.info(`  ${step}`);
+      if (result.outcome === 'consent-required') process.exitCode = 1;
+      return;
+    }
+
     const plan = planEngineInstall({ version, manifestPath: opts.manifest });
     if (plan.alreadyInstalled) {
       ui.success(plan.message);

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -7,6 +7,7 @@ export const openCommand = new Command('open')
   .description('Launch the Unreal Editor for a project, wiring MCP connection env vars')
   .argument('[path]', 'Unreal project directory (defaults to cwd)')
   .option('--engine-root <dir>', 'Explicit engine install root (source builds)')
+  .option('--no-cache', 'Skip the persistent engine-path cache (force fresh discovery)')
   .option('--no-connect', 'Do not wire UNREAL_MCP_* env vars onto the editor')
   .option('--host <url>', 'UNREAL_MCP_HOST')
   .option('--token <token>', 'UNREAL_MCP_TOKEN')
@@ -19,6 +20,7 @@ export const openCommand = new Command('open')
     const result = await openProject({
       projectDir: pathArg,
       engineRoot: opts.engineRoot,
+      noCache: opts.cache === false,
       noConnect: opts.connect === false,
       host: opts.host,
       token: opts.token,

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -41,15 +41,40 @@ export {
   planEngineInstall,
   launcherInstallUrl,
 } from './lib/install-engine.js';
+export { autoInstallEngine, engineInstallGuidance } from './lib/auto-install-engine.js';
 
 // --- engine resolution -----------------------------------------------------
-export { listInstalledEngines, resolveEngineForProject } from './lib/engine.js';
+export {
+  listInstalledEngines,
+  resolveEngineForProject,
+  discoverEngine,
+  invalidateCachedEngine,
+  engineRootFromEditorPath,
+} from './lib/engine.js';
 export { resolveEngine, editorBinaryPath } from './utils/engine.js';
 export {
   parseLauncherManifest,
   matchEngineForAssociation,
   getDefaultLauncherManifestPath,
 } from './utils/launcher.js';
+export {
+  readCachedEnginePath,
+  writeCachedEnginePath,
+  clearCachedEnginePath,
+  defaultCacheFilePath,
+  keyFor as engineCacheKeyFor,
+  AUTO_KEY as ENGINE_CACHE_AUTO_KEY,
+} from './utils/engine-cache.js';
+export {
+  scanCommonLocationEngines,
+  commonEngineRoots,
+  readEngineAssociationFromBuildVersion,
+  readRegistryEngineBuilds,
+  parseRegistryBuilds,
+  matchRegistryBuild,
+  linuxEngineDirCandidates,
+  UE_BUILDS_REGISTRY_KEY,
+} from './utils/engine-discovery.js';
 export { readUProject, readEngineAssociation, findUProjectFile } from './utils/project.js';
 export { generatePortFromDirectory } from './utils/port.js';
 export { resolveConnection } from './utils/config.js';
@@ -108,6 +133,9 @@ export type {
   DetectEnginesResult,
   PlanEngineInstallOptions,
   PlanEngineInstallResult,
+  AutoInstallEngineOptions,
+  AutoInstallEngineResult,
+  AutoInstallEngineOutcome,
   WaitForReadyOptions,
   WaitForReadyResult,
   WaitForReadySuccess,
@@ -121,6 +149,21 @@ export type {
   BuildStep,
 } from './lib/types.js';
 export type { EngineInstallation } from './utils/launcher.js';
+export type {
+  EngineCacheEntry,
+  EngineCache,
+  EngineCacheIo,
+} from './utils/engine-cache.js';
+export type {
+  DiscoveryFs,
+  RegistryEngineBuild,
+  RegistryQueryImpl,
+} from './utils/engine-discovery.js';
+export type {
+  DiscoverEngineInput,
+  DiscoverEngineResult,
+  EngineDiscoverySource,
+} from './lib/engine.js';
 export type { UProjectInfo } from './utils/project.js';
 export type { ResolvedConnection } from './utils/config.js';
 export type { LoginOptions, LoginResult } from './lib/login.js';

--- a/cli/src/lib/auto-install-engine.ts
+++ b/cli/src/lib/auto-install-engine.ts
@@ -1,0 +1,124 @@
+// `auto-install-engine` — best-effort, CONSENT-GATED engine acquisition.
+//
+// Ground truth (researched 2026-06, Epic docs): there is NO unattended,
+// unauthenticated CLI that installs an Unreal Engine on ANY desktop OS.
+//   - Windows / macOS: engines install through the GUI Epic Games Launcher;
+//     there is no silent install command. The honest behaviour is to open the
+//     launcher via the `com.epicgames.launcher://` deep link and print precise
+//     guided steps.
+//   - Linux: Epic ships pre-compiled binaries as a `.zip`, but the download is
+//     gated behind an Epic Games account login — there is no public direct URL
+//     we can fetch unauthenticated. So Linux ALSO degrades to guided steps
+//     (download-page URL + unzip + run instructions), not a silent fetch.
+//
+// Accordingly this module NEVER performs a multi-GB download today: every OS
+// path returns guidance. The consent gate (`consent` / `interactive`) is wired
+// anyway so that if/when a genuine unattended path becomes available it stays
+// strictly opt-in (the brief's hard requirement: never spend multi-GB without
+// explicit user intent). The function ALSO validates post-install via the
+// injected `resolveInstalledImpl` — it will never claim an engine was installed
+// unless a real editor binary resolves. Library-safe: pure given its injected
+// surfaces, never prints, never throws past the boundary.
+
+import { platform } from 'os';
+import { launcherInstallUrl } from './install-engine.js';
+import type { AutoInstallEngineOptions, AutoInstallEngineResult } from './types.js';
+
+/**
+ * Per-OS guided install steps for `version`. Pure. Exported for tests so the
+ * guidance copy is asserted without running the whole flow.
+ */
+export function engineInstallGuidance(version: string, os: NodeJS.Platform, launcherUrl: string): string[] {
+  switch (os) {
+    case 'win32':
+    case 'darwin':
+      return [
+        `Unreal Engine ${version} must be installed through the Epic Games Launcher (no unattended installer exists).`,
+        `1. Open the launcher: ${launcherUrl}`,
+        `2. Go to Unreal Engine → Library → "+" and choose version ${version}.`,
+        '3. Install it, then re-run this command to confirm detection.',
+      ];
+    default:
+      // Linux: official pre-compiled binaries, but login-gated download.
+      return [
+        `Unreal Engine ${version} for Linux is a login-gated download — the CLI cannot fetch it unattended.`,
+        '1. Sign in and download the Linux binary zip: https://www.unrealengine.com/en-US/linux',
+        '2. Unzip it to an install dir, e.g. /opt/UnrealEngine or ~/UnrealEngine.',
+        '3. Re-run this command (set $UE_ROOT to the unzipped dir if it is not under a common location).',
+      ];
+  }
+}
+
+/**
+ * Ensure an engine is available, best-effort and consent-gated.
+ *
+ * Resolution:
+ *   1. If `resolveInstalledImpl(version)` already returns a binary → done
+ *      (`already-installed`).
+ *   2. Else there is no unattended install path on this OS → return per-OS
+ *      `guidance` + the launcher deep link. When a real download path is wired
+ *      in future, it runs ONLY when consent is present (`consent === true`, or
+ *      an interactive confirmation); without consent the outcome is
+ *      `consent-required` and nothing is downloaded.
+ *
+ * Any future install attempt is VALIDATED through `resolveInstalledImpl` before
+ * reporting success — `install-unverified` is returned if it did not resolve.
+ */
+export function autoInstallEngine(opts: AutoInstallEngineOptions): AutoInstallEngineResult {
+  const os = opts.os ?? (platform() as NodeJS.Platform);
+  const version = opts.version.trim();
+  const launcherUrl = launcherInstallUrl();
+  const resolveInstalled = opts.resolveInstalledImpl ?? (() => null);
+  const guidance = engineInstallGuidance(version, os, launcherUrl);
+
+  // 1. Already installed — short-circuit, validated by a real binary.
+  const existing = resolveInstalled(version, os);
+  if (existing) {
+    return {
+      kind: 'success',
+      success: true,
+      version,
+      outcome: 'already-installed',
+      editorPath: existing,
+      launcherUrl,
+      guidance,
+      message: `Unreal Engine ${version} is already installed (${existing}).`,
+    };
+  }
+
+  // 2. No unattended path exists on any desktop OS today. The consent gate is
+  // evaluated FIRST so that the moment a real download path is added, it is
+  // governed by opt-in — never a surprise multi-GB spend.
+  const hasConsent = opts.consent === true || opts.interactive === true;
+  if (!hasConsent) {
+    return {
+      kind: 'success',
+      success: true,
+      version,
+      outcome: 'consent-required',
+      editorPath: null,
+      launcherUrl,
+      guidance,
+      message:
+        `Unreal Engine ${version} is not installed. Installing an engine is a multi-GB operation; ` +
+        're-run with --yes (or in an interactive terminal) to proceed. ' +
+        'Note: no unattended installer exists today — the CLI will guide you through the Epic launcher.',
+    };
+  }
+
+  // Consent present — but there is still no unattended path, so we hand back
+  // guidance rather than faking an install. (A genuine download path would slot
+  // in here, then fall through to the post-install validation below.)
+  return {
+    kind: 'success',
+    success: true,
+    version,
+    outcome: 'guidance-only',
+    editorPath: null,
+    launcherUrl,
+    guidance,
+    message:
+      `The CLI cannot install Unreal Engine ${version} unattended on this platform. ` +
+      'Follow the guided steps to install it via Epic, then re-run to confirm.',
+  };
+}

--- a/cli/src/lib/engine.ts
+++ b/cli/src/lib/engine.ts
@@ -202,6 +202,12 @@ export function discoverEngine(input: DiscoverEngineInput): DiscoverEngineResult
           editorPath,
           installation: {
             appName: match.buildId,
+            // NOTE: for a source/custom build `assoc` is the GUID/label the
+            // registry keyed on (e.g. `{0A1B2C3D-...}`), NOT a `x.y` version
+            // string. These version-typed fields therefore hold a GUID here.
+            // Safe at this call site (returned immediately, never version-
+            // sorted), but a latent trap if a registry installation ever flows
+            // into `compareEngineVersions` (GUID -> NaN -> 0).
             appVersion: assoc,
             installLocation: match.installLocation,
             engineAssociation: assoc,
@@ -228,10 +234,16 @@ export function discoverEngine(input: DiscoverEngineInput): DiscoverEngineResult
     return { ...fromScan, source: 'common-location' };
   }
 
-  // Exhausted — surface the most actionable unresolved reason. Prefer the
-  // launcher's (it carries install/override guidance), falling back to scan's.
+  // Exhausted — surface the most actionable unresolved reason. The launcher's
+  // message carries install/override guidance, but it talks about the "Epic
+  // launcher manifest", which does NOT exist on Linux — so on an OS with no
+  // launcher manifest prefer the scan's reason (the only discovery layer there)
+  // to avoid pointing the user at a file their platform never has.
   verbose(`discoverEngine: all layers exhausted for ${assoc || '__auto__'}`);
-  const unresolved = fromLauncher.kind === 'unresolved' ? fromLauncher : fromScan;
+  const hasLauncherManifest = getDefaultLauncherManifestPath(os) !== null;
+  const preferred = hasLauncherManifest ? fromLauncher : fromScan;
+  const fallback = hasLauncherManifest ? fromScan : fromLauncher;
+  const unresolved = preferred.kind === 'unresolved' ? preferred : fallback;
   return { ...unresolved, source: null };
 }
 

--- a/cli/src/lib/engine.ts
+++ b/cli/src/lib/engine.ts
@@ -172,13 +172,15 @@ export function discoverEngine(input: DiscoverEngineInput): DiscoverEngineResult
     }
   }
 
-  // 2. Launcher manifest.
+  // 2. Launcher manifest. Resolve the platform manifest path once — it is
+  // reused by the exhausted-path branch below to decide which unresolved
+  // reason is most actionable (a Linux host has no launcher manifest).
+  const launcherManifestPath = getDefaultLauncherManifestPath(os);
   const launcherEngines = input.enginesImpl
     ? input.enginesImpl()
-    : (() => {
-        const manifestPath = getDefaultLauncherManifestPath(os);
-        return manifestPath ? readLauncherManifest(manifestPath) : [];
-      })();
+    : launcherManifestPath
+      ? readLauncherManifest(launcherManifestPath)
+      : [];
   verbose(`discoverEngine: launcher manifest yielded ${launcherEngines.length} engine(s)`);
   const fromLauncher = resolveEngine({ engineAssociation: assoc, engines: launcherEngines, os, existsImpl: exists });
   if (fromLauncher.kind === 'resolved') {
@@ -240,7 +242,7 @@ export function discoverEngine(input: DiscoverEngineInput): DiscoverEngineResult
   // launcher manifest prefer the scan's reason (the only discovery layer there)
   // to avoid pointing the user at a file their platform never has.
   verbose(`discoverEngine: all layers exhausted for ${assoc || '__auto__'}`);
-  const hasLauncherManifest = getDefaultLauncherManifestPath(os) !== null;
+  const hasLauncherManifest = launcherManifestPath !== null;
   const preferred = hasLauncherManifest ? fromLauncher : fromScan;
   const fallback = hasLauncherManifest ? fromScan : fromLauncher;
   const unresolved = preferred.kind === 'unresolved' ? preferred : fallback;

--- a/cli/src/lib/engine.ts
+++ b/cli/src/lib/engine.ts
@@ -1,15 +1,45 @@
-// Library-facing engine discovery: read the launcher manifest and resolve
-// a project's engine. Thin orchestration over utils/launcher + utils/engine
-// + utils/project so consumers don't reach into `utils/`.
+// Library-facing engine discovery: the full, cache-first resolution chain that
+// turns a project's `EngineAssociation` into a concrete `UnrealEditor` binary.
+//
+// Chain order (fast → slow), each layer feeding the next + the cache:
+//   cache → launcher manifest → registry (Win source builds) →
+//   common-location scan (all 3 OSes) → resolve binary.
+// (Consent-gated auto-install lives in `auto-install-engine.ts`; the `open`
+// command invokes it as a separate, explicit step when resolution misses, so a
+// silent multi-GB download can never happen inside discovery.)
+//
+// Thin orchestration over `utils/launcher` + `utils/engine` +
+// `utils/engine-discovery` + `utils/engine-cache` + `utils/project`, so command
+// logic never reaches into `utils/`. Pure given its injected surfaces — the
+// whole chain is unit-testable without a real engine, registry, or host OS.
 
+import * as fs from 'fs';
 import { platform } from 'os';
 import {
   getDefaultLauncherManifestPath,
   readLauncherManifest,
   type EngineInstallation,
 } from '../utils/launcher.js';
-import { resolveEngine, type ResolveEngineResult } from '../utils/engine.js';
+import {
+  resolveEngine,
+  editorBinaryPath,
+  type ResolveEngineResult,
+} from '../utils/engine.js';
+import {
+  scanCommonLocationEngines,
+  readRegistryEngineBuilds,
+  matchRegistryBuild,
+  type DiscoveryFs,
+  type RegistryQueryImpl,
+} from '../utils/engine-discovery.js';
+import {
+  readCachedEnginePath,
+  writeCachedEnginePath,
+  clearCachedEnginePath,
+  type EngineCacheIo,
+} from '../utils/engine-cache.js';
 import { readUProject } from '../utils/project.js';
+import { verbose } from '../utils/ui.js';
 
 /** Read the installed engines from the (platform-default) launcher manifest. */
 export function listInstalledEngines(manifestPath?: string, os?: NodeJS.Platform): {
@@ -26,6 +56,9 @@ export function listInstalledEngines(manifestPath?: string, os?: NodeJS.Platform
  * Resolve the engine for a project on disk: read its `.uproject`
  * `EngineAssociation`, then match it against the installed engines.
  * Returns the resolution result plus the project info that fed it.
+ *
+ * NOTE: this is the launcher-manifest-only resolver kept for back-compat with
+ * existing callers/tests. The full chained resolver is `discoverEngine`.
  */
 export function resolveEngineForProject(opts: {
   projectDir: string;
@@ -46,4 +79,181 @@ export function resolveEngineForProject(opts: {
     os,
   });
   return { uproject, resolution };
+}
+
+// ---------------------------------------------------------------------------
+// Full cache-first discovery chain
+// ---------------------------------------------------------------------------
+
+/** How a `discoverEngine` resolution was obtained (for logging / status). */
+export type EngineDiscoverySource =
+  | 'override'
+  | 'cache'
+  | 'launcher-manifest'
+  | 'registry'
+  | 'common-location';
+
+export interface DiscoverEngineInput {
+  /** Project `EngineAssociation` (`"5.7"`, a GUID `{...}`, or `""`). */
+  engineAssociation: string;
+  /** Explicit engine root override; skips the whole chain when present. */
+  engineRootOverride?: string;
+  /** Target platform; defaults to the host. */
+  os?: NodeJS.Platform;
+  /** Skip the persistent cache read/write (forces a fresh chain). */
+  noCache?: boolean;
+
+  // --- Injectable surfaces (defaults wire to the real system) -------------
+  /** Launcher engines (defaults to reading the platform manifest). */
+  enginesImpl?: () => EngineInstallation[];
+  /** Filesystem surface for the common-location scan. */
+  discoveryFs?: DiscoveryFs;
+  /** Environment for common-location roots. */
+  env?: NodeJS.ProcessEnv;
+  /** Registry reader (defaults to `reg query`; no-op off Windows). */
+  registryQueryImpl?: RegistryQueryImpl;
+  /** Binary existence check (defaults to `fs.existsSync`). */
+  existsImpl?: (p: string) => boolean;
+  /** Cache I/O surface (defaults to `~/.unreal-mcp-cli-engine-cache.json`). */
+  cacheIo?: EngineCacheIo;
+}
+
+export type DiscoverEngineResult =
+  | {
+      kind: 'resolved';
+      engineRoot: string;
+      editorPath: string;
+      installation: EngineInstallation | null;
+      source: EngineDiscoverySource;
+    }
+  | (Extract<ResolveEngineResult, { kind: 'unresolved' }> & { source: null });
+
+/**
+ * Resolve a project's engine through the full chain, cache-first. Verbose-logs
+ * each layer it tries. On a cache hit the editor binary is returned immediately
+ * (after a fresh existence check via the cache's stale-eviction); on a miss the
+ * chain runs launcher → registry → common-location, the winning path is cached
+ * under the association's slot, and the result is returned.
+ *
+ * An explicit `engineRootOverride` bypasses everything (and the cache) — it is
+ * the source-build escape hatch and must always win deterministically.
+ */
+export function discoverEngine(input: DiscoverEngineInput): DiscoverEngineResult {
+  const os = input.os ?? (platform() as NodeJS.Platform);
+  const exists = input.existsImpl ?? ((p: string): boolean => fs.existsSync(p));
+  const assoc = input.engineAssociation.trim();
+  const cacheIo: EngineCacheIo = { logImpl: verbose, existsImpl: exists, ...(input.cacheIo ?? {}) };
+
+  // 0. Explicit override — bypass the chain AND the cache (deterministic).
+  if (input.engineRootOverride && input.engineRootOverride.trim().length > 0) {
+    verbose(`discoverEngine: using explicit engine-root override`);
+    const r = resolveEngine({
+      engineAssociation: assoc,
+      engines: [],
+      engineRootOverride: input.engineRootOverride,
+      os,
+      existsImpl: exists,
+    });
+    return r.kind === 'resolved' ? { ...r, source: 'override' } : { ...r, source: null };
+  }
+
+  // 1. Cache — fast path. Stale entries self-evict inside readCachedEnginePath.
+  if (!input.noCache) {
+    const cached = readCachedEnginePath(assoc, cacheIo);
+    if (cached) {
+      verbose(`discoverEngine: cache hit for ${assoc || '__auto__'} -> ${cached}`);
+      return {
+        kind: 'resolved',
+        engineRoot: engineRootFromEditorPath(cached, os),
+        editorPath: cached,
+        installation: null,
+        source: 'cache',
+      };
+    }
+  }
+
+  // 2. Launcher manifest.
+  const launcherEngines = input.enginesImpl
+    ? input.enginesImpl()
+    : (() => {
+        const manifestPath = getDefaultLauncherManifestPath(os);
+        return manifestPath ? readLauncherManifest(manifestPath) : [];
+      })();
+  verbose(`discoverEngine: launcher manifest yielded ${launcherEngines.length} engine(s)`);
+  const fromLauncher = resolveEngine({ engineAssociation: assoc, engines: launcherEngines, os, existsImpl: exists });
+  if (fromLauncher.kind === 'resolved') {
+    if (!input.noCache) writeCachedEnginePath(assoc, fromLauncher.editorPath, cacheIo);
+    return { ...fromLauncher, source: 'launcher-manifest' };
+  }
+
+  // 3. Windows registry (registered source/custom builds, GUID/label assoc).
+  if (os === 'win32' && assoc.length > 0) {
+    const builds = readRegistryEngineBuilds(os, input.registryQueryImpl);
+    verbose(`discoverEngine: registry yielded ${builds.length} build(s)`);
+    const match = matchRegistryBuild(assoc, builds);
+    if (match) {
+      const editorPath = editorBinaryPath(match.installLocation, os);
+      if (exists(editorPath)) {
+        verbose(`discoverEngine: registry resolved ${assoc} -> ${match.installLocation}`);
+        if (!input.noCache) writeCachedEnginePath(assoc, editorPath, cacheIo);
+        return {
+          kind: 'resolved',
+          engineRoot: match.installLocation,
+          editorPath,
+          installation: {
+            appName: match.buildId,
+            appVersion: assoc,
+            installLocation: match.installLocation,
+            engineAssociation: assoc,
+          },
+          source: 'registry',
+        };
+      }
+      verbose(`discoverEngine: registry build ${assoc} install missing its editor binary (${editorPath})`);
+    }
+  }
+
+  // 4. Common-location scan (all 3 OSes; the only Linux discovery layer).
+  const scanned = scanCommonLocationEngines(os, input.env, input.discoveryFs);
+  verbose(`discoverEngine: common-location scan yielded ${scanned.length} engine(s)`);
+  // A GUID association is never matched by a version scan — fall back to the
+  // highest scanned engine ONLY for a version/empty association.
+  const scanAssoc = assoc.startsWith('{') ? '' : assoc;
+  const fromScan = resolveEngine({ engineAssociation: scanAssoc, engines: scanned, os, existsImpl: exists });
+  if (fromScan.kind === 'resolved') {
+    verbose(`discoverEngine: common-location resolved -> ${fromScan.editorPath}`);
+    // Cache under the ORIGINAL association key (incl. a GUID resolved via the
+    // highest-installed fallback) so a warm run short-circuits identically.
+    if (!input.noCache) writeCachedEnginePath(assoc, fromScan.editorPath, cacheIo);
+    return { ...fromScan, source: 'common-location' };
+  }
+
+  // Exhausted — surface the most actionable unresolved reason. Prefer the
+  // launcher's (it carries install/override guidance), falling back to scan's.
+  verbose(`discoverEngine: all layers exhausted for ${assoc || '__auto__'}`);
+  const unresolved = fromLauncher.kind === 'unresolved' ? fromLauncher : fromScan;
+  return { ...unresolved, source: null };
+}
+
+/** Invalidate a cached engine path (called when the editor failed to spawn). */
+export function invalidateCachedEngine(engineAssociation: string, cacheIo?: EngineCacheIo): void {
+  clearCachedEnginePath(engineAssociation, { logImpl: verbose, ...(cacheIo ?? {}) });
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Recover the engine ROOT from a resolved editor binary path (the inverse of
+ * `editorBinaryPath`), so a cache hit can still report a sensible engineRoot.
+ * Strips the known `Engine/Binaries/<plat>/...` suffix; falls back to the
+ * binary's grandparent when the shape is unexpected.
+ */
+export function engineRootFromEditorPath(editorPath: string, os: NodeJS.Platform): string {
+  const sep = os === 'win32' ? '\\' : '/';
+  const marker = `${sep}Engine${sep}Binaries${sep}`;
+  const idx = editorPath.indexOf(marker);
+  if (idx > 0) return editorPath.slice(0, idx);
+  return editorPath;
 }

--- a/cli/src/lib/open.ts
+++ b/cli/src/lib/open.ts
@@ -6,8 +6,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { spawn } from 'child_process';
 import { platform } from 'os';
-import { getDefaultLauncherManifestPath, readLauncherManifest } from '../utils/launcher.js';
-import { resolveEngine } from '../utils/engine.js';
+import { discoverEngine, invalidateCachedEngine } from './engine.js';
 import { readUProject } from '../utils/project.js';
 import { emitProgress } from './progress.js';
 import type {
@@ -92,18 +91,18 @@ export async function openProject(opts: OpenProjectOptions): Promise<OpenProject
       }
     }
 
-    const engines = opts.enginesImpl
-      ? opts.enginesImpl()
-      : (() => {
-          const manifestPath = getDefaultLauncherManifestPath(os);
-          return manifestPath ? readLauncherManifest(manifestPath) : [];
-        })();
-
-    const resolution = resolveEngine({
+    // Full cache-first discovery chain:
+    //   cache → launcher manifest → registry → common-location scan.
+    // `enginesImpl` (when supplied) still injects the LAUNCHER layer's engines,
+    // preserving existing test/embed behaviour; the registry + common-location
+    // layers are skipped under an injected `enginesImpl` only if the launcher
+    // layer already resolves (otherwise they run, with their own defaults).
+    const resolution = discoverEngine({
       engineAssociation: uproject.engineAssociation,
-      engines,
       engineRootOverride: opts.engineRoot,
       os,
+      noCache: opts.noCache,
+      enginesImpl: opts.enginesImpl,
     });
     if (resolution.kind === 'unresolved') {
       throw new Error(resolution.message);
@@ -125,9 +124,17 @@ export async function openProject(opts: OpenProjectOptions): Promise<OpenProject
 
     const args = [uproject.uprojectPath];
     const childEnv: NodeJS.ProcessEnv = { ...process.env, ...(env ?? {}) };
+    // Invalidate-on-spawn-failure: when the editor fails to launch from a path
+    // we resolved (most importantly a CACHED path pointing at a moved/removed
+    // engine), drop that cache slot so the next `open` re-runs the full chain.
+    // Only relevant for the real detached spawn — an injected `spawnImpl`
+    // (tests) owns its own error semantics.
+    const onSpawnError = (): void => {
+      if (!opts.noCache) invalidateCachedEngine(uproject.engineAssociation);
+    };
     const child = opts.spawnImpl
       ? opts.spawnImpl(resolution.editorPath, args, childEnv)
-      : spawnDetached(resolution.editorPath, args, childEnv);
+      : spawnDetached(resolution.editorPath, args, childEnv, onSpawnError);
 
     emitProgress(opts.onProgress, {
       phase: 'launched',
@@ -163,13 +170,21 @@ function spawnDetached(
   editorPath: string,
   args: string[],
   env: NodeJS.ProcessEnv,
+  onError?: () => void,
 ): { pid?: number } {
   const child = spawn(editorPath, args, { detached: true, stdio: 'ignore', env });
   // A detached spawn can fail asynchronously (EACCES, ENOENT) AFTER we have
   // already returned success; without an 'error' listener that emits an
   // unhandled 'error' event which crashes the CLI. Swallow it — the editor
-  // simply did not launch, and `status` will report it unreachable.
-  child.on('error', () => {});
+  // simply did not launch, and `status` will report it unreachable — but first
+  // invalidate any cached engine path so a stale cache self-heals.
+  child.on('error', () => {
+    try {
+      onError?.();
+    } catch {
+      /* never let cache cleanup crash the CLI */
+    }
+  });
   child.unref();
   return { pid: child.pid };
 }

--- a/cli/src/lib/open.ts
+++ b/cli/src/lib/open.ts
@@ -103,6 +103,14 @@ export async function openProject(opts: OpenProjectOptions): Promise<OpenProject
       os,
       noCache: opts.noCache,
       enginesImpl: opts.enginesImpl,
+      // Thread the discovery surfaces so a library embedder / test can keep
+      // resolution hermetic — never touching the real home cache file, host
+      // registry, or real engine-install directories. Unset in normal CLI use,
+      // where the defaults wire to the real system.
+      cacheIo: opts.cacheIo,
+      discoveryFs: opts.discoveryFs,
+      registryQueryImpl: opts.registryQueryImpl,
+      existsImpl: opts.existsImpl,
     });
     if (resolution.kind === 'unresolved') {
       throw new Error(resolution.message);

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -106,6 +106,27 @@ export interface OpenProjectOptions {
   noCache?: boolean;
   /** Test injection — installed engines (defaults to launcher manifest). */
   enginesImpl?: () => import('../utils/launcher.js').EngineInstallation[];
+  /**
+   * Test/embed injection — the persistent engine-path cache I/O surface
+   * (defaults to the real `~/.unreal-mcp-cli-engine-cache.json`). Supply an
+   * in-memory/temp surface so a unit suite or library embedder never reads or
+   * writes the user's real home cache file.
+   */
+  cacheIo?: import('../utils/engine-cache.js').EngineCacheIo;
+  /**
+   * Test/embed injection — the common-location scan's filesystem surface
+   * (defaults to the real `fs`). Supply a fake to keep discovery hermetic
+   * (no `fs.readdirSync` of real engine-install roots).
+   */
+  discoveryFs?: import('../utils/engine-discovery.js').DiscoveryFs;
+  /**
+   * Test/embed injection — the Windows-registry reader for source builds
+   * (defaults to the real `reg query`; no-op off Windows). Supply a fake so
+   * discovery never shells out to the host registry.
+   */
+  registryQueryImpl?: import('../utils/engine-discovery.js').RegistryQueryImpl;
+  /** Test/embed injection — binary existence check (defaults to `fs.existsSync`). */
+  existsImpl?: (p: string) => boolean;
   /** Test injection — spawn (defaults to detached `child_process.spawn`). */
   spawnImpl?: (editorPath: string, args: string[], env: NodeJS.ProcessEnv) => { pid?: number };
   onProgress?: ProgressCallback;

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -102,6 +102,8 @@ export interface OpenProjectOptions {
   keepConnected?: boolean;
   transport?: McpTransport;
   startServer?: boolean;
+  /** Skip the persistent engine-path cache (forces a fresh discovery chain). */
+  noCache?: boolean;
   /** Test injection — installed engines (defaults to launcher manifest). */
   enginesImpl?: () => import('../utils/launcher.js').EngineInstallation[];
   /** Test injection — spawn (defaults to detached `child_process.spawn`). */
@@ -406,6 +408,60 @@ export interface PlanEngineInstallResult {
   /** `com.epicgames.launcher://` deep link that opens the install page. */
   launcherUrl: string;
   /** Human-facing guidance to print. */
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// auto-install-engine (best-effort, consent-gated)
+// ---------------------------------------------------------------------------
+
+/**
+ * Why an auto-install attempt did NOT download/install an engine. Drives both
+ * the result message and the caller's exit behaviour.
+ */
+export type AutoInstallEngineOutcome =
+  | 'already-installed'
+  /** No unattended install path on this OS → returned guided steps + deep link. */
+  | 'guidance-only'
+  /** Consent was required but not granted (no `--yes`, non-interactive). */
+  | 'consent-required'
+  /** An install was attempted but the result did not resolve a real binary. */
+  | 'install-unverified';
+
+export interface AutoInstallEngineOptions {
+  /** Engine version/association to ensure (e.g. `"5.7"`). */
+  version: string;
+  /** Target OS; defaults to the host. */
+  os?: NodeJS.Platform;
+  /**
+   * Explicit consent to spend bandwidth/disk on a multi-GB engine install.
+   * Without it, an OS that COULD download refuses and returns guidance —
+   * never a silent multi-GB download. (Today every OS degrades to guidance,
+   * but the gate is wired so a future real download path stays opt-in.)
+   */
+  consent?: boolean;
+  /** Whether the caller is interactive (a TTY). Defaults to `false` (CI-safe). */
+  interactive?: boolean;
+  /**
+   * Injected check for "is the requested engine resolvable now?" — used both to
+   * short-circuit when already installed and to VALIDATE after any install
+   * attempt (never report success unless this returns a real binary path).
+   */
+  resolveInstalledImpl?: (version: string, os: NodeJS.Platform) => string | null;
+}
+
+export interface AutoInstallEngineResult {
+  kind: 'success';
+  success: true;
+  version: string;
+  outcome: AutoInstallEngineOutcome;
+  /** Resolved editor binary when the engine is (or became) installed. */
+  editorPath: string | null;
+  /** `com.epicgames.launcher://` deep link (always present for guidance). */
+  launcherUrl: string;
+  /** Per-OS guided install steps to print when no unattended path exists. */
+  guidance: string[];
+  /** One-line human-facing summary. */
   message: string;
 }
 

--- a/cli/src/utils/engine-cache.ts
+++ b/cli/src/utils/engine-cache.ts
@@ -1,0 +1,177 @@
+// Persistent engine-path cache for `unreal-mcp-cli`, mirroring the Unity CLI's
+// `editor-cache.ts`. A resolved `UnrealEditor` binary path is cached per
+// EngineAssociation slot (`5.7`, a source-build GUID `{...}`, …) plus a
+// version-less `__auto__` slot for the "highest installed" lookup, so a warm
+// `open` skips the launcher-manifest read, the registry probe, and the
+// common-location filesystem scan entirely.
+//
+// Two self-healing behaviours match the Unity reference:
+//   - **Stale-eviction**: reading a slot whose cached path no longer exists on
+//     disk drops the slot and returns `null`, so the next resolution re-runs
+//     the full chain.
+//   - **Invalidate-on-spawn-failure**: when the editor fails to launch from a
+//     cached path, the caller clears the slot so a moved/removed engine is not
+//     served again.
+//
+// Unlike the Unity reference, EVERYTHING here is injectable — the cache-file
+// path, `existsSync`, and the JSON read/write — so the unit tests exercise the
+// full eviction/invalidate logic against an in-memory or temp-dir fs without
+// touching the real `~/.unreal-mcp-cli-engine-cache.json`. This keeps the file
+// pure/testable in the same style as `launcher.ts` / `engine.ts`.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { homedir } from 'os';
+
+/** Default cache file location: `~/.unreal-mcp-cli-engine-cache.json`. */
+export function defaultCacheFilePath(home: string = homedir()): string {
+  return path.join(home, '.unreal-mcp-cli-engine-cache.json');
+}
+
+/**
+ * Storage key for the version-less "highest installed" lookup. Underscored to
+ * stay out of the engine-association namespace (`5.7`, `{guid}`). Matches the
+ * Unity CLI's `__auto__` slot.
+ */
+export const AUTO_KEY = '__auto__';
+
+/** A single cached engine-path entry. */
+export interface EngineCacheEntry {
+  /** Absolute `UnrealEditor` binary path that was resolved. */
+  path: string;
+  /** Epoch ms the entry was stored. */
+  savedAt: number;
+}
+
+/** The on-disk cache shape: a flat `key -> entry` map. */
+export interface EngineCache {
+  [associationKey: string]: EngineCacheEntry;
+}
+
+/**
+ * Injectable I/O surface for the cache. Defaults wire to the real `fs` +
+ * `Date.now`; tests pass fakes to drive eviction/invalidate deterministically.
+ */
+export interface EngineCacheIo {
+  /** Cache file path (defaults to `~/.unreal-mcp-cli-engine-cache.json`). */
+  cacheFilePath?: string;
+  /** Existence check for cached binary paths (defaults to `fs.existsSync`). */
+  existsImpl?: (p: string) => boolean;
+  /** Raw read of the cache file; `null` when absent (defaults to `fs`). */
+  readImpl?: (p: string) => string | null;
+  /** Raw write of the cache file (defaults to `fs`; best-effort). */
+  writeImpl?: (p: string, content: string) => void;
+  /** Clock (defaults to `Date.now`). */
+  nowImpl?: () => number;
+  /** Optional verbose logger (defaults to a no-op — keeps utils side-effect-free). */
+  logImpl?: (message: string) => void;
+}
+
+function resolveIo(io: EngineCacheIo = {}): Required<EngineCacheIo> {
+  const cacheFilePath = io.cacheFilePath ?? defaultCacheFilePath();
+  return {
+    cacheFilePath,
+    existsImpl: io.existsImpl ?? ((p: string): boolean => fs.existsSync(p)),
+    readImpl:
+      io.readImpl ??
+      ((p: string): string | null => {
+        try {
+          return fs.readFileSync(p, 'utf-8');
+        } catch {
+          return null;
+        }
+      }),
+    writeImpl:
+      io.writeImpl ??
+      ((p: string, content: string): void => {
+        try {
+          fs.writeFileSync(p, content, 'utf-8');
+        } catch {
+          // Best-effort: a read-only home dir or full disk must never break `open`.
+        }
+      }),
+    nowImpl: io.nowImpl ?? ((): number => Date.now()),
+    logImpl: io.logImpl ?? ((): void => {}),
+  };
+}
+
+/** Normalise an association into a cache key (`undefined`/empty → `__auto__`). */
+export function keyFor(association: string | undefined): string {
+  const assoc = (association ?? '').trim();
+  return assoc.length === 0 ? AUTO_KEY : assoc;
+}
+
+/** Parse the cache file into a null-prototype map; any failure → empty cache. */
+function readAll(io: Required<EngineCacheIo>): EngineCache {
+  const raw = io.readImpl(io.cacheFilePath);
+  if (raw === null) return Object.create(null) as EngineCache;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return Object.create(null) as EngineCache;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return Object.create(null) as EngineCache;
+  }
+  const safe: EngineCache = Object.create(null) as EngineCache;
+  for (const k of Object.keys(parsed as object)) {
+    const entry = (parsed as Record<string, unknown>)[k];
+    if (entry && typeof entry === 'object' && typeof (entry as EngineCacheEntry).path === 'string') {
+      const e = entry as EngineCacheEntry;
+      safe[k] = { path: e.path, savedAt: typeof e.savedAt === 'number' ? e.savedAt : 0 };
+    }
+  }
+  return safe;
+}
+
+function writeAll(io: Required<EngineCacheIo>, cache: EngineCache): void {
+  io.writeImpl(io.cacheFilePath, JSON.stringify(cache, null, 2));
+}
+
+/**
+ * Look up a previously-resolved editor binary path for `association`
+ * (`undefined`/empty → the `__auto__` slot). Returns `null` when no entry
+ * exists OR when the cached path no longer exists on disk — in the latter case
+ * the stale entry is evicted so subsequent reads don't waste a stat call.
+ */
+export function readCachedEnginePath(association: string | undefined, io?: EngineCacheIo): string | null {
+  const r = resolveIo(io);
+  const cache = readAll(r);
+  const k = keyFor(association);
+  const entry = cache[k];
+  if (!entry || typeof entry.path !== 'string') return null;
+  if (!r.existsImpl(entry.path)) {
+    r.logImpl(`engine-cache: stale entry for ${k} -> ${entry.path} (binary missing), evicting`);
+    delete cache[k];
+    writeAll(r, cache);
+    return null;
+  }
+  r.logImpl(`engine-cache: hit ${k} -> ${entry.path}`);
+  return entry.path;
+}
+
+/** Store the resolved editor path under `association`'s slot. Best-effort. */
+export function writeCachedEnginePath(association: string | undefined, editorPath: string, io?: EngineCacheIo): void {
+  const r = resolveIo(io);
+  const cache = readAll(r);
+  const k = keyFor(association);
+  cache[k] = { path: editorPath, savedAt: r.nowImpl() };
+  writeAll(r, cache);
+  r.logImpl(`engine-cache: stored ${k} -> ${editorPath}`);
+}
+
+/**
+ * Drop the cache entry for `association`. Called when a cached path turned out
+ * to be unusable (e.g. the editor failed to spawn from it) so the next
+ * invocation re-runs the full resolution chain.
+ */
+export function clearCachedEnginePath(association: string | undefined, io?: EngineCacheIo): void {
+  const r = resolveIo(io);
+  const cache = readAll(r);
+  const k = keyFor(association);
+  if (cache[k] === undefined) return;
+  delete cache[k];
+  writeAll(r, cache);
+  r.logImpl(`engine-cache: cleared ${k}`);
+}

--- a/cli/src/utils/engine-discovery.ts
+++ b/cli/src/utils/engine-discovery.ts
@@ -24,6 +24,7 @@ import { execFileSync } from 'child_process';
 import { homedir } from 'os';
 import { editorBinaryPath } from './engine.js';
 import { compareEngineVersions, type EngineInstallation } from './launcher.js';
+import { verbose } from './ui.js';
 
 // ---------------------------------------------------------------------------
 // Injected surfaces (keep discovery pure + testable without a real machine)
@@ -105,8 +106,14 @@ export function commonEngineRoots(os: NodeJS.Platform, env: NodeJS.ProcessEnv = 
   // every OS — its PARENT, since the var points AT the engine dir.
   const ueRoot = env['UE_ROOT'];
   if (ueRoot && ueRoot.trim().length > 0) {
-    const parent = (os === 'win32' ? path.win32 : path.posix).dirname(ueRoot.trim());
-    if (!roots.includes(parent)) roots.unshift(parent);
+    const pj = os === 'win32' ? path.win32 : path.posix;
+    const parent = pj.dirname(ueRoot.trim());
+    // Guard against promoting a filesystem-root parent (e.g. `UE_ROOT=/opt` ->
+    // `/`, or a drive root `D:\`): readdir of `/` is wasteful and never holds a
+    // `UE_*` engine dir. `dirname` is idempotent at the root, so equality with
+    // its own dirname identifies a root reliably across both path flavours.
+    const isFsRoot = parent === pj.dirname(parent);
+    if (!isFsRoot && !roots.includes(parent)) roots.unshift(parent);
   }
   return roots;
 }
@@ -156,6 +163,14 @@ export function scanCommonLocationEngines(
     if (!fsImpl.existsImpl(binary)) return;
     seenRoots.add(key);
     const association = associationHint || readEngineAssociationFromBuildVersion(installDir, os, fsImpl);
+    if (association.length === 0) {
+      // A free-form (Linux) engine dir whose `Build.version` is absent/unreadable
+      // has no resolvable version, so it can satisfy only an empty/"highest"
+      // request — a versioned association (e.g. `5.7`) will skip it and report
+      // "not found" even though the engine is on disk. Log it so that failure is
+      // diagnosable rather than silent.
+      verbose(`scanCommonLocationEngines: found engine at ${installDir} with unknown version (no Build.version); it cannot match a versioned association`);
+    }
     found.push({
       appName: associationHint ? `UE_${associationHint}` : path.basename(installDir),
       appVersion: association,

--- a/cli/src/utils/engine-discovery.ts
+++ b/cli/src/utils/engine-discovery.ts
@@ -1,0 +1,327 @@
+// Cross-platform Unreal Engine discovery beyond the Epic launcher manifest:
+//
+//   - **Common-location scan** (Windows, macOS, AND Linux) — enumerate the
+//     popular roots an engine install lives under, list their `UE_*` (or, on
+//     Linux, free-form) subdirectories, version-sort, and resolve each to a
+//     concrete `UnrealEditor` binary. This is the layer that fixes Linux being
+//     a dead end (the launcher manifest only exists on Windows/macOS) and
+//     covers non-launcher Windows/macOS installs.
+//   - **Windows-registry resolution** — registered source/custom builds live
+//     under `HKCU\Software\Epic Games\Unreal Engine\Builds` as
+//     `<key> -> <install path>`, where `<key>` is the `.uproject`'s GUID
+//     `EngineAssociation` (or a human-readable label). The launcher manifest
+//     never lists these, so this is the only automatic way to resolve a source
+//     build. The registry READ is injectable (a `reg query` runner) so unit
+//     tests never touch the real registry.
+//
+// Everything is pure given its injected OS / fs / env / registry surface,
+// mirroring the existing `launcher.ts` + `engine.ts` style so the whole module
+// is unit-testable without a real engine, registry, or specific host OS.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { homedir } from 'os';
+import { editorBinaryPath } from './engine.js';
+import { compareEngineVersions, type EngineInstallation } from './launcher.js';
+
+// ---------------------------------------------------------------------------
+// Injected surfaces (keep discovery pure + testable without a real machine)
+// ---------------------------------------------------------------------------
+
+/** Filesystem surface the scan needs — all injectable for tests. */
+export interface DiscoveryFs {
+  existsImpl: (p: string) => boolean;
+  /** List directory entry NAMES (not full paths); `[]` on any error. */
+  readdirImpl: (p: string) => string[];
+}
+
+function defaultFs(): DiscoveryFs {
+  return {
+    existsImpl: (p: string): boolean => fs.existsSync(p),
+    readdirImpl: (p: string): string[] => {
+      try {
+        return fs.readdirSync(p);
+      } catch {
+        return [];
+      }
+    },
+  };
+}
+
+/** Matches `UE_5.7`, `UE_5.7.4`, `UE_4.27` install-dir names. */
+const UE_DIRNAME_RE = /^UE_(\d+(?:\.\d+)*)$/;
+
+// ---------------------------------------------------------------------------
+// Common-location roots, per OS
+// ---------------------------------------------------------------------------
+
+/**
+ * The popular roots under which `UE_*` engine installs live, for the target OS.
+ * Env-driven where Epic/users vary the location (`PROGRAMFILES`, custom drive,
+ * `$HOME`, `$UE_ROOT`). Pure given the injected `env`. Exported for tests.
+ *
+ * Windows : `%PROGRAMFILES%\Epic Games`, `%PROGRAMW6432%\Epic Games`, common
+ *           alt drives `D:`/`E:\Epic Games`.
+ * macOS   : `/Users/Shared/Epic`, `/Applications/Epic Games`.
+ * Linux   : `/opt`, `/usr/local`, `$HOME`, `$HOME/.local/share` — no launcher
+ *           manifest exists, so this is the ONLY discovery layer on Linux.
+ */
+export function commonEngineRoots(os: NodeJS.Platform, env: NodeJS.ProcessEnv = process.env): string[] {
+  const roots: string[] = [];
+  switch (os) {
+    case 'win32': {
+      const pj = path.win32;
+      const programFiles = env['PROGRAMFILES'] ?? 'C:\\Program Files';
+      const programFilesW64 = env['PROGRAMW6432'];
+      roots.push(pj.join(programFiles, 'Epic Games'));
+      if (programFilesW64 && programFilesW64 !== programFiles) {
+        roots.push(pj.join(programFilesW64, 'Epic Games'));
+      }
+      // Engines are routinely moved to a bigger data drive.
+      roots.push('D:\\Epic Games', 'E:\\Epic Games', 'D:\\Program Files\\Epic Games');
+      break;
+    }
+    case 'darwin': {
+      const pj = path.posix;
+      roots.push(pj.join('/Users', 'Shared', 'Epic'));
+      roots.push(pj.join('/Applications', 'Epic Games'));
+      const home = env['HOME'];
+      if (home) roots.push(pj.join(home, 'Epic'));
+      break;
+    }
+    default: {
+      // Linux + any other posix.
+      const pj = path.posix;
+      roots.push('/opt', '/usr/local');
+      const home = env['HOME'];
+      if (home) {
+        roots.push(home, pj.join(home, '.local', 'share'));
+      }
+      break;
+    }
+  }
+  // An explicit `$UE_ROOT` (community convention) wins as a first-class root on
+  // every OS — its PARENT, since the var points AT the engine dir.
+  const ueRoot = env['UE_ROOT'];
+  if (ueRoot && ueRoot.trim().length > 0) {
+    const parent = (os === 'win32' ? path.win32 : path.posix).dirname(ueRoot.trim());
+    if (!roots.includes(parent)) roots.unshift(parent);
+  }
+  return roots;
+}
+
+/**
+ * On Linux there is no `UE_x.y` naming convention — installs are free-form
+ * directory names (`UnrealEngine`, `UnrealEngine-5.7`, `ue5`, …). These are the
+ * candidate engine-dir basenames we probe directly under each root (in addition
+ * to scanning for `UE_*`). Pure. Exported for tests.
+ */
+export function linuxEngineDirCandidates(): string[] {
+  return ['UnrealEngine', 'UnrealEngine5', 'UE5', 'ue5', 'Unreal'];
+}
+
+// ---------------------------------------------------------------------------
+// Common-location scan
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan the common roots for installed engines and return them as
+ * `EngineInstallation`s — the SAME shape the launcher manifest produces, so the
+ * resolution chain treats manifest- and scan-discovered engines uniformly.
+ *
+ * For each root:
+ *   - Windows/macOS: list `UE_<version>` subdirs, derive the association from
+ *     the dir name, keep the install dir whose `UnrealEditor` binary exists.
+ *   - Linux: probe the well-known free-form dir names; the association is read
+ *     from `Engine/Build/Build.version` when present (else left empty so the
+ *     engine is still usable as the "highest installed" fallback).
+ *
+ * Highest-version first. Pure given the injected fs/env. Never throws.
+ */
+export function scanCommonLocationEngines(
+  os: NodeJS.Platform,
+  env: NodeJS.ProcessEnv = process.env,
+  fsImpl: DiscoveryFs = defaultFs(),
+): EngineInstallation[] {
+  const roots = commonEngineRoots(os, env);
+  const pj = os === 'win32' ? path.win32 : path.posix;
+  const found: EngineInstallation[] = [];
+  const seenRoots = new Set<string>();
+
+  const tryAddEngine = (installDir: string, associationHint: string): void => {
+    const key = os === 'win32' ? installDir.toLowerCase() : installDir;
+    if (seenRoots.has(key)) return;
+    const binary = editorBinaryPath(installDir, os);
+    if (!fsImpl.existsImpl(binary)) return;
+    seenRoots.add(key);
+    const association = associationHint || readEngineAssociationFromBuildVersion(installDir, os, fsImpl);
+    found.push({
+      appName: associationHint ? `UE_${associationHint}` : path.basename(installDir),
+      appVersion: association,
+      installLocation: installDir,
+      engineAssociation: association,
+    });
+  };
+
+  for (const root of roots) {
+    if (!fsImpl.existsImpl(root)) continue;
+    const entries = fsImpl.readdirImpl(root);
+
+    // 1. `UE_<version>` dirs (Windows/macOS launcher layout, also seen on Linux).
+    for (const name of entries) {
+      const m = name.match(UE_DIRNAME_RE);
+      if (!m) continue;
+      tryAddEngine(pj.join(root, name), m[1]);
+    }
+
+    // 2. Linux free-form engine dirs (`UnrealEngine`, …) — probe by name.
+    if (os !== 'win32' && os !== 'darwin') {
+      const candidateNames = new Set(linuxEngineDirCandidates());
+      for (const name of entries) {
+        if (candidateNames.has(name)) {
+          tryAddEngine(pj.join(root, name), '');
+        }
+      }
+    }
+  }
+
+  found.sort((a, b) => compareEngineVersions(b.engineAssociation, a.engineAssociation));
+  return found;
+}
+
+/**
+ * Best-effort read of `Engine/Build/Build.version` (`{"MajorVersion":5,
+ * "MinorVersion":7,...}`) under an engine root → `"5.7"`. Returns `''` when the
+ * file is absent/malformed (a source-build root may not ship it). Pure given
+ * the injected fs. Exported for tests.
+ */
+export function readEngineAssociationFromBuildVersion(
+  engineRoot: string,
+  os: NodeJS.Platform,
+  fsImpl: DiscoveryFs = defaultFs(),
+): string {
+  const pj = os === 'win32' ? path.win32 : path.posix;
+  const versionFile = pj.join(engineRoot, 'Engine', 'Build', 'Build.version');
+  if (!fsImpl.existsImpl(versionFile)) return '';
+  let raw: string;
+  try {
+    raw = fs.readFileSync(versionFile, 'utf-8');
+  } catch {
+    return '';
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return '';
+  }
+  if (!parsed || typeof parsed !== 'object') return '';
+  const rec = parsed as Record<string, unknown>;
+  const major = rec['MajorVersion'];
+  const minor = rec['MinorVersion'];
+  if (typeof major === 'number' && typeof minor === 'number') {
+    return `${major}.${minor}`;
+  }
+  return '';
+}
+
+// ---------------------------------------------------------------------------
+// Windows-registry resolution of source/custom builds
+// ---------------------------------------------------------------------------
+
+/** A registered source/custom build from `HKCU\...\Unreal Engine\Builds`. */
+export interface RegistryEngineBuild {
+  /** Registry value name — the `.uproject` GUID association or a label. */
+  buildId: string;
+  /** Install path the registry maps the build id to. */
+  installLocation: string;
+}
+
+/** Injectable registry reader: returns raw `reg query` stdout, or `null`. */
+export type RegistryQueryImpl = (keyPath: string) => string | null;
+
+/** The registry key Epic registers source/custom builds under. */
+export const UE_BUILDS_REGISTRY_KEY = 'HKCU\\Software\\Epic Games\\Unreal Engine\\Builds';
+
+/**
+ * Default registry reader — runs `reg query` (Windows only). Returns `null` on
+ * any failure (key absent, non-Windows host, `reg` unavailable) so the caller
+ * degrades to the other discovery layers. Tests inject a fake instead.
+ */
+export function defaultRegistryQuery(keyPath: string): string | null {
+  try {
+    // Pipe (not inherit) stderr: when the Builds key does not exist, `reg query`
+    // writes "ERROR: The system was unable to find the specified registry key or
+    // value." to stderr and exits non-zero. That is the normal "no source builds
+    // registered" case — capture it into the thrown error (which we swallow)
+    // rather than letting it pollute the CLI's / tests' stderr.
+    return execFileSync('reg', ['query', keyPath], {
+      encoding: 'utf-8',
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse `reg query "HKCU\...\Builds"` stdout into `{ buildId, installLocation }`
+ * pairs. `reg query` output lines look like:
+ *
+ *   HKEY_CURRENT_USER\Software\Epic Games\Unreal Engine\Builds
+ *       {0A1B2C3D-...}    REG_SZ    D:\CustomUE
+ *       MyCustom419       REG_SZ    E:\src\UnrealEngine
+ *
+ * The value name may itself contain spaces (a human-readable label), so we
+ * anchor on the ` REG_SZ ` type token and split around it. Pure. Exported for
+ * tests.
+ */
+export function parseRegistryBuilds(regOutput: string): RegistryEngineBuild[] {
+  const builds: RegistryEngineBuild[] = [];
+  for (const rawLine of regOutput.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    // Only value lines are indented and carry a REG_ type token.
+    const typeMatch = line.match(/\s+(REG_SZ|REG_EXPAND_SZ)\s+/);
+    if (!typeMatch) continue;
+    const typeToken = typeMatch[0];
+    const idx = line.indexOf(typeToken);
+    if (idx < 0) continue;
+    const buildId = line.slice(0, idx).trim();
+    const installLocation = line.slice(idx + typeToken.length).trim();
+    if (buildId.length === 0 || installLocation.length === 0) continue;
+    builds.push({ buildId, installLocation });
+  }
+  return builds;
+}
+
+/**
+ * Read the registered source/custom builds. Windows-only in practice (the
+ * registry doesn't exist elsewhere); on a non-win32 `os` we return `[]` without
+ * even invoking the reader. Pure given the injected `queryImpl`. Never throws.
+ */
+export function readRegistryEngineBuilds(
+  os: NodeJS.Platform,
+  queryImpl: RegistryQueryImpl = defaultRegistryQuery,
+): RegistryEngineBuild[] {
+  if (os !== 'win32') return [];
+  const out = queryImpl(UE_BUILDS_REGISTRY_KEY);
+  if (!out) return [];
+  return parseRegistryBuilds(out);
+}
+
+/**
+ * Resolve a GUID/label `EngineAssociation` to its install path via the registry
+ * builds. Matches the build id case-insensitively (GUIDs are written with
+ * varying brace/case styles). Returns `null` when unmatched. Pure. Exported for
+ * tests.
+ */
+export function matchRegistryBuild(
+  association: string,
+  builds: RegistryEngineBuild[],
+): RegistryEngineBuild | null {
+  const assoc = association.trim().toLowerCase();
+  if (assoc.length === 0) return null;
+  return builds.find((b) => b.buildId.trim().toLowerCase() === assoc) ?? null;
+}

--- a/cli/src/utils/engine-discovery.ts
+++ b/cli/src/utils/engine-discovery.ts
@@ -172,7 +172,10 @@ export function scanCommonLocationEngines(
       verbose(`scanCommonLocationEngines: found engine at ${installDir} with unknown version (no Build.version); it cannot match a versioned association`);
     }
     found.push({
-      appName: associationHint ? `UE_${associationHint}` : path.basename(installDir),
+      // os-flavoured basename so a cross-os scan labels free-form Linux dirs
+      // correctly off a posix `installDir` even on a Windows host (the install
+      // path was built with the target-os `pj` above).
+      appName: associationHint ? `UE_${associationHint}` : pj.basename(installDir),
       appVersion: association,
       installLocation: installDir,
       engineAssociation: association,

--- a/cli/src/utils/engine.ts
+++ b/cli/src/utils/engine.ts
@@ -93,7 +93,13 @@ export function resolveEngine(input: ResolveEngineInput): ResolveEngineResult {
   const exists = input.existsImpl ?? ((p: string) => fs.existsSync(p));
 
   if (input.engineRootOverride && input.engineRootOverride.trim().length > 0) {
-    const engineRoot = path.resolve(input.engineRootOverride.trim());
+    // Normalise the override with the TARGET-os path flavour, not the host's:
+    // the default `path.resolve` is `path.posix` on a non-Windows host (CI), so
+    // it would mangle a Windows engine root (`C:\Src\UE5` is not POSIX-absolute,
+    // so posix.resolve prepends cwd) and the binary check would then miss. This
+    // mirrors `editorBinaryPath`, which already picks the flavour by `os`.
+    const pj = os === 'win32' ? path.win32 : path.posix;
+    const engineRoot = pj.resolve(input.engineRootOverride.trim());
     const editorPath = editorBinaryPath(engineRoot, os);
     if (!exists(editorPath)) {
       return {

--- a/cli/tests/auto-install-engine.test.ts
+++ b/cli/tests/auto-install-engine.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { autoInstallEngine, engineInstallGuidance } from '../src/lib/auto-install-engine.js';
+
+describe('engineInstallGuidance', () => {
+  it('points Windows/macOS at the Epic launcher deep link', () => {
+    const win = engineInstallGuidance('5.7', 'win32', 'com.epicgames.launcher://ue/');
+    expect(win.join('\n')).toContain('Epic Games Launcher');
+    expect(win.join('\n')).toContain('com.epicgames.launcher://ue/');
+    const mac = engineInstallGuidance('5.7', 'darwin', 'com.epicgames.launcher://ue/');
+    expect(mac.join('\n')).toContain('Epic Games Launcher');
+  });
+  it('points Linux at the login-gated official download page', () => {
+    const lin = engineInstallGuidance('5.7', 'linux', 'com.epicgames.launcher://ue/');
+    expect(lin.join('\n')).toContain('login-gated');
+    expect(lin.join('\n')).toContain('unrealengine.com');
+  });
+});
+
+describe('autoInstallEngine — already installed short-circuit (validated)', () => {
+  it('returns already-installed with the resolved binary', () => {
+    const r = autoInstallEngine({
+      version: '5.7',
+      os: 'win32',
+      resolveInstalledImpl: () => 'C:\\UE\\UnrealEditor.exe',
+    });
+    expect(r.outcome).toBe('already-installed');
+    expect(r.editorPath).toBe('C:\\UE\\UnrealEditor.exe');
+  });
+});
+
+describe('autoInstallEngine — consent gating (never silent multi-GB)', () => {
+  it('refuses without consent in a non-interactive context', () => {
+    const r = autoInstallEngine({
+      version: '5.7',
+      os: 'win32',
+      consent: false,
+      interactive: false,
+      resolveInstalledImpl: () => null,
+    });
+    expect(r.outcome).toBe('consent-required');
+    expect(r.editorPath).toBeNull();
+    expect(r.message).toContain('--yes');
+  });
+
+  it('with explicit consent, degrades to guidance (no unattended installer exists)', () => {
+    const r = autoInstallEngine({
+      version: '5.7',
+      os: 'win32',
+      consent: true,
+      resolveInstalledImpl: () => null,
+    });
+    expect(r.outcome).toBe('guidance-only');
+    expect(r.editorPath).toBeNull();
+    expect(r.guidance.length).toBeGreaterThan(0);
+  });
+
+  it('an interactive terminal counts as consent', () => {
+    const r = autoInstallEngine({
+      version: '5.7',
+      os: 'linux',
+      interactive: true,
+      resolveInstalledImpl: () => null,
+    });
+    expect(r.outcome).toBe('guidance-only');
+  });
+
+  it('always surfaces the launcher deep link + per-OS guidance', () => {
+    const r = autoInstallEngine({ version: '5.7', os: 'darwin', resolveInstalledImpl: () => null });
+    expect(r.launcherUrl).toBe('com.epicgames.launcher://ue/');
+    expect(r.guidance.length).toBeGreaterThan(0);
+  });
+
+  it('never claims an install succeeded when no binary resolves', () => {
+    const r = autoInstallEngine({
+      version: '5.7',
+      os: 'win32',
+      consent: true,
+      resolveInstalledImpl: () => null, // nothing got installed
+    });
+    expect(r.editorPath).toBeNull();
+    expect(r.outcome).not.toBe('already-installed');
+  });
+});

--- a/cli/tests/engine-cache.test.ts
+++ b/cli/tests/engine-cache.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import {
+  readCachedEnginePath,
+  writeCachedEnginePath,
+  clearCachedEnginePath,
+  keyFor,
+  AUTO_KEY,
+  defaultCacheFilePath,
+  type EngineCache,
+  type EngineCacheIo,
+} from '../src/utils/engine-cache.js';
+
+/**
+ * Build an in-memory cache IO: the cache "file" is a single string cell, plus
+ * an injectable existence set. No real fs, no real home dir — the whole
+ * eviction/invalidate logic is exercised deterministically.
+ */
+function memoryIo(opts?: { initial?: EngineCache; existing?: Set<string>; now?: number }): {
+  io: EngineCacheIo;
+  read: () => EngineCache;
+} {
+  let cell: string | null = opts?.initial ? JSON.stringify(opts.initial) : null;
+  const existing = opts?.existing ?? new Set<string>();
+  const io: EngineCacheIo = {
+    cacheFilePath: '/virtual/cache.json',
+    existsImpl: (p) => existing.has(p),
+    readImpl: () => cell,
+    writeImpl: (_p, content) => {
+      cell = content;
+    },
+    nowImpl: () => opts?.now ?? 1000,
+  };
+  return {
+    io,
+    read: () => (cell ? (JSON.parse(cell) as EngineCache) : (Object.create(null) as EngineCache)),
+  };
+}
+
+describe('keyFor', () => {
+  it('maps undefined / empty / whitespace to the __auto__ slot', () => {
+    expect(keyFor(undefined)).toBe(AUTO_KEY);
+    expect(keyFor('')).toBe(AUTO_KEY);
+    expect(keyFor('   ')).toBe(AUTO_KEY);
+  });
+  it('keeps a concrete association as its own slot', () => {
+    expect(keyFor('5.7')).toBe('5.7');
+    expect(keyFor('{guid}')).toBe('{guid}');
+  });
+});
+
+describe('defaultCacheFilePath', () => {
+  it('lands at ~/.unreal-mcp-cli-engine-cache.json', () => {
+    expect(defaultCacheFilePath('/home/u')).toMatch(/[\\/]\.unreal-mcp-cli-engine-cache\.json$/);
+  });
+});
+
+describe('readCachedEnginePath', () => {
+  it('returns null on an empty cache', () => {
+    const { io } = memoryIo();
+    expect(readCachedEnginePath('5.7', io)).toBeNull();
+  });
+
+  it('returns a hit whose path still exists on disk', () => {
+    const { io } = memoryIo({
+      initial: { '5.7': { path: '/Engine/UnrealEditor', savedAt: 1 } },
+      existing: new Set(['/Engine/UnrealEditor']),
+    });
+    expect(readCachedEnginePath('5.7', io)).toBe('/Engine/UnrealEditor');
+  });
+
+  it('evicts a stale entry (cached path no longer exists) and returns null', () => {
+    const { io, read } = memoryIo({
+      initial: { '5.7': { path: '/gone/UnrealEditor', savedAt: 1 } },
+      existing: new Set(), // path missing
+    });
+    expect(readCachedEnginePath('5.7', io)).toBeNull();
+    expect(read()['5.7']).toBeUndefined(); // slot dropped
+  });
+
+  it('uses the __auto__ slot for an empty association', () => {
+    const { io } = memoryIo({
+      initial: { [AUTO_KEY]: { path: '/Engine/UnrealEditor', savedAt: 1 } },
+      existing: new Set(['/Engine/UnrealEditor']),
+    });
+    expect(readCachedEnginePath('', io)).toBe('/Engine/UnrealEditor');
+    expect(readCachedEnginePath(undefined, io)).toBe('/Engine/UnrealEditor');
+  });
+
+  it('tolerates a corrupt cache file', () => {
+    let cell = 'not json at all';
+    const io: EngineCacheIo = {
+      cacheFilePath: '/v/c.json',
+      existsImpl: () => true,
+      readImpl: () => cell,
+      writeImpl: (_p, c) => {
+        cell = c;
+      },
+    };
+    expect(readCachedEnginePath('5.7', io)).toBeNull();
+  });
+});
+
+describe('writeCachedEnginePath', () => {
+  it('stores under the association slot with a savedAt timestamp', () => {
+    const { io, read } = memoryIo({ now: 4242 });
+    writeCachedEnginePath('5.7', '/E/UnrealEditor', io);
+    expect(read()['5.7']).toEqual({ path: '/E/UnrealEditor', savedAt: 4242 });
+  });
+
+  it('stores an empty association under __auto__', () => {
+    const { io, read } = memoryIo();
+    writeCachedEnginePath('', '/E/UnrealEditor', io);
+    expect(read()[AUTO_KEY].path).toBe('/E/UnrealEditor');
+  });
+});
+
+describe('clearCachedEnginePath (invalidate-on-spawn-failure)', () => {
+  it('drops a slot', () => {
+    const { io, read } = memoryIo({
+      initial: { '5.7': { path: '/E/UnrealEditor', savedAt: 1 } },
+      existing: new Set(['/E/UnrealEditor']),
+    });
+    clearCachedEnginePath('5.7', io);
+    expect(read()['5.7']).toBeUndefined();
+  });
+
+  it('is a no-op when the slot is absent', () => {
+    const { io, read } = memoryIo({ initial: { '5.7': { path: '/E/X', savedAt: 1 } } });
+    clearCachedEnginePath('5.5', io);
+    expect(read()['5.7']).toBeDefined();
+  });
+});

--- a/cli/tests/engine-chain.test.ts
+++ b/cli/tests/engine-chain.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import {
+  discoverEngine,
+  engineRootFromEditorPath,
+  type DiscoverEngineInput,
+} from '../src/lib/engine.js';
+import { editorBinaryPath } from '../src/utils/engine.js';
+import type { EngineInstallation } from '../src/utils/launcher.js';
+import type { EngineCacheIo } from '../src/utils/engine-cache.js';
+import type { DiscoveryFs } from '../src/utils/engine-discovery.js';
+
+/** In-memory cache IO so the chain's cache writes/reads are observable. */
+function memCache(initial: Record<string, { path: string; savedAt: number }> = {}, existing?: Set<string>): {
+  io: EngineCacheIo;
+  current: () => Record<string, { path: string; savedAt: number }>;
+} {
+  let cell: string | null = Object.keys(initial).length ? JSON.stringify(initial) : null;
+  return {
+    io: {
+      cacheFilePath: '/v/c.json',
+      existsImpl: (p) => existing?.has(p) ?? false,
+      readImpl: () => cell,
+      writeImpl: (_p, c) => {
+        cell = c;
+      },
+      nowImpl: () => 1,
+    },
+    current: () => (cell ? JSON.parse(cell) : {}),
+  };
+}
+
+function launcherEngine(association: string, os: NodeJS.Platform, install: string): EngineInstallation {
+  return { appName: `UE_${association}`, appVersion: association, installLocation: install, engineAssociation: association };
+}
+
+const WIN = 'win32' as NodeJS.Platform;
+
+describe('discoverEngine — override always wins (bypasses cache + chain)', () => {
+  it('resolves an explicit engine root without touching the manifest', () => {
+    const root = 'C:\\Src\\UE5';
+    const bin = editorBinaryPath(root, WIN);
+    const input: DiscoverEngineInput = {
+      engineAssociation: '{guid}',
+      engineRootOverride: root,
+      os: WIN,
+      existsImpl: (p) => p === bin,
+      enginesImpl: () => {
+        throw new Error('manifest must not be consulted under an override');
+      },
+    };
+    const r = discoverEngine(input);
+    expect(r.kind).toBe('resolved');
+    if (r.kind === 'resolved') expect(r.source).toBe('override');
+  });
+});
+
+describe('discoverEngine — cache is the fast path', () => {
+  it('returns a cached hit without consulting the launcher manifest', () => {
+    const cachedBin = 'C:\\Program Files\\Epic Games\\UE_5.7\\Engine\\Binaries\\Win64\\UnrealEditor.exe';
+    const { io } = memCache({ '5.7': { path: cachedBin, savedAt: 1 } }, new Set([cachedBin]));
+    const r = discoverEngine({
+      engineAssociation: '5.7',
+      os: WIN,
+      existsImpl: (p) => p === cachedBin,
+      cacheIo: io,
+      enginesImpl: () => {
+        throw new Error('cache hit must short-circuit before the manifest');
+      },
+    });
+    expect(r.kind).toBe('resolved');
+    if (r.kind === 'resolved') expect(r.source).toBe('cache');
+  });
+
+  it('falls through a stale cache entry (evicted) into the launcher manifest', () => {
+    const staleBin = 'C:\\old\\UnrealEditor.exe';
+    const install = 'C:\\Program Files\\Epic Games\\UE_5.7';
+    const liveBin = editorBinaryPath(install, WIN);
+    const { io, current } = memCache({ '5.7': { path: staleBin, savedAt: 1 } }, new Set([liveBin]));
+    const r = discoverEngine({
+      engineAssociation: '5.7',
+      os: WIN,
+      existsImpl: (p) => p === liveBin, // stale path missing, live present
+      cacheIo: io,
+      enginesImpl: () => [launcherEngine('5.7', WIN, install)],
+    });
+    expect(r.kind).toBe('resolved');
+    if (r.kind === 'resolved') {
+      expect(r.source).toBe('launcher-manifest');
+      // The fresh resolution was re-cached under the same slot.
+      expect(current()['5.7'].path).toBe(liveBin);
+    }
+  });
+});
+
+describe('discoverEngine — layer ordering: launcher → registry → common-location', () => {
+  it('resolves a GUID source build via the registry when the manifest misses', () => {
+    const install = 'D:\\CustomUE';
+    const bin = editorBinaryPath(install, WIN);
+    const { io } = memCache();
+    const r = discoverEngine({
+      engineAssociation: '{abc}',
+      os: WIN,
+      existsImpl: (p) => p === bin,
+      cacheIo: io,
+      enginesImpl: () => [], // launcher empty
+      registryQueryImpl: () => `    {abc}    REG_SZ    ${install}`,
+    });
+    expect(r.kind).toBe('resolved');
+    if (r.kind === 'resolved') {
+      expect(r.source).toBe('registry');
+      expect(r.engineRoot).toBe(install);
+    }
+  });
+
+  it('falls to the common-location scan when launcher + registry miss', () => {
+    const root = 'C:\\Program Files\\Epic Games';
+    const install = 'C:\\Program Files\\Epic Games\\UE_5.7';
+    const bin = editorBinaryPath(install, WIN);
+    const { io } = memCache();
+    const discoveryFs: DiscoveryFs = {
+      existsImpl: (p) => p === root || p === bin,
+      readdirImpl: (p) => (p === root ? ['UE_5.7'] : []),
+    };
+    const r = discoverEngine({
+      engineAssociation: '5.7',
+      os: WIN,
+      existsImpl: (p) => p === bin,
+      cacheIo: io,
+      env: { PROGRAMFILES: 'C:\\Program Files' },
+      enginesImpl: () => [],
+      registryQueryImpl: () => null, // registry empty
+      discoveryFs,
+    });
+    expect(r.kind).toBe('resolved');
+    if (r.kind === 'resolved') expect(r.source).toBe('common-location');
+  });
+
+  it('resolves an empty association to the highest engine via common-location on Linux', () => {
+    const root = '/opt';
+    const install = '/opt/UnrealEngine';
+    const bin = editorBinaryPath(install, 'linux');
+    const { io } = memCache();
+    const discoveryFs: DiscoveryFs = {
+      existsImpl: (p) => p === root || p === bin,
+      readdirImpl: (p) => (p === root ? ['UnrealEngine'] : []),
+    };
+    const r = discoverEngine({
+      engineAssociation: '',
+      os: 'linux',
+      existsImpl: (p) => p === bin,
+      cacheIo: io,
+      env: {},
+      enginesImpl: () => [], // Linux has no launcher manifest anyway
+      discoveryFs,
+    });
+    expect(r.kind).toBe('resolved');
+    if (r.kind === 'resolved') expect(r.source).toBe('common-location');
+  });
+
+  it('returns unresolved (source null) when every layer misses', () => {
+    const { io } = memCache();
+    const r = discoverEngine({
+      engineAssociation: '5.7',
+      os: WIN,
+      existsImpl: () => false,
+      cacheIo: io,
+      enginesImpl: () => [],
+      registryQueryImpl: () => null,
+      discoveryFs: { existsImpl: () => false, readdirImpl: () => [] },
+    });
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') expect(r.source).toBeNull();
+  });
+});
+
+describe('discoverEngine — noCache disables read AND write', () => {
+  it('does not write a resolved path to the cache', () => {
+    const install = 'C:\\Program Files\\Epic Games\\UE_5.7';
+    const bin = editorBinaryPath(install, WIN);
+    const { io, current } = memCache();
+    const r = discoverEngine({
+      engineAssociation: '5.7',
+      os: WIN,
+      noCache: true,
+      existsImpl: (p) => p === bin,
+      cacheIo: io,
+      enginesImpl: () => [launcherEngine('5.7', WIN, install)],
+    });
+    expect(r.kind).toBe('resolved');
+    expect(current()).toEqual({});
+  });
+});
+
+describe('engineRootFromEditorPath', () => {
+  it('recovers the engine root from a Win64 editor path', () => {
+    const root = 'C:\\Program Files\\Epic Games\\UE_5.7';
+    expect(engineRootFromEditorPath(editorBinaryPath(root, WIN), WIN)).toBe(root);
+  });
+  it('recovers the engine root from a Linux editor path', () => {
+    const root = '/opt/UnrealEngine';
+    expect(engineRootFromEditorPath(editorBinaryPath(root, 'linux'), 'linux')).toBe(root);
+  });
+});

--- a/cli/tests/engine-chain.test.ts
+++ b/cli/tests/engine-chain.test.ts
@@ -4,10 +4,14 @@ import {
   engineRootFromEditorPath,
   type DiscoverEngineInput,
 } from '../src/lib/engine.js';
+import { openProject } from '../src/lib/open.js';
 import { editorBinaryPath } from '../src/utils/engine.js';
 import type { EngineInstallation } from '../src/utils/launcher.js';
 import type { EngineCacheIo } from '../src/utils/engine-cache.js';
 import type { DiscoveryFs } from '../src/utils/engine-discovery.js';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
 /** In-memory cache IO so the chain's cache writes/reads are observable. */
 function memCache(initial: Record<string, { path: string; savedAt: number }> = {}, existing?: Set<string>): {
@@ -188,6 +192,57 @@ describe('discoverEngine — noCache disables read AND write', () => {
     });
     expect(r.kind).toBe('resolved');
     expect(current()).toEqual({});
+  });
+});
+
+describe('openProject — forwards the discovery surfaces (hermetic, no home cache / host registry / host fs)', () => {
+  it('resolves through an INJECTED cacheIo + discoveryFs + registryQueryImpl, never the real home cache file', async () => {
+    // A real temp project + a real fake editor binary (so the default
+    // existence check passes), but every DISCOVERY surface is injected.
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'umcp-openproj-'));
+    const engineRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'umcp-engine-'));
+    try {
+      fs.writeFileSync(
+        path.join(projectDir, 'MyGame.uproject'),
+        JSON.stringify({ FileVersion: 3, EngineAssociation: '5.7' }),
+        'utf-8',
+      );
+      const bin = editorBinaryPath(engineRoot, process.platform);
+      fs.mkdirSync(path.dirname(bin), { recursive: true });
+      fs.writeFileSync(bin, '', 'utf-8');
+
+      // The injected cache slot lives only in `store`; the real home file path
+      // is asserted untouched below. registry + scan are no-ops.
+      const store = new Map<string, string>();
+      const homeCacheFile = path.join(os.homedir(), '.unreal-mcp-cli-engine-cache.json');
+      const homeCacheExistedBefore = fs.existsSync(homeCacheFile);
+
+      const r = await openProject({
+        projectDir,
+        enginesImpl: () => [
+          { appName: 'UE_5.7', appVersion: '5.7', installLocation: engineRoot, engineAssociation: '5.7' },
+        ],
+        cacheIo: {
+          cacheFilePath: '<in-memory>',
+          readImpl: (p) => store.get(p) ?? null,
+          writeImpl: (p, c) => void store.set(p, c),
+        },
+        discoveryFs: { existsImpl: () => false, readdirImpl: () => [] },
+        registryQueryImpl: () => null,
+        spawnImpl: () => ({ pid: 99 }),
+      });
+
+      expect(r.kind).toBe('success');
+      if (r.kind === 'success') expect(r.editorPid).toBe(99);
+      // The resolved path was cached into the INJECTED store, proving the
+      // cacheIo surface was threaded through openProject → discoverEngine.
+      expect(store.size).toBeGreaterThan(0);
+      // And the user's real home cache file was never created by this run.
+      expect(fs.existsSync(homeCacheFile)).toBe(homeCacheExistedBefore);
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+      fs.rmSync(engineRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/cli/tests/engine-chain.test.ts
+++ b/cli/tests/engine-chain.test.ts
@@ -56,6 +56,47 @@ describe('discoverEngine — override always wins (bypasses cache + chain)', () 
     expect(r.kind).toBe('resolved');
     if (r.kind === 'resolved') expect(r.source).toBe('override');
   });
+
+  it('honours the INJECTED os for the override (not the host platform) — a WIN root resolves off-Windows', () => {
+    // Regression: the override path normalised the root with the host `path`
+    // (posix on Linux CI), so a Windows engine root resolved on Windows but
+    // came back `unresolved` on Linux. The override must use the injected `os`
+    // path flavour, hermetically, so this holds on every runner OS.
+    const winRoot = 'C:\\Src\\UE5';
+    const winBin = editorBinaryPath(winRoot, WIN);
+    const rWin = discoverEngine({
+      engineAssociation: '{guid}',
+      engineRootOverride: winRoot,
+      os: WIN,
+      existsImpl: (p) => p === winBin,
+      enginesImpl: () => {
+        throw new Error('manifest must not be consulted under an override');
+      },
+    });
+    expect(rWin.kind).toBe('resolved');
+    if (rWin.kind === 'resolved') {
+      expect(rWin.engineRoot).toBe(winRoot);
+      expect(rWin.editorPath).toBe(winBin);
+    }
+
+    // The symmetric case: a posix root resolved under an injected linux os.
+    const linRoot = '/opt/UnrealEngine';
+    const linBin = editorBinaryPath(linRoot, 'linux');
+    const rLin = discoverEngine({
+      engineAssociation: '',
+      engineRootOverride: linRoot,
+      os: 'linux',
+      existsImpl: (p) => p === linBin,
+      enginesImpl: () => {
+        throw new Error('manifest must not be consulted under an override');
+      },
+    });
+    expect(rLin.kind).toBe('resolved');
+    if (rLin.kind === 'resolved') {
+      expect(rLin.engineRoot).toBe(linRoot);
+      expect(rLin.editorPath).toBe(linBin);
+    }
+  });
 });
 
 describe('discoverEngine — cache is the fast path', () => {

--- a/cli/tests/engine-discovery.test.ts
+++ b/cli/tests/engine-discovery.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import {
+  commonEngineRoots,
+  scanCommonLocationEngines,
+  readEngineAssociationFromBuildVersion,
+  parseRegistryBuilds,
+  readRegistryEngineBuilds,
+  matchRegistryBuild,
+  linuxEngineDirCandidates,
+  UE_BUILDS_REGISTRY_KEY,
+  type DiscoveryFs,
+} from '../src/utils/engine-discovery.js';
+import { editorBinaryPath } from '../src/utils/engine.js';
+
+/** Build a DiscoveryFs from a set of existing paths + a dir->names listing. */
+function fakeFs(existing: Set<string>, dirs: Record<string, string[]> = {}): DiscoveryFs {
+  return {
+    existsImpl: (p) => existing.has(p),
+    readdirImpl: (p) => dirs[p] ?? [],
+  };
+}
+
+describe('commonEngineRoots', () => {
+  it('includes Epic Games under PROGRAMFILES on Windows', () => {
+    const roots = commonEngineRoots('win32', { PROGRAMFILES: 'C:\\Program Files' });
+    expect(roots).toContain('C:\\Program Files\\Epic Games');
+  });
+  it('includes the Shared + Applications roots on macOS', () => {
+    const roots = commonEngineRoots('darwin', {});
+    expect(roots).toContain('/Users/Shared/Epic');
+    expect(roots).toContain('/Applications/Epic Games');
+  });
+  it('includes /opt and $HOME on Linux (no manifest there)', () => {
+    const roots = commonEngineRoots('linux', { HOME: '/home/dev' });
+    expect(roots).toContain('/opt');
+    expect(roots).toContain('/home/dev');
+  });
+  it('promotes the PARENT of $UE_ROOT to the front when set', () => {
+    const roots = commonEngineRoots('linux', { UE_ROOT: '/data/UnrealEngine' });
+    expect(roots[0]).toBe('/data');
+  });
+});
+
+describe('linuxEngineDirCandidates', () => {
+  it('lists the well-known free-form engine dir names', () => {
+    expect(linuxEngineDirCandidates()).toContain('UnrealEngine');
+  });
+});
+
+describe('scanCommonLocationEngines (Windows UE_* layout)', () => {
+  it('finds a UE_5.7 install whose editor binary exists', () => {
+    const root = 'C:\\Program Files\\Epic Games';
+    const install = 'C:\\Program Files\\Epic Games\\UE_5.7';
+    const bin = editorBinaryPath(install, 'win32');
+    const fs = fakeFs(new Set([root, bin]), { [root]: ['UE_5.7', 'UE_5.5-uninstalled-junk', 'Launcher'] });
+    const engines = scanCommonLocationEngines('win32', { PROGRAMFILES: 'C:\\Program Files' }, fs);
+    expect(engines).toHaveLength(1);
+    expect(engines[0].engineAssociation).toBe('5.7');
+    expect(engines[0].installLocation).toBe(install);
+  });
+
+  it('skips a UE_* dir whose editor binary is absent', () => {
+    const root = 'C:\\Program Files\\Epic Games';
+    const fs = fakeFs(new Set([root]), { [root]: ['UE_5.7'] }); // binary NOT in existing
+    expect(scanCommonLocationEngines('win32', { PROGRAMFILES: 'C:\\Program Files' }, fs)).toEqual([]);
+  });
+
+  it('sorts multiple installs highest-version first', () => {
+    const root = 'C:\\Program Files\\Epic Games';
+    const i57 = 'C:\\Program Files\\Epic Games\\UE_5.7';
+    const i55 = 'C:\\Program Files\\Epic Games\\UE_5.5';
+    const fs = fakeFs(new Set([root, editorBinaryPath(i57, 'win32'), editorBinaryPath(i55, 'win32')]), {
+      [root]: ['UE_5.5', 'UE_5.7'],
+    });
+    const engines = scanCommonLocationEngines('win32', { PROGRAMFILES: 'C:\\Program Files' }, fs);
+    expect(engines.map((e) => e.engineAssociation)).toEqual(['5.7', '5.5']);
+  });
+});
+
+describe('scanCommonLocationEngines (Linux free-form layout — fixes the dead end)', () => {
+  it('finds /opt/UnrealEngine and reads its association from Build.version', () => {
+    const install = '/opt/UnrealEngine';
+    const bin = editorBinaryPath(install, 'linux');
+    const buildVersion = '/opt/UnrealEngine/Engine/Build/Build.version';
+    // Note: readEngineAssociationFromBuildVersion uses the REAL fs.readFileSync,
+    // so we can only assert the existsImpl-gated branch here; association falls
+    // back to '' when the file is not present on the real disk. The engine is
+    // still discovered (usable as the highest-installed fallback).
+    const fs = fakeFs(new Set(['/opt', bin]), { '/opt': ['UnrealEngine', 'other'] });
+    const engines = scanCommonLocationEngines('linux', {}, fs);
+    expect(engines).toHaveLength(1);
+    expect(engines[0].installLocation).toBe(install);
+    void buildVersion;
+  });
+
+  it('finds a UE_5.7 dir on Linux too', () => {
+    const install = '/home/dev/UE_5.7';
+    const bin = editorBinaryPath(install, 'linux');
+    const fs = fakeFs(new Set(['/home/dev', bin]), { '/home/dev': ['UE_5.7'] });
+    const engines = scanCommonLocationEngines('linux', { HOME: '/home/dev' }, fs);
+    expect(engines.map((e) => e.engineAssociation)).toEqual(['5.7']);
+  });
+});
+
+describe('readEngineAssociationFromBuildVersion', () => {
+  it('returns "" when the file does not exist (injected fs)', () => {
+    const fs = fakeFs(new Set());
+    expect(readEngineAssociationFromBuildVersion('/opt/UE', 'linux', fs)).toBe('');
+  });
+});
+
+describe('parseRegistryBuilds', () => {
+  const sample = [
+    'HKEY_CURRENT_USER\\Software\\Epic Games\\Unreal Engine\\Builds',
+    '    {0A1B2C3D-1234-5678-9ABC-DEF012345678}    REG_SZ    D:\\CustomUE',
+    '    MyCustom 419    REG_SZ    E:\\src\\UnrealEngine',
+    '',
+  ].join('\r\n');
+
+  it('parses GUID + spaced-label build ids and their install paths', () => {
+    const builds = parseRegistryBuilds(sample);
+    expect(builds).toHaveLength(2);
+    expect(builds[0]).toEqual({
+      buildId: '{0A1B2C3D-1234-5678-9ABC-DEF012345678}',
+      installLocation: 'D:\\CustomUE',
+    });
+    expect(builds[1]).toEqual({ buildId: 'MyCustom 419', installLocation: 'E:\\src\\UnrealEngine' });
+  });
+
+  it('ignores the key header line and blank lines', () => {
+    expect(parseRegistryBuilds('HKEY_...\\Builds\n\n')).toEqual([]);
+  });
+
+  it('handles REG_EXPAND_SZ values', () => {
+    const out = '    Label    REG_EXPAND_SZ    C:\\UE';
+    expect(parseRegistryBuilds(out)).toEqual([{ buildId: 'Label', installLocation: 'C:\\UE' }]);
+  });
+});
+
+describe('readRegistryEngineBuilds', () => {
+  it('returns [] off Windows without invoking the reader', () => {
+    let called = false;
+    const out = readRegistryEngineBuilds('linux', () => {
+      called = true;
+      return 'whatever';
+    });
+    expect(out).toEqual([]);
+    expect(called).toBe(false);
+  });
+
+  it('reads + parses via the injected query on Windows', () => {
+    const out = readRegistryEngineBuilds('win32', (key) => {
+      expect(key).toBe(UE_BUILDS_REGISTRY_KEY);
+      return '    {abc}    REG_SZ    D:\\UE';
+    });
+    expect(out).toEqual([{ buildId: '{abc}', installLocation: 'D:\\UE' }]);
+  });
+
+  it('returns [] when the registry key is absent (reader → null)', () => {
+    expect(readRegistryEngineBuilds('win32', () => null)).toEqual([]);
+  });
+});
+
+describe('matchRegistryBuild', () => {
+  const builds = [
+    { buildId: '{ABC-DEF}', installLocation: 'D:\\UE' },
+    { buildId: 'Label', installLocation: 'E:\\UE' },
+  ];
+  it('matches a GUID association case-insensitively', () => {
+    expect(matchRegistryBuild('{abc-def}', builds)?.installLocation).toBe('D:\\UE');
+  });
+  it('returns null for an unmatched association', () => {
+    expect(matchRegistryBuild('{nope}', builds)).toBeNull();
+  });
+  it('returns null for an empty association', () => {
+    expect(matchRegistryBuild('', builds)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Brings `unreal-mcp-cli` engine resolution to Unity-CLI parity: a persistent, self-healing engine-path **cache** (per-association + `__auto__` slots, stale-eviction, invalidate-on-spawn-failure), **common-location discovery for Windows/macOS/Linux** (Linux was a dead end — no launcher manifest there), and **Windows-registry resolution** of source/custom builds (`HKCU\Software\Epic Games\Unreal Engine\Builds`).
- Wires the full **cache-first chain** into `open`: cache → launcher manifest → registry → common-location scan (verbose-logged, `--engine-root` override preserved, new `--no-cache`).
- **Best-effort, consent-gated engine auto-install** (`install-engine --install`/`--yes`): no unattended UE installer exists on any desktop OS (Win/macOS use the GUI launcher; Linux binaries are login-gated), so every path degrades to a `com.epicgames.launcher://` deep link + precise guided steps and **never downloads multi-GB without explicit consent**; post-install is validated through the discovery chain so success is never falsely reported.
- All new logic is pure + injectable (OS/fs/env/registry/child_process) and unit-tested without a real engine: **228 tests pass (+50 new)**.

## Test plan
- [x] Target-specific local tests passed (unreal-mcp profile Suite 6): `npm run build` (tsc, 0 errors) + `npm test` (vitest, 228 passed / 1 skipped, 0 failures).

Closes #81