### PR TITLE
test(plugin): bridge-driven smoke coverage for every AI Game Developer window control

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
@@ -4,6 +4,7 @@
 #include "DevControl/UnrealMcpDevControlServer.h"
 #include "UI/UnrealMcpEditorViewModel.h"
 #include "UI/UnrealMcpAuxWindows.h"
+#include "UI/UnrealMcpExternalLinks.h"
 #include "Config/UnrealMcpConfig.h"
 #include "UnrealMcpLog.h"
 
@@ -58,6 +59,46 @@ namespace
 		if (Raw.Equals(TEXT("Cloud"), ESearchCase::IgnoreCase)) { OutMode = EUnrealMcpConnectionMode::Cloud; return true; }
 		if (Raw.Equals(TEXT("Custom"), ESearchCase::IgnoreCase)) { OutMode = EUnrealMcpConnectionMode::Custom; return true; }
 		return false;
+	}
+
+	// The transport string the dev-control surface speaks ("stdio"/"http") — matches the §7 segmented control.
+	const TCHAR* DevControlTransportLabel(EUnrealMcpTransportMethod Transport)
+	{
+		return Transport == EUnrealMcpTransportMethod::Http ? TEXT("http") : TEXT("stdio");
+	}
+
+	// Parse a "stdio"/"http" transport string (case-insensitive). Returns true + the transport on a match.
+	bool DevControlParseTransport(const FString& Raw, EUnrealMcpTransportMethod& OutTransport)
+	{
+		if (Raw.Equals(TEXT("stdio"), ESearchCase::IgnoreCase)) { OutTransport = EUnrealMcpTransportMethod::Stdio; return true; }
+		if (Raw.Equals(TEXT("http"), ESearchCase::IgnoreCase))  { OutTransport = EUnrealMcpTransportMethod::Http;  return true; }
+		return false;
+	}
+
+	// The auth-option string the dev-control surface speaks ("none"/"required") — matches the §7 segmented control.
+	const TCHAR* DevControlAuthOptionLabel(EUnrealMcpAuthOption Option)
+	{
+		return Option == EUnrealMcpAuthOption::Required ? TEXT("required") : TEXT("none");
+	}
+
+	// Parse a "none"/"required" auth-option string (case-insensitive). Returns true + the option on a match.
+	bool DevControlParseAuthOption(const FString& Raw, EUnrealMcpAuthOption& OutOption)
+	{
+		if (Raw.Equals(TEXT("none"), ESearchCase::IgnoreCase))     { OutOption = EUnrealMcpAuthOption::None;     return true; }
+		if (Raw.Equals(TEXT("required"), ESearchCase::IgnoreCase)) { OutOption = EUnrealMcpAuthOption::Required; return true; }
+		return false;
+	}
+
+	// The canonical device-code auth-state label the /state snapshot reports (the §7 Authorize/Cancel/Revoke flow).
+	const TCHAR* DevControlDeviceAuthLabel(EUnrealMcpDeviceAuthState State)
+	{
+		switch (State)
+		{
+			case EUnrealMcpDeviceAuthState::Pending:    return TEXT("Pending");
+			case EUnrealMcpDeviceAuthState::Authorized: return TEXT("Authorized");
+			case EUnrealMcpDeviceAuthState::Failed:     return TEXT("Failed");
+			case EUnrealMcpDeviceAuthState::Idle: default: return TEXT("Idle");
+		}
 	}
 
 	// Build a `{"ok":false,"error":<msg>}` result into OutResult and return the given status code.
@@ -132,9 +173,14 @@ bool FUnrealMcpDevControlServer::Start(uint32 Port, const TSharedPtr<FUnrealMcpE
 	Bind(TEXT("/health"),                   EHttpServerRequestVerbs::VERB_GET,  TEXT("GET"));
 	Bind(TEXT("/state"),                    EHttpServerRequestVerbs::VERB_GET,  TEXT("GET"));
 	Bind(TEXT("/inject/connection-status"), EHttpServerRequestVerbs::VERB_POST, TEXT("POST"));
+	Bind(TEXT("/inject/device-auth"),       EHttpServerRequestVerbs::VERB_POST, TEXT("POST"));
 	Bind(TEXT("/control/server-url"),       EHttpServerRequestVerbs::VERB_POST, TEXT("POST"));
 	Bind(TEXT("/control/connection-mode"),  EHttpServerRequestVerbs::VERB_POST, TEXT("POST"));
+	Bind(TEXT("/control/transport"),        EHttpServerRequestVerbs::VERB_POST, TEXT("POST"));
+	Bind(TEXT("/control/auth-option"),      EHttpServerRequestVerbs::VERB_POST, TEXT("POST"));
+	Bind(TEXT("/control/auth-token"),       EHttpServerRequestVerbs::VERB_POST, TEXT("POST"));
 	Bind(TEXT("/control/select-agent"),     EHttpServerRequestVerbs::VERB_POST, TEXT("POST"));
+	Bind(TEXT("/control/external-link"),    EHttpServerRequestVerbs::VERB_POST, TEXT("POST"));
 	Bind(TEXT("/control/click"),            EHttpServerRequestVerbs::VERB_POST, TEXT("POST"));
 
 	// FHttpServerModule only ticks listeners that have been started; start them so this router accepts.
@@ -249,6 +295,25 @@ int32 FUnrealMcpDevControlServer::RouteRequest(
 		OutResult->SetStringField(TEXT("connectionMode"), DevControlConnectionModeLabel(ViewModelPtr->GetConnectionMode()));
 		OutResult->SetStringField(TEXT("customHost"), ViewModelPtr->GetCustomHost());
 		OutResult->SetStringField(TEXT("selectedAgentId"), ViewModelPtr->GetSelectedAgentId());
+		// Transport / auth readouts so the smoke test can assert the §7 segmented controls + token field reacted.
+		OutResult->SetStringField(TEXT("transport"), DevControlTransportLabel(ViewModelPtr->GetEffectiveTransport()));
+		OutResult->SetBoolField(TEXT("transportSelectable"), ViewModelPtr->IsTransportSelectable());
+		OutResult->SetStringField(TEXT("authOption"), DevControlAuthOptionLabel(ViewModelPtr->GetAuthOption()));
+		// The custom token is reported MASKED only (§8 — the raw bearer never crosses the dev-control wire);
+		// `hasCustomToken` lets a test assert presence without leaking the value.
+		OutResult->SetStringField(TEXT("customTokenMasked"),
+			FUnrealMcpEditorViewModel::MaskTokenForDisplay(ViewModelPtr->GetCustomToken(), /*bReveal*/ false));
+		OutResult->SetBoolField(TEXT("hasCustomToken"), !ViewModelPtr->GetCustomToken().IsEmpty());
+		// Cloud device-auth + connection readouts (the status dots/labels mirror these).
+		OutResult->SetStringField(TEXT("deviceAuthState"), DevControlDeviceAuthLabel(ViewModelPtr->GetDeviceAuthState()));
+		OutResult->SetBoolField(TEXT("hasCloudToken"), ViewModelPtr->HasCloudToken());
+		OutResult->SetBoolField(TEXT("keepConnected"), ViewModelPtr->IsReconnectArmed());
+		// The Connect/Disconnect/Stop button label + the "Unreal: <status>" label the dock renders for this state,
+		// so the smoke test asserts the exact text a screenshot would show without reading pixels.
+		OutResult->SetStringField(TEXT("buttonLabel"),
+			FUnrealMcpEditorViewModel::GetButtonText(ViewModelPtr->GetConnectionState()).ToString());
+		OutResult->SetStringField(TEXT("statusLabel"),
+			FUnrealMcpEditorViewModel::GetStatusLabel(ViewModelPtr->GetConnectionState()).ToString());
 		// The Serialization Check window's tab id — lets the smoke test assert membership and (with a
 		// `check` click) drive the same footer "Check" button the dock renders.
 		OutResult->SetStringField(TEXT("serializationCheckTabId"), FUnrealMcpAuxWindows::SerializationCheckTabId.ToString());
@@ -257,6 +322,15 @@ int32 FUnrealMcpDevControlServer::RouteRequest(
 		for (const FString& Agent : ViewModelPtr->GetAiAgents())
 			Agents.Add(MakeShared<FJsonValueString>(Agent));
 		OutResult->SetArrayField(TEXT("aiAgents"), Agents);
+		OutResult->SetNumberField(TEXT("aiAgentCount"), ViewModelPtr->GetAiAgents().Num());
+
+		// The footer external links (assert intent, never launched) — the same urls UnrealMcpExternalLinks feeds
+		// the Help/Talk, Bug Report and GitHub Star buttons.
+		TSharedPtr<FJsonObject> Links = MakeShared<FJsonObject>();
+		Links->SetStringField(TEXT("help"), FUnrealMcpExternalLinks::Discord());
+		Links->SetStringField(TEXT("bug"), FUnrealMcpExternalLinks::Issues());
+		Links->SetStringField(TEXT("star"), FUnrealMcpExternalLinks::Star());
+		OutResult->SetObjectField(TEXT("externalLinks"), Links);
 		return 200;
 	}
 
@@ -290,6 +364,25 @@ int32 FUnrealMcpDevControlServer::RouteRequest(
 		return 200;
 	}
 
+	if (Path == TEXT("/inject/device-auth"))
+	{
+		// Inject a §1.3 `device-auth` feed message verbatim (state / verificationUrl / userCode / token / message)
+		// so the smoke test can drive the Cloud device-code rows (Pending code row, Authorized indicator, Failed
+		// reason) the same way the sidecar would. The body IS the device-auth envelope; a missing `state` is a 400.
+		FString DeviceState;
+		if (!Body.IsValid() || !Body->TryGetStringField(TEXT("state"), DeviceState) || DeviceState.IsEmpty())
+		{
+			DevControlFail(OutResult, TEXT("missing 'state' (pending|authorized|failed)"));
+			return 400;
+		}
+		ViewModelPtr->ApplyDeviceAuth(Body);
+
+		OutResult->SetBoolField(TEXT("ok"), true);
+		OutResult->SetStringField(TEXT("deviceAuthState"), DevControlDeviceAuthLabel(ViewModelPtr->GetDeviceAuthState()));
+		OutResult->SetBoolField(TEXT("hasCloudToken"), ViewModelPtr->HasCloudToken());
+		return 200;
+	}
+
 	if (Path == TEXT("/control/server-url"))
 	{
 		FString Url;
@@ -319,6 +412,57 @@ int32 FUnrealMcpDevControlServer::RouteRequest(
 		return 200;
 	}
 
+	if (Path == TEXT("/control/transport"))
+	{
+		FString TransportRaw;
+		EUnrealMcpTransportMethod Transport;
+		if (!Body.IsValid() || !Body->TryGetStringField(TEXT("transport"), TransportRaw) || !DevControlParseTransport(TransportRaw, Transport))
+		{
+			DevControlFail(OutResult, TEXT("missing/invalid 'transport' (stdio|http)"));
+			return 400;
+		}
+		// SetTransportMethod is a no-op in Cloud mode (the selector is locked to Http); the echoed effective
+		// transport tells the caller what actually took (mirrors the §7 segmented control's locked state).
+		ViewModelPtr->SetTransportMethod(Transport);
+		OutResult->SetBoolField(TEXT("ok"), true);
+		OutResult->SetStringField(TEXT("transport"), DevControlTransportLabel(ViewModelPtr->GetEffectiveTransport()));
+		OutResult->SetBoolField(TEXT("transportSelectable"), ViewModelPtr->IsTransportSelectable());
+		return 200;
+	}
+
+	if (Path == TEXT("/control/auth-option"))
+	{
+		FString OptionRaw;
+		EUnrealMcpAuthOption Option;
+		if (!Body.IsValid() || !Body->TryGetStringField(TEXT("option"), OptionRaw) || !DevControlParseAuthOption(OptionRaw, Option))
+		{
+			DevControlFail(OutResult, TEXT("missing/invalid 'option' (none|required)"));
+			return 400;
+		}
+		ViewModelPtr->SetAuthOption(Option);
+		OutResult->SetBoolField(TEXT("ok"), true);
+		OutResult->SetStringField(TEXT("authOption"), DevControlAuthOptionLabel(ViewModelPtr->GetAuthOption()));
+		return 200;
+	}
+
+	if (Path == TEXT("/control/auth-token"))
+	{
+		FString Token;
+		if (!Body.IsValid() || !Body->TryGetStringField(TEXT("token"), Token))
+		{
+			DevControlFail(OutResult, TEXT("missing 'token'"));
+			return 400;
+		}
+		// Set the Custom-mode bearer the §7 token field commits. The response reports presence + the MASKED
+		// form only — the raw token never crosses the dev-control wire (§8).
+		ViewModelPtr->SetCustomToken(Token);
+		OutResult->SetBoolField(TEXT("ok"), true);
+		OutResult->SetBoolField(TEXT("hasCustomToken"), !ViewModelPtr->GetCustomToken().IsEmpty());
+		OutResult->SetStringField(TEXT("customTokenMasked"),
+			FUnrealMcpEditorViewModel::MaskTokenForDisplay(ViewModelPtr->GetCustomToken(), /*bReveal*/ false));
+		return 200;
+	}
+
 	if (Path == TEXT("/control/select-agent"))
 	{
 		FString AgentId;
@@ -333,24 +477,50 @@ int32 FUnrealMcpDevControlServer::RouteRequest(
 		return 200;
 	}
 
+	if (Path == TEXT("/control/external-link"))
+	{
+		// Resolve a footer external-link button to the url it WOULD launch — assert intent, never open a browser
+		// (the dev-control bridge never launches a URL; that side effect belongs to the live Slate button only).
+		FString LinkName;
+		FString Url;
+		if (!Body.IsValid() || !Body->TryGetStringField(TEXT("link"), LinkName) || !FUnrealMcpExternalLinks::Resolve(LinkName, Url))
+		{
+			DevControlFail(OutResult, TEXT("missing/invalid 'link' (help|bug|star)"));
+			return 400;
+		}
+		OutResult->SetBoolField(TEXT("ok"), true);
+		OutResult->SetStringField(TEXT("link"), LinkName.ToLower());
+		OutResult->SetStringField(TEXT("url"), Url);
+		OutResult->SetBoolField(TEXT("launched"), false); // intent only — never opened
+		return 200;
+	}
+
 	if (Path == TEXT("/control/click"))
 	{
 		FString Target;
 		if (!Body.IsValid() || !Body->TryGetStringField(TEXT("target"), Target) || Target.IsEmpty())
 		{
-			DevControlFail(OutResult, TEXT("missing 'target' (connect|disconnect|authorize|revoke|generate-token|check)"));
+			DevControlFail(OutResult, TEXT("missing 'target' (connect|start|disconnect|stop|authorize|cancel|revoke|generate-token|check|restart-bridge|open-log)"));
 			return 400;
 		}
 
 		// Map the click target onto the matching view-model mutator — the same action the Slate button fires.
-		// `check` is the odd one out: it opens the Serialization Check aux window rather than mutating the
-		// view-model, so it routes through the static aux-window invoker (a headless no-op — see the helper).
+		// `start` is the MCP-server Start button (a (re)Connect); `stop` is the tri-state Disconnect/Stop. `check`,
+		// `restart-bridge` and `open-log` do NOT mutate the view-model: `check` opens the Serialization Check aux
+		// window (headless no-op via the static invoker); `restart-bridge` (a runtime bridge restart) and `open-log`
+		// (a folder-explore) are runtime/Slate side effects the dev-control bridge deliberately does NOT perform —
+		// they are acknowledged as dispatched intents so the smoke test can exercise every footer button.
 		if (Target.Equals(TEXT("connect"), ESearchCase::IgnoreCase))               ViewModelPtr->Connect();
+		else if (Target.Equals(TEXT("start"), ESearchCase::IgnoreCase))            ViewModelPtr->Connect();
 		else if (Target.Equals(TEXT("disconnect"), ESearchCase::IgnoreCase))       ViewModelPtr->Disconnect();
+		else if (Target.Equals(TEXT("stop"), ESearchCase::IgnoreCase))             ViewModelPtr->Disconnect();
 		else if (Target.Equals(TEXT("authorize"), ESearchCase::IgnoreCase))        ViewModelPtr->Authorize();
+		else if (Target.Equals(TEXT("cancel"), ESearchCase::IgnoreCase))           ViewModelPtr->CancelAuth();
 		else if (Target.Equals(TEXT("revoke"), ESearchCase::IgnoreCase))           ViewModelPtr->Revoke();
 		else if (Target.Equals(TEXT("generate-token"), ESearchCase::IgnoreCase))   ViewModelPtr->GenerateCustomToken();
 		else if (Target.Equals(TEXT("check"), ESearchCase::IgnoreCase))            FUnrealMcpAuxWindows::TryInvokeSerializationCheckTab();
+		else if (Target.Equals(TEXT("restart-bridge"), ESearchCase::IgnoreCase))   { /* runtime side effect — intent only */ }
+		else if (Target.Equals(TEXT("open-log"), ESearchCase::IgnoreCase))         { /* Slate folder-explore — intent only */ }
 		else
 		{
 			DevControlFail(OutResult, FString::Printf(TEXT("unknown click target '%s'"), *Target));

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -5,6 +5,7 @@
 #include "UI/SUnrealMcpAgentConfigurators.h"
 #include "UI/SUnrealMcpAgentWidgets.h"
 #include "UI/UnrealMcpAuxWindows.h"
+#include "UI/UnrealMcpExternalLinks.h"
 #include "UI/FUnrealMcpStyle.h"
 #include "UnrealMcpLog.h"
 
@@ -34,9 +35,10 @@ using UnrealMcpStyleWidgets::EDot;
 namespace
 {
 	// Footer links (mirrors the Unity reference footer: Discord Help/Talk, GitHub bug report, GitHub star).
-	const FString DiscordUrl = TEXT("https://discord.gg/");
-	const FString IssuesUrl  = TEXT("https://github.com/IvanMurzak/Unreal-MCP/issues");
-	const FString StarUrl    = TEXT("https://github.com/IvanMurzak/Unreal-MCP");
+	// Single source of truth in UnrealMcpExternalLinks.h so the dev-control bridge reports the SAME urls.
+	const FString DiscordUrl = FUnrealMcpExternalLinks::Discord();
+	const FString IssuesUrl  = FUnrealMcpExternalLinks::Issues();
+	const FString StarUrl    = FUnrealMcpExternalLinks::Star();
 
 	// Segment value-tags for the segmented controls (the int the control reports; mapped to the enums here).
 	constexpr int32 TagCustom = 0;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpExternalLinks.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpExternalLinks.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * The canonical external-link URLs the "AI Game Developer" window footer launches (docs/ARCHITECTURE.md §7,
+ * mirroring the Unity reference footer): Discord Help/Talk, the GitHub issues bug-report page, and the
+ * GitHub repo "Star" page. Lifted out of SUnrealMcpMainWindow.cpp into one header so the dev-control bridge
+ * can report + validate the SAME url a footer button would launch (`assert intent, don't open` — the
+ * headless smoke test reads these without opening a browser), keeping a single source of truth for both.
+ */
+struct FUnrealMcpExternalLinks
+{
+	/** Discord invite — the footer "Help / Talk" button. */
+	static const TCHAR* Discord() { return TEXT("https://discord.gg/cfbdMZX99G"); }
+	/** GitHub issues — the footer "Bug Report" button. */
+	static const TCHAR* Issues()  { return TEXT("https://github.com/IvanMurzak/Unreal-MCP/issues"); }
+	/** GitHub repo — the footer golden "GitHub Star" button. */
+	static const TCHAR* Star()    { return TEXT("https://github.com/IvanMurzak/Unreal-MCP"); }
+
+	/**
+	 * Resolve a dev-control external-link name ("help"|"discord", "bug"|"issues", "star"|"github") to the URL
+	 * the matching footer button would launch. Returns true + the URL on a match; false for an unknown name.
+	 * Pure — never opens a browser (the dev-control `external-link` action asserts intent only).
+	 */
+	static bool Resolve(const FString& Name, FString& OutUrl)
+	{
+		if (Name.Equals(TEXT("help"), ESearchCase::IgnoreCase) || Name.Equals(TEXT("discord"), ESearchCase::IgnoreCase))
+		{
+			OutUrl = Discord();
+			return true;
+		}
+		if (Name.Equals(TEXT("bug"), ESearchCase::IgnoreCase) || Name.Equals(TEXT("issues"), ESearchCase::IgnoreCase))
+		{
+			OutUrl = Issues();
+			return true;
+		}
+		if (Name.Equals(TEXT("star"), ESearchCase::IgnoreCase) || Name.Equals(TEXT("github"), ESearchCase::IgnoreCase))
+		{
+			OutUrl = Star();
+			return true;
+		}
+		return false;
+	}
+};

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDevControlSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDevControlSpec.cpp
@@ -120,6 +120,47 @@ void FUnrealMcpDevControlSpec::Define()
 				if (OutAgents->Num() == 1)
 					TestEqual("aiAgents[0]", (*OutAgents)[0]->AsString(), FString(TEXT("Claude Code")));
 			}
+			TestEqual("aiAgentCount", (int32)Result->GetNumberField(TEXT("aiAgentCount")), 1);
+		});
+
+		It("reports the transport / auth / device-auth / readout fields and the footer external links", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			VM->SetTransportMethod(EUnrealMcpTransportMethod::Stdio);
+			VM->SetAuthOption(EUnrealMcpAuthOption::Required);
+			VM->SetCustomToken(TEXT("super-secret-bearer-1234567890"));
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(TEXT("GET"), TEXT("/state"), nullptr, &VM.Get(), Result);
+			TestEqual("status", Status, 200);
+
+			// Transport + selectability mirror the §7 segmented control.
+			TestEqual("transport", Result->GetStringField(TEXT("transport")), FString(TEXT("stdio")));
+			TestTrue("transport selectable in Custom", Result->GetBoolField(TEXT("transportSelectable")));
+			// Auth option + token presence; the raw token is NEVER reported (§8) — only the masked form.
+			TestEqual("authOption", Result->GetStringField(TEXT("authOption")), FString(TEXT("required")));
+			TestTrue("hasCustomToken", Result->GetBoolField(TEXT("hasCustomToken")));
+			const FString MaskedInState = Result->GetStringField(TEXT("customTokenMasked"));
+			TestFalse("masked token is not the raw value", MaskedInState.Equals(TEXT("super-secret-bearer-1234567890")));
+			TestFalse("masked token leaks no raw substring", MaskedInState.Contains(TEXT("secret")));
+			// Device-auth + connection readouts.
+			TestEqual("deviceAuthState idle by default", Result->GetStringField(TEXT("deviceAuthState")), FString(TEXT("Idle")));
+			TestFalse("no cloud token", Result->GetBoolField(TEXT("hasCloudToken")));
+			// Status dot/label readouts the smoke test asserts instead of reading pixels.
+			TestFalse("buttonLabel non-empty", Result->GetStringField(TEXT("buttonLabel")).IsEmpty());
+			TestFalse("statusLabel non-empty", Result->GetStringField(TEXT("statusLabel")).IsEmpty());
+
+			// The footer external links — assert intent (the same urls the Help/Bug/Star buttons launch).
+			const TSharedPtr<FJsonObject>* Links = nullptr;
+			TestTrue("externalLinks present", Result->TryGetObjectField(TEXT("externalLinks"), Links) && Links != nullptr);
+			if (Links)
+			{
+				TestTrue("help link is discord", (*Links)->GetStringField(TEXT("help")).Contains(TEXT("discord.gg")));
+				TestTrue("bug link is github issues", (*Links)->GetStringField(TEXT("bug")).Contains(TEXT("/issues")));
+				TestTrue("star link is the repo", (*Links)->GetStringField(TEXT("star")).Contains(TEXT("IvanMurzak/Unreal-MCP")));
+			}
 		});
 	});
 
@@ -276,6 +317,73 @@ void FUnrealMcpDevControlSpec::Define()
 			TestEqual("target echoed", Result->GetStringField(TEXT("target")), FString(TEXT("check")));
 		});
 
+		It("click=start (the MCP-server Start button) arms reconnect and goes Connecting", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"start\"}")), &VM.Get(), Result);
+
+			TestEqual("status", Status, 200);
+			TestTrue("reconnect armed", VM->IsReconnectArmed());
+			TestEqual("state", VM->GetConnectionState(), EUnrealMcpConnectionState::Connecting);
+		});
+
+		It("click=stop (the tri-state Stop button) halts the reconnect loop", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			VM->Connect();
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"stop\"}")), &VM.Get(), Result);
+
+			TestEqual("status", Status, 200);
+			TestFalse("reconnect disarmed", VM->IsReconnectArmed());
+			TestEqual("state", VM->GetConnectionState(), EUnrealMcpConnectionState::Disconnected);
+		});
+
+		It("click=authorize then click=cancel drives the device-auth flow back to Idle", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+
+			TSharedRef<FJsonObject> AuthResult = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"authorize\"}")), &VM.Get(), AuthResult);
+			TestEqual("pending after authorize", VM->GetDeviceAuthState(), EUnrealMcpDeviceAuthState::Pending);
+			TestTrue("auth-start sent", Rec->AuthSent.Contains(TEXT("auth-start")));
+
+			TSharedRef<FJsonObject> CancelResult = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"cancel\"}")), &VM.Get(), CancelResult);
+			TestEqual("status", Status, 200);
+			TestEqual("idle after cancel (no stored token)", VM->GetDeviceAuthState(), EUnrealMcpDeviceAuthState::Idle);
+		});
+
+		It("click=restart-bridge / open-log are acknowledged intents (no view-model mutation)", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			const int32 PushBefore = Rec->PushCount;
+
+			TSharedRef<FJsonObject> R1 = MakeShared<FJsonObject>();
+			TestEqual("restart-bridge status", FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"restart-bridge\"}")), &VM.Get(), R1), 200);
+			TestTrue("restart-bridge ok", R1->GetBoolField(TEXT("ok")));
+
+			TSharedRef<FJsonObject> R2 = MakeShared<FJsonObject>();
+			TestEqual("open-log status", FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"open-log\"}")), &VM.Get(), R2), 200);
+			TestTrue("open-log ok", R2->GetBoolField(TEXT("ok")));
+
+			// Neither launches a side effect through the view-model (no config push).
+			TestEqual("no config push for intent-only clicks", Rec->PushCount, PushBefore);
+		});
+
 		It("rejects an unknown click target with 400", [this]()
 		{
 			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
@@ -285,6 +393,197 @@ void FUnrealMcpDevControlSpec::Define()
 				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"explode\"}")), &VM.Get(), Result);
 			TestEqual("status", Status, 400);
 			TestFalse("not ok", Result->GetBoolField(TEXT("ok")));
+		});
+	});
+
+	Describe("Transport / auth-option / auth-token routes (§7 segmented controls + token field)", [this]()
+	{
+		It("transport drives SetTransportMethod and echoes the effective transport", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/transport"), DevCtlBody(TEXT("{\"transport\":\"http\"}")), &VM.Get(), Result);
+
+			TestEqual("status", Status, 200);
+			TestEqual("effective transport", VM->GetEffectiveTransport(), EUnrealMcpTransportMethod::Http);
+			TestEqual("echoed transport", Result->GetStringField(TEXT("transport")), FString(TEXT("http")));
+		});
+
+		It("transport is locked to http in Cloud mode (echo reflects the lock)", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Cloud);
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/transport"), DevCtlBody(TEXT("{\"transport\":\"stdio\"}")), &VM.Get(), Result);
+
+			TestEqual("status", Status, 200);
+			// Cloud forces Http and the selector is not user-editable — the stray stdio set is ignored.
+			TestEqual("echoed transport stays http", Result->GetStringField(TEXT("transport")), FString(TEXT("http")));
+			TestFalse("not selectable in Cloud", Result->GetBoolField(TEXT("transportSelectable")));
+		});
+
+		It("rejects an invalid transport with 400", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/transport"), DevCtlBody(TEXT("{\"transport\":\"carrier-pigeon\"}")), &VM.Get(), Result);
+			TestEqual("status", Status, 400);
+		});
+
+		It("auth-option drives SetAuthOption", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/auth-option"), DevCtlBody(TEXT("{\"option\":\"required\"}")), &VM.Get(), Result);
+
+			TestEqual("status", Status, 200);
+			TestEqual("auth option", VM->GetAuthOption(), EUnrealMcpAuthOption::Required);
+			TestEqual("echoed auth option", Result->GetStringField(TEXT("authOption")), FString(TEXT("required")));
+		});
+
+		It("rejects an invalid auth-option with 400", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/auth-option"), DevCtlBody(TEXT("{\"option\":\"maybe\"}")), &VM.Get(), Result);
+			TestEqual("status", Status, 400);
+		});
+
+		It("auth-token drives SetCustomToken and reports only the masked form (§8)", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/auth-token"), DevCtlBody(TEXT("{\"token\":\"super-secret-bearer-1234567890\"}")), &VM.Get(), Result);
+
+			TestEqual("status", Status, 200);
+			TestEqual("token stored in view-model", VM->GetCustomToken(), FString(TEXT("super-secret-bearer-1234567890")));
+			TestTrue("hasCustomToken", Result->GetBoolField(TEXT("hasCustomToken")));
+			// The raw token is NEVER reported back over the dev-control wire.
+			const FString Masked = Result->GetStringField(TEXT("customTokenMasked"));
+			TestFalse("masked != raw", Masked.Equals(TEXT("super-secret-bearer-1234567890")));
+			TestFalse("masked leaks no raw substring", Masked.Contains(TEXT("secret")));
+		});
+
+		It("rejects a missing auth-token with 400", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/auth-token"), DevCtlBody(TEXT("{}")), &VM.Get(), Result);
+			TestEqual("status", Status, 400);
+		});
+	});
+
+	Describe("External-link intent (assert intent, never launched)", [this]()
+	{
+		It("resolves help / bug / star to their urls without launching a browser", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+
+			TSharedRef<FJsonObject> Help = MakeShared<FJsonObject>();
+			TestEqual("help status", FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/external-link"), DevCtlBody(TEXT("{\"link\":\"help\"}")), &VM.Get(), Help), 200);
+			TestTrue("help url is discord", Help->GetStringField(TEXT("url")).Contains(TEXT("discord.gg")));
+			TestFalse("help not launched", Help->GetBoolField(TEXT("launched")));
+
+			TSharedRef<FJsonObject> Bug = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/external-link"), DevCtlBody(TEXT("{\"link\":\"bug\"}")), &VM.Get(), Bug);
+			TestTrue("bug url is github issues", Bug->GetStringField(TEXT("url")).Contains(TEXT("/issues")));
+
+			TSharedRef<FJsonObject> Star = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/external-link"), DevCtlBody(TEXT("{\"link\":\"star\"}")), &VM.Get(), Star);
+			TestTrue("star url is the repo", Star->GetStringField(TEXT("url")).Contains(TEXT("IvanMurzak/Unreal-MCP")));
+		});
+
+		It("rejects an unknown external-link with 400", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/external-link"), DevCtlBody(TEXT("{\"link\":\"facebook\"}")), &VM.Get(), Result);
+			TestEqual("status", Status, 400);
+		});
+	});
+
+	Describe("Inject device-auth (the Cloud device-code rows)", [this]()
+	{
+		It("injects a pending then authorized device-auth feed so /state surfaces the cloud token", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			// A pending device-auth only takes effect after Authorize armed the flow (the cancel-race guard).
+			VM->Authorize();
+
+			TSharedRef<FJsonObject> Pending = MakeShared<FJsonObject>();
+			const int32 PendingStatus = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/inject/device-auth"),
+				DevCtlBody(TEXT("{\"state\":\"pending\",\"verificationUrl\":\"https://ai-game.dev/device\",\"userCode\":\"WXYZ-1234\"}")),
+				&VM.Get(), Pending);
+			TestEqual("pending status", PendingStatus, 200);
+			TestEqual("pending echoed", Pending->GetStringField(TEXT("deviceAuthState")), FString(TEXT("Pending")));
+			TestEqual("user code surfaced", VM->GetDeviceUserCode(), FString(TEXT("WXYZ-1234")));
+
+			TSharedRef<FJsonObject> Authorized = MakeShared<FJsonObject>();
+			const int32 AuthStatus = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/inject/device-auth"),
+				DevCtlBody(TEXT("{\"state\":\"authorized\",\"token\":\"cloud-bearer-abc\"}")), &VM.Get(), Authorized);
+			TestEqual("authorized status", AuthStatus, 200);
+			TestTrue("hasCloudToken echoed", Authorized->GetBoolField(TEXT("hasCloudToken")));
+			TestTrue("cloud token stored", VM->HasCloudToken());
+
+			// /state now reflects the authorized device-auth + stored cloud token.
+			TSharedRef<FJsonObject> State = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(TEXT("GET"), TEXT("/state"), nullptr, &VM.Get(), State);
+			TestEqual("state deviceAuthState", State->GetStringField(TEXT("deviceAuthState")), FString(TEXT("Authorized")));
+			TestTrue("state hasCloudToken", State->GetBoolField(TEXT("hasCloudToken")));
+		});
+
+		It("injects a failed device-auth so /state surfaces the Failed indicator", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+
+			TSharedRef<FJsonObject> Failed = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/inject/device-auth"),
+				DevCtlBody(TEXT("{\"state\":\"failed\",\"message\":\"Authorization was denied.\"}")), &VM.Get(), Failed);
+			TestEqual("status", Status, 200);
+			TestEqual("failed state", VM->GetDeviceAuthState(), EUnrealMcpDeviceAuthState::Failed);
+			TestEqual("failure reason surfaced", VM->GetDeviceAuthError(), FString(TEXT("Authorization was denied.")));
+		});
+
+		It("rejects a missing device-auth state with 400", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/inject/device-auth"), DevCtlBody(TEXT("{}")), &VM.Get(), Result);
+			TestEqual("status", Status, 400);
 		});
 	});
 }

--- a/scripts/window_smoke.py
+++ b/scripts/window_smoke.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+window_smoke.py — LIVE (GUI) end-to-end smoke for the "AI Game Developer" window.
+
+This is the live complement to the headless C++ Automation specs
+(`UnrealMcpDevControlSpec` / `UnrealMcpEditorViewModelSpec`, run under
+`Automation RunTests UnrealMcp`). Those specs are the CI regression gate; this script is
+run ONCE by an operator to prove the real Slate dock reacts to EVERY button/event — it
+drives each control over the dev-control HTTP bridge, reads `/state` back to confirm the
+view-model (and thus the dock) updated, and optionally captures window screenshots.
+
+It is deliberately NOT a CI gate (it needs a GUI editor + a GPU and is inherently flaky
+under automation). It is evidence. Self-contained: depends only on this repo + a UE editor
+(screenshot capture is optional — see --capture-script).
+
+What it drives
+--------------
+Connection mode (Custom/Cloud), Server URL, Transport (stdio/http), Auth option
+(none/required) + token field + Generate, Connect / Disconnect / Stop / Start, Cloud
+Authorize / Cancel / Revoke (+ injected device-auth pending/authorized/failed rows), the
+agent selector, the footer Check button (Serialization Check window), Restart bridge /
+Open log (intent only), and the footer external links Help/Bug/Star (intent only — asserts
+the URL the button WOULD launch, never opens a browser). After each it reads `GET /state`
+and asserts the readout (status dot/label, button label, transport, auth, token presence
+MASKED, device-auth state, cloud-token presence) reflects the change.
+
+Usage
+-----
+    # Port from the worktree's .worktree.env (UNREAL_MCP_DEV_CONTROL_PORT):
+    python scripts/window_smoke.py --project <.uproject> --port 5177 --out-dir tmp/window-smoke
+
+    # Drive an ALREADY-RUNNING editor you launched with the dev-control env set:
+    #   set UNREAL_MCP_DEV_CONTROL=1 && set UNREAL_MCP_DEV_CONTROL_PORT=5177
+    python scripts/window_smoke.py --port 5177 --attach --out-dir tmp/window-smoke
+
+Screenshots are best-effort: pass --capture-script pointing at a window-capture tool
+(e.g. the infra repo's .scripts/capture_window.py) to enable them; omitted → skipped.
+
+Exit code 0 = every assertion passed; non-zero = a FAIL or the bridge never came up.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+DEFAULT_EDITOR = r"C:/Program Files/Epic Games/UE_5.7/Engine/Binaries/Win64/UnrealEditor.exe"
+WINDOW_TITLE = "AI Game Developer"
+
+
+def _req(port: int, method: str, path: str, body: dict | None = None) -> tuple[int, dict]:
+    """Send one dev-control request; return (status_code, parsed-json-body)."""
+    url = f"http://127.0.0.1:{port}{path}"
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:  # 4xx/5xx still carry a JSON body
+        try:
+            return e.code, json.loads(e.read().decode("utf-8"))
+        except Exception:
+            return e.code, {}
+
+
+def _wait_health(port: int, timeout_s: float) -> bool:
+    """Poll /health until it answers ok or the timeout elapses."""
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            code, body = _req(port, "GET", "/health")
+            if code == 200 and body.get("ok"):
+                return True
+        except Exception:
+            pass
+        time.sleep(2.0)
+    return False
+
+
+class Driver:
+    """Runs the control/state assertions and tallies pass/fail."""
+
+    def __init__(self, port: int, out_dir: Path, capture_script: str | None) -> None:
+        self.port = port
+        self.out_dir = out_dir
+        self.capture_script = capture_script
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, cond: bool, detail: str = "") -> None:
+        mark = "PASS" if cond else "FAIL"
+        if cond:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"  [{mark}] {label}" + (f" — {detail}" if detail else ""))
+
+    def shot(self, name: str) -> None:
+        """Best-effort window screenshot (only when --capture-script was given)."""
+        if not self.capture_script:
+            return
+        out = self.out_dir / f"{name}.png"
+        try:
+            subprocess.run(
+                [sys.executable, self.capture_script, "--title", WINDOW_TITLE, "--out", str(out), "--no-stitch"],
+                timeout=60, check=False,
+            )
+            print(f"  [shot] {out}")
+        except Exception as e:  # capture is evidence, not a gate
+            print(f"  [shot] capture failed ({e}); continuing")
+
+    def state(self) -> dict:
+        _, body = _req(self.port, "GET", "/state")
+        return body
+
+    def run(self) -> None:
+        port = self.port
+
+        # --- Connection mode ---
+        _req(port, "POST", "/control/connection-mode", {"mode": "Custom"})
+        s = self.state()
+        self.check("connection-mode -> Custom", s.get("connectionMode") == "Custom", s.get("connectionMode"))
+
+        # --- Server URL ---
+        _req(port, "POST", "/control/server-url", {"url": "http://127.0.0.1:5244"})
+        s = self.state()
+        self.check("server-url stored", s.get("customHost") == "http://127.0.0.1:5244", s.get("customHost"))
+
+        # --- Transport (stdio/http) ---
+        _req(port, "POST", "/control/transport", {"transport": "http"})
+        s = self.state()
+        self.check("transport -> http", s.get("transport") == "http", s.get("transport"))
+        _req(port, "POST", "/control/transport", {"transport": "stdio"})
+        s = self.state()
+        self.check("transport -> stdio", s.get("transport") == "stdio", s.get("transport"))
+
+        # --- Auth option + token + generate ---
+        _req(port, "POST", "/control/auth-option", {"option": "required"})
+        s = self.state()
+        self.check("auth-option -> required", s.get("authOption") == "required", s.get("authOption"))
+        _req(port, "POST", "/control/auth-token", {"token": "smoke-bearer-abcdef123456"})
+        s = self.state()
+        self.check("auth-token stored (presence)", s.get("hasCustomToken") is True)
+        self.check("auth-token reported MASKED only (§8)",
+                   "smoke-bearer" not in json.dumps(s), "raw token must not appear in /state")
+        _req(port, "POST", "/control/click", {"target": "generate-token"})
+        s = self.state()
+        self.check("generate-token kept a token", s.get("hasCustomToken") is True)
+        self.shot("01-custom-required-token")
+
+        # --- Connect / Disconnect / Stop / Start ---
+        _req(port, "POST", "/control/click", {"target": "connect"})
+        s = self.state()
+        self.check("connect -> keepConnected", s.get("keepConnected") is True, s.get("connectionState"))
+        self.shot("02-connecting")
+        _req(port, "POST", "/control/click", {"target": "stop"})
+        s = self.state()
+        self.check("stop -> not keepConnected", s.get("keepConnected") is False, s.get("connectionState"))
+        _req(port, "POST", "/control/click", {"target": "start"})
+        s = self.state()
+        self.check("start -> keepConnected", s.get("keepConnected") is True, s.get("connectionState"))
+        _req(port, "POST", "/control/click", {"target": "disconnect"})
+
+        # --- Injected connection-status (status dots/labels readouts) ---
+        _req(port, "POST", "/inject/connection-status", {"status": "Connected"})
+        s = self.state()
+        self.check("injected Connected -> /state", s.get("connectionState") == "Connected", s.get("connectionState"))
+        self.check("button label is Disconnect", s.get("buttonLabel") == "Disconnect", s.get("buttonLabel"))
+        self.shot("03-connected")
+
+        # --- Cloud authorize / cancel / revoke (+ injected device-auth rows) ---
+        _req(port, "POST", "/control/connection-mode", {"mode": "Cloud"})
+        _req(port, "POST", "/control/click", {"target": "authorize"})
+        s = self.state()
+        self.check("authorize -> Pending", s.get("deviceAuthState") == "Pending", s.get("deviceAuthState"))
+        _req(port, "POST", "/inject/device-auth",
+             {"state": "pending", "verificationUrl": "https://ai-game.dev/device", "userCode": "WXYZ-1234"})
+        self.shot("04-cloud-pending")
+        _req(port, "POST", "/inject/device-auth", {"state": "authorized", "token": "cloud-bearer-smoke"})
+        s = self.state()
+        self.check("device-auth authorized -> hasCloudToken", s.get("hasCloudToken") is True, s.get("deviceAuthState"))
+        self.shot("05-cloud-authorized")
+        _req(port, "POST", "/control/click", {"target": "revoke"})
+        s = self.state()
+        self.check("revoke -> no cloud token", s.get("hasCloudToken") is False)
+        # Re-authorize then cancel.
+        _req(port, "POST", "/control/click", {"target": "authorize"})
+        _req(port, "POST", "/control/click", {"target": "cancel"})
+        s = self.state()
+        self.check("cancel -> Idle", s.get("deviceAuthState") == "Idle", s.get("deviceAuthState"))
+        _req(port, "POST", "/control/connection-mode", {"mode": "Custom"})
+
+        # --- Agent selector ---
+        _req(port, "POST", "/control/select-agent", {"agentId": "claude-code"})
+        s = self.state()
+        self.check("select-agent stored", s.get("selectedAgentId") == "claude-code", s.get("selectedAgentId"))
+
+        # --- The Check button (Serialization Check window) ---
+        code, body = _req(port, "POST", "/control/click", {"target": "check"})
+        self.check("check button dispatched", code == 200 and body.get("ok") is True)
+        s = self.state()
+        self.check("serializationCheckTabId present", bool(s.get("serializationCheckTabId")), s.get("serializationCheckTabId"))
+        self.shot("06-after-check")
+
+        # --- Restart bridge / Open log (intent only) ---
+        for target in ("restart-bridge", "open-log"):
+            code, body = _req(port, "POST", "/control/click", {"target": target})
+            self.check(f"{target} acknowledged (intent only)", code == 200 and body.get("ok") is True)
+
+        # --- Footer external links (assert intent, never launched) ---
+        for link, needle in (("help", "discord.gg"), ("bug", "/issues"), ("star", "IvanMurzak/Unreal-MCP")):
+            code, body = _req(port, "POST", "/control/external-link", {"link": link})
+            ok = code == 200 and needle in body.get("url", "") and body.get("launched") is False
+            self.check(f"external-link {link} (intent, not launched)", ok, body.get("url"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--project", help="Path to the host .uproject (omit with --attach).")
+    ap.add_argument("--port", type=int, required=True, help="UNREAL_MCP_DEV_CONTROL_PORT (from .worktree.env).")
+    ap.add_argument("--editor", default=DEFAULT_EDITOR, help="UnrealEditor.exe (GUI, not -Cmd).")
+    ap.add_argument("--attach", action="store_true",
+                    help="Drive an already-running editor (you launched it with the dev-control env set).")
+    ap.add_argument("--out-dir", default="tmp/window-smoke", help="Screenshot output directory.")
+    ap.add_argument("--capture-script", default=os.environ.get("UNREAL_MCP_CAPTURE_SCRIPT"),
+                    help="Path to a window-capture script (e.g. the infra repo's .scripts/capture_window.py); "
+                         "omit to skip screenshots.")
+    ap.add_argument("--boot-timeout", type=float, default=600.0,
+                    help="Seconds to wait for /health (first boot warms shaders).")
+    args = ap.parse_args(argv)
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    proc: subprocess.Popen | None = None
+    if not args.attach:
+        if not args.project:
+            ap.error("--project is required unless --attach is given.")
+        env = dict(os.environ)
+        env["UNREAL_MCP_DEV_CONTROL"] = "1"
+        env["UNREAL_MCP_DEV_CONTROL_PORT"] = str(args.port)
+        print(f"Launching editor: {args.editor}\n  project={args.project}\n  dev-control port={args.port}")
+        proc = subprocess.Popen([args.editor, args.project], env=env)
+
+    try:
+        print(f"Waiting for dev-control /health on port {args.port} (up to {args.boot_timeout:.0f}s)...")
+        if not _wait_health(args.port, args.boot_timeout):
+            print("FAIL: dev-control bridge never came up. Is UNREAL_MCP_DEV_CONTROL=1 set and the dock open?")
+            return 2
+        print("Bridge is up. Driving controls...\n")
+        driver = Driver(args.port, out_dir, args.capture_script)
+        driver.run()
+        print(f"\n=== Summary: {driver.passed} passed, {driver.failed} failed ===")
+        if args.capture_script:
+            print(f"Screenshots in: {out_dir.resolve()}")
+        return 0 if driver.failed == 0 else 1
+    finally:
+        if proc is not None:
+            print("Tearing down the editor...")
+            proc.terminate()
+            try:
+                proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Extend the dev-control bridge (`UnrealMcpDevControlServer`) + its Automation spec so EVERY button/event in the "AI Game Developer" Slate window is asserted at the router/view-model level — connection mode, server URL, transport, auth option/token/generate, connect/disconnect/stop/start, cloud authorize/cancel/revoke (+ injected device-auth rows), agent selector, the Check button, restart-bridge/open-log intents, the footer external links (assert intent, never launched), and the status dot/label/version/count readouts via `/state`.
- New routes (`/control/transport`, `/control/auth-option`, `/control/auth-token`, `/control/external-link`, `/inject/device-auth`) + new `/control/click` targets (`start`, `stop`, `cancel`, `restart-bridge`, `open-log`); enriched `/state` readouts (transport, authOption, masked token presence, deviceAuthState, hasCloudToken, keepConnected, button/status labels, aiAgentCount, externalLinks).
- Lift the footer link urls into `UnrealMcpExternalLinks.h` (single source of truth shared by the window + the bridge); fix the placeholder Discord url to the real invite.
- Add `scripts/window_smoke.py` — a documented LIVE (GUI) harness that boots the editor with the dev-control env, drives each control over HTTP, reads `/state` back, and optionally captures screenshots. Operator-run evidence, NOT a CI gate.

## Test plan
- [x] UBT build (`UnrealTestProjectEditor`) — exit 0.
- [x] Headless boot smoke — `[Unreal-MCP] plugin loaded` + `Engine is initialized` logged (the exit-3 `GenericWindow.cpp` teardown crash on `QUIT_EDITOR` is the documented pre-existing out-of-scope shutdown quirk).
- [x] `Automation RunTests UnrealMcp` — `failed: 0`, `succeeded: 269` (+16 with warnings), 33 DevControl entries.
- [ ] Live `scripts/window_smoke.py` run — operator-owned (TD owns the editor); evidence capture pending.

Closes #90