### PR TITLE
ui: connection-timeline connecting-line between status dots (Unity-MCP parity, round-3)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentWidgets.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentWidgets.h
@@ -212,6 +212,44 @@ namespace UnrealMcpStyleWidgets
 	}
 
 	/**
+	 * A connection-timeline indicator column (Unity's .timeline-indicator): a fixed 20px-wide column holding
+	 * the 14px status dot centred horizontally, with a 2px vertical connecting-line (rgb(80,80,80), Unity's
+	 * .timeline-line) running DOWN from the dot toward the next timeline point when @p DrawLineBelow is true.
+	 * The line FillHeight-fills the slot below the dot so it stretches to whatever height the row resolves to
+	 * (Unity uses position:absolute bottom:-10px; Slate has no absolute positioning, so a fill slot that grows
+	 * with the row is the structural equivalent). The last point in the cluster passes DrawLineBelow=false
+	 * (Unity's .timeline-point-last hides the line) — supplied as a TAttribute so it can react to mode changes
+	 * (e.g. the MCP-server point only exists in Custom mode, so the dot above it draws no dangling line in Cloud).
+	 *
+	 * Width 20px + the line centred at x=9px mirror the USS exactly; the dot is 14px so a centred line at the
+	 * dot's horizontal midpoint reads as one continuous vertical rule joining the dots.
+	 */
+	inline TSharedRef<SWidget> TimelineIndicator(const TAttribute<EDot>& DotState, const TAttribute<bool>& DrawLineBelow)
+	{
+		return SNew(SBox).WidthOverride(20.0f)
+		[
+			SNew(SVerticalBox)
+			// The status dot, centred horizontally in the 20px column.
+			+ SVerticalBox::Slot().AutoHeight().HAlign(HAlign_Center)
+			[
+				StatusDot(DotState)
+			]
+			// The 2px connecting-line below the dot — fills the remaining row height, centred under the dot.
+			+ SVerticalBox::Slot().FillHeight(1.0f).HAlign(HAlign_Center).Padding(0, 2, 0, 0)
+			[
+				SNew(SBox).WidthOverride(2.0f)
+				.Visibility_Lambda([DrawLineBelow]()
+				{
+					return DrawLineBelow.Get() ? EVisibility::HitTestInvisible : EVisibility::Collapsed;
+				})
+				[
+					SNew(SImage).Image(FUnrealMcpStyle::Get().GetBrush("UnrealMcp.ConnectingLine"))
+				]
+			]
+		];
+	}
+
+	/**
 	 * A tab-like segmented control (Unity .segmented-control): a rounded track holding N toggle segments;
 	 * the selected segment renders its text teal. Each segment is a toggle-style SCheckBox bound to the
 	 * shared IsSelected/OnSelect lambdas so it stays a thin view over the caller's state.

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentWidgets.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentWidgets.h
@@ -211,41 +211,68 @@ namespace UnrealMcpStyleWidgets
 		];
 	}
 
-	/**
-	 * A connection-timeline indicator column (Unity's .timeline-indicator): a fixed 20px-wide column holding
-	 * the 14px status dot centred horizontally, with a 2px vertical connecting-line (rgb(80,80,80), Unity's
-	 * .timeline-line) running DOWN from the dot toward the next timeline point when @p DrawLineBelow is true.
-	 * The line FillHeight-fills the slot below the dot so it stretches to whatever height the row resolves to
-	 * (Unity uses position:absolute bottom:-10px; Slate has no absolute positioning, so a fill slot that grows
-	 * with the row is the structural equivalent). The last point in the cluster passes DrawLineBelow=false
-	 * (Unity's .timeline-point-last hides the line) — supplied as a TAttribute so it can react to mode changes
-	 * (e.g. the MCP-server point only exists in Custom mode, so the dot above it draws no dangling line in Cloud).
-	 *
-	 * Width 20px + the line centred at x=9px mirror the USS exactly; the dot is 14px so a centred line at the
-	 * dot's horizontal midpoint reads as one continuous vertical rule joining the dots.
-	 */
-	inline TSharedRef<SWidget> TimelineIndicator(const TAttribute<EDot>& DotState, const TAttribute<bool>& DrawLineBelow)
+	/** A fixed 2px-wide vertical connecting-line segment (Unity's .timeline-line, rgb(80,80,80)), centred in
+	 *  the rail's 20px column. Used as a FillHeight rail segment BETWEEN two dots so it absorbs the full
+	 *  inter-dot slack and reads as one continuous rule joining them; @p bVisible collapses it when the
+	 *  upper dot does not exist (e.g. the MCP-server point only exists in Custom mode). */
+	inline TSharedRef<SWidget> TimelineLineSegment(const TAttribute<EVisibility>& Visibility)
 	{
+		return SNew(SBox).WidthOverride(2.0f)
+			.Visibility(Visibility)
+			[
+				SNew(SImage).Image(FUnrealMcpStyle::Get().GetBrush("UnrealMcp.ConnectingLine"))
+			];
+	}
+
+	/**
+	 * A connection-timeline RAIL (Unity's .connection-timeline left column): a fixed 20px-wide vertical column
+	 * that owns ALL the cluster's status dots and the connecting-line segments BETWEEN them, so the line is a
+	 * continuous rule spanning from one dot to the next regardless of the content rows beside it. This is the
+	 * structural fix for the per-row approach (which trapped each line inside an AutoHeight row with no slack):
+	 * here the line slots are FillHeight at the CLUSTER level, between the dots, with the full inter-dot height
+	 * as slack to fill.
+	 *
+	 * Slots are supplied as alternating dot / line entries. A dot slot is AutoHeight (top-aligned so it pins to
+	 * the top of its content row beside it); a line slot is FillHeight(1) so it stretches to fill the gap down to
+	 * the next dot. Each line carries its own visibility attribute so a segment collapses when its upper dot is
+	 * absent (e.g. in Cloud mode the MCP-server dot + its line vanish, leaving only the Unreal dot).
+	 *
+	 * Width 20px + the dots/line centred horizontally mirror Unity's .timeline-indicator (20px column, line at
+	 * x=9px). The whole rail is VAlign_Fill in its parent SHorizontalBox so it matches the content column's height.
+	 */
+	struct FTimelineRailDot
+	{
+		TAttribute<EDot> DotState;
+		TAttribute<EVisibility> DotVisibility = EVisibility::Visible;
+		// Visibility of the connecting-line segment BELOW this dot; Collapsed on the last dot (no line below it).
+		TAttribute<EVisibility> LineBelowVisibility = EVisibility::Collapsed;
+		// Top padding to vertically centre the 14px dot on its sibling content row's first line (the content row
+		// may begin below the rail's y=0, e.g. a card's 8px top padding) — purely cosmetic alignment.
+		float DotTopPadding = 0.0f;
+	};
+
+	inline TSharedRef<SWidget> TimelineRail(const TArray<FTimelineRailDot>& Dots)
+	{
+		TSharedRef<SVerticalBox> Rail = SNew(SVerticalBox);
+		for (const FTimelineRailDot& Point : Dots)
+		{
+			// The dot — AutoHeight, top-aligned so it pins to the top of its sibling content row.
+			Rail->AddSlot().AutoHeight().HAlign(HAlign_Center).Padding(0, Point.DotTopPadding, 0, 0)
+			[
+				SNew(SBox).Visibility(Point.DotVisibility)
+				[
+					StatusDot(Point.DotState)
+				]
+			];
+			// The connecting line BELOW it — FillHeight so it absorbs the slack down to the next dot.
+			Rail->AddSlot().FillHeight(1.0f).HAlign(HAlign_Center).Padding(0, 2, 0, 2)
+			[
+				TimelineLineSegment(Point.LineBelowVisibility)
+			];
+		}
 		return SNew(SBox).WidthOverride(20.0f)
 		[
-			SNew(SVerticalBox)
-			// The status dot, centred horizontally in the 20px column.
-			+ SVerticalBox::Slot().AutoHeight().HAlign(HAlign_Center)
-			[
-				StatusDot(DotState)
-			]
-			// The 2px connecting-line below the dot — fills the remaining row height, centred under the dot.
-			+ SVerticalBox::Slot().FillHeight(1.0f).HAlign(HAlign_Center).Padding(0, 2, 0, 0)
-			[
-				SNew(SBox).WidthOverride(2.0f)
-				.Visibility_Lambda([DrawLineBelow]()
-				{
-					return DrawLineBelow.Get() ? EVisibility::HitTestInvisible : EVisibility::Collapsed;
-				})
-				[
-					SNew(SImage).Image(FUnrealMcpStyle::Get().GetBrush("UnrealMcp.ConnectingLine"))
-				]
-			]
+			Rail
 		];
 	}
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentWidgets.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentWidgets.h
@@ -242,7 +242,9 @@ namespace UnrealMcpStyleWidgets
 	 */
 	struct FTimelineRailDot
 	{
-		TAttribute<EDot> DotState;
+		// Default Offline (red) rather than the enum's value-0 Online (green) so a future rail point that forgets to
+		// set DotState reads as not-connected, not falsely healthy. Both current call sites set this explicitly.
+		TAttribute<EDot> DotState = EDot::Offline;
 		TAttribute<EVisibility> DotVisibility = EVisibility::Visible;
 		// Visibility of the connecting-line segment BELOW this dot; Collapsed on the last dot (no line below it).
 		TAttribute<EVisibility> LineBelowVisibility = EVisibility::Collapsed;
@@ -254,8 +256,9 @@ namespace UnrealMcpStyleWidgets
 	inline TSharedRef<SWidget> TimelineRail(const TArray<FTimelineRailDot>& Dots)
 	{
 		TSharedRef<SVerticalBox> Rail = SNew(SVerticalBox);
-		for (const FTimelineRailDot& Point : Dots)
+		for (int32 DotIndex = 0; DotIndex < Dots.Num(); ++DotIndex)
 		{
+			const FTimelineRailDot& Point = Dots[DotIndex];
 			// The dot — AutoHeight, top-aligned so it pins to the top of its sibling content row.
 			Rail->AddSlot().AutoHeight().HAlign(HAlign_Center).Padding(0, Point.DotTopPadding, 0, 0)
 			[
@@ -264,11 +267,16 @@ namespace UnrealMcpStyleWidgets
 					StatusDot(Point.DotState)
 				]
 			];
-			// The connecting line BELOW it — FillHeight so it absorbs the slack down to the next dot.
-			Rail->AddSlot().FillHeight(1.0f).HAlign(HAlign_Center).Padding(0, 2, 0, 2)
-			[
-				TimelineLineSegment(Point.LineBelowVisibility)
-			];
+			// The connecting line BELOW it — FillHeight so it absorbs the slack down to the next dot. Only emit it
+			// BETWEEN consecutive dots: a trailing FillHeight slot after the last dot (even Collapsed) would still
+			// claim its STRETCH share of the rail's slack, so the inter-dot line would visibly absorb only part of it.
+			if (DotIndex < Dots.Num() - 1)
+			{
+				Rail->AddSlot().FillHeight(1.0f).HAlign(HAlign_Center).Padding(0, 2, 0, 2)
+				[
+					TimelineLineSegment(Point.LineBelowVisibility)
+				];
+			}
 		}
 		return SNew(SBox).WidthOverride(20.0f)
 		[

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -236,26 +236,31 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildConnectionSection()
 		+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)[ BuildCloudAuthRow() ]
 		// Custom Server URL + MCP-server sub-card — visible only in Custom mode.
 		+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)[ BuildCustomServerSection() ]
-		// Shared connection-status row (status dot + underlined "Unreal: <status>" label + Connect/Disconnect/Stop).
+		// Shared connection-status row (timeline indicator + underlined "Unreal: <status>" label + Connect/Disconnect/Stop).
+		// This is the LAST visible timeline point in the connection cluster (it sits below the MCP-server card in the
+		// Unreal layout), so its indicator draws NO connecting-line below (Unity's .timeline-point-last). The line that
+		// joins it to the MCP-server dot above is drawn by the MCP-server card's indicator (see BuildCustomServerSection).
 		+ SVerticalBox::Slot().AutoHeight().Padding(0, 10, 0, 0)
 		[
 			SNew(SHorizontalBox)
-			// The status dot.
-			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(0, 0, 8, 0)
+			// The timeline indicator (status dot only — last point, no downward line).
+			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Fill).Padding(0, 0, 8, 0)
 			[
-				UnrealMcpStyleWidgets::StatusDot(TAttribute<EDot>::Create([this]()
-				{
-					if (!IsViewModelValid())
-						return EDot::Offline;
-					switch (ViewModel->GetConnectionState())
+				UnrealMcpStyleWidgets::TimelineIndicator(
+					TAttribute<EDot>::Create([this]()
 					{
-						case EUnrealMcpConnectionState::Connected:  return EDot::Online;
-						case EUnrealMcpConnectionState::Connecting:  return EDot::Ring;
-						// Degraded must NOT use the (green) Ring brush — that reads as healthy. Show Offline.
-						case EUnrealMcpConnectionState::Degraded:    return EDot::Offline;
-						default:                                     return EDot::Offline;
-					}
-				}))
+						if (!IsViewModelValid())
+							return EDot::Offline;
+						switch (ViewModel->GetConnectionState())
+						{
+							case EUnrealMcpConnectionState::Connected:  return EDot::Online;
+							case EUnrealMcpConnectionState::Connecting:  return EDot::Ring;
+							// Degraded must NOT use the (green) Ring brush — that reads as healthy. Show Offline.
+							case EUnrealMcpConnectionState::Degraded:    return EDot::Offline;
+							default:                                     return EDot::Offline;
+						}
+					}),
+					/*DrawLineBelow*/ false)
 			]
 			// The underlined "Unreal: <status>" label — spans only the text (issue #80 item 3).
 			+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
@@ -467,8 +472,11 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCustomServerSection()
 				+ SVerticalBox::Slot().AutoHeight()
 				[
 					SNew(SHorizontalBox)
-					+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(0, 0, 8, 0)
-					[ UnrealMcpStyleWidgets::StatusDot(EDot::Offline) ]
+					// MCP-server timeline indicator: the dot + a 2px connecting-line DOWN toward the Unreal status
+					// dot below it (the connection cluster's second point — Unity's TimelinePointMcpServer). VAlign_Fill
+					// lets the line stretch the full header-row height so it visually reaches the next point.
+					+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Fill).Padding(0, 0, 8, 0)
+					[ UnrealMcpStyleWidgets::TimelineIndicator(EDot::Offline, /*DrawLineBelow*/ true) ]
 					+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
 					[ UnderlinedLabel(LOCTEXT("McpServer", "MCP server")) ]
 					+ SHorizontalBox::Slot().AutoWidth().HAlign(HAlign_Right).VAlign(VAlign_Center)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -234,58 +234,106 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildConnectionSection()
 		]
 		// Cloud auth row (masked token + Revoke / Authorize) — visible only in Cloud mode.
 		+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)[ BuildCloudAuthRow() ]
-		// Custom Server URL + MCP-server sub-card — visible only in Custom mode.
+		// Custom Server URL + validation (NOT part of the dot cluster) — visible only in Custom mode.
 		+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)[ BuildCustomServerSection() ]
-		// Shared connection-status row (timeline indicator + underlined "Unreal: <status>" label + Connect/Disconnect/Stop).
-		// This is the LAST visible timeline point in the connection cluster (it sits below the MCP-server card in the
-		// Unreal layout), so its indicator draws NO connecting-line below (Unity's .timeline-point-last). The line that
-		// joins it to the MCP-server dot above is drawn by the MCP-server card's indicator (see BuildCustomServerSection).
+		// The connection cluster (Unity's .connection-timeline): a 2-column layout where the LEFT column is one
+		// continuous vertical rail [MCP-server dot] → [FillHeight line] → [Unreal dot], and the RIGHT column holds
+		// the matching content rows. The per-row approach (round-2) trapped each line inside an AutoHeight row with
+		// no vertical slack — structurally incapable of a continuous line. Here the line slot lives BETWEEN the two
+		// dots at the CLUSTER level, so it has the full inter-dot height as slack to fill (Unity's .timeline-line).
 		+ SVerticalBox::Slot().AutoHeight().Padding(0, 10, 0, 0)
 		[
-			SNew(SHorizontalBox)
-			// The timeline indicator (status dot only — last point, no downward line).
-			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Fill).Padding(0, 0, 8, 0)
+			BuildConnectionCluster()
+		];
+}
+
+TSharedRef<SWidget> SUnrealMcpMainWindow::BuildConnectionCluster()
+{
+	// The Unreal status dot — driven by the live connection state.
+	TAttribute<EDot> UnrealDot = TAttribute<EDot>::Create([this]()
+	{
+		if (!IsViewModelValid())
+			return EDot::Offline;
+		switch (ViewModel->GetConnectionState())
+		{
+			case EUnrealMcpConnectionState::Connected:  return EDot::Online;
+			case EUnrealMcpConnectionState::Connecting:  return EDot::Ring;
+			// Degraded must NOT use the (green) Ring brush — that reads as healthy. Show Offline.
+			case EUnrealMcpConnectionState::Degraded:    return EDot::Offline;
+			default:                                     return EDot::Offline;
+		}
+	});
+
+	// The MCP-server dot + the line below it exist only in Custom mode (the MCP-server content row is Custom-only).
+	// In Cloud mode the rail collapses to just the Unreal dot, leaving no dangling line above it.
+	TAttribute<EVisibility> CustomOnly = MakeAttributeLambda([this]() -> EVisibility
+	{
+		return (IsViewModelValid() && ViewModel->GetConnectionMode() == EUnrealMcpConnectionMode::Custom)
+			? EVisibility::Visible : EVisibility::Collapsed;
+	});
+
+	UnrealMcpStyleWidgets::FTimelineRailDot McpPoint;
+	McpPoint.DotState = EDot::Offline;
+	McpPoint.DotVisibility = CustomOnly;
+	// The connecting line runs DOWN from the MCP-server dot to the Unreal dot — present only in Custom mode.
+	McpPoint.LineBelowVisibility = CustomOnly;
+	// Nudge the dot down to centre it on the "MCP server" label inside the card (8px card padding + ~half a line).
+	McpPoint.DotTopPadding = 8.0f;
+
+	UnrealMcpStyleWidgets::FTimelineRailDot UnrealPoint;
+	UnrealPoint.DotState = UnrealDot;
+	UnrealPoint.DotVisibility = EVisibility::Visible;
+	// Last point — no line below it (Unity's .timeline-point-last).
+	UnrealPoint.LineBelowVisibility = EVisibility::Collapsed;
+	// Small nudge to centre the dot on the "Unreal: <status>" label's text line.
+	UnrealPoint.DotTopPadding = 2.0f;
+
+	return SNew(SHorizontalBox)
+		// LEFT column: the continuous timeline rail owning both dots + the line between them. VAlign_Fill so the
+		// rail matches the content column's height and the FillHeight line slot can absorb the full inter-dot slack.
+		+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Fill).Padding(0, 0, 8, 0)
+		[
+			UnrealMcpStyleWidgets::TimelineRail({ McpPoint, UnrealPoint })
+		]
+		// RIGHT column: the stacked content rows, one per dot. Each row's top aligns with its dot in the rail.
+		+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Fill)
+		[
+			SNew(SVerticalBox)
+			// MCP-server card body (Custom-only) — aligns with the MCP-server dot.
+			+ SVerticalBox::Slot().AutoHeight()[ BuildMcpServerCard() ]
+			// Unreal status row — aligns with the Unreal dot.
+			+ SVerticalBox::Slot().AutoHeight()[ BuildUnrealStatusRow() ]
+		];
+}
+
+TSharedRef<SWidget> SUnrealMcpMainWindow::BuildUnrealStatusRow()
+{
+	// The "Unreal: <status>" row — underlined label + Connect/Disconnect/Stop. The dot for this row lives in the
+	// shared rail (BuildConnectionCluster), so this row carries only its content.
+	return SNew(SHorizontalBox)
+		// The underlined "Unreal: <status>" label — spans only the text (issue #80 item 3).
+		+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
+		[
+			UnderlinedLabel(TAttribute<FText>::Create([this]()
+			{
+				return IsViewModelValid()
+					? FUnrealMcpEditorViewModel::GetStatusLabel(ViewModel->GetConnectionState())
+					: FText::GetEmpty();
+			}))
+		]
+		// Connect / Disconnect / Stop button — right-aligned to the shared right edge.
+		+ SHorizontalBox::Slot().AutoWidth().HAlign(HAlign_Right).VAlign(VAlign_Center)
+		[
+			SNew(SBox).MinDesiredWidth(RightControlColumnWidth).HAlign(HAlign_Right)
 			[
-				UnrealMcpStyleWidgets::TimelineIndicator(
-					TAttribute<EDot>::Create([this]()
+				UnrealMcpStyleWidgets::StyledButton("UnrealMcp.Button.Secondary",
+					SNew(STextBlock).Text_Lambda([this]()
 					{
-						if (!IsViewModelValid())
-							return EDot::Offline;
-						switch (ViewModel->GetConnectionState())
-						{
-							case EUnrealMcpConnectionState::Connected:  return EDot::Online;
-							case EUnrealMcpConnectionState::Connecting:  return EDot::Ring;
-							// Degraded must NOT use the (green) Ring brush — that reads as healthy. Show Offline.
-							case EUnrealMcpConnectionState::Degraded:    return EDot::Offline;
-							default:                                     return EDot::Offline;
-						}
+						return IsViewModelValid()
+							? FUnrealMcpEditorViewModel::GetButtonText(ViewModel->GetConnectionState())
+							: FText::GetEmpty();
 					}),
-					/*DrawLineBelow*/ false)
-			]
-			// The underlined "Unreal: <status>" label — spans only the text (issue #80 item 3).
-			+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
-			[
-				UnderlinedLabel(TAttribute<FText>::Create([this]()
-				{
-					return IsViewModelValid()
-						? FUnrealMcpEditorViewModel::GetStatusLabel(ViewModel->GetConnectionState())
-						: FText::GetEmpty();
-				}))
-			]
-			// Connect / Disconnect / Stop button — right-aligned to the shared right edge.
-			+ SHorizontalBox::Slot().AutoWidth().HAlign(HAlign_Right).VAlign(VAlign_Center)
-			[
-				SNew(SBox).MinDesiredWidth(RightControlColumnWidth).HAlign(HAlign_Right)
-				[
-					UnrealMcpStyleWidgets::StyledButton("UnrealMcp.Button.Secondary",
-						SNew(STextBlock).Text_Lambda([this]()
-						{
-							return IsViewModelValid()
-								? FUnrealMcpEditorViewModel::GetButtonText(ViewModel->GetConnectionState())
-								: FText::GetEmpty();
-						}),
-						FOnClicked::CreateSP(this, &SUnrealMcpMainWindow::OnConnectClicked))
-				]
+					FOnClicked::CreateSP(this, &SUnrealMcpMainWindow::OnConnectClicked))
 			]
 		];
 }
@@ -427,6 +475,9 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCloudAuthRow()
 
 TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCustomServerSection()
 {
+	// The Server URL row + validation — Custom-only, and NOT part of the dot cluster (it has no timeline point in
+	// the reference). The MCP-server sub-card moved into the cluster's content column (BuildMcpServerCard) so the
+	// connecting line can run continuously from the MCP-server dot down to the Unreal dot.
 	TSharedRef<SVerticalBox> Body = SNew(SVerticalBox)
 		// Server URL row — label left, input right-aligned to the shared right edge (issue #80 item 4).
 		+ SVerticalBox::Slot().AutoHeight()
@@ -462,41 +513,6 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCustomServerSection()
 				return FUnrealMcpEditorViewModel::ValidateServerUrl(ViewModel->GetCustomHost(), Error)
 					? FText::GetEmpty() : FText::FromString(Error);
 			})
-		]
-		// The "MCP server" sub-card: the ONE blue rounded card kept in the Connection section (Unity .frame-mcp-server).
-		+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)
-		[
-			UnrealMcpStyleWidgets::StyledCard(
-				SNew(SVerticalBox)
-				// MCP server header row (dot + underlined label + teal Start, right-aligned to the shared edge).
-				+ SVerticalBox::Slot().AutoHeight()
-				[
-					SNew(SHorizontalBox)
-					// MCP-server timeline indicator: the dot + a 2px connecting-line DOWN toward the Unreal status
-					// dot below it (the connection cluster's second point — Unity's TimelinePointMcpServer). VAlign_Fill
-					// lets the line stretch the full header-row height so it visually reaches the next point.
-					+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Fill).Padding(0, 0, 8, 0)
-					[ UnrealMcpStyleWidgets::TimelineIndicator(EDot::Offline, /*DrawLineBelow*/ true) ]
-					+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
-					[ UnderlinedLabel(LOCTEXT("McpServer", "MCP server")) ]
-					+ SHorizontalBox::Slot().AutoWidth().HAlign(HAlign_Right).VAlign(VAlign_Center)
-					[
-						SNew(SBox).MinDesiredWidth(RightControlColumnWidth).HAlign(HAlign_Right)
-						[
-							UnrealMcpStyleWidgets::StyledTextButton("UnrealMcp.Button.Primary", LOCTEXT("Start", "Start"),
-								FOnClicked::CreateLambda([this]()
-								{
-									// Start mirrors the reference's local-server Start: (re)connect through the view-model.
-									if (IsViewModelValid()) ViewModel->Connect();
-									return FReply::Handled();
-								}))
-						]
-					]
-				]
-				// Transport (stdio / http) segmented — indented to the section-title start, control right-aligned.
-				+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)[ BuildTransportSelector() ]
-				// Authorization (none / required) + masked token + New.
-				+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)[ BuildCustomAuthSelector() ])
 		];
 
 	Body->SetVisibility(MakeAttributeLambda([this]() -> EVisibility
@@ -505,6 +521,47 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCustomServerSection()
 			? EVisibility::Visible : EVisibility::Collapsed;
 	}));
 	return Body;
+}
+
+TSharedRef<SWidget> SUnrealMcpMainWindow::BuildMcpServerCard()
+{
+	// The "MCP server" sub-card: the ONE blue rounded card kept in the Connection section (Unity .frame-mcp-server).
+	// The card's timeline DOT now lives in the shared rail (BuildConnectionCluster) so the connecting line is
+	// continuous from this dot down to the Unreal dot; this card carries only its content. The whole card is
+	// Custom-only — it shares the same visibility predicate as the rail's MCP-server dot + line above it.
+	TSharedRef<SWidget> Card = UnrealMcpStyleWidgets::StyledCard(
+		SNew(SVerticalBox)
+		// MCP server header row (underlined label + teal Start, right-aligned to the shared edge).
+		+ SVerticalBox::Slot().AutoHeight()
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
+			[ UnderlinedLabel(LOCTEXT("McpServer", "MCP server")) ]
+			+ SHorizontalBox::Slot().AutoWidth().HAlign(HAlign_Right).VAlign(VAlign_Center)
+			[
+				SNew(SBox).MinDesiredWidth(RightControlColumnWidth).HAlign(HAlign_Right)
+				[
+					UnrealMcpStyleWidgets::StyledTextButton("UnrealMcp.Button.Primary", LOCTEXT("Start", "Start"),
+						FOnClicked::CreateLambda([this]()
+						{
+							// Start mirrors the reference's local-server Start: (re)connect through the view-model.
+							if (IsViewModelValid()) ViewModel->Connect();
+							return FReply::Handled();
+						}))
+				]
+			]
+		]
+		// Transport (stdio / http) segmented — indented to the section-title start, control right-aligned.
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)[ BuildTransportSelector() ]
+		// Authorization (none / required) + masked token + New.
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)[ BuildCustomAuthSelector() ]);
+
+	Card->SetVisibility(MakeAttributeLambda([this]() -> EVisibility
+	{
+		return (IsViewModelValid() && ViewModel->GetConnectionMode() == EUnrealMcpConnectionMode::Custom)
+			? EVisibility::Visible : EVisibility::Collapsed;
+	}));
+	return Card;
 }
 
 TSharedRef<SWidget> SUnrealMcpMainWindow::BuildTransportSelector()

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
@@ -56,10 +56,19 @@ private:
 	// styled footer (Discord / GitHub bug-report / gold GitHub Star).
 	TSharedRef<SWidget> BuildHeaderSection();
 	TSharedRef<SWidget> BuildConnectionSection();
+	// The connection cluster (Unity's .connection-timeline): a 2-column layout — a continuous vertical rail
+	// [MCP-server dot] → [line] → [Unreal dot] on the LEFT, the matching content rows on the RIGHT — so the
+	// connecting line spans continuously between the dots (the round-2 per-row line could not span the gap).
+	TSharedRef<SWidget> BuildConnectionCluster();
 	// The Cloud auth controls (masked token + Revoke/Authorize), shown inline in the Connection card in Cloud mode.
 	TSharedRef<SWidget> BuildCloudAuthRow();
-	// The Custom auth + MCP-server sub-card (Server URL, Start, Transport, none/required, masked token + New).
+	// The Custom Server URL row + validation (Custom-only; NOT part of the dot cluster).
 	TSharedRef<SWidget> BuildCustomServerSection();
+	// The MCP-server sub-card body (Start, Transport, none/required, masked token + New) — Custom-only. Its
+	// timeline dot lives in the shared rail (BuildConnectionCluster), not in this card.
+	TSharedRef<SWidget> BuildMcpServerCard();
+	// The "Unreal: <status>" content row (underlined label + Connect/Disconnect/Stop) — its dot lives in the rail.
+	TSharedRef<SWidget> BuildUnrealStatusRow();
 	// The Custom-mode transport selector (stdio/http) segmented control.
 	TSharedRef<SWidget> BuildTransportSelector();
 	// The Custom-mode authorization selector (none/required) + masked token + New.


### PR DESCRIPTION
## Summary
- Renders Unity's connection-timeline **connecting-line** in the "AI Game Developer" Slate window: a continuous 2px vertical line (rgb(80,80,80), Unity's `.timeline-line`) links the connection-cluster status dots. Round-2 (#80/#85) left the dots standalone and explicitly deferred this.
- New `UnrealMcpStyleWidgets::TimelineIndicator` (Unity's `.timeline-indicator`): a 20px-wide column holding the 14px status dot centred, with a 2px connecting-line below it (reusing the existing `UnrealMcp.ConnectingLine` brush) that `FillHeight`-stretches toward the next point. `DrawLineBelow` is a `TAttribute` so it reacts to mode changes; the last visible point omits it (Unity's `.timeline-point-last`).
- Wired the MCP-server card dot to draw the line down toward the Unreal connection-status dot (last visible point, no line). In Cloud mode the MCP-server point is hidden, so the lone dot shows no dangling line.

Ported the exact Unity USS values (20px indicator width, 2px line, line centred at the dot midpoint, rgb(80,80,80)). **Slate deviation:** UE has no absolute positioning (Unity uses `position:absolute`), so the per-point line is a `FillHeight` slot below the dot rather than an overlay — same visual result, structurally faithful to Unity's per-point line model. Visual/windowed verification pending operator (Slate windows aren't verifiable headless).

## Test plan
- [x] Suite 1 — UBT build (`UnrealTestProjectEditor Win64 Development`): **0 errors**.
- [x] Suite 2 — Headless smoke: `[Unreal-MCP] plugin loaded` + `Engine is initialized`. The `QUIT_EDITOR` exit-3 teardown crash (`GenericWindow.cpp:113` → `FUnrealMcpRuntime::Shutdown():325`) reproduces **unchanged on pristine `main`** — pre-existing shutdown quirk, not a load failure; graceful `Quit` (Suite 3) exits 0.
- [x] Suite 3 — Automation `UnrealMcp`: **0 failed**, 247 succeeded + 16 succeededWithWarnings (matches round-2 baseline; no regression).

Closes #87