### PR TITLE
feat(ui): dev-only inject/control HTTP bridge for the dock

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![MCP](https://badge.mcpx.dev 'MCP Server')](https://modelcontextprotocol.io/introduction)
 [![Unreal Engine](https://img.shields.io/badge/Unreal%20Engine-5.5%2B-0E1128?style=flat&logo=unrealengine&logoColor=white&labelColor=333A41 'Unreal Engine 5.5+, developed and CI-tested against 5.7')](https://www.unrealengine.com/)
-[![test-pull-request](https://github.com/IvanMurzak/Unreal-MCP/actions/workflows/test_pull_request.yml/badge.svg 'CI — test-pull-request')](https://github.com/IvanMurzak/Unreal-MCP/actions/workflows/test_pull_request.yml)</br>
+[![release](https://github.com/IvanMurzak/Unreal-MCP/workflows/release/badge.svg 'release')](https://github.com/IvanMurzak/Unreal-MCP/actions/workflows/release.yml)</br>
 [![Discord](https://img.shields.io/badge/Discord-Join-7289da?logo=discord&logoColor=white&labelColor=333A41 'Join')](https://discord.gg/cfbdMZX99G)
 [![Stars](https://img.shields.io/github/stars/IvanMurzak/Unreal-MCP 'Stars')](https://github.com/IvanMurzak/Unreal-MCP/stargazers)
 [![License](https://img.shields.io/github/license/IvanMurzak/Unreal-MCP?label=License&labelColor=333A41)](https://github.com/IvanMurzak/Unreal-MCP/blob/main/LICENSE)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
@@ -1,0 +1,361 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "DevControl/UnrealMcpDevControlServer.h"
+#include "UI/UnrealMcpEditorViewModel.h"
+#include "Config/UnrealMcpConfig.h"
+#include "UnrealMcpLog.h"
+
+#include "HttpServerModule.h"
+#include "HttpServerResponse.h"
+#include "HttpServerRequest.h"
+#include "HttpPath.h"
+#include "IHttpRouter.h"
+#include "IPAddress.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
+
+// Unity-build ODR rule (CLAUDE.md): every file-local helper carries the family-unique `DevControl` prefix
+// so a same-name/same-signature helper in another unity-grouped .cpp cannot collide.
+namespace
+{
+	// Serialize a JSON object to a condensed string (the dev-control response body / state snapshot).
+	FString DevControlSerialize(const TSharedRef<FJsonObject>& Object)
+	{
+		FString Out;
+		const TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =
+			TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&Out);
+		FJsonSerializer::Serialize(Object, Writer);
+		return Out;
+	}
+
+	// The canonical connection-state label the dev-control /state snapshot reports (matches ParseConnectionState).
+	const TCHAR* DevControlConnectionStateLabel(EUnrealMcpConnectionState State)
+	{
+		switch (State)
+		{
+			case EUnrealMcpConnectionState::Connected:    return TEXT("Connected");
+			case EUnrealMcpConnectionState::Connecting:   return TEXT("Connecting");
+			case EUnrealMcpConnectionState::Degraded:     return TEXT("Degraded");
+			case EUnrealMcpConnectionState::Disconnected: default: return TEXT("Disconnected");
+		}
+	}
+
+	// The connection-mode string the dev-control surface speaks ("Cloud"/"Custom").
+	const TCHAR* DevControlConnectionModeLabel(EUnrealMcpConnectionMode Mode)
+	{
+		return Mode == EUnrealMcpConnectionMode::Cloud ? TEXT("Cloud") : TEXT("Custom");
+	}
+
+	// Parse a "Cloud"/"Custom" mode string (case-insensitive). Returns true + the mode on a match.
+	bool DevControlParseMode(const FString& Raw, EUnrealMcpConnectionMode& OutMode)
+	{
+		if (Raw.Equals(TEXT("Cloud"), ESearchCase::IgnoreCase)) { OutMode = EUnrealMcpConnectionMode::Cloud; return true; }
+		if (Raw.Equals(TEXT("Custom"), ESearchCase::IgnoreCase)) { OutMode = EUnrealMcpConnectionMode::Custom; return true; }
+		return false;
+	}
+
+	// Build a `{"ok":false,"error":<msg>}` result into OutResult and return the given status code.
+	int32 DevControlFail(TSharedRef<FJsonObject>& OutResult, const FString& Error)
+	{
+		OutResult->SetBoolField(TEXT("ok"), false);
+		OutResult->SetStringField(TEXT("error"), Error);
+		return -1; // status filled in by the caller
+	}
+
+	// Whether a peer address is loopback. FInternetAddr has no IsLoopbackAddress(), so compare the IP-only
+	// string form against the IPv4 / IPv6 loopback literals (covers 127.0.0.1 and ::1 across protocol types).
+	bool DevControlIsLoopback(const TSharedPtr<FInternetAddr>& Addr)
+	{
+		if (!Addr.IsValid())
+			return false;
+		const FString Ip = Addr->ToString(/*bAppendPort*/ false);
+		return Ip.StartsWith(TEXT("127.")) || Ip == TEXT("::1") || Ip == TEXT("0:0:0:0:0:0:0:1");
+	}
+}
+
+FUnrealMcpDevControlServer::FUnrealMcpDevControlServer() = default;
+
+FUnrealMcpDevControlServer::~FUnrealMcpDevControlServer()
+{
+	Stop();
+}
+
+bool FUnrealMcpDevControlServer::Start(uint32 Port, const TSharedPtr<FUnrealMcpEditorViewModel>& InViewModel)
+{
+	if (bRunning)
+		return true;
+
+	// A link-time dependency on "HTTPServer" does NOT auto-LOAD the module at runtime, so force-load it before
+	// FHttpServerModule::Get() (otherwise IsAvailable() is false and the bridge silently never starts).
+	if (!FModuleManager::Get().IsModuleLoaded(TEXT("HTTPServer")))
+	{
+		FModuleManager::Get().LoadModule(TEXT("HTTPServer"));
+	}
+
+	if (!FHttpServerModule::IsAvailable())
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[dev-control] HTTPServer module unavailable; dev-control server not started."));
+		return false;
+	}
+
+	FHttpServerModule& HttpServerModule = FHttpServerModule::Get();
+	Router = HttpServerModule.GetHttpRouter(Port, /*bFailOnBindFailure*/ true);
+	if (!Router.IsValid())
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[dev-control] could not bind HTTP router on port %u; dev-control server not started."), Port);
+		return false;
+	}
+
+	ViewModel = InViewModel;
+	BoundPort = Port;
+
+	// Bind the v1 routes. Each handler funnels through HandleRequest(<method>, ...) so loopback verification,
+	// body parsing, view-model resolution and JSON response framing live in exactly one place.
+	auto Bind = [this](const TCHAR* InPath, EHttpServerRequestVerbs Verbs, const FString& Method)
+	{
+		const FString Path = InPath;
+		FHttpRouteHandle Handle = Router->BindRoute(FHttpPath(Path), Verbs,
+			FHttpRequestHandler::CreateLambda([this, Method, Path](const FHttpServerRequest& Request, const FHttpResultCallback& OnComplete) -> bool
+			{
+				return HandleRequest(Method, Path, Request, OnComplete);
+			}));
+		if (Handle.IsValid())
+			RouteHandles.Add(Handle);
+	};
+
+	Bind(TEXT("/health"),                   EHttpServerRequestVerbs::VERB_GET,  TEXT("GET"));
+	Bind(TEXT("/state"),                    EHttpServerRequestVerbs::VERB_GET,  TEXT("GET"));
+	Bind(TEXT("/inject/connection-status"), EHttpServerRequestVerbs::VERB_POST, TEXT("POST"));
+	Bind(TEXT("/control/server-url"),       EHttpServerRequestVerbs::VERB_POST, TEXT("POST"));
+	Bind(TEXT("/control/connection-mode"),  EHttpServerRequestVerbs::VERB_POST, TEXT("POST"));
+	Bind(TEXT("/control/select-agent"),     EHttpServerRequestVerbs::VERB_POST, TEXT("POST"));
+	Bind(TEXT("/control/click"),            EHttpServerRequestVerbs::VERB_POST, TEXT("POST"));
+
+	// FHttpServerModule only ticks listeners that have been started; start them so this router accepts.
+	HttpServerModule.StartAllListeners();
+
+	bRunning = true;
+	UE_LOG(LogUnrealMcp, Log, TEXT("[dev-control] Listening on http://127.0.0.1:%u"), BoundPort);
+	return true;
+}
+
+void FUnrealMcpDevControlServer::Stop()
+{
+	if (Router.IsValid())
+	{
+		for (const FHttpRouteHandle& Handle : RouteHandles)
+		{
+			if (Handle.IsValid())
+				Router->UnbindRoute(Handle);
+		}
+	}
+	RouteHandles.Reset();
+	Router.Reset();
+	ViewModel.Reset();
+	BoundPort = 0;
+
+	if (bRunning)
+	{
+		UE_LOG(LogUnrealMcp, Log, TEXT("[dev-control] stopped."));
+		bRunning = false;
+	}
+}
+
+bool FUnrealMcpDevControlServer::HandleRequest(const FString& Method, const FString& Path, const FHttpServerRequest& Request, const FHttpResultCallback& OnComplete) const
+{
+	auto Respond = [&OnComplete](int32 StatusCode, const TSharedRef<FJsonObject>& Result)
+	{
+		const FString Body = DevControlSerialize(Result);
+		TUniquePtr<FHttpServerResponse> Response = FHttpServerResponse::Create(Body, TEXT("application/json"));
+		Response->Code = static_cast<EHttpServerResponseCodes>(StatusCode);
+		OnComplete(MoveTemp(Response));
+	};
+
+	// Defence in depth behind the env gate: HTTPServer binds all interfaces, so reject any non-loopback peer.
+	// (PeerAddress may be null on some transports; treat unknown as untrusted.)
+	if (!DevControlIsLoopback(Request.PeerAddress))
+	{
+		TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+		Result->SetBoolField(TEXT("ok"), false);
+		Result->SetStringField(TEXT("error"), TEXT("dev-control accepts loopback requests only"));
+		Respond(403, Result);
+		return true;
+	}
+
+	// Parse the JSON body (empty body → null object, tolerated by RouteRequest; malformed → 400).
+	TSharedPtr<FJsonObject> Body;
+	FString BodyString;
+	if (Request.Body.Num() > 0)
+	{
+		const FUTF8ToTCHAR Converter(reinterpret_cast<const ANSICHAR*>(Request.Body.GetData()), Request.Body.Num());
+		BodyString = FString(Converter.Length(), Converter.Get());
+	}
+	if (!BodyString.IsEmpty())
+	{
+		const TSharedRef<TJsonReader<TCHAR>> Reader = TJsonReaderFactory<TCHAR>::Create(BodyString);
+		if (!FJsonSerializer::Deserialize(Reader, Body) || !Body.IsValid())
+		{
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			Result->SetBoolField(TEXT("ok"), false);
+			Result->SetStringField(TEXT("error"), TEXT("malformed JSON body"));
+			Respond(400, Result);
+			return true;
+		}
+	}
+
+	// Handlers run on the game thread (FHttpServerModule ticks there), so it is safe to touch the view-model.
+	TSharedPtr<FUnrealMcpEditorViewModel> VM = ViewModel.Pin();
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	const int32 Status = RouteRequest(Method, Path, Body, VM.Get(), Result);
+	Respond(Status, Result);
+	return true;
+}
+
+int32 FUnrealMcpDevControlServer::RouteRequest(
+	const FString& Method,
+	const FString& Path,
+	const TSharedPtr<FJsonObject>& Body,
+	FUnrealMcpEditorViewModel* ViewModelPtr,
+	TSharedRef<FJsonObject>& OutResult)
+{
+	// /health needs no view-model — it is the liveness probe.
+	if (Method == TEXT("GET") && Path == TEXT("/health"))
+	{
+		OutResult->SetBoolField(TEXT("ok"), true);
+		OutResult->SetStringField(TEXT("service"), TEXT("unreal-mcp-dev-control"));
+		OutResult->SetNumberField(TEXT("version"), 1);
+		return 200;
+	}
+
+	// Every other route drives or reads the live dock view-model. If it is gone (teardown / not yet created),
+	// answer 503 rather than fabricating state.
+	if (ViewModelPtr == nullptr)
+	{
+		DevControlFail(OutResult, TEXT("view-model unavailable (dock not initialized)"));
+		return 503;
+	}
+
+	if (Method == TEXT("GET") && Path == TEXT("/state"))
+	{
+		OutResult->SetBoolField(TEXT("ok"), true);
+		OutResult->SetStringField(TEXT("connectionState"), DevControlConnectionStateLabel(ViewModelPtr->GetConnectionState()));
+		OutResult->SetStringField(TEXT("connectionMode"), DevControlConnectionModeLabel(ViewModelPtr->GetConnectionMode()));
+		OutResult->SetStringField(TEXT("customHost"), ViewModelPtr->GetCustomHost());
+		OutResult->SetStringField(TEXT("selectedAgentId"), ViewModelPtr->GetSelectedAgentId());
+
+		TArray<TSharedPtr<FJsonValue>> Agents;
+		for (const FString& Agent : ViewModelPtr->GetAiAgents())
+			Agents.Add(MakeShared<FJsonValueString>(Agent));
+		OutResult->SetArrayField(TEXT("aiAgents"), Agents);
+		return 200;
+	}
+
+	// All remaining routes are POSTs that consume the JSON body. A missing body for a body-required route
+	// is a 400.
+	if (Method != TEXT("POST"))
+	{
+		DevControlFail(OutResult, FString::Printf(TEXT("no route for %s %s"), *Method, *Path));
+		return 404;
+	}
+
+	if (Path == TEXT("/inject/connection-status"))
+	{
+		FString StatusLabel;
+		if (!Body.IsValid() || !Body->TryGetStringField(TEXT("status"), StatusLabel) || StatusLabel.IsEmpty())
+		{
+			DevControlFail(OutResult, TEXT("missing 'status' (Connected|Connecting|Disconnected|Degraded)"));
+			return 400;
+		}
+
+		// Build the minimal §1.3 `status` envelope the view-model's ApplyStatus consumes: connectionState +
+		// keepConnected. A Disconnected status implies the reconnect loop is off; everything else keeps it armed.
+		const bool bKeepConnected = !StatusLabel.Equals(TEXT("Disconnected"), ESearchCase::IgnoreCase);
+		TSharedPtr<FJsonObject> StatusJson = MakeShared<FJsonObject>();
+		StatusJson->SetStringField(TEXT("connectionState"), StatusLabel);
+		StatusJson->SetBoolField(TEXT("keepConnected"), bKeepConnected);
+		ViewModelPtr->ApplyStatus(StatusJson);
+
+		OutResult->SetBoolField(TEXT("ok"), true);
+		OutResult->SetStringField(TEXT("connectionState"), DevControlConnectionStateLabel(ViewModelPtr->GetConnectionState()));
+		return 200;
+	}
+
+	if (Path == TEXT("/control/server-url"))
+	{
+		FString Url;
+		if (!Body.IsValid() || !Body->TryGetStringField(TEXT("url"), Url))
+		{
+			DevControlFail(OutResult, TEXT("missing 'url'"));
+			return 400;
+		}
+		ViewModelPtr->SetCustomHost(Url);
+		OutResult->SetBoolField(TEXT("ok"), true);
+		OutResult->SetStringField(TEXT("customHost"), ViewModelPtr->GetCustomHost());
+		return 200;
+	}
+
+	if (Path == TEXT("/control/connection-mode"))
+	{
+		FString ModeRaw;
+		EUnrealMcpConnectionMode Mode;
+		if (!Body.IsValid() || !Body->TryGetStringField(TEXT("mode"), ModeRaw) || !DevControlParseMode(ModeRaw, Mode))
+		{
+			DevControlFail(OutResult, TEXT("missing/invalid 'mode' (Cloud|Custom)"));
+			return 400;
+		}
+		ViewModelPtr->SetConnectionMode(Mode);
+		OutResult->SetBoolField(TEXT("ok"), true);
+		OutResult->SetStringField(TEXT("connectionMode"), DevControlConnectionModeLabel(ViewModelPtr->GetConnectionMode()));
+		return 200;
+	}
+
+	if (Path == TEXT("/control/select-agent"))
+	{
+		FString AgentId;
+		if (!Body.IsValid() || !Body->TryGetStringField(TEXT("agentId"), AgentId) || AgentId.IsEmpty())
+		{
+			DevControlFail(OutResult, TEXT("missing 'agentId'"));
+			return 400;
+		}
+		ViewModelPtr->SetSelectedAgentId(AgentId);
+		OutResult->SetBoolField(TEXT("ok"), true);
+		OutResult->SetStringField(TEXT("selectedAgentId"), ViewModelPtr->GetSelectedAgentId());
+		return 200;
+	}
+
+	if (Path == TEXT("/control/click"))
+	{
+		FString Target;
+		if (!Body.IsValid() || !Body->TryGetStringField(TEXT("target"), Target) || Target.IsEmpty())
+		{
+			DevControlFail(OutResult, TEXT("missing 'target' (connect|disconnect|authorize|revoke|generate-token)"));
+			return 400;
+		}
+
+		// Map the click target onto the matching view-model mutator — the same action the Slate button fires.
+		if (Target.Equals(TEXT("connect"), ESearchCase::IgnoreCase))               ViewModelPtr->Connect();
+		else if (Target.Equals(TEXT("disconnect"), ESearchCase::IgnoreCase))       ViewModelPtr->Disconnect();
+		else if (Target.Equals(TEXT("authorize"), ESearchCase::IgnoreCase))        ViewModelPtr->Authorize();
+		else if (Target.Equals(TEXT("revoke"), ESearchCase::IgnoreCase))           ViewModelPtr->Revoke();
+		else if (Target.Equals(TEXT("generate-token"), ESearchCase::IgnoreCase))   ViewModelPtr->GenerateCustomToken();
+		else
+		{
+			DevControlFail(OutResult, FString::Printf(TEXT("unknown click target '%s'"), *Target));
+			return 400;
+		}
+
+		OutResult->SetBoolField(TEXT("ok"), true);
+		OutResult->SetStringField(TEXT("target"), Target.ToLower());
+		OutResult->SetStringField(TEXT("connectionState"), DevControlConnectionStateLabel(ViewModelPtr->GetConnectionState()));
+		return 200;
+	}
+
+	DevControlFail(OutResult, FString::Printf(TEXT("no route for %s %s"), *Method, *Path));
+	return 404;
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Templates/SharedPointer.h"
+#include "HttpRouteHandle.h"   // FHttpRouteHandle is a TSharedPtr typedef — cannot be forward-declared.
+#include "HttpResultCallback.h" // FHttpResultCallback is a TFunction typedef — cannot be forward-declared.
+
+class FUnrealMcpEditorViewModel;
+class FJsonObject;
+class IHttpRouter;
+struct FHttpServerRequest;
+
+/**
+ * DEV-ONLY inject/control HTTP bridge over the live "AI Game Developer" Slate dock (docs/ARCHITECTURE.md
+ * §4/§7). A sibling of the Godot-MCP dev-control bridge: it lets a terminal / AI agent INJECT fake states
+ * into the dock view-model and CONTROL it (simulate the same button actions the Slate widgets fire), for
+ * tests + AI-driven dev. NOT a product feature — it never ships listening.
+ *
+ * Security / scope (NON-NEGOTIABLE, mirrored from the design spec):
+ *  - Started ONLY when the editor process env `UNREAL_MCP_DEV_CONTROL == "1"`; OFF by default, so a
+ *    shipped plugin never opens a port. The port comes from `UNREAL_MCP_DEV_CONTROL_PORT` (default 9921).
+ *  - UE's FHttpServerModule binds all interfaces, so every handler additionally verifies the request's
+ *    PeerAddress is loopback (127.0.0.1 / ::1) and rejects anything else — defence in depth behind the
+ *    env gate. The port is documented loopback-dev-only.
+ *  - Handlers run on the GAME THREAD (FHttpServerModule ticks there), so they call the view-model directly
+ *    with no extra marshalling — the view-model is game-thread-only and the dock reads it on the same thread.
+ *
+ * The server holds the live view-model weakly (the runtime owns it); a request that straddles teardown is a
+ * clean 503, never a use-after-free. Start(Port)/Stop() are idempotent and game-thread only.
+ */
+class FUnrealMcpDevControlServer
+{
+public:
+	FUnrealMcpDevControlServer();
+	~FUnrealMcpDevControlServer();
+
+	/**
+	 * Bind the HTTP router on @p Port and register the v1 routes. @p InViewModel is the live dock view-model
+	 * (held weakly). Returns true when the router bound and routes registered. Idempotent: a second Start is
+	 * a no-op. Logs `[dev-control] Listening on http://127.0.0.1:<port>` on success.
+	 */
+	bool Start(uint32 Port, const TSharedPtr<FUnrealMcpEditorViewModel>& InViewModel);
+
+	/** Unbind every route, drop the router, and forget the view-model. Idempotent. */
+	void Stop();
+
+	bool IsRunning() const { return bRunning; }
+	uint32 GetPort() const { return BoundPort; }
+
+	/**
+	 * The PURE request → view-model router (the spec-friendly heart, no live HTTP socket). Applies @p Method
+	 * + @p Path + parsed @p Body to @p ViewModel and writes a JSON result object into @p OutResult
+	 * (`{"ok":true,...}` / `{"ok":false,"error":...}`). Returns the HTTP status code the handler would send
+	 * (200 / 400 / 404 / 503). @p ViewModel may be null (→ 503). Static + side-effect-confined to the
+	 * view-model so the UnrealMcpEditorTests spec drives it directly.
+	 */
+	// UNREALMCPEDITOR_API-exported so the UnrealMcpEditorTests module (a separate DLL) links this static router.
+	static UNREALMCPEDITOR_API int32 RouteRequest(
+		const FString& Method,
+		const FString& Path,
+		const TSharedPtr<FJsonObject>& Body,
+		FUnrealMcpEditorViewModel* ViewModel,
+		TSharedRef<FJsonObject>& OutResult);
+
+private:
+	// The single FHttpRequestHandler body, shared by every bound route: verifies loopback, parses the JSON
+	// body, resolves the view-model, calls RouteRequest, and writes the JSON response. The bound @p Method +
+	// @p Path are captured per-route (NOT read from the request — FHttpServerRequest::RelativePath is route-
+	// relative, so it is "/" for an exact match). Returns true (always completes synchronously on the game thread).
+	bool HandleRequest(const FString& Method, const FString& Path, const FHttpServerRequest& Request, const FHttpResultCallback& OnComplete) const;
+
+	TSharedPtr<IHttpRouter> Router;
+	TArray<FHttpRouteHandle> RouteHandles;
+	TWeakPtr<FUnrealMcpEditorViewModel> ViewModel;
+	uint32 BoundPort = 0;
+	bool bRunning = false;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -16,6 +16,7 @@
 #include "UI/SUnrealMcpToolsWindow.h"
 #include "UI/SUnrealMcpFeatureListWindow.h"
 #include "Tools/UnrealMcpLogCollector.h"
+#include "DevControl/UnrealMcpDevControlServer.h"
 
 #include "Misc/CoreDelegates.h"
 #include "Misc/Paths.h"
@@ -237,6 +238,36 @@ void FUnrealMcpRuntime::Startup()
 		[]() -> TArray<FUnrealMcpFeatureEntry> { return {}; },  // prompts (none surfaced to the plugin yet)
 		[]() -> TArray<FUnrealMcpFeatureEntry> { return {}; }); // resources (none surfaced to the plugin yet)
 
+	// DEV-ONLY inject/control HTTP bridge (docs/ARCHITECTURE.md §7). Started ONLY when the editor process env
+	// UNREAL_MCP_DEV_CONTROL == "1" — OFF by default, so a shipped plugin never opens a port. The port comes
+	// from UNREAL_MCP_DEV_CONTROL_PORT (default 9921). Handlers run on the game thread and drive the SAME live
+	// view-model the dock binds to, so an injected state / simulated click is reflected in the open window.
+	// Loopback-only (the server verifies the peer is 127.0.0.1/::1 in addition to the env gate).
+	{
+		const bool bDevControlEnabled =
+			FPlatformMisc::GetEnvironmentVariable(TEXT("UNREAL_MCP_DEV_CONTROL")) == TEXT("1");
+		if (bDevControlEnabled)
+		{
+			uint32 DevControlPort = 9921;
+			const FString PortRaw = FPlatformMisc::GetEnvironmentVariable(TEXT("UNREAL_MCP_DEV_CONTROL_PORT"));
+			if (!PortRaw.IsEmpty())
+			{
+				const int32 Parsed = FCString::Atoi(*PortRaw);
+				if (Parsed > 0 && Parsed <= 65535)
+					DevControlPort = static_cast<uint32>(Parsed);
+				else
+					UE_LOG(LogUnrealMcp, Warning, TEXT("[dev-control] ignoring invalid UNREAL_MCP_DEV_CONTROL_PORT '%s'; using %u."), *PortRaw, DevControlPort);
+			}
+
+			DevControlServer = MakeUnique<FUnrealMcpDevControlServer>();
+			if (!DevControlServer->Start(DevControlPort, ViewModel))
+			{
+				UE_LOG(LogUnrealMcp, Warning, TEXT("[dev-control] failed to start on port %u; inject/control bridge disabled."), DevControlPort);
+				DevControlServer.Reset();
+			}
+		}
+	}
+
 	// §1.5: tear down on editor pre-exit so the sidecar never orphans (layer 1).
 	PreExitHandle = FCoreDelegates::OnEnginePreExit.AddLambda([this]() { Shutdown(); });
 }
@@ -260,6 +291,15 @@ void FUnrealMcpRuntime::Shutdown()
 	// give the child a bounded grace to self-exit, (4) terminate as a backstop.
 	if (SidecarManager.IsValid())
 		SidecarManager->StopRestarts();
+
+	// DEV-ONLY inject/control bridge: stop it FIRST so no in-flight HTTP handler can touch the view-model
+	// after the teardown below frees it (the server holds the view-model weakly, but stopping unbinds the
+	// routes so the port closes cleanly). No-op when it was never started (env gate off).
+	if (DevControlServer.IsValid())
+	{
+		DevControlServer->Stop();
+		DevControlServer.Reset();
+	}
 
 	// §7 UI teardown FIRST: unregister the tab and drop the bridge's status sink so no marshalled status can
 	// touch the view-model after this, then release the view-model. Clear the sink before the bridge tears

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.h
@@ -13,6 +13,7 @@ class FUnrealMcpExtensionManager;
 class FUnrealMcpEditorViewModel;
 class FUnrealMcpMainWindowTab;
 class FUnrealMcpAuxWindows;
+class FUnrealMcpDevControlServer;
 
 /**
  * Plugin-lifetime coordinator (docs/ARCHITECTURE.md §0). Wires the four subsystems together: the tool
@@ -49,6 +50,10 @@ private:
 	TSharedPtr<FUnrealMcpEditorViewModel> ViewModel;
 	TUniquePtr<FUnrealMcpMainWindowTab> MainWindowTab;
 	TUniquePtr<FUnrealMcpAuxWindows> AuxWindows;
+
+	// DEV-ONLY inject/control HTTP bridge over the live dock (docs/ARCHITECTURE.md §7). Created + started in
+	// Startup() ONLY when the editor process env UNREAL_MCP_DEV_CONTROL == "1"; null (never listening) otherwise.
+	TUniquePtr<FUnrealMcpDevControlServer> DevControlServer;
 
 	FDelegateHandle PreExitHandle;
 	bool bStarted = false;

--- a/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
+++ b/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
@@ -31,6 +31,10 @@ public class UnrealMcpEditor : ModuleRules
 			"SlateCore",
 			"Networking",
 			"Sockets",
+			// DEV-ONLY inject/control bridge over the live Slate dock (FUnrealMcpDevControlServer): UE's
+			// in-process HTTP server. Env-gated (UNREAL_MCP_DEV_CONTROL=1) + loopback-only — never listens
+			// in a shipped plugin. The module is always linked; the listener is only started when gated on.
+			"HTTPServer",
 			"Json",
 			"JsonUtilities",
 			"Projects",

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDevControlSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDevControlSpec.cpp
@@ -1,0 +1,273 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Dom/JsonObject.h"
+#include "DevControl/UnrealMcpDevControlServer.h"
+#include "UI/UnrealMcpEditorViewModel.h"
+#include "Config/UnrealMcpConfig.h"
+
+/**
+ * Dev-control bridge specs (docs/ARCHITECTURE.md §7): the PURE request → view-model routing/parsing that
+ * FUnrealMcpDevControlServer::RouteRequest performs — health/state snapshots, the inject + control verbs,
+ * and the error surface (bad method / path / body) — all WITHOUT a live HTTP socket. The view-model is the
+ * real one, wired with recording sinks so a spec can assert the mutators fired (it is drivable with no live
+ * bridge, see its docblock). Helpers carry the spec-unique `DevCtl` prefix (CLAUDE.md unity-build ODR rule).
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpDevControlSpec, "UnrealMcp.DevControl",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	// A view-model wired with recording sinks so a route can be asserted as having driven the dock.
+	struct FDevCtlRecording
+	{
+		int32 PersistCount = 0;
+		int32 PushCount = 0;
+		TArray<FString> AuthSent;
+	};
+
+	static TSharedRef<FUnrealMcpEditorViewModel> DevCtlMakeViewModel(TSharedRef<FDevCtlRecording> Rec)
+	{
+		TSharedRef<FUnrealMcpEditorViewModel> VM = MakeShared<FUnrealMcpEditorViewModel>();
+		VM->OnPersistConfig = [Rec](const FUnrealMcpConfig&) { Rec->PersistCount++; };
+		VM->OnPushConfig = [Rec](const FUnrealMcpConfig&) { Rec->PushCount++; };
+		VM->OnSendAuth = [Rec](const FString& Type) -> bool { Rec->AuthSent.Add(Type); return true; };
+		VM->OnOpenBrowser = [](const FString&) {};
+		return VM;
+	}
+
+	// Parse a JSON body string into an object (the spec's stand-in for the request body the HTTP layer parses).
+	static TSharedPtr<FJsonObject> DevCtlBody(const FString& Json)
+	{
+		TSharedPtr<FJsonObject> Out;
+		const TSharedRef<TJsonReader<TCHAR>> Reader = TJsonReaderFactory<TCHAR>::Create(Json);
+		FJsonSerializer::Deserialize(Reader, Out);
+		return Out;
+	}
+
+END_DEFINE_SPEC(FUnrealMcpDevControlSpec)
+
+void FUnrealMcpDevControlSpec::Define()
+{
+	Describe("Health + missing view-model", [this]()
+	{
+		It("answers /health 200 with no view-model required", [this]()
+		{
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(TEXT("GET"), TEXT("/health"), nullptr, nullptr, Result);
+			TestEqual("status", Status, 200);
+			TestTrue("ok", Result->GetBoolField(TEXT("ok")));
+		});
+
+		It("answers 503 for a view-model-required route when the dock is gone", [this]()
+		{
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(TEXT("GET"), TEXT("/state"), nullptr, nullptr, Result);
+			TestEqual("status", Status, 503);
+			TestFalse("not ok", Result->GetBoolField(TEXT("ok")));
+		});
+
+		It("answers 404 for an unknown route", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(TEXT("GET"), TEXT("/nope"), nullptr, &VM.Get(), Result);
+			TestEqual("status", Status, 404);
+			TestFalse("not ok", Result->GetBoolField(TEXT("ok")));
+		});
+	});
+
+	Describe("State snapshot", [this]()
+	{
+		It("reports the live connection state, mode, host, agent and ai-agents", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			VM->SetCustomHost(TEXT("http://localhost:8080"));
+			VM->SetSelectedAgentId(TEXT("cursor"));
+
+			// Inject an aiAgents list via a status message so /state surfaces it.
+			TSharedPtr<FJsonObject> StatusJson = MakeShared<FJsonObject>();
+			StatusJson->SetStringField(TEXT("connectionState"), TEXT("Connected"));
+			StatusJson->SetBoolField(TEXT("keepConnected"), true);
+			TArray<TSharedPtr<FJsonValue>> Agents;
+			Agents.Add(MakeShared<FJsonValueString>(TEXT("Claude Code")));
+			StatusJson->SetArrayField(TEXT("aiAgents"), Agents);
+			VM->ApplyStatus(StatusJson);
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(TEXT("GET"), TEXT("/state"), nullptr, &VM.Get(), Result);
+
+			TestEqual("status", Status, 200);
+			TestTrue("ok", Result->GetBoolField(TEXT("ok")));
+			TestEqual("connectionState", Result->GetStringField(TEXT("connectionState")), FString(TEXT("Connected")));
+			TestEqual("connectionMode", Result->GetStringField(TEXT("connectionMode")), FString(TEXT("Custom")));
+			TestEqual("customHost", Result->GetStringField(TEXT("customHost")), FString(TEXT("http://localhost:8080")));
+			TestEqual("selectedAgentId", Result->GetStringField(TEXT("selectedAgentId")), FString(TEXT("cursor")));
+
+			const TArray<TSharedPtr<FJsonValue>>* OutAgents = nullptr;
+			TestTrue("aiAgents present", Result->TryGetArrayField(TEXT("aiAgents"), OutAgents) && OutAgents != nullptr);
+			if (OutAgents)
+			{
+				TestEqual("aiAgents count", OutAgents->Num(), 1);
+				if (OutAgents->Num() == 1)
+					TestEqual("aiAgents[0]", (*OutAgents)[0]->AsString(), FString(TEXT("Claude Code")));
+			}
+		});
+	});
+
+	Describe("Inject connection-status", [this]()
+	{
+		It("applies a Connected status to the view-model", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/inject/connection-status"), DevCtlBody(TEXT("{\"status\":\"Connected\"}")), &VM.Get(), Result);
+
+			TestEqual("status", Status, 200);
+			TestTrue("ok", Result->GetBoolField(TEXT("ok")));
+			TestEqual("view-model state", VM->GetConnectionState(), EUnrealMcpConnectionState::Connected);
+		});
+
+		It("applies a Disconnected status (reconnect off)", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/inject/connection-status"), DevCtlBody(TEXT("{\"status\":\"Disconnected\"}")), &VM.Get(), Result);
+
+			TestEqual("view-model state", VM->GetConnectionState(), EUnrealMcpConnectionState::Disconnected);
+		});
+
+		It("rejects a missing status with 400", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/inject/connection-status"), DevCtlBody(TEXT("{}")), &VM.Get(), Result);
+			TestEqual("status", Status, 400);
+			TestFalse("not ok", Result->GetBoolField(TEXT("ok")));
+		});
+	});
+
+	Describe("Control mutators", [this]()
+	{
+		It("server-url drives SetCustomHost (valid URL persists + pushes)", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/server-url"), DevCtlBody(TEXT("{\"url\":\"http://127.0.0.1:5244\"}")), &VM.Get(), Result);
+
+			TestEqual("status", Status, 200);
+			TestEqual("custom host", VM->GetCustomHost(), FString(TEXT("http://127.0.0.1:5244")));
+		});
+
+		It("connection-mode drives SetConnectionMode", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Cloud);
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/connection-mode"), DevCtlBody(TEXT("{\"mode\":\"Custom\"}")), &VM.Get(), Result);
+
+			TestEqual("status", Status, 200);
+			TestEqual("mode", VM->GetConnectionMode(), EUnrealMcpConnectionMode::Custom);
+		});
+
+		It("rejects an invalid connection-mode with 400", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/connection-mode"), DevCtlBody(TEXT("{\"mode\":\"Banana\"}")), &VM.Get(), Result);
+			TestEqual("status", Status, 400);
+		});
+
+		It("select-agent drives SetSelectedAgentId", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/select-agent"), DevCtlBody(TEXT("{\"agentId\":\"copilot\"}")), &VM.Get(), Result);
+
+			TestEqual("status", Status, 200);
+			TestEqual("selected agent", VM->GetSelectedAgentId(), FString(TEXT("copilot")));
+		});
+
+		It("click=connect arms the reconnect loop and goes Connecting", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"connect\"}")), &VM.Get(), Result);
+
+			TestEqual("status", Status, 200);
+			TestTrue("reconnect armed", VM->IsReconnectArmed());
+			TestEqual("state", VM->GetConnectionState(), EUnrealMcpConnectionState::Connecting);
+		});
+
+		It("click=disconnect halts the reconnect loop", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			VM->Connect();
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"disconnect\"}")), &VM.Get(), Result);
+
+			TestFalse("reconnect disarmed", VM->IsReconnectArmed());
+			TestEqual("state", VM->GetConnectionState(), EUnrealMcpConnectionState::Disconnected);
+		});
+
+		It("click=generate-token replaces the custom token", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			const FString Before = VM->GetCustomToken();
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"generate-token\"}")), &VM.Get(), Result);
+
+			TestEqual("status", Status, 200);
+			TestFalse("token changed", VM->GetCustomToken().Equals(Before));
+			TestFalse("token non-empty", VM->GetCustomToken().IsEmpty());
+		});
+
+		It("rejects an unknown click target with 400", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"explode\"}")), &VM.Get(), Result);
+			TestEqual("status", Status, 400);
+			TestFalse("not ok", Result->GetBoolField(TEXT("ok")));
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/UnrealMcpEditorTests.Build.cs
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/UnrealMcpEditorTests.Build.cs
@@ -19,6 +19,7 @@ public class UnrealMcpEditorTests : ModuleRules
 			"Json",
 			"UnrealMcpEditor",
 			"BlueprintGraph", // UK2Node_Event — asserting add-event produced an ENABLED node (§10)
+			"HTTPServer",     // the dev-control server header (FUnrealMcpDevControlServer) includes HttpRouteHandle.h
 		});
 
 		// Reach the sibling editor module's PRIVATE headers (FUnrealMcpNdjsonAccumulator §1.2,


### PR DESCRIPTION
A **dev-only** HTTP bridge in the C++ editor plugin so a terminal / AI agent can **inject fake states** into the live "AI Game Developer" dock and **simulate user actions** — for tests + AI-driven dev. Sibling of the Godot-MCP dev-control bridge (merged).

## Security (the boundary is the server)
- Starts **only** when `UNREAL_MCP_DEV_CONTROL=1` (port `UNREAL_MCP_DEV_CONTROL_PORT`, default 9921). **OFF by default** → a shipped plugin never opens a port.
- Defence in depth: every handler **verifies the peer is loopback** (`127.*`/`::1`) → 403 otherwise.
- `.scripts/worktree.py` (infra) allocates the port per-worktree + sets the flag, so worktrees run dev servers on unique ports simultaneously.

## Design
- `FUnrealMcpDevControlServer` — engine `FHttpServerModule`; handlers run on the **game thread** and drive `FUnrealMcpEditorViewModel` directly (no marshalling). Held as a `TWeakPtr` (a request straddling teardown → 503, never UAF). **Force-loads the HTTPServer module** (a link-time dep is not auto-loaded at runtime — this was the one bug the live test caught).
- `RouteRequest` (`UNREALMCPEDITOR_API`) — the pure request→view-model router, covered by a **15-case automation spec** (`UnrealMcp.DevControl`) with recording sinks (no live socket).
- Wired into `UnrealMcpRuntime::Startup`/`Shutdown`, after the view-model/tab exist.

## Endpoints
`GET /health`, `/state`; `POST /inject/connection-status`, `/control/server-url`, `/control/connection-mode`, `/control/select-agent`, `/control/click`.

## Verification
- **UBT build** (UnrealTestProjectEditor, UE 5.7) clean.
- **Automation `UnrealMcp.DevControl`: 15 / 15** pass, no crashes.
- **Live-verified** against a headless editor: `/health` + `/state` ok, injected "Connected" sticks, `select-agent`→cursor applies, bad route → 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)