### PR TITLE
feat(ui): enable the dev-control bridge from the project .env file

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.cpp
@@ -507,6 +507,39 @@ TMap<FString, FString> FUnrealMcpConfig::LoadEnvFile(const FString& Path)
 	return ParseEnvLines(Lines);
 }
 
+FString FUnrealMcpConfig::LookupEnvFileValue(const FString& Path, const FString& Key)
+{
+	if (Path.IsEmpty() || Key.IsEmpty() || !FPaths::FileExists(Path))
+		return FString();
+
+	TArray<FString> Lines;
+	if (!FFileHelper::LoadFileToStringArray(Lines, *Path))
+		return FString();
+
+	FString Found; // last occurrence wins (matches ParseEnvLines)
+	for (const FString& RawLine : Lines)
+	{
+		FString Line = RawLine;
+		Line.TrimStartAndEndInline();
+		if (Line.IsEmpty() || Line[0] == TCHAR('#'))
+			continue;
+
+		int32 EqIndex = INDEX_NONE;
+		if (!Line.FindChar(TCHAR('='), EqIndex) || EqIndex <= 0)
+			continue;
+
+		FString LineKey = Line.Left(EqIndex);
+		LineKey.TrimStartAndEndInline();
+		if (!LineKey.Equals(Key, ESearchCase::CaseSensitive))
+			continue;
+
+		const FString Value = SanitizeValue(Line.Mid(EqIndex + 1));
+		if (!Value.IsEmpty())
+			Found = Value;
+	}
+	return Found;
+}
+
 void FUnrealMcpConfig::ExportDotEnvToProcessEnv(const TMap<FString, FString>& DotEnv)
 {
 	// Export ONLY the bridge-path key into the process env. That is the single var the editor process itself

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Config/UnrealMcpConfig.h
@@ -221,6 +221,17 @@ public:
 	static UNREALMCPEDITOR_API TMap<FString, FString> LoadEnvFile(const FString& Path);
 
 	/**
+	 * Read ONE arbitrary key's sanitized value from the .env file at @p Path — NOT limited to the recognized
+	 * UNREAL_MCP_* connection keys ParseEnvLines keeps. The C++ analog of Godot's GodotMcpEnvFile.LookupRaw:
+	 * used by features outside the connection config (e.g. the dev-control bridge gate, UNREAL_MCP_DEV_CONTROL)
+	 * that want the same "process env > .env > default" precedence — the caller checks process env first, then
+	 * falls back to this. Same line rules as ParseEnvLines (skip blanks/`#`, split on first `=`, case-sensitive
+	 * key, sanitize value, last occurrence wins). Returns an empty string when the file is missing/unreadable,
+	 * the key is absent, or its value is blank. Never throws.
+	 */
+	static UNREALMCPEDITOR_API FString LookupEnvFileValue(const FString& Path, const FString& Key);
+
+	/**
 	 * Export the UNREAL_MCP_BRIDGE_PATH .env value into the editor's process environment (and ONLY that key),
 	 * set-if-absent so the §8 precedence "process env > .env" is preserved. That is the single var the editor
 	 * process itself must read out-of-band (FUnrealMcpSidecarManager resolves the sidecar binary from it, §6),

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -244,12 +244,23 @@ void FUnrealMcpRuntime::Startup()
 	// view-model the dock binds to, so an injected state / simulated click is reflected in the open window.
 	// Loopback-only (the server verifies the peer is 127.0.0.1/::1 in addition to the env gate).
 	{
-		const bool bDevControlEnabled =
-			FPlatformMisc::GetEnvironmentVariable(TEXT("UNREAL_MCP_DEV_CONTROL")) == TEXT("1");
+		// Resolve with precedence process env > project-root .env > default — so a developer can enable the
+		// bridge by dropping the flag into the project's .env (the editor is launched from the GUI with no
+		// shell exports) WITHOUT exporting a process env var. Mirrors the §8 connection-config env-file layer
+		// (and Godot's GodotMcpPlugin.StartDevControlIfEnabled). UNREAL_MCP_DEV_CONTROL[_PORT] are NOT §8
+		// recognized keys, so they are read straight from the .env via LookupEnvFileValue, never the DotEnv map.
+		const FString DevEnvPath = FUnrealMcpConfig::DefaultEnvFilePath();
+		auto ResolveDevVar = [&DevEnvPath](const TCHAR* Key) -> FString
+		{
+			const FString FromProcess = FPlatformMisc::GetEnvironmentVariable(Key);
+			return !FromProcess.IsEmpty() ? FromProcess : FUnrealMcpConfig::LookupEnvFileValue(DevEnvPath, Key);
+		};
+
+		const bool bDevControlEnabled = ResolveDevVar(TEXT("UNREAL_MCP_DEV_CONTROL")) == TEXT("1");
 		if (bDevControlEnabled)
 		{
 			uint32 DevControlPort = 9921;
-			const FString PortRaw = FPlatformMisc::GetEnvironmentVariable(TEXT("UNREAL_MCP_DEV_CONTROL_PORT"));
+			const FString PortRaw = ResolveDevVar(TEXT("UNREAL_MCP_DEV_CONTROL_PORT"));
 			if (!PortRaw.IsEmpty())
 			{
 				const int32 Parsed = FCString::Atoi(*PortRaw);

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConfigSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConfigSpec.cpp
@@ -9,6 +9,7 @@
 #include "Misc/OutputDevice.h"
 #include "Misc/OutputDeviceRedirector.h"
 #include "HAL/FileManager.h"
+#include "Misc/FileHelper.h"
 #include "Config/UnrealMcpConfig.h"
 #include "UnrealMcpLog.h"
 
@@ -95,6 +96,38 @@ void FUnrealMcpConfigSpec::Define()
 		{
 			const TMap<FString, FString> Parsed = FUnrealMcpConfig::ParseEnvLines({ TEXT("UNREAL_MCP_TOKEN=a=b=c") });
 			TestEqual(TEXT("value keeps later '='"), Parsed.FindRef(FUnrealMcpConfig::EnvToken), FString(TEXT("a=b=c")));
+		});
+	});
+
+	// LookupEnvFileValue is the single-key .env reader the dev-control gate uses (process env > .env > default).
+	// Unlike ParseEnvLines it reads an ARBITRARY key (not the §8 recognized set), so it must surface the
+	// UNREAL_MCP_DEV_CONTROL[_PORT] flags that ParseEnvLines deliberately drops. Drive it through a real temp file.
+	Describe("LookupEnvFileValue (arbitrary single key, for the dev-control gate)", [this]()
+	{
+		It("returns the sanitized value of an unrecognized key, last-wins, and empty for absent/missing", [this]()
+		{
+			const FString TempEnv = FPaths::CreateTempFilename(*FPaths::ProjectIntermediateDir(), TEXT("UnrealMcpEnvLookup-"), TEXT(".env"));
+			const FString Contents =
+				TEXT("# header comment\n")
+				TEXT("UNKNOWN_KEY=ignored-by-parse-but-readable\n")
+				TEXT("UNREAL_MCP_DEV_CONTROL=0\n")
+				TEXT("UNREAL_MCP_DEV_CONTROL=1\n")          // last occurrence wins
+				TEXT("UNREAL_MCP_DEV_CONTROL_PORT = \"9930\" \n"); // whitespace + quotes stripped
+			TestTrue(TEXT("temp .env written"), FFileHelper::SaveStringToFile(Contents, *TempEnv));
+
+			TestEqual(TEXT("dev-control flag last-wins"),
+				FUnrealMcpConfig::LookupEnvFileValue(TempEnv, TEXT("UNREAL_MCP_DEV_CONTROL")), FString(TEXT("1")));
+			TestEqual(TEXT("dev-control port sanitized"),
+				FUnrealMcpConfig::LookupEnvFileValue(TempEnv, TEXT("UNREAL_MCP_DEV_CONTROL_PORT")), FString(TEXT("9930")));
+			TestEqual(TEXT("arbitrary unrecognized key is readable"),
+				FUnrealMcpConfig::LookupEnvFileValue(TempEnv, TEXT("UNKNOWN_KEY")), FString(TEXT("ignored-by-parse-but-readable")));
+			TestEqual(TEXT("absent key yields empty"),
+				FUnrealMcpConfig::LookupEnvFileValue(TempEnv, TEXT("NOT_PRESENT")), FString());
+
+			IFileManager::Get().Delete(*TempEnv);
+
+			TestEqual(TEXT("missing file yields empty (never throws)"),
+				FUnrealMcpConfig::LookupEnvFileValue(TempEnv, TEXT("UNREAL_MCP_DEV_CONTROL")), FString());
 		});
 	});
 


### PR DESCRIPTION
Follow-up to the dev-control bridge: read its enable flag + port from the project-root `.env` as a fallback, precedence **process env > project `.env` > default (9921)**, mirroring the Godot bridge. UE editors launch from the GUI with no shell exports, so the `.env` layer is how local config is supplied — without this, a flag in `.env` did nothing.

- `FUnrealMcpConfig::LookupEnvFileValue(Path, Key)` — generic single-key `.env` reader (the §8 connection parser only keeps recognized keys, excluding `UNREAL_MCP_DEV_CONTROL[_PORT]`). Covered by a `UnrealMcp.Config` automation case.
- `UnrealMcpRuntime::Startup` resolves both vars via that precedence; still OFF by default.

**Live-verified** (the key proof): with the process-env vars removed, `UNREAL_MCP_DEV_CONTROL=1` in the test project `.env` alone starts the server — log `[dev-control] Listening on http://127.0.0.1:9921`, `/health` + `/state` green. UBT build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)