### PR TITLE
feat(ui): add "Check" button + Serialization Check window (Unity-MCP parity)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
@@ -3,6 +3,7 @@
 
 #include "DevControl/UnrealMcpDevControlServer.h"
 #include "UI/UnrealMcpEditorViewModel.h"
+#include "UI/UnrealMcpAuxWindows.h"
 #include "Config/UnrealMcpConfig.h"
 #include "UnrealMcpLog.h"
 
@@ -248,6 +249,9 @@ int32 FUnrealMcpDevControlServer::RouteRequest(
 		OutResult->SetStringField(TEXT("connectionMode"), DevControlConnectionModeLabel(ViewModelPtr->GetConnectionMode()));
 		OutResult->SetStringField(TEXT("customHost"), ViewModelPtr->GetCustomHost());
 		OutResult->SetStringField(TEXT("selectedAgentId"), ViewModelPtr->GetSelectedAgentId());
+		// The Serialization Check window's tab id — lets the smoke test assert membership and (with a
+		// `check` click) drive the same footer "Check" button the dock renders.
+		OutResult->SetStringField(TEXT("serializationCheckTabId"), FUnrealMcpAuxWindows::SerializationCheckTabId.ToString());
 
 		TArray<TSharedPtr<FJsonValue>> Agents;
 		for (const FString& Agent : ViewModelPtr->GetAiAgents())
@@ -334,16 +338,19 @@ int32 FUnrealMcpDevControlServer::RouteRequest(
 		FString Target;
 		if (!Body.IsValid() || !Body->TryGetStringField(TEXT("target"), Target) || Target.IsEmpty())
 		{
-			DevControlFail(OutResult, TEXT("missing 'target' (connect|disconnect|authorize|revoke|generate-token)"));
+			DevControlFail(OutResult, TEXT("missing 'target' (connect|disconnect|authorize|revoke|generate-token|check)"));
 			return 400;
 		}
 
 		// Map the click target onto the matching view-model mutator — the same action the Slate button fires.
+		// `check` is the odd one out: it opens the Serialization Check aux window rather than mutating the
+		// view-model, so it routes through the static aux-window invoker (a headless no-op — see the helper).
 		if (Target.Equals(TEXT("connect"), ESearchCase::IgnoreCase))               ViewModelPtr->Connect();
 		else if (Target.Equals(TEXT("disconnect"), ESearchCase::IgnoreCase))       ViewModelPtr->Disconnect();
 		else if (Target.Equals(TEXT("authorize"), ESearchCase::IgnoreCase))        ViewModelPtr->Authorize();
 		else if (Target.Equals(TEXT("revoke"), ESearchCase::IgnoreCase))           ViewModelPtr->Revoke();
 		else if (Target.Equals(TEXT("generate-token"), ESearchCase::IgnoreCase))   ViewModelPtr->GenerateCustomToken();
+		else if (Target.Equals(TEXT("check"), ESearchCase::IgnoreCase))            FUnrealMcpAuxWindows::TryInvokeSerializationCheckTab();
 		else
 		{
 			DevControlFail(OutResult, FString::Printf(TEXT("unknown click target '%s'"), *Target));

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -4,6 +4,7 @@
 #include "UI/SUnrealMcpMainWindow.h"
 #include "UI/SUnrealMcpAgentConfigurators.h"
 #include "UI/SUnrealMcpAgentWidgets.h"
+#include "UI/UnrealMcpAuxWindows.h"
 #include "UI/FUnrealMcpStyle.h"
 #include "UnrealMcpLog.h"
 
@@ -674,6 +675,13 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildFooterSection()
 			[
 				UnrealMcpStyleWidgets::IconButton("UnrealMcp.Button.Secondary", "UnrealMcp.GitHub", LOCTEXT("BugReport", "Bug Report"),
 					FOnClicked::CreateLambda([]() { FPlatformProcess::LaunchURL(*IssuesUrl, nullptr, nullptr); return FReply::Handled(); }))
+			]
+			// "Check" — opens the Serialization Check window (Unity-MCP parity). Secondary style, beside the
+			// support links. Delegates to the static aux-window invoker so it focuses an already-open tab.
+			+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 8, 0)
+			[
+				UnrealMcpStyleWidgets::StyledTextButton("UnrealMcp.Button.Secondary", LOCTEXT("Check", "Check"),
+					FOnClicked::CreateLambda([]() { FUnrealMcpAuxWindows::TryInvokeSerializationCheckTab(); return FReply::Handled(); }))
 			]
 			+ SHorizontalBox::Slot().AutoWidth()
 			[

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSerializationCheckWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSerializationCheckWindow.cpp
@@ -1,0 +1,310 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UI/SUnrealMcpSerializationCheckWindow.h"
+#include "UI/SUnrealMcpAgentWidgets.h"
+#include "UI/FUnrealMcpStyle.h"
+#include "Tools/UnrealMcpPropertyJson.h"
+#include "Tools/UnrealMcpObjectRef.h"
+#include "UnrealMcpLog.h"
+
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/SNullWidget.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Layout/SScrollBox.h"
+#include "Widgets/Layout/SSeparator.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SCheckBox.h"
+#include "Widgets/Input/SEditableTextBox.h"
+#include "Widgets/Input/SMultiLineEditableTextBox.h"
+#include "Styling/AppStyle.h"
+#include "Styling/CoreStyle.h"
+#include "HAL/PlatformApplicationMisc.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Policies/PrettyJsonPrintPolicy.h"
+
+#include "Editor.h"
+#include "Engine/Selection.h"
+#include "GameFramework/Actor.h"
+
+#define LOCTEXT_NAMESPACE "UnrealMcp"
+
+using UnrealMcpAgentWidgets::TemplateFoldout;
+using UnrealMcpAgentWidgets::TemplateLabelDescription;
+
+namespace
+{
+	// Unity-build ODR rule (CLAUDE.md): every file-local helper carries the family-unique `SerCheck` prefix
+	// so a same-name/same-signature helper in another unity-grouped .cpp cannot collide.
+
+	// Pretty-print a JSON object the way the Unity reference does (reflector .ToPrettyJson()). The tool
+	// families return condensed JSON over the wire; this window is for a HUMAN to read, so it pretty-prints.
+	FString SerCheckPrettyPrint(const TSharedRef<FJsonObject>& Object)
+	{
+		FString Out;
+		const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> Writer =
+			TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Out);
+		FJsonSerializer::Serialize(Object, Writer);
+		return Out;
+	}
+
+	// The first selected actor (preferred), else the first selected non-actor object — the "use current
+	// editor selection" affordance the Unity ObjectField gives implicitly. Returns null when nothing is
+	// selected or there is no editor.
+	UObject* SerCheckCurrentSelection()
+	{
+		if (!GEditor)
+			return nullptr;
+
+		if (USelection* ActorSelection = GEditor->GetSelectedActors())
+		{
+			TArray<AActor*> Actors;
+			ActorSelection->GetSelectedObjects<AActor>(Actors);
+			if (Actors.Num() > 0 && Actors[0])
+				return Actors[0];
+		}
+		if (USelection* ObjectSelection = GEditor->GetSelectedObjects())
+		{
+			TArray<UObject*> Objects;
+			ObjectSelection->GetSelectedObjects<UObject>(Objects);
+			if (Objects.Num() > 0 && Objects[0])
+				return Objects[0];
+		}
+		return nullptr;
+	}
+
+	// A short, label-able ref for an object: an actor uses its editor label (what ResolveObject matches first
+	// via the world); everything else uses its object path. Keeps the "Use selection" round-trip stable.
+	FString SerCheckRefForObject(UObject* Object)
+	{
+		if (const AActor* Actor = Cast<AActor>(Object))
+			return Actor->GetActorLabel();
+		return Object ? Object->GetPathName() : FString();
+	}
+}
+
+TSharedRef<FJsonObject> SUnrealMcpSerializationCheckWindow::ShallowFilter(const TSharedPtr<FJsonObject>& Source)
+{
+	// Keep scalars (string/number/bool/null), drop nested objects + arrays — the "Recursive OFF" shallow view.
+	TSharedRef<FJsonObject> Shallow = MakeShared<FJsonObject>();
+	if (!Source.IsValid())
+		return Shallow;
+	for (const TPair<FString, TSharedPtr<FJsonValue>>& Field : Source->Values)
+	{
+		const EJson Type = Field.Value.IsValid() ? Field.Value->Type : EJson::Null;
+		if (Type != EJson::Object && Type != EJson::Array)
+			Shallow->SetField(Field.Key, Field.Value);
+	}
+	return Shallow;
+}
+
+void SUnrealMcpSerializationCheckWindow::Construct(const FArguments& InArgs)
+{
+	OutputHeader = LOCTEXT("OutputHeaderEmpty", "Output");
+	CopyLabel = LOCTEXT("Copy", "Copy");
+
+	ChildSlot
+	[
+		SNew(SScrollBox)
+		+ SScrollBox::Slot().Padding(12.0f)
+		[
+			SNew(SVerticalBox)
+			// 1. Information foldout (collapsed help text).
+			+ SVerticalBox::Slot().AutoHeight()[ BuildInformationFoldout() ]
+			// 2. Separator.
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 10)[ SNew(SSeparator) ]
+			// 3. Input row: target ref + Use selection + Recursive + Serialize.
+			+ SVerticalBox::Slot().AutoHeight()[ BuildInputRow() ]
+			// 4. Separator.
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 10)[ SNew(SSeparator) ]
+			// 5/6/7. Output header + scrollable JSON + Copy.
+			+ SVerticalBox::Slot().FillHeight(1.0f)[ BuildOutputSection() ]
+		]
+	];
+}
+
+TSharedRef<SWidget> SUnrealMcpSerializationCheckWindow::BuildInformationFoldout()
+{
+	return TemplateFoldout(
+		LOCTEXT("InfoHeading", "Information"),
+		TemplateLabelDescription(LOCTEXT("InfoBody",
+			"Pick a target by its actor label or object path (or press \"Use selection\" to fill it from the "
+			"current editor selection), then press Serialize. The object is serialized to JSON in-process via "
+			"the same reflection-based converter the object-get-data / actor-get-data MCP tools use — no sidecar "
+			"round-trip. Recursive ON emits the full reflected property graph; OFF emits only the object's "
+			"identity and top-level fields. Copy puts the JSON on the clipboard.")),
+		/*bInitiallyExpanded*/ false);
+}
+
+TSharedRef<SWidget> SUnrealMcpSerializationCheckWindow::BuildInputRow()
+{
+	return SNew(SVerticalBox)
+		// Target ref + Use selection.
+		+ SVerticalBox::Slot().AutoHeight()
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(0, 0, 8, 0)
+			[
+				SNew(SBox).WidthOverride(60.0f)
+				[
+					SNew(STextBlock)
+					.TextStyle(&FUnrealMcpStyle::Get().GetWidgetStyle<FTextBlockStyle>("UnrealMcp.Text.Description"))
+					.Text(LOCTEXT("TargetLabel", "Target"))
+				]
+			]
+			+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
+			[
+				SAssignNew(TargetField, SEditableTextBox)
+				.HintText(LOCTEXT("TargetHint", "Actor label or object path (e.g. /Game/Maps/Demo.Demo:PersistentLevel.Cube)"))
+			]
+			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(6, 0, 0, 0)
+			[
+				UnrealMcpStyleWidgets::CompactTextButton(LOCTEXT("UseSelection", "Use selection"),
+					FOnClicked::CreateSP(this, &SUnrealMcpSerializationCheckWindow::OnUseSelectionClicked))
+			]
+		]
+		// Recursive + Serialize.
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center)
+			[
+				SAssignNew(RecursiveToggle, SCheckBox)
+				.IsChecked(ECheckBoxState::Checked)
+				[
+					SNew(STextBlock).Margin(FMargin(4, 0, 0, 0)).Text(LOCTEXT("Recursive", "Recursive"))
+				]
+			]
+			+ SHorizontalBox::Slot().FillWidth(1.0f)[ SNullWidget::NullWidget ]
+			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center)
+			[
+				UnrealMcpStyleWidgets::StyledTextButton("UnrealMcp.Button.Primary", LOCTEXT("Serialize", "Serialize"),
+					FOnClicked::CreateSP(this, &SUnrealMcpSerializationCheckWindow::OnSerializeClicked))
+			]
+		];
+}
+
+TSharedRef<SWidget> SUnrealMcpSerializationCheckWindow::BuildOutputSection()
+{
+	return SNew(SVerticalBox)
+		// Output header ("Output" / "Output (NN ms)").
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 4)
+		[
+			SNew(STextBlock)
+			.Font(FUnrealMcpStyle::SubHeaderFont())
+			.Text_Lambda([this]() { return OutputHeader; })
+		]
+		// Scrollable monospace JSON output in a dark rounded panel.
+		+ SVerticalBox::Slot().FillHeight(1.0f)
+		[
+			SNew(SBorder)
+			.BorderImage(FUnrealMcpStyle::Get().GetBrush("UnrealMcp.Input"))
+			.Padding(8.0f)
+			[
+				SAssignNew(OutputBox, SMultiLineEditableTextBox)
+				.IsReadOnly(true)
+				.AllowMultiLine(true)
+				.Font(FCoreStyle::GetDefaultFontStyle("Mono", 9))
+				.Text(FText::GetEmpty())
+			]
+		]
+		// Copy button.
+		+ SVerticalBox::Slot().AutoHeight().HAlign(HAlign_Right).Padding(0, 6, 0, 0)
+		[
+			SAssignNew(CopyButton, SButton)
+			.ButtonStyle(&FUnrealMcpStyle::Get().GetWidgetStyle<FButtonStyle>("UnrealMcp.Button.Secondary"))
+			.HAlign(HAlign_Center).VAlign(VAlign_Center)
+			.OnClicked(FOnClicked::CreateSP(this, &SUnrealMcpSerializationCheckWindow::OnCopyClicked))
+			[
+				SNew(STextBlock).Text_Lambda([this]() { return CopyLabel; })
+			]
+		];
+}
+
+FReply SUnrealMcpSerializationCheckWindow::OnUseSelectionClicked()
+{
+	if (UObject* Selected = SerCheckCurrentSelection())
+	{
+		if (TargetField.IsValid())
+			TargetField->SetText(FText::FromString(SerCheckRefForObject(Selected)));
+	}
+	return FReply::Handled();
+}
+
+FReply SUnrealMcpSerializationCheckWindow::OnSerializeClicked()
+{
+	const FString Ref = TargetField.IsValid() ? TargetField->GetText().ToString().TrimStartAndEnd() : FString();
+	const bool bRecursive = RecursiveToggle.IsValid() && RecursiveToggle->IsChecked();
+
+	if (Ref.IsEmpty())
+	{
+		OutputHeader = LOCTEXT("OutputHeaderEmpty", "Output");
+		SetOutput(LOCTEXT("ErrNoTarget", "Error: enter an actor label or object path (or press \"Use selection\").").ToString());
+		return FReply::Handled();
+	}
+
+	// Resolve via the SAME ref rule the tool families use (path or actor label against the editor world).
+	UObject* Target = FUnrealMcpObjectRef::ResolveObject(Ref, FUnrealMcpObjectRef::GetEditorWorld());
+	if (!Target)
+	{
+		OutputHeader = LOCTEXT("OutputHeaderEmpty", "Output");
+		SetOutput(FString::Printf(TEXT("Error: could not resolve target '%s' (not a known actor label or object path)."), *Ref));
+		return FReply::Handled();
+	}
+
+	const double StartSeconds = FPlatformTime::Seconds();
+
+	// In-process serialization (§3.2) via the converter the object-get-data / actor-get-data tools use.
+	// Recursive OFF: only the object's identity + top-level scalar fields are wanted, so request the
+	// non-object leaves. SerializeObject has no `recursive` arg (FJsonObjectConverter always walks the
+	// reflected graph), so the shallow variant prunes nested object fields AFTER serialization — matching
+	// Unity's recursive=false "shallow" intent without forking the serialization path.
+	TSharedPtr<FJsonObject> Json = FUnrealMcpPropertyJson::SerializeObject(Target, /*Paths*/ {});
+	if (!Json.IsValid())
+		Json = MakeShared<FJsonObject>();
+
+	if (!bRecursive)
+		Json = ShallowFilter(Json);
+
+	const FString Pretty = SerCheckPrettyPrint(Json.ToSharedRef());
+	const int32 ElapsedMs = FMath::RoundToInt((FPlatformTime::Seconds() - StartSeconds) * 1000.0);
+
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] Serialization Check: serialized '%s' (%s) in %d ms."),
+		*Ref, bRecursive ? TEXT("recursive") : TEXT("shallow"), ElapsedMs);
+
+	OutputHeader = FText::Format(LOCTEXT("OutputHeaderMs", "Output ({0} ms)"), FText::AsNumber(ElapsedMs));
+	SetOutput(Pretty);
+	return FReply::Handled();
+}
+
+void SUnrealMcpSerializationCheckWindow::SetOutput(const FString& Text)
+{
+	FullOutputText = Text;
+	if (OutputBox.IsValid())
+		OutputBox->SetText(FText::FromString(Text));
+}
+
+FReply SUnrealMcpSerializationCheckWindow::OnCopyClicked()
+{
+	FPlatformApplicationMisc::ClipboardCopy(*FullOutputText);
+
+	// Flash "Copied!" and restore the label ~1.5s later. The timer is registered on this widget so it is
+	// torn down with the tab (no dangling callback). RegisterActiveTimer fires once (returns Stop).
+	CopyLabel = LOCTEXT("Copied", "Copied!");
+	RegisterActiveTimer(1.5f, FWidgetActiveTimerDelegate::CreateSP(this, &SUnrealMcpSerializationCheckWindow::OnCopyResetTimer));
+	return FReply::Handled();
+}
+
+EActiveTimerReturnType SUnrealMcpSerializationCheckWindow::OnCopyResetTimer(double, float)
+{
+	CopyLabel = LOCTEXT("Copy", "Copy");
+	return EActiveTimerReturnType::Stop;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSerializationCheckWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSerializationCheckWindow.cpp
@@ -217,7 +217,7 @@ TSharedRef<SWidget> SUnrealMcpSerializationCheckWindow::BuildOutputSection()
 		// Copy button.
 		+ SVerticalBox::Slot().AutoHeight().HAlign(HAlign_Right).Padding(0, 6, 0, 0)
 		[
-			SAssignNew(CopyButton, SButton)
+			SNew(SButton)
 			.ButtonStyle(&FUnrealMcpStyle::Get().GetWidgetStyle<FButtonStyle>("UnrealMcp.Button.Secondary"))
 			.HAlign(HAlign_Center).VAlign(VAlign_Center)
 			.OnClicked(FOnClicked::CreateSP(this, &SUnrealMcpSerializationCheckWindow::OnCopyClicked))

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSerializationCheckWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSerializationCheckWindow.h
@@ -24,9 +24,10 @@ class STextBlock;
  * reflected FProperties), the SAME path the `object-get-data` / `actor-get-data` tools use to return Unreal
  * object data over MCP. ReflectorNet lives in the .NET sidecar and only wraps the MCP wire layer — the editor
  * plugin never needs it to serialize a UObject — so this window calls SerializeObject directly on the game
- * thread. The Recursive toggle mirrors Unity's `recursive` flag: when OFF, nested UObject* references serialize
- * as their identity (path/name) only; when ON, the full reflected graph is emitted (FJsonObjectConverter walks
- * referenced sub-objects). Target resolution reuses FUnrealMcpObjectRef::ResolveObject (path or actor label),
+ * thread. The Recursive toggle mirrors Unity's `recursive` flag: when OFF, only the top-level scalar fields are
+ * kept and every nested object/array field is DROPPED (no identity/path/name fallback — see ShallowFilter); when
+ * ON, the full reflected graph is emitted (FJsonObjectConverter walks referenced sub-objects). Target resolution
+ * reuses FUnrealMcpObjectRef::ResolveObject (path or actor label),
  * matching the tool families' ref rule. "Use selection" fills the input from the current editor selection.
  *
  * Headless-safe: like the other §7 windows, construction guards Slate-only work and the window is registered

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSerializationCheckWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSerializationCheckWindow.h
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+
+class SButton;
+class SCheckBox;
+class SEditableTextBox;
+class SMultiLineEditableTextBox;
+class STextBlock;
+
+/**
+ * The "Serialization Check" window (docs/ARCHITECTURE.md §7, Unity's SerializationCheckWindow analog), a
+ * pure-Slate compound widget — NO UMG / editor-utility dependency. Lets a developer pick a UObject/Actor by
+ * its path-or-label string ref, toggle Recursive, serialize it to pretty-printed JSON, see the elapsed time,
+ * and Copy the output.
+ *
+ * Serialization path (the §22.5/§3.2 in-process JSON converter — NOT a sidecar round-trip): Unreal serializes
+ * objects to JSON in-process via FUnrealMcpPropertyJson::SerializeObject (FJsonObjectConverter over the object's
+ * reflected FProperties), the SAME path the `object-get-data` / `actor-get-data` tools use to return Unreal
+ * object data over MCP. ReflectorNet lives in the .NET sidecar and only wraps the MCP wire layer — the editor
+ * plugin never needs it to serialize a UObject — so this window calls SerializeObject directly on the game
+ * thread. The Recursive toggle mirrors Unity's `recursive` flag: when OFF, nested UObject* references serialize
+ * as their identity (path/name) only; when ON, the full reflected graph is emitted (FJsonObjectConverter walks
+ * referenced sub-objects). Target resolution reuses FUnrealMcpObjectRef::ResolveObject (path or actor label),
+ * matching the tool families' ref rule. "Use selection" fills the input from the current editor selection.
+ *
+ * Headless-safe: like the other §7 windows, construction guards Slate-only work and the window is registered
+ * as a nomad tab by FUnrealMcpAuxWindows. All serialization runs on the game thread (FProperty reads require it).
+ */
+class SUnrealMcpSerializationCheckWindow : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SUnrealMcpSerializationCheckWindow) {}
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+	/**
+	 * The "Recursive OFF" shallow view: keep only the scalar (non-object, non-array) top-level fields of a full
+	 * serialization — the object's identity + flat properties, dropping nested reflected sub-objects. Pure
+	 * JSON→JSON so a spec can assert it without launching Slate; exported so the test module links it. When
+	 * @p Source is null, returns an empty object.
+	 */
+	static UNREALMCPEDITOR_API TSharedRef<class FJsonObject> ShallowFilter(const TSharedPtr<class FJsonObject>& Source);
+
+private:
+	// Build the Information foldout (collapsed help text).
+	TSharedRef<SWidget> BuildInformationFoldout();
+	// Build the Target ref input row + "Use selection" + Recursive + Serialize.
+	TSharedRef<SWidget> BuildInputRow();
+	// Build the Output header + scrollable monospace JSON panel + Copy.
+	TSharedRef<SWidget> BuildOutputSection();
+
+	// Resolve the target ref, serialize via FUnrealMcpPropertyJson, pretty-print, and fill the output.
+	FReply OnSerializeClicked();
+	// Fill the target input from the current editor selection (first selected actor, else first selected object).
+	FReply OnUseSelectionClicked();
+	// Copy the full output text to the clipboard and flash "Copied!" for ~1.5s.
+	FReply OnCopyClicked();
+	// One-shot active-timer callback that restores the Copy label after the "Copied!" flash.
+	EActiveTimerReturnType OnCopyResetTimer(double InCurrentTime, float InDeltaTime);
+
+	// Replace the output panel text + remember the full text for Copy.
+	void SetOutput(const FString& Text);
+
+	// Widgets bound after Construct (read on the game thread only).
+	TSharedPtr<SEditableTextBox> TargetField;
+	TSharedPtr<SCheckBox> RecursiveToggle;
+	TSharedPtr<SMultiLineEditableTextBox> OutputBox;
+	TSharedPtr<SButton> CopyButton;
+
+	// The output header text ("Output" / "Output (NN ms)"), bound live.
+	FText OutputHeader;
+	// The full serialized text the Copy button writes (the OutputBox is read-only but we keep the canonical copy).
+	FString FullOutputText;
+	// The Copy button's resting label; swapped to "Copied!" on click and restored by a timer.
+	FText CopyLabel;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSerializationCheckWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpSerializationCheckWindow.h
@@ -72,7 +72,6 @@ private:
 	TSharedPtr<SEditableTextBox> TargetField;
 	TSharedPtr<SCheckBox> RecursiveToggle;
 	TSharedPtr<SMultiLineEditableTextBox> OutputBox;
-	TSharedPtr<SButton> CopyButton;
 
 	// The output header text ("Output" / "Output (NN ms)"), bound live.
 	FText OutputHeader;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.cpp
@@ -3,6 +3,7 @@
 
 #include "UI/UnrealMcpAuxWindows.h"
 #include "UI/SUnrealMcpSettingsWindow.h"
+#include "UI/SUnrealMcpSerializationCheckWindow.h"
 #include "UI/UnrealMcpEditorViewModel.h"
 #include "UnrealMcpLog.h"
 
@@ -22,6 +23,7 @@ const FName FUnrealMcpAuxWindows::ToolsTabId(TEXT("UnrealMcpToolsWindow"));
 const FName FUnrealMcpAuxWindows::PromptsTabId(TEXT("UnrealMcpPromptsWindow"));
 const FName FUnrealMcpAuxWindows::ResourcesTabId(TEXT("UnrealMcpResourcesWindow"));
 const FName FUnrealMcpAuxWindows::SettingsTabId(TEXT("UnrealMcpSettingsWindow"));
+const FName FUnrealMcpAuxWindows::SerializationCheckTabId(TEXT("UnrealMcpSerializationCheckWindow"));
 
 namespace
 {
@@ -96,6 +98,12 @@ void FUnrealMcpAuxWindows::Register(
 		.SetGroup(Group)
 		.SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "Icons.Toolbar.Settings"));
 
+	TabManager.RegisterNomadTabSpawner(SerializationCheckTabId, FOnSpawnTab::CreateRaw(this, &FUnrealMcpAuxWindows::SpawnSerializationCheckTab))
+		.SetDisplayName(LOCTEXT("SerCheckTabTitle", "Serialization Check"))
+		.SetTooltipText(LOCTEXT("SerCheckTabTooltip", "Serialize a selected UObject/Actor to JSON and inspect the output (Unity-MCP parity)."))
+		.SetGroup(Group)
+		.SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "Icons.Adjust"));
+
 	// Also register the Settings page as a Project Settings section rendering a SECOND SUnrealMcpSettingsWindow
 	// instance (§7) — UE users expect Project Settings discoverability. The nomad tab satisfies the 4-aux-windows
 	// mandate; this is the additional, conventional entry point. Both instances bind the same view-model, so they
@@ -132,7 +140,7 @@ void FUnrealMcpAuxWindows::Unregister()
 		FGlobalTabmanager& TabManager = *FGlobalTabmanager::Get();
 		// Close any live tab first so its hosted widget (a strong view-model ref) is torn down before the runtime
 		// frees the view-model — same use-after-free guard as the main-window tab.
-		for (const FName& TabId : { ToolsTabId, PromptsTabId, ResourcesTabId, SettingsTabId })
+		for (const FName& TabId : { ToolsTabId, PromptsTabId, ResourcesTabId, SettingsTabId, SerializationCheckTabId })
 		{
 			if (TSharedPtr<SDockTab> LiveTab = TabManager.FindExistingLiveTab(TabId))
 				LiveTab->RequestCloseTab();
@@ -196,6 +204,25 @@ TSharedRef<SDockTab> FUnrealMcpAuxWindows::SpawnSettingsTab(const FSpawnTabArgs&
 		.ViewModel(ViewModel)
 		.PortStatusProvider(PortStatusProvider));
 	return Tab;
+}
+
+TSharedRef<SDockTab> FUnrealMcpAuxWindows::SpawnSerializationCheckTab(const FSpawnTabArgs& Args)
+{
+	// The Serialization Check window is self-contained (it serializes in-process via FUnrealMcpPropertyJson and
+	// resolves the target via FUnrealMcpObjectRef) — it binds NO view-model, so there is no teardown race to
+	// guard here (unlike the registry/bridge-backed Tools/Settings windows).
+	TSharedRef<SDockTab> Tab = SNew(SDockTab).TabRole(ETabRole::NomadTab);
+	Tab->SetContent(SNew(SUnrealMcpSerializationCheckWindow));
+	return Tab;
+}
+
+bool FUnrealMcpAuxWindows::TryInvokeSerializationCheckTab()
+{
+	if (!FSlateApplication::IsInitialized())
+		return false; // headless / -nullrhi: nothing to open (matches the Register() headless guard)
+
+	FGlobalTabmanager::Get()->TryInvokeTab(SerializationCheckTabId);
+	return true;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.h
@@ -20,6 +20,8 @@ class FSpawnTabArgs;
  *   - UnrealMcpPromptsWindow   — MCP prompts (honest empty state until a prompts feed lands).
  *   - UnrealMcpResourcesWindow — MCP resources (honest empty state).
  *   - UnrealMcpSettingsWindow  — §8 connection settings (also the ISettingsModule section).
+ *   - UnrealMcpSerializationCheckWindow — serialize a picked UObject/Actor to JSON (Unity-MCP parity); opened
+ *     by the main window's footer "Check" button via the static TryInvokeSerializationCheckTab().
  *
  * Dedup/focus (the known Godot [low] fixed here): nomad tabs are owned by FGlobalTabmanager, which keeps a
  * single live tab per id and FOCUSES the existing one when the menu entry is invoked again — invoking a
@@ -36,6 +38,15 @@ public:
 	static const FName PromptsTabId;
 	static const FName ResourcesTabId;
 	static const FName SettingsTabId;
+	static const FName SerializationCheckTabId;
+
+	/**
+	 * Open (or focus, if already open) the Serialization Check tab. Static so the footer "Check" button and the
+	 * dev-control `check` action can both drive it without holding an FUnrealMcpAuxWindows instance. Guards on
+	 * FSlateApplication::IsInitialized() so a headless / -nullrhi run is a safe no-op. Returns true when a live
+	 * tab was invoked (false when Slate is unavailable). Game-thread only — TryInvokeTab pumps Slate.
+	 */
+	static bool TryInvokeSerializationCheckTab();
 
 	/**
 	 * Register the four nomad tabs + the ISettingsModule settings section. @p InViewModel is the shared state
@@ -67,6 +78,7 @@ private:
 	TSharedRef<SDockTab> SpawnPromptsTab(const FSpawnTabArgs& Args);
 	TSharedRef<SDockTab> SpawnResourcesTab(const FSpawnTabArgs& Args);
 	TSharedRef<SDockTab> SpawnSettingsTab(const FSpawnTabArgs& Args);
+	TSharedRef<SDockTab> SpawnSerializationCheckTab(const FSpawnTabArgs& Args);
 
 	TSharedPtr<FUnrealMcpEditorViewModel> ViewModel;
 	TFunction<TArray<FUnrealMcpToolListEntry>()> ToolListProvider;

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDevControlSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDevControlSpec.cpp
@@ -108,6 +108,9 @@ void FUnrealMcpDevControlSpec::Define()
 			TestEqual("connectionMode", Result->GetStringField(TEXT("connectionMode")), FString(TEXT("Custom")));
 			TestEqual("customHost", Result->GetStringField(TEXT("customHost")), FString(TEXT("http://localhost:8080")));
 			TestEqual("selectedAgentId", Result->GetStringField(TEXT("selectedAgentId")), FString(TEXT("cursor")));
+			// The Serialization Check tab id is exposed so the smoke test can assert the window exists + drive it.
+			TestEqual("serializationCheckTabId", Result->GetStringField(TEXT("serializationCheckTabId")),
+				FString(TEXT("UnrealMcpSerializationCheckWindow")));
 
 			const TArray<TSharedPtr<FJsonValue>>* OutAgents = nullptr;
 			TestTrue("aiAgents present", Result->TryGetArrayField(TEXT("aiAgents"), OutAgents) && OutAgents != nullptr);
@@ -255,6 +258,22 @@ void FUnrealMcpDevControlSpec::Define()
 			TestEqual("status", Status, 200);
 			TestFalse("token changed", VM->GetCustomToken().Equals(Before));
 			TestFalse("token non-empty", VM->GetCustomToken().IsEmpty());
+		});
+
+		It("click=check returns 200 (opens the Serialization Check window; headless no-op)", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"check\"}")), &VM.Get(), Result);
+
+			// `check` opens an aux window rather than mutating the view-model. Under -nullrhi automation the
+			// tab invoke is a guarded no-op, but the route still succeeds (the action was dispatched).
+			TestEqual("status", Status, 200);
+			TestTrue("ok", Result->GetBoolField(TEXT("ok")));
+			TestEqual("target echoed", Result->GetStringField(TEXT("target")), FString(TEXT("check")));
 		});
 
 		It("rejects an unknown click target with 400", [this]()

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSerializationCheckSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSerializationCheckSpec.cpp
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "UI/SUnrealMcpSerializationCheckWindow.h"
+#include "Tools/UnrealMcpPropertyJson.h"
+
+#include "GameFramework/Actor.h"
+
+/**
+ * Serialization Check window specs (docs/ARCHITECTURE.md §7, Unity's SerializationCheckWindow parity): the
+ * HEADLESS-provable core of the window WITHOUT launching Slate — (1) the Recursive=OFF shallow filter
+ * (SUnrealMcpSerializationCheckWindow::ShallowFilter, pure JSON→JSON), and (2) that the in-process
+ * serialization path the window uses (FUnrealMcpPropertyJson::SerializeObject — the SAME converter the
+ * object-get-data / actor-get-data tools use, NOT a sidecar/ReflectorNet round-trip) yields a non-empty
+ * reflected object for a real UObject. The Slate window itself (target picker, output panel, Copy flash) is
+ * windowed-verified by the operator; these specs lock the serialization contract underneath it.
+ *
+ * Helpers carry the spec-unique `SerChk` prefix (CLAUDE.md unity-build ODR rule).
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpSerializationCheckSpec, "UnrealMcp.SerializationCheck",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	// Build a full-serialization-shaped object with a mix of scalar and nested fields, the way
+	// FJsonObjectConverter emits one for a reflected UObject.
+	static TSharedRef<FJsonObject> SerChkMakeMixed()
+	{
+		TSharedRef<FJsonObject> Obj = MakeShared<FJsonObject>();
+		Obj->SetStringField(TEXT("name"), TEXT("Cube"));
+		Obj->SetNumberField(TEXT("count"), 3);
+		Obj->SetBoolField(TEXT("hidden"), false);
+
+		// A nested object field (e.g. rootComponent) — dropped by the shallow view.
+		TSharedRef<FJsonObject> Nested = MakeShared<FJsonObject>();
+		Nested->SetNumberField(TEXT("x"), 1.0);
+		Obj->SetObjectField(TEXT("rootComponent"), Nested);
+
+		// An array field — also dropped by the shallow view.
+		TArray<TSharedPtr<FJsonValue>> Tags;
+		Tags.Add(MakeShared<FJsonValueString>(TEXT("a")));
+		Obj->SetArrayField(TEXT("tags"), Tags);
+		return Obj;
+	}
+
+END_DEFINE_SPEC(FUnrealMcpSerializationCheckSpec)
+
+void FUnrealMcpSerializationCheckSpec::Define()
+{
+	Describe("Shallow filter (Recursive OFF)", [this]()
+	{
+		It("keeps scalar fields and drops nested objects + arrays", [this]()
+		{
+			const TSharedRef<FJsonObject> Shallow = SUnrealMcpSerializationCheckWindow::ShallowFilter(SerChkMakeMixed());
+
+			TestTrue("scalar string kept", Shallow->HasField(TEXT("name")));
+			TestTrue("scalar number kept", Shallow->HasField(TEXT("count")));
+			TestTrue("scalar bool kept", Shallow->HasField(TEXT("hidden")));
+			TestFalse("nested object dropped", Shallow->HasField(TEXT("rootComponent")));
+			TestFalse("array dropped", Shallow->HasField(TEXT("tags")));
+			TestEqual("name value preserved", Shallow->GetStringField(TEXT("name")), FString(TEXT("Cube")));
+		});
+
+		It("returns an empty object for a null source (no crash)", [this]()
+		{
+			const TSharedRef<FJsonObject> Shallow = SUnrealMcpSerializationCheckWindow::ShallowFilter(nullptr);
+			TestEqual("empty", Shallow->Values.Num(), 0);
+		});
+	});
+
+	Describe("In-process serialization path", [this]()
+	{
+		It("serializes a real UObject to a non-empty reflected object (the window's path)", [this]()
+		{
+			// Use a transient AActor CDO-free instance is heavy; the transient package + a plain UObject is enough
+			// to prove SerializeObject walks reflected FProperties without a sidecar. AActor has reflected props.
+			AActor* Actor = NewObject<AActor>(GetTransientPackage());
+			TestNotNull("actor created", Actor);
+			if (!Actor)
+				return;
+
+			const TSharedPtr<FJsonObject> Json = FUnrealMcpPropertyJson::SerializeObject(Actor, /*Paths*/ {});
+			TestTrue("json valid", Json.IsValid());
+			if (Json.IsValid())
+				TestTrue("non-empty reflected object", Json->Values.Num() > 0);
+		});
+
+		It("returns an empty object for a null target (no crash)", [this]()
+		{
+			const TSharedPtr<FJsonObject> Json = FUnrealMcpPropertyJson::SerializeObject(nullptr, /*Paths*/ {});
+			TestTrue("json valid", Json.IsValid());
+			if (Json.IsValid())
+				TestEqual("empty", Json->Values.Num(), 0);
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSerializationCheckSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpSerializationCheckSpec.cpp
@@ -76,8 +76,8 @@ void FUnrealMcpSerializationCheckSpec::Define()
 	{
 		It("serializes a real UObject to a non-empty reflected object (the window's path)", [this]()
 		{
-			// Use a transient AActor CDO-free instance is heavy; the transient package + a plain UObject is enough
-			// to prove SerializeObject walks reflected FProperties without a sidecar. AActor has reflected props.
+			// Construct a transient AActor instance (not the CDO) to prove SerializeObject walks reflected
+			// FProperties without a sidecar. AActor has reflected props, so the result is a non-empty object.
 			AActor* Actor = NewObject<AActor>(GetTransientPackage());
 			TestNotNull("actor created", Actor);
 			if (!Actor)


### PR DESCRIPTION
## Summary
- Adds a **"Check"** button to the AI Game Developer window footer that opens a new **Serialization Check** aux window — the Unreal analog of Unity-MCP's `SerializationCheckWindow`. Pick a UObject/Actor (by actor label / object path, or "Use selection"), toggle **Recursive**, **Serialize** to pretty-printed JSON, see elapsed time, and **Copy** (with "Copied!" flash).
- Serialization runs **in-process** via `FUnrealMcpPropertyJson::SerializeObject` (`FJsonObjectConverter` over the object's reflected `FProperty`s) — the **same path** the `object-get-data` / `actor-get-data` MCP tools already use. **No sidecar round-trip / no ReflectorNet**: ReflectorNet lives only in the .NET sidecar and wraps the MCP wire layer; the C++ editor serializes UObjects locally. Recursive OFF prunes nested object/array fields to a shallow scalar view; ON emits the full reflected graph.
- New `SUnrealMcpSerializationCheckWindow` (pure Slate, reuses `FUnrealMcpStyle` + `SUnrealMcpAgentWidgets`), registered as a 5th nomad aux tab; opened via the static `FUnrealMcpAuxWindows::TryInvokeSerializationCheckTab()` (headless-safe).
- Dev-control bridge: new `/control/click` target **`check`** + `serializationCheckTabId` in `/state`, so the smoke-test task can drive and assert the window.

## Serialization path (investigated, per the task's critical architecture note)
`FUnrealMcpPropertyJson::SerializeObject(UObject*, Paths)` (`UnrealMCP/.../Private/Tools/UnrealMcpPropertyJson.cpp`) is the established in-process converter used by the actor/object tool families. The window calls it directly on the game thread — the documented, non-parallel path.

## Test plan
- [x] UBT build `UnrealTestProjectEditor Win64 Development` — exit 0.
- [x] Headless smoke — `[Unreal-MCP] plugin loaded` + `Engine is initialized` (clean on graceful `Quit`; the `QUIT_EDITOR` exit-3 is the pre-existing engine-side Slate teardown crash documented in the test profile, not a load failure).
- [x] Automation `UnrealMcp.` — `failed: 0`, `succeeded: 252` (incl. new `UnrealMcp.SerializationCheck.*` + `UnrealMcp.DevControl` `check` / `serializationCheckTabId` specs).
- [ ] Windowed layout vs the Unity reference — operator-verified (not headless-provable).

Closes #86