### PR TITLE
feat(plugin): launch & supervise a local gamedev-mcp-server from the MCP Server Start button

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
@@ -308,6 +308,11 @@ int32 FUnrealMcpDevControlServer::RouteRequest(
 		OutResult->SetStringField(TEXT("deviceAuthState"), DevControlDeviceAuthLabel(ViewModelPtr->GetDeviceAuthState()));
 		OutResult->SetBoolField(TEXT("hasCloudToken"), ViewModelPtr->HasCloudToken());
 		OutResult->SetBoolField(TEXT("keepConnected"), ViewModelPtr->IsReconnectArmed());
+		// §7 in-UI local-server (issue #95): the MCP-server card's Start/Stop readouts so the smoke test can
+		// assert gating (launchable only in Custom+http) + the live server run-state + the toggling button label.
+		OutResult->SetBoolField(TEXT("serverLaunchable"), ViewModelPtr->IsLocalServerLaunchable());
+		OutResult->SetBoolField(TEXT("serverRunning"), ViewModelPtr->IsLocalServerRunning());
+		OutResult->SetStringField(TEXT("serverButtonLabel"), ViewModelPtr->GetLocalServerButtonText().ToString());
 		// The Connect/Disconnect/Stop button label + the "Unreal: <status>" label the dock renders for this state,
 		// so the smoke test asserts the exact text a screenshot would show without reading pixels.
 		OutResult->SetStringField(TEXT("buttonLabel"),
@@ -500,20 +505,38 @@ int32 FUnrealMcpDevControlServer::RouteRequest(
 		FString Target;
 		if (!Body.IsValid() || !Body->TryGetStringField(TEXT("target"), Target) || Target.IsEmpty())
 		{
-			DevControlFail(OutResult, TEXT("missing 'target' (connect|start|disconnect|stop|authorize|cancel|revoke|generate-token|check|restart-bridge|open-log)"));
+			DevControlFail(OutResult, TEXT("missing 'target' (connect|disconnect|stop|start|start-server|stop-server|authorize|cancel|revoke|generate-token|check|restart-bridge|open-log)"));
 			return 400;
 		}
 
 		// Map the click target onto the matching view-model mutator — the same action the Slate button fires.
-		// `start` is the MCP-server Start button (a (re)Connect); `stop` is the tri-state Disconnect/Stop. `check`,
-		// `restart-bridge` and `open-log` do NOT mutate the view-model: `check` opens the Serialization Check aux
-		// window (headless no-op via the static invoker); `restart-bridge` (a runtime bridge restart) and `open-log`
-		// (a folder-explore) are runtime/Slate side effects the dev-control bridge deliberately does NOT perform —
-		// they are acknowledged as dispatched intents so the smoke test can exercise every footer button.
+		//  - `connect`/`disconnect`/`stop` drive the Unreal-side SignalR connect (the "Unreal: <status>" row).
+		//  - `start`/`start-server`/`stop-server` drive the MCP-server card's LOCAL gamedev-mcp-server (issue #95):
+		//    `start` toggles (Start↔Stop) exactly like the Slate button; `start-server`/`stop-server` are explicit
+		//    so the smoke test can drive a deterministic start THEN stop. ALL route through ToggleLocalServer /
+		//    the gated sinks, which NO-OP outside Custom+http — a click in Cloud/stdio can never spawn a server.
+		//  - `check` opens the Serialization Check aux window (headless no-op via the static invoker);
+		//    `restart-bridge` (a runtime bridge restart) and `open-log` (a folder-explore) are runtime/Slate side
+		//    effects the dev-control bridge deliberately does NOT perform — acknowledged as dispatched intents.
+		bool bServerTarget = false;
 		if (Target.Equals(TEXT("connect"), ESearchCase::IgnoreCase))               ViewModelPtr->Connect();
-		else if (Target.Equals(TEXT("start"), ESearchCase::IgnoreCase))            ViewModelPtr->Connect();
 		else if (Target.Equals(TEXT("disconnect"), ESearchCase::IgnoreCase))       ViewModelPtr->Disconnect();
 		else if (Target.Equals(TEXT("stop"), ESearchCase::IgnoreCase))             ViewModelPtr->Disconnect();
+		else if (Target.Equals(TEXT("start"), ESearchCase::IgnoreCase))            { ViewModelPtr->ToggleLocalServer(); bServerTarget = true; }
+		else if (Target.Equals(TEXT("start-server"), ESearchCase::IgnoreCase))
+		{
+			// Explicit start: toggle only if currently stopped (so a repeat start-server is idempotent, not a stop).
+			if (!ViewModelPtr->IsLocalServerRunning())
+				ViewModelPtr->ToggleLocalServer();
+			bServerTarget = true;
+		}
+		else if (Target.Equals(TEXT("stop-server"), ESearchCase::IgnoreCase))
+		{
+			// Explicit stop: toggle only if currently running.
+			if (ViewModelPtr->IsLocalServerRunning())
+				ViewModelPtr->ToggleLocalServer();
+			bServerTarget = true;
+		}
 		else if (Target.Equals(TEXT("authorize"), ESearchCase::IgnoreCase))        ViewModelPtr->Authorize();
 		else if (Target.Equals(TEXT("cancel"), ESearchCase::IgnoreCase))           ViewModelPtr->CancelAuth();
 		else if (Target.Equals(TEXT("revoke"), ESearchCase::IgnoreCase))           ViewModelPtr->Revoke();
@@ -530,6 +553,12 @@ int32 FUnrealMcpDevControlServer::RouteRequest(
 		OutResult->SetBoolField(TEXT("ok"), true);
 		OutResult->SetStringField(TEXT("target"), Target.ToLower());
 		OutResult->SetStringField(TEXT("connectionState"), DevControlConnectionStateLabel(ViewModelPtr->GetConnectionState()));
+		// Server-target clicks also report the live server state so the smoke test asserts launch/stop + gating.
+		if (bServerTarget)
+		{
+			OutResult->SetBoolField(TEXT("serverLaunchable"), ViewModelPtr->IsLocalServerLaunchable());
+			OutResult->SetBoolField(TEXT("serverRunning"), ViewModelPtr->IsLocalServerRunning());
+		}
 		return 200;
 	}
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
@@ -369,8 +369,19 @@ bool FUnrealMcpServerManager::DownloadBinaryIfNeeded(FString& OutBinaryPath)
 		if (!BinaryDirPrefix.IsEmpty() && !Name.StartsWith(BinaryDirPrefix))
 			continue;
 		const FString Leaf = Name.RightChop(BinaryDirPrefix.Len());
-		if (Leaf.IsEmpty() || Leaf.Contains(TEXT("/"))) // flatten one level; skip deeper nesting
+		// Zip-slip hardening (defense in depth): only write a SINGLE safe path segment directly under InstallDir.
+		// Reject anything that could escape it — a nested path (forward OR backslash), a ".." traversal segment,
+		// or a non-relative / drive-letter / absolute leaf (e.g. "..\x", "C:evil", "\\unc\x"). A crafted entry
+		// that the slash-only check missed is dropped here rather than written outside InstallDir.
+		if (Leaf.IsEmpty()
+			|| Leaf.Contains(TEXT("/")) || Leaf.Contains(TEXT("\\"))   // no nested path segments (either separator)
+			|| Leaf.Contains(TEXT(".."))                                // no parent-dir traversal segment
+			|| !FPaths::IsRelative(Leaf)                                // reject absolute paths
+			|| Leaf.Contains(TEXT(":")))                                // reject drive-letter / ADS prefixes (e.g. "C:evil")
+		{
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] skipped unsafe zip entry leaf '%s' (from '%s')."), *Leaf, *Name);
 			continue;
+		}
 
 		TArray<uint8> FileData;
 		if (!Reader.TryReadFile(Name, FileData))

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
@@ -46,8 +46,6 @@ namespace
 	const int32 ServerBackoffSeconds[] = { 1, 2, 5, 10, 30 };
 	constexpr int32 ServerMaxCrashesPerWindow = 5;
 	constexpr double ServerCrashWindowSeconds = 300.0;
-	// Startup-verification window: the child must survive this long for Start to be considered healthy.
-	constexpr double ServerStartupVerifySeconds = 5.0;
 	const TCHAR* ServerProcessNameNeedle = TEXT("gamedev-mcp-server");
 
 	// GitHub release-asset URL for a rid + version (v-prefixed tags), matching the CLI's serverDownloadUrl.

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
@@ -29,6 +29,12 @@
 #include <sys/sysctl.h>
 #endif
 
+#if PLATFORM_WINDOWS
+#include "Windows/AllowWindowsPlatformTypes.h"
+#include <Windows.h>
+#include "Windows/HideWindowsPlatformTypes.h"
+#endif
+
 // Single source of the consumed shared-server version. Kept in lockstep with cli/src/lib/server-version.ts
 // (SERVER_VERSION) and Unity's McpServerManager.ServerVersion — the three plugins consume the SAME server.
 const TCHAR* FUnrealMcpServerManager::ServerVersion = TEXT("8.0.0");
@@ -58,6 +64,15 @@ FUnrealMcpServerManager::FUnrealMcpServerManager() = default;
 FUnrealMcpServerManager::~FUnrealMcpServerManager()
 {
 	Stop(/*bForce*/ true);
+#if PLATFORM_WINDOWS
+	// Close the kill-on-job-close Job Object handle. If any server process is still assigned to it, closing the
+	// LAST handle here trips JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE and reaps it — a final backstop on top of Stop().
+	if (JobHandle != nullptr)
+	{
+		::CloseHandle(static_cast<HANDLE>(JobHandle));
+		JobHandle = nullptr;
+	}
+#endif
 }
 
 FString FUnrealMcpServerManager::ServerBinaryBasename()
@@ -249,6 +264,7 @@ bool FUnrealMcpServerManager::DownloadBinaryIfNeeded(FString& OutBinaryPath)
 			{
 				ZipBytes = Resp->GetContent();
 				bOk = true;
+				UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] server download completed: %d bytes."), ZipBytes.Num());
 			}
 			else
 			{
@@ -282,7 +298,10 @@ bool FUnrealMcpServerManager::DownloadBinaryIfNeeded(FString& OutBinaryPath)
 	// deflate entries on read). Mirror download-server.ts: find the binary at the shallowest path, then move it
 	// + its sidecar files (appsettings.json, NLog.config, server.json, …) into the install dir.
 	IFileManager& FM = IFileManager::Get();
-	const FString TempZipPath = FPaths::CreateTempFilename(*FPaths::ProjectIntermediateDir(), TEXT("gamedev-mcp-server-"), TEXT(".zip"));
+	// Absolute temp path: CreateTempFilename's dir is project-relative; OpenRead and SaveArrayToFile can resolve a
+	// relative path against different CWDs across the engine, so make it absolute to keep both on the same file.
+	const FString TempZipPath = FPaths::ConvertRelativePathToFull(
+		FPaths::CreateTempFilename(*FPaths::ProjectIntermediateDir(), TEXT("gamedev-mcp-server-"), TEXT(".zip")));
 	if (!FFileHelper::SaveArrayToFile(ZipBytes, *TempZipPath))
 	{
 		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] could not stage the downloaded server zip."));
@@ -293,17 +312,19 @@ bool FUnrealMcpServerManager::DownloadBinaryIfNeeded(FString& OutBinaryPath)
 	IFileHandle* ZipHandle = FPlatformFileManager::Get().GetPlatformFile().OpenRead(*TempZipPath);
 	if (ZipHandle == nullptr)
 	{
-		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] could not reopen the staged server zip."));
+		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] could not reopen the staged server zip at %s."), *TempZipPath);
 		return false;
 	}
 	FZipArchiveReader Reader(ZipHandle); // takes ownership of ZipHandle (closes it in its dtor)
 	if (!Reader.IsValid())
 	{
-		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] downloaded server zip is malformed/unreadable."));
+		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] downloaded server zip is malformed/unreadable (%lld bytes staged)."),
+			(long long)ZipBytes.Num());
 		return false;
 	}
 
 	const TArray<FString> Names = Reader.GetFileNames();
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] server zip opened: %d entries."), Names.Num());
 	const FString Basename = ServerBinaryBasename();
 
 	// Find the shallowest entry whose leaf name equals the binary (flat win zip OR nested <rid>/ unix zip).
@@ -339,11 +360,15 @@ bool FUnrealMcpServerManager::DownloadBinaryIfNeeded(FString& OutBinaryPath)
 	FM.DeleteDirectory(*InstallDir, /*RequireExists*/ false, /*Tree*/ true);
 	FM.MakeDirectory(*InstallDir, /*Tree*/ true);
 
+	int32 FilesWritten = 0;
 	for (const FString& Name : Names)
 	{
 		if (Name.EndsWith(TEXT("/"))) // directory entry
 			continue;
-		if (!Name.StartsWith(BinaryDirPrefix))
+		// Only files in the binary's own folder. NOTE: FString::StartsWith returns FALSE for an empty prefix,
+		// so a FLAT win zip (BinaryDirPrefix == "") would filter out EVERYTHING — guard the empty-prefix case
+		// explicitly (every entry is "in" the root folder when the prefix is empty).
+		if (!BinaryDirPrefix.IsEmpty() && !Name.StartsWith(BinaryDirPrefix))
 			continue;
 		const FString Leaf = Name.RightChop(BinaryDirPrefix.Len());
 		if (Leaf.IsEmpty() || Leaf.Contains(TEXT("/"))) // flatten one level; skip deeper nesting
@@ -361,11 +386,14 @@ bool FUnrealMcpServerManager::DownloadBinaryIfNeeded(FString& OutBinaryPath)
 			UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] failed to write '%s'."), *OutPath);
 			return false;
 		}
+		++FilesWritten;
 	}
 
 	if (!FPaths::FileExists(BinPath))
 	{
-		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] server binary missing after unpack at: %s"), *BinPath);
+		UE_LOG(LogUnrealMcp, Error,
+			TEXT("[Unreal-MCP] server binary missing after unpack at: %s (entry='%s', prefix='%s', files written=%d)"),
+			*BinPath, *BinaryEntryName, *BinaryDirPrefix, FilesWritten);
 		return false;
 	}
 	PrepareBinaryForSpawn(BinPath);
@@ -399,9 +427,60 @@ bool FUnrealMcpServerManager::SpawnProcess(const FString& InBinaryPath)
 		ProcHandle = NewHandle;
 		ProcId = NewProcId;
 	}
+	// Bind the child to the kill-on-job-close job so it dies with the editor by ANY exit path (graceful, hard
+	// TerminateProcess, or crash) — the load-bearing guarantee for "Start then close editor → no orphan" when
+	// the engine's graceful OnEnginePreExit teardown never runs. The handle (HANDLE on Windows) is ProcHandle.Get().
+	BindProcessToKillOnCloseJob(NewHandle.Get());
 	WritePidFile(NewProcId);
 	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] spawned local server pid=%u on port=%d."), NewProcId, ListenPort);
 	return true;
+}
+
+void FUnrealMcpServerManager::BindProcessToKillOnCloseJob(void* ProcessHandle)
+{
+#if PLATFORM_WINDOWS
+	if (ProcessHandle == nullptr)
+		return;
+
+	// Create the job lazily on the first spawn; reuse it for restarts so one editor session = one job.
+	if (JobHandle == nullptr)
+	{
+		HANDLE NewJob = ::CreateJobObject(nullptr, nullptr);
+		if (NewJob == nullptr)
+		{
+			UE_LOG(LogUnrealMcp, Warning,
+				TEXT("[Unreal-MCP] CreateJobObject failed (err=%lu); relying on the graceful shutdown stop only."),
+				::GetLastError());
+			return;
+		}
+		JOBOBJECT_EXTENDED_LIMIT_INFORMATION Info = {};
+		Info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+		if (!::SetInformationJobObject(NewJob, JobObjectExtendedLimitInformation, &Info, sizeof(Info)))
+		{
+			UE_LOG(LogUnrealMcp, Warning,
+				TEXT("[Unreal-MCP] SetInformationJobObject failed (err=%lu); job will not kill-on-close."),
+				::GetLastError());
+			::CloseHandle(NewJob);
+			return;
+		}
+		JobHandle = NewJob;
+	}
+
+	if (!::AssignProcessToJobObject(static_cast<HANDLE>(JobHandle), static_cast<HANDLE>(ProcessHandle)))
+	{
+		// A common benign cause: the process was created in a job that disallows nesting/breakaway. Log and move
+		// on — the graceful OnEnginePreExit stop still covers a clean editor close.
+		UE_LOG(LogUnrealMcp, Warning,
+			TEXT("[Unreal-MCP] AssignProcessToJobObject failed (err=%lu); kill-on-editor-exit not guaranteed for this server."),
+			::GetLastError());
+	}
+	else
+	{
+		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] local server bound to kill-on-close job."));
+	}
+#else
+	(void)ProcessHandle; // non-Windows: graceful PreExit stop + KillTree cover the supported cases.
+#endif
 }
 
 bool FUnrealMcpServerManager::Start(int32 Port, int32 PluginTimeoutMs, bool bAuthRequired, const FString& Token)
@@ -479,6 +558,9 @@ bool FUnrealMcpServerManager::ReattachIfRunning(int32 Port, int32 PluginTimeoutM
 		ProcHandle = Adopted;
 		ProcId = static_cast<uint32>(SavedPid);
 	}
+	// Re-bind the adopted survivor to a kill-on-close job so it too dies with THIS editor session by any exit
+	// path (the original spawning session's job died with that session's editor).
+	BindProcessToKillOnCloseJob(Adopted.Get());
 	bStopRequested = false;
 	WindowStartSeconds = FPlatformTime::Seconds();
 	CrashesInWindow = 0;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
@@ -1,0 +1,736 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "Server/UnrealMcpServerManager.h"
+#include "UnrealMcpLog.h"
+
+#include "Async/Async.h"
+#include "HAL/PlatformProcess.h"
+#include "HAL/PlatformFileManager.h"
+#include "HAL/FileManager.h"
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "Misc/ScopeLock.h"
+#include "Misc/ScopeExit.h"
+#include "GenericPlatform/GenericPlatformFile.h"
+
+#include "HttpModule.h"
+#include "HttpManager.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+
+#include "FileUtilities/ZipArchiveReader.h"
+
+#if PLATFORM_MAC || PLATFORM_LINUX
+#include <cerrno>
+#include <sys/stat.h>
+#endif
+#if PLATFORM_MAC
+#include <sys/sysctl.h>
+#endif
+
+// Single source of the consumed shared-server version. Kept in lockstep with cli/src/lib/server-version.ts
+// (SERVER_VERSION) and Unity's McpServerManager.ServerVersion — the three plugins consume the SAME server.
+const TCHAR* FUnrealMcpServerManager::ServerVersion = TEXT("8.0.0");
+const TCHAR* FUnrealMcpServerManager::ServerPathEnvVar = TEXT("UNREAL_MCP_SERVER_PATH");
+
+namespace
+{
+	// Restart backoff schedule (seconds) — mirrors the sidecar §1.5 watchdog.
+	const int32 ServerBackoffSeconds[] = { 1, 2, 5, 10, 30 };
+	constexpr int32 ServerMaxCrashesPerWindow = 5;
+	constexpr double ServerCrashWindowSeconds = 300.0;
+	// Startup-verification window: the child must survive this long for Start to be considered healthy.
+	constexpr double ServerStartupVerifySeconds = 5.0;
+	const TCHAR* ServerProcessNameNeedle = TEXT("gamedev-mcp-server");
+
+	// GitHub release-asset URL for a rid + version (v-prefixed tags), matching the CLI's serverDownloadUrl.
+	FString ServerDownloadUrl(const FString& Rid, const FString& Version)
+	{
+		return FString::Printf(
+			TEXT("https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v%s/gamedev-mcp-server-%s.zip"),
+			*Version, *Rid);
+	}
+}
+
+FUnrealMcpServerManager::FUnrealMcpServerManager() = default;
+
+FUnrealMcpServerManager::~FUnrealMcpServerManager()
+{
+	Stop(/*bForce*/ true);
+}
+
+FString FUnrealMcpServerManager::ServerBinaryBasename()
+{
+#if PLATFORM_WINDOWS
+	return TEXT("gamedev-mcp-server.exe");
+#else
+	return TEXT("gamedev-mcp-server");
+#endif
+}
+
+FString FUnrealMcpServerManager::ResolveRid(bool bArm64DirExists)
+{
+#if PLATFORM_WINDOWS
+	(void)bArm64DirExists;
+	return TEXT("win-x64");
+#elif PLATFORM_MAC
+	int32 IsArm64 = 0;
+	size_t Size = sizeof(IsArm64);
+	if (sysctlbyname("hw.optional.arm64", &IsArm64, &Size, nullptr, 0) != 0)
+		IsArm64 = 0;
+	if (IsArm64 == 1 && bArm64DirExists)
+		return TEXT("osx-arm64");
+	return TEXT("osx-x64");
+#elif PLATFORM_LINUX
+	(void)bArm64DirExists;
+	return TEXT("linux-x64");
+#else
+	(void)bArm64DirExists;
+	return FString();
+#endif
+}
+
+FString FUnrealMcpServerManager::ServerInstallDir(const FString& ProjectDir, const FString& Rid)
+{
+	if (ProjectDir.IsEmpty() || Rid.IsEmpty())
+		return FString();
+	const FString Path = ProjectDir / TEXT("Intermediate") / TEXT("UnrealMCP") / TEXT("server") / Rid;
+	return FPaths::ConvertRelativePathToFull(Path);
+}
+
+FString FUnrealMcpServerManager::ServerBinaryPathFor(const FString& ProjectDir, const FString& Rid)
+{
+	const FString Dir = ServerInstallDir(ProjectDir, Rid);
+	if (Dir.IsEmpty())
+		return FString();
+	return Dir / ServerBinaryBasename();
+}
+
+FString FUnrealMcpServerManager::ReadVersionMarker(const FString& InstallDir)
+{
+	if (InstallDir.IsEmpty())
+		return FString();
+	const FString Marker = InstallDir / TEXT("version");
+	FString Contents;
+	if (FFileHelper::LoadFileToString(Contents, *Marker))
+		return Contents.TrimStartAndEnd();
+	return FString();
+}
+
+int32 FUnrealMcpServerManager::ParsePortFromHost(const FString& HostUrl, int32 DefaultPort)
+{
+	const FString Trimmed = HostUrl.TrimStartAndEnd();
+	if (Trimmed.IsEmpty())
+		return DefaultPort;
+
+	// Strip the scheme, remember it for the default-port inference.
+	FString Rest = Trimmed;
+	bool bHttps = false;
+	bool bHadScheme = false;
+	if (Rest.StartsWith(TEXT("https://"), ESearchCase::IgnoreCase)) { Rest.RightChopInline(8); bHttps = true; bHadScheme = true; }
+	else if (Rest.StartsWith(TEXT("http://"), ESearchCase::IgnoreCase)) { Rest.RightChopInline(7); bHadScheme = true; }
+
+	// Drop any path / query after the authority.
+	int32 SlashIdx;
+	if (Rest.FindChar(TEXT('/'), SlashIdx))
+		Rest.LeftInline(SlashIdx);
+
+	// authority is host[:port]. An IPv6 literal (in []) has colons inside the brackets — guard against it.
+	int32 ColonIdx;
+	if (Rest.StartsWith(TEXT("[")))
+	{
+		int32 CloseIdx;
+		if (Rest.FindChar(TEXT(']'), CloseIdx) && CloseIdx + 1 < Rest.Len() && Rest[CloseIdx + 1] == TEXT(':'))
+		{
+			const FString PortStr = Rest.RightChop(CloseIdx + 2);
+			const int32 Port = FCString::Atoi(*PortStr);
+			if (Port > 0 && Port <= 65535)
+				return Port;
+		}
+	}
+	else if (Rest.FindLastChar(TEXT(':'), ColonIdx))
+	{
+		const FString PortStr = Rest.RightChop(ColonIdx + 1);
+		const int32 Port = FCString::Atoi(*PortStr);
+		if (Port > 0 && Port <= 65535)
+			return Port;
+	}
+
+	// No explicit port: infer from the scheme, else fall back to the supplied default.
+	if (bHadScheme)
+		return bHttps ? 443 : 80;
+	return DefaultPort;
+}
+
+FString FUnrealMcpServerManager::BuildLaunchArgs(int32 Port, int32 PluginTimeoutMs, bool bAuthRequired, const FString& Token)
+{
+	// Unity BuildArguments parity. client-transport is ALWAYS streamableHttp for a launched local server.
+	FString Args = FString::Printf(
+		TEXT("port=%d plugin-timeout=%d client-transport=streamableHttp authorization=%s"),
+		Port, PluginTimeoutMs, bAuthRequired ? TEXT("required") : TEXT("none"));
+	if (bAuthRequired && !Token.IsEmpty())
+		Args += FString::Printf(TEXT(" token=%s"), *Token);
+	return Args;
+}
+
+bool FUnrealMcpServerManager::IsLaunchAllowed(bool bIsCustomMode, bool bIsHttpTransport)
+{
+	return bIsCustomMode && bIsHttpTransport;
+}
+
+void FUnrealMcpServerManager::PrepareBinaryForSpawn(const FString& Path)
+{
+#if PLATFORM_MAC || PLATFORM_LINUX
+	if (Path.IsEmpty())
+		return;
+	const auto Utf8Path = StringCast<ANSICHAR>(*Path);
+	if (chmod(Utf8Path.Get(), 0755) != 0)
+	{
+		UE_LOG(LogUnrealMcp, Warning,
+			TEXT("[Unreal-MCP] could not set +x on the local server '%s' (errno=%d); spawn may fail."), *Path, errno);
+	}
+#else
+	(void)Path;
+#endif
+}
+
+FString FUnrealMcpServerManager::ResolveBinaryPath() const
+{
+	// 1. Dev/CI override — wins when set + present (mirrors the sidecar's UNREAL_MCP_BRIDGE_PATH and the CLI's
+	//    UNREAL_MCP_SERVER_PATH). Skips the version check, exactly like download-server.ts's override branch.
+	const FString Override = FPlatformMisc::GetEnvironmentVariable(ServerPathEnvVar);
+	if (!Override.IsEmpty() && FPaths::FileExists(Override))
+		return Override;
+
+	// 2. Cached binary under the §6 install dir whose `version` marker matches the pin → reuse (no network).
+	const FString ProjectDir = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
+	const FString Rid = ResolveRid();
+	const FString InstallDir = ServerInstallDir(ProjectDir, Rid);
+	const FString BinPath = ServerBinaryPathFor(ProjectDir, Rid);
+	if (!BinPath.IsEmpty() && FPaths::FileExists(BinPath) && ReadVersionMarker(InstallDir) == ServerVersion)
+		return BinPath;
+
+	// 3. Neither resolves — caller downloads (or surfaces the CLI hint).
+	return FString();
+}
+
+bool FUnrealMcpServerManager::DownloadBinaryIfNeeded(FString& OutBinaryPath)
+{
+	const FString ProjectDir = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
+	const FString Rid = ResolveRid();
+	if (Rid.IsEmpty())
+	{
+		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] no RID for this host; cannot download the local server."));
+		return false;
+	}
+	const FString InstallDir = ServerInstallDir(ProjectDir, Rid);
+	const FString BinPath = ServerBinaryPathFor(ProjectDir, Rid);
+	const FString Url = ServerDownloadUrl(Rid, ServerVersion);
+
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] downloading gamedev-mcp-server %s (%s) from %s"), ServerVersion, *Rid, *Url);
+
+	// Blocking HTTP GET via the engine HTTP module. We tick the module on this (game) thread until the request
+	// completes or a generous deadline elapses — the user explicitly clicked Start, so a bounded synchronous
+	// wait is acceptable here (matches the CLI's await downloadServer()).
+	FHttpModule& Http = FHttpModule::Get();
+	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> Request = Http.CreateRequest();
+	Request->SetURL(Url);
+	Request->SetVerb(TEXT("GET"));
+
+	bool bDone = false;
+	bool bOk = false;
+	TArray<uint8> ZipBytes;
+	Request->OnProcessRequestComplete().BindLambda(
+		[&bDone, &bOk, &ZipBytes](FHttpRequestPtr Req, FHttpResponsePtr Resp, bool bConnectedOk)
+		{
+			bDone = true;
+			if (bConnectedOk && Resp.IsValid() && Resp->GetResponseCode() == 200)
+			{
+				ZipBytes = Resp->GetContent();
+				bOk = true;
+			}
+			else
+			{
+				UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] server download failed (HTTP %d)."),
+					Resp.IsValid() ? Resp->GetResponseCode() : -1);
+			}
+		});
+
+	if (!Request->ProcessRequest())
+	{
+		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] could not start the server download request."));
+		return false;
+	}
+
+	const double Deadline = FPlatformTime::Seconds() + 120.0; // 2-minute ceiling
+	while (!bDone && FPlatformTime::Seconds() < Deadline)
+	{
+		Http.GetHttpManager().Tick(0.1f);
+		FPlatformProcess::Sleep(0.05f);
+	}
+	if (!bDone)
+	{
+		Request->CancelRequest();
+		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] server download timed out."));
+		return false;
+	}
+	if (!bOk || ZipBytes.Num() == 0)
+		return false;
+
+	// Stage the downloaded bytes to a temp file and open it with FZipArchiveReader (libzip-backed: it inflates
+	// deflate entries on read). Mirror download-server.ts: find the binary at the shallowest path, then move it
+	// + its sidecar files (appsettings.json, NLog.config, server.json, …) into the install dir.
+	IFileManager& FM = IFileManager::Get();
+	const FString TempZipPath = FPaths::CreateTempFilename(*FPaths::ProjectIntermediateDir(), TEXT("gamedev-mcp-server-"), TEXT(".zip"));
+	if (!FFileHelper::SaveArrayToFile(ZipBytes, *TempZipPath))
+	{
+		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] could not stage the downloaded server zip."));
+		return false;
+	}
+	ON_SCOPE_EXIT { FM.Delete(*TempZipPath, /*RequireExists*/ false, /*EvenReadOnly*/ true, /*Quiet*/ true); };
+
+	IFileHandle* ZipHandle = FPlatformFileManager::Get().GetPlatformFile().OpenRead(*TempZipPath);
+	if (ZipHandle == nullptr)
+	{
+		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] could not reopen the staged server zip."));
+		return false;
+	}
+	FZipArchiveReader Reader(ZipHandle); // takes ownership of ZipHandle (closes it in its dtor)
+	if (!Reader.IsValid())
+	{
+		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] downloaded server zip is malformed/unreadable."));
+		return false;
+	}
+
+	const TArray<FString> Names = Reader.GetFileNames();
+	const FString Basename = ServerBinaryBasename();
+
+	// Find the shallowest entry whose leaf name equals the binary (flat win zip OR nested <rid>/ unix zip).
+	FString BinaryEntryName;
+	int32 BestDepth = MAX_int32;
+	for (const FString& Name : Names)
+	{
+		if (Name.EndsWith(TEXT("/")))
+			continue;
+		if (FPaths::GetCleanFilename(Name) == Basename)
+		{
+			int32 Depth = 0;
+			for (const TCHAR C : Name)
+				if (C == TEXT('/')) ++Depth;
+			if (Depth < BestDepth) { BestDepth = Depth; BinaryEntryName = Name; }
+		}
+	}
+	if (BinaryEntryName.IsEmpty())
+	{
+		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] '%s' not found inside the downloaded zip."), *Basename);
+		return false;
+	}
+
+	// The zip-relative prefix the binary lives in — its sidecar files sit beside it.
+	FString BinaryDirPrefix;
+	{
+		int32 SlashIdx;
+		if (BinaryEntryName.FindLastChar(TEXT('/'), SlashIdx))
+			BinaryDirPrefix = BinaryEntryName.Left(SlashIdx + 1); // includes trailing '/'
+	}
+
+	// Replace any stale install dir so a partial/old extract cannot linger.
+	FM.DeleteDirectory(*InstallDir, /*RequireExists*/ false, /*Tree*/ true);
+	FM.MakeDirectory(*InstallDir, /*Tree*/ true);
+
+	for (const FString& Name : Names)
+	{
+		if (Name.EndsWith(TEXT("/"))) // directory entry
+			continue;
+		if (!Name.StartsWith(BinaryDirPrefix))
+			continue;
+		const FString Leaf = Name.RightChop(BinaryDirPrefix.Len());
+		if (Leaf.IsEmpty() || Leaf.Contains(TEXT("/"))) // flatten one level; skip deeper nesting
+			continue;
+
+		TArray<uint8> FileData;
+		if (!Reader.TryReadFile(Name, FileData))
+		{
+			UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] failed to extract '%s' from the server zip."), *Name);
+			return false;
+		}
+		const FString OutPath = InstallDir / Leaf;
+		if (!FFileHelper::SaveArrayToFile(FileData, *OutPath))
+		{
+			UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] failed to write '%s'."), *OutPath);
+			return false;
+		}
+	}
+
+	if (!FPaths::FileExists(BinPath))
+	{
+		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] server binary missing after unpack at: %s"), *BinPath);
+		return false;
+	}
+	PrepareBinaryForSpawn(BinPath);
+	FFileHelper::SaveStringToFile(FString(ServerVersion), *(InstallDir / TEXT("version")));
+
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] local server ready: %s (version %s)"), *BinPath, ServerVersion);
+	OutBinaryPath = BinPath;
+	return true;
+}
+
+bool FUnrealMcpServerManager::SpawnProcess(const FString& InBinaryPath)
+{
+	uint32 NewProcId = 0;
+	FProcHandle NewHandle = FPlatformProcess::CreateProc(
+		*InBinaryPath,
+		*LaunchArgs,
+		/*bLaunchDetached*/ false,
+		/*bLaunchHidden*/ true,
+		/*bLaunchReallyHidden*/ true,
+		&NewProcId,
+		/*PriorityModifier*/ 0,
+		/*OptionalWorkingDirectory*/ *FPaths::GetPath(InBinaryPath),
+		/*PipeWriteChild*/ nullptr,
+		/*PipeReadChild*/ nullptr);
+
+	if (!NewHandle.IsValid())
+		return false;
+
+	{
+		FScopeLock Lock(&ProcessMutex);
+		ProcHandle = NewHandle;
+		ProcId = NewProcId;
+	}
+	WritePidFile(NewProcId);
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] spawned local server pid=%u on port=%d."), NewProcId, ListenPort);
+	return true;
+}
+
+bool FUnrealMcpServerManager::Start(int32 Port, int32 PluginTimeoutMs, bool bAuthRequired, const FString& Token)
+{
+	if (IsRunning() || bStarting)
+	{
+		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] local server already running/starting; Start is a no-op."));
+		return true;
+	}
+
+	bStarting = true;
+	bStopRequested = false;
+	ListenPort = Port;
+	LaunchArgs = BuildLaunchArgs(Port, PluginTimeoutMs, bAuthRequired, Token);
+
+	// Resolve the binary (override → cache); download on a miss.
+	BinaryPath = ResolveBinaryPath();
+	if (BinaryPath.IsEmpty())
+	{
+		FString Downloaded;
+		if (!DownloadBinaryIfNeeded(Downloaded))
+		{
+			bStarting = false;
+			UE_LOG(LogUnrealMcp, Error,
+				TEXT("[Unreal-MCP] could not resolve or download the local gamedev-mcp-server. ")
+				TEXT("Set %s to a local build, or run `unreal-mcp-cli` to populate the server cache."),
+				ServerPathEnvVar);
+			return false;
+		}
+		BinaryPath = Downloaded;
+	}
+
+	PrepareBinaryForSpawn(BinaryPath);
+
+	// Free the port if an orphaned server from a previous session is squatting on it.
+	KillOrphanedServerOnPort(Port);
+
+	if (!SpawnProcess(BinaryPath))
+	{
+		bStarting = false;
+		UE_LOG(LogUnrealMcp, Error, TEXT("[Unreal-MCP] failed to spawn the local server from '%s'."), *BinaryPath);
+		return false;
+	}
+
+	WindowStartSeconds = FPlatformTime::Seconds();
+	CrashesInWindow = 0;
+	RestartCount.Reset();
+	StartWatchdog();
+	bStarting = false;
+	return true;
+}
+
+bool FUnrealMcpServerManager::ReattachIfRunning(int32 Port, int32 PluginTimeoutMs, bool bAuthRequired, const FString& Token)
+{
+	const int32 SavedPid = ReadPidFile();
+	if (SavedPid <= 0 || !IsServerProcessAlive(SavedPid))
+	{
+		ClearPidFile();
+		return false;
+	}
+
+	// Adopt the survivor: open a handle so a later Stop can terminate it, and re-arm supervision.
+	FProcHandle Adopted = FPlatformProcess::OpenProcess(static_cast<uint32>(SavedPid));
+	if (!Adopted.IsValid())
+	{
+		ClearPidFile();
+		return false;
+	}
+
+	ListenPort = Port;
+	LaunchArgs = BuildLaunchArgs(Port, PluginTimeoutMs, bAuthRequired, Token);
+	BinaryPath = ResolveBinaryPath();
+	{
+		FScopeLock Lock(&ProcessMutex);
+		ProcHandle = Adopted;
+		ProcId = static_cast<uint32>(SavedPid);
+	}
+	bStopRequested = false;
+	WindowStartSeconds = FPlatformTime::Seconds();
+	CrashesInWindow = 0;
+	StartWatchdog();
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] reattached to existing local server pid=%d on port=%d."), SavedPid, Port);
+	return true;
+}
+
+void FUnrealMcpServerManager::StartWatchdog()
+{
+	if (WatchdogFuture.IsValid())
+		return;
+
+	WatchdogFuture = Async(EAsyncExecution::Thread, [this]()
+	{
+		int32 BackoffIndex = 0;
+		while (!bStopRequested)
+		{
+			FPlatformProcess::Sleep(1.0f);
+			if (bStopRequested)
+				break;
+
+			bool bAlive;
+			{
+				FScopeLock Lock(&ProcessMutex);
+				bAlive = ProcHandle.IsValid() && FPlatformProcess::IsProcRunning(ProcHandle);
+			}
+			if (bAlive)
+			{
+				BackoffIndex = 0;
+				continue;
+			}
+
+			// Process died unexpectedly — crash-restart with backoff + a crash-rate guard.
+			const double Now = FPlatformTime::Seconds();
+			if (Now - WindowStartSeconds > ServerCrashWindowSeconds)
+			{
+				WindowStartSeconds = Now;
+				CrashesInWindow = 0;
+			}
+			if (++CrashesInWindow > ServerMaxCrashesPerWindow)
+			{
+				UE_LOG(LogUnrealMcp, Error,
+					TEXT("[Unreal-MCP] local server crashed > %d times in %.0fs; giving up auto-restart."),
+					ServerMaxCrashesPerWindow, ServerCrashWindowSeconds);
+				ClearPidFile();
+				return;
+			}
+
+			const int32 DelaySeconds = ServerBackoffSeconds[FMath::Min(BackoffIndex, (int32)UE_ARRAY_COUNT(ServerBackoffSeconds) - 1)];
+			++BackoffIndex;
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] local server exited; restarting in %ds (restart #%d)."),
+				DelaySeconds, RestartCount.GetValue() + 1);
+
+			// Chunk the backoff so editor shutdown (which joins this thread) is not stalled by one long sleep.
+			const double BackoffUntil = FPlatformTime::Seconds() + DelaySeconds;
+			while (!bStopRequested && FPlatformTime::Seconds() < BackoffUntil)
+				FPlatformProcess::Sleep(0.5f);
+			if (bStopRequested)
+				break;
+
+			{
+				FScopeLock Lock(&ProcessMutex);
+				if (ProcHandle.IsValid())
+				{
+					FPlatformProcess::CloseProc(ProcHandle);
+					ProcHandle.Reset();
+				}
+			}
+			if (ListenPort > 0)
+				KillOrphanedServerOnPort(ListenPort);
+			if (SpawnProcess(BinaryPath))
+				RestartCount.Increment();
+		}
+	});
+}
+
+void FUnrealMcpServerManager::StopWatchdog()
+{
+	bStopRequested = true;
+	if (WatchdogFuture.IsValid())
+	{
+		WatchdogFuture.Wait();
+		WatchdogFuture = TFuture<void>();
+	}
+}
+
+void FUnrealMcpServerManager::TerminateProcess(bool bForce)
+{
+	FProcHandle Handle;
+	{
+		FScopeLock Lock(&ProcessMutex);
+		Handle = ProcHandle;
+	}
+	if (Handle.IsValid())
+	{
+		if (FPlatformProcess::IsProcRunning(Handle))
+			FPlatformProcess::TerminateProc(Handle, /*KillTree*/ true);
+		if (bForce)
+		{
+			// Bounded wait so editor shutdown does not orphan the child if TerminateProc is still propagating.
+			const double Deadline = FPlatformTime::Seconds() + 5.0;
+			while (FPlatformProcess::IsProcRunning(Handle) && FPlatformTime::Seconds() < Deadline)
+				FPlatformProcess::Sleep(0.05f);
+		}
+		FPlatformProcess::CloseProc(Handle);
+	}
+	{
+		FScopeLock Lock(&ProcessMutex);
+		ProcHandle.Reset();
+		ProcId = 0;
+	}
+}
+
+void FUnrealMcpServerManager::Stop(bool bForce)
+{
+	StopWatchdog();        // stop restarting BEFORE terminating, so a relaunch cannot undo the kill
+	TerminateProcess(bForce);
+	ClearPidFile();
+}
+
+bool FUnrealMcpServerManager::IsRunning() const
+{
+	FScopeLock Lock(&ProcessMutex);
+	return ProcHandle.IsValid() && FPlatformProcess::IsProcRunning(const_cast<FProcHandle&>(ProcHandle));
+}
+
+FString FUnrealMcpServerManager::PidFilePath()
+{
+	const FString ProjectDir = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
+	return ProjectDir / TEXT("Intermediate") / TEXT("UnrealMCP") / TEXT("server") / TEXT("server.pid");
+}
+
+void FUnrealMcpServerManager::WritePidFile(uint32 Pid)
+{
+	const FString Path = PidFilePath();
+	IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), /*Tree*/ true);
+	FFileHelper::SaveStringToFile(FString::FromInt(static_cast<int32>(Pid)), *Path);
+}
+
+void FUnrealMcpServerManager::ClearPidFile()
+{
+	IFileManager::Get().Delete(*PidFilePath(), /*RequireExists*/ false, /*EvenReadOnly*/ true, /*Quiet*/ true);
+}
+
+int32 FUnrealMcpServerManager::ReadPidFile()
+{
+	FString Contents;
+	if (FFileHelper::LoadFileToString(Contents, *PidFilePath()))
+	{
+		const int32 Pid = FCString::Atoi(*Contents.TrimStartAndEnd());
+		return Pid > 0 ? Pid : -1;
+	}
+	return -1;
+}
+
+bool FUnrealMcpServerManager::IsServerProcessAlive(int32 Pid)
+{
+	if (Pid <= 0)
+		return false;
+	const FString Name = FPlatformProcess::GetApplicationName(static_cast<uint32>(Pid));
+	if (Name.IsEmpty())
+		return false;
+	return Name.Contains(ServerProcessNameNeedle);
+}
+
+int32 FUnrealMcpServerManager::GetPidListeningOnPort(int32 Port)
+{
+	int32 ReturnCode = -1;
+	FString StdOut;
+	FString StdErr;
+
+#if PLATFORM_WINDOWS
+	const FString Cmd = TEXT("netstat.exe");
+	const FString Params = TEXT("-ano -p tcp");
+#else
+	const FString Cmd = TEXT("lsof");
+	const FString Params = FString::Printf(TEXT("-ti tcp:%d -sTCP:LISTEN"), Port);
+#endif
+
+	if (!FPlatformProcess::ExecProcess(*Cmd, *Params, &ReturnCode, &StdOut, &StdErr))
+		return -1;
+
+#if PLATFORM_WINDOWS
+	const FString PortSuffix = FString::Printf(TEXT(":%d"), Port);
+	TArray<FString> Lines;
+	StdOut.ParseIntoArrayLines(Lines);
+	for (const FString& Line : Lines)
+	{
+		const FString Trimmed = Line.TrimStartAndEnd();
+		if (!Trimmed.Contains(TEXT("LISTENING")))
+			continue;
+		TArray<FString> Parts;
+		Trimmed.ParseIntoArray(Parts, TEXT(" "), /*CullEmpty*/ true);
+		if (Parts.Num() < 5)
+			continue;
+		// Parts: Proto LocalAddr ForeignAddr State PID
+		if (Parts[1].EndsWith(PortSuffix))
+		{
+			const int32 Pid = FCString::Atoi(*Parts.Last());
+			if (Pid > 0)
+				return Pid;
+		}
+	}
+#else
+	const FString Trimmed = StdOut.TrimStartAndEnd();
+	if (!Trimmed.IsEmpty())
+	{
+		TArray<FString> Lines;
+		Trimmed.ParseIntoArrayLines(Lines);
+		if (Lines.Num() > 0)
+		{
+			const int32 Pid = FCString::Atoi(*Lines[0].TrimStartAndEnd());
+			if (Pid > 0)
+				return Pid;
+		}
+	}
+#endif
+	return -1;
+}
+
+void FUnrealMcpServerManager::KillOrphanedServerOnPort(int32 Port)
+{
+	const int32 ListeningPid = GetPidListeningOnPort(Port);
+	if (ListeningPid <= 0)
+		return;
+
+	uint32 OwnPid;
+	{
+		FScopeLock Lock(&ProcessMutex);
+		OwnPid = ProcId;
+	}
+	if (static_cast<uint32>(ListeningPid) == OwnPid)
+		return; // our own child
+
+	// Fail safe: only kill it when it is actually a gamedev-mcp-server (never a random port owner).
+	if (!IsServerProcessAlive(ListeningPid))
+	{
+		UE_LOG(LogUnrealMcp, Warning,
+			TEXT("[Unreal-MCP] port %d is held by a non-server process (pid=%d); not killing it. ")
+			TEXT("Free the port or change the Custom host."), Port, ListeningPid);
+		return;
+	}
+
+	UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] killing orphaned local server pid=%d holding port %d."), ListeningPid, Port);
+	FProcHandle Orphan = FPlatformProcess::OpenProcess(static_cast<uint32>(ListeningPid));
+	if (Orphan.IsValid())
+	{
+		FPlatformProcess::TerminateProc(Orphan, /*KillTree*/ true);
+		const double Deadline = FPlatformTime::Seconds() + 3.0;
+		while (FPlatformProcess::IsProcRunning(Orphan) && FPlatformTime::Seconds() < Deadline)
+			FPlatformProcess::Sleep(0.05f);
+		FPlatformProcess::CloseProc(Orphan);
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.h
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "HAL/ThreadSafeBool.h"
+#include "HAL/CriticalSection.h"
+#include "GenericPlatform/GenericPlatformProcess.h"
+
+/**
+ * Owns the lifecycle of the LOCAL shared `gamedev-mcp-server` process (the engine-agnostic MCP server
+ * released from GameDev-MCP-Server, binary `gamedev-mcp-server`), the plugin-side analog of Unity's
+ * in-process `McpServerManager.cs`. Adapted to UE/C++ (FPlatformProcess::CreateProc, a watchdog thread
+ * for crash-restart, FCoreDelegates editor-shutdown teardown) — distinct from FUnrealMcpSidecarManager,
+ * which owns the `unreal-mcp-bridge` sidecar (always required). The local server is ONLY relevant in
+ * Custom connection mode with http transport: the AI agent dials `http://localhost:<port>` and this
+ * process is what listens there.
+ *
+ * Lifecycle parity with Unity's manager: ResolveBinaryPath (env override → cached binary → download),
+ * Start/Stop(force)/IsRunning, startup verification, crash-restart with backoff, orphan-port kill,
+ * PID persistence + reattach across module reloads, graceful-then-force stop on editor shutdown so NO
+ * orphaned `gamedev-mcp-server` survives editor close.
+ *
+ * Threading: Start/Stop/IsRunning and every status read are GAME-THREAD only (the UI calls them there).
+ * A background watchdog thread owns ProcHandle mutation between Start and Stop; ProcessMutex guards the
+ * handle so the game-thread Stop can race the watchdog safely.
+ */
+class FUnrealMcpServerManager
+{
+public:
+	/** The pinned shared server version this plugin consumes. Kept in lockstep with cli/src/lib/server-version.ts. */
+	static UNREALMCPEDITOR_API const TCHAR* ServerVersion;
+
+	/** Env var that overrides the resolved server binary path (skips cache + download). Mirrors the CLI's UNREAL_MCP_SERVER_PATH. */
+	static UNREALMCPEDITOR_API const TCHAR* ServerPathEnvVar;
+
+	UNREALMCPEDITOR_API FUnrealMcpServerManager();
+	UNREALMCPEDITOR_API ~FUnrealMcpServerManager();
+
+	/**
+	 * Launch + supervise the local server on @p Port with the given launch parameters (auth/token). Resolves
+	 * the binary (override → cache → download), kills any orphaned `gamedev-mcp-server` already holding @p Port,
+	 * spawns the process, verifies it survives a brief startup window, then arms the crash-restart watchdog.
+	 * Returns true when the process was spawned (verification + supervision proceed asynchronously). Idempotent:
+	 * a call while already running/starting is a no-op that returns true. Game-thread only.
+	 *
+	 * @p bAuthRequired / @p Token shape the `authorization` + `token` launch args exactly like Unity's BuildArguments.
+	 */
+	bool Start(int32 Port, int32 PluginTimeoutMs, bool bAuthRequired, const FString& Token);
+
+	/**
+	 * Stop the supervised server. Stops the watchdog first (so a relaunch cannot undo the kill), then sends the
+	 * platform terminate (KillTree) and, when @p bForce, blocks (bounded) until the child has actually exited —
+	 * used on editor shutdown so no orphan survives. Clears the persisted PID. Idempotent. Game-thread only.
+	 */
+	void Stop(bool bForce = false);
+
+	/** Whether the supervised server process is currently running. Game-thread only. */
+	bool IsRunning() const;
+
+	/** Total auto-restarts the watchdog performed since the last Start (for the UI status string). */
+	int32 GetRestartCount() const { return RestartCount.GetValue(); }
+
+	/**
+	 * Reattach to a server this plugin spawned in a PREVIOUS editor module load (a hot-reload / domain-reload
+	 * survivor) whose PID is persisted under {Project}/Intermediate/UnrealMCP/server/server.pid. When the PID
+	 * still names a live `gamedev-mcp-server`, adopt it (so a later Stop tears it down) and re-arm the watchdog;
+	 * otherwise clear the stale marker. Returns true when an existing process was adopted. Game-thread only.
+	 */
+	bool ReattachIfRunning(int32 Port, int32 PluginTimeoutMs, bool bAuthRequired, const FString& Token);
+
+	// --- Pure / static helpers (the spec-friendly heart — no live process, injectable filesystem). ---
+
+	/** The platform server binary basename: "gamedev-mcp-server.exe" on Windows, "gamedev-mcp-server" elsewhere. */
+	static UNREALMCPEDITOR_API FString ServerBinaryBasename();
+
+	/**
+	 * The .NET RID directory name for the current host (matches FUnrealMcpSidecarManager::ResolveRid and the
+	 * CLI's ridForPlatform): "win-x64" / "linux-x64", or on macOS "osx-arm64" vs "osx-x64" from the physical
+	 * host CPU. @p bArm64DirExists lets a caller degrade a missing arm64 slice to osx-x64; pure + injectable.
+	 */
+	static UNREALMCPEDITOR_API FString ResolveRid(bool bArm64DirExists = true);
+
+	/**
+	 * The §6 install dir for the local server under a project: <ProjectDir>/Intermediate/UnrealMCP/server/<rid>.
+	 * Pure string composition (no FileExists), absolute-ized. Matches the CLI's serverInstallDir layout so the
+	 * cli-downloaded binary and a plugin-downloaded binary share ONE cache. @p Rid lets a spec pin the slice.
+	 */
+	static UNREALMCPEDITOR_API FString ServerInstallDir(const FString& ProjectDir, const FString& Rid);
+
+	/** The absolute path to the installed server binary under ServerInstallDir. Pure. */
+	static UNREALMCPEDITOR_API FString ServerBinaryPathFor(const FString& ProjectDir, const FString& Rid);
+
+	/** Read the `version` marker file in @p InstallDir (the version of the cached binary), or empty when absent. */
+	static UNREALMCPEDITOR_API FString ReadVersionMarker(const FString& InstallDir);
+
+	/**
+	 * Parse the listen port out of a Custom-mode host URL ("http://localhost:8080" → 8080, "https://h" → 443,
+	 * "http://h" → 80). Returns @p DefaultPort when the URL has no explicit port and no inferable scheme default,
+	 * or when @p HostUrl is empty/unparseable. Pure — the launch port the agent dials must equal the port the
+	 * server listens on, so both are derived from the SAME Custom host the UI shows (mirrors Unity's Port).
+	 */
+	static UNREALMCPEDITOR_API int32 ParsePortFromHost(const FString& HostUrl, int32 DefaultPort = 8080);
+
+	/**
+	 * Compose the server launch args (Unity BuildArguments parity, the order the server's CLI parser expects):
+	 *   port=<port> plugin-timeout=<ms> client-transport=streamableHttp authorization=<none|required> [token=<t>]
+	 * The token arg is appended ONLY when @p bAuthRequired AND @p Token is non-empty. Pure — exercised by a spec.
+	 * The transport is ALWAYS streamableHttp for a launched local server (the agent's stdio/http choice is about
+	 * how the AGENT reaches the server, not how the server is hosted) — matching Unity's hard-coded launch transport.
+	 */
+	static UNREALMCPEDITOR_API FString BuildLaunchArgs(int32 Port, int32 PluginTimeoutMs, bool bAuthRequired, const FString& Token);
+
+	/**
+	 * Whether the local server may be launched for the given mode + transport. ONLY Custom mode + http transport
+	 * targets a locally-hosted server; Cloud (remote) and Custom+stdio never launch one. Pure (no engine access)
+	 * so it is unit-testable and so the UI can hide/disable the Start affordance off this single predicate.
+	 */
+	static UNREALMCPEDITOR_API bool IsLaunchAllowed(bool bIsCustomMode, bool bIsHttpTransport);
+
+	/**
+	 * Resolve the server binary path for the LIVE project: ServerPathEnvVar override first (when set + present),
+	 * else the cached binary under the §6 install dir when its `version` marker matches ServerVersion, else empty
+	 * (caller downloads). Reads real env + filesystem; the project dir / rid come from the engine.
+	 */
+	UNREALMCPEDITOR_API FString ResolveBinaryPath() const;
+
+private:
+	/** macOS/Linux pre-spawn: chmod +x the resolved binary so a freshly-downloaded server is runnable. No-op on Windows. */
+	static void PrepareBinaryForSpawn(const FString& Path);
+
+	/** Download + unpack the pinned server zip into the §6 install dir (override/cache miss path). Blocking; game-thread. */
+	bool DownloadBinaryIfNeeded(FString& OutBinaryPath);
+
+	/** Spawn the resolved binary with the current launch args; records ProcHandle + ProcId under ProcessMutex. */
+	bool SpawnProcess(const FString& BinaryPath);
+
+	/** PID of the `gamedev-mcp-server` listening on @p Port, or -1. Uses netstat (Win) / lsof (Unix) like Unity. */
+	static int32 GetPidListeningOnPort(int32 Port);
+
+	/** Kill an ORPHANED `gamedev-mcp-server` holding @p Port that is not our own child (fails safe — never kills a non-server). */
+	void KillOrphanedServerOnPort(int32 Port);
+
+	void StartWatchdog();
+	void StopWatchdog();
+	void TerminateProcess(bool bForce);
+
+	/** {Project}/Intermediate/UnrealMCP/server/server.pid — survives a module reload for ReattachIfRunning. */
+	static FString PidFilePath();
+	static void WritePidFile(uint32 Pid);
+	static void ClearPidFile();
+	static int32 ReadPidFile();
+	/** Whether @p Pid currently names a live process whose name contains "gamedev-mcp-server". */
+	static bool IsServerProcessAlive(int32 Pid);
+
+	FString BinaryPath;
+	FString LaunchArgs;
+	int32 ListenPort = -1;
+
+	mutable FCriticalSection ProcessMutex;
+	FProcHandle ProcHandle;
+	uint32 ProcId = 0;
+
+	FThreadSafeBool bStopRequested = false;
+	FThreadSafeBool bStarting = false;
+	FThreadSafeCounter RestartCount;
+	TFuture<void> WatchdogFuture;
+
+	// Crash-rate guard (mirrors the sidecar §1.5): > 5 crashes in 5 minutes → stop restarting.
+	double WindowStartSeconds = 0.0;
+	int32 CrashesInWindow = 0;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.h
@@ -41,8 +41,8 @@ public:
 	/**
 	 * Launch + supervise the local server on @p Port with the given launch parameters (auth/token). Resolves
 	 * the binary (override → cache → download), kills any orphaned `gamedev-mcp-server` already holding @p Port,
-	 * spawns the process, verifies it survives a brief startup window, then arms the crash-restart watchdog.
-	 * Returns true when the process was spawned (verification + supervision proceed asynchronously). Idempotent:
+	 * spawns the process, then arms the crash-restart watchdog (which detects an early exit and re-launches with
+	 * backoff). Returns true when the process was spawned (supervision proceeds asynchronously). Idempotent:
 	 * a call while already running/starting is a no-op that returns true. Game-thread only.
 	 *
 	 * @p bAuthRequired / @p Token shape the `authorization` + `token` launch args exactly like Unity's BuildArguments.

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.h
@@ -146,6 +146,16 @@ private:
 	void StopWatchdog();
 	void TerminateProcess(bool bForce);
 
+	/**
+	 * Windows-only: bind the just-spawned process @p ProcessHandle to a kill-on-job-close Job Object so the OS
+	 * terminates the local server when THIS editor process dies by ANY means — including a hard
+	 * TerminateProcess / crash that never runs FUnrealMcpRuntime::Shutdown's graceful stop. The job handle is
+	 * owned by the manager (JobHandle) for the manager's lifetime; the editor process's death closes the last
+	 * handle to it, tripping JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. No-op on non-Windows (the graceful PreExit stop
+	 * and KillTree terminate cover those; a hard-kill orphan there is out of scope for this Windows testbed).
+	 */
+	void BindProcessToKillOnCloseJob(void* ProcessHandle);
+
 	/** {Project}/Intermediate/UnrealMCP/server/server.pid — survives a module reload for ReattachIfRunning. */
 	static FString PidFilePath();
 	static void WritePidFile(uint32 Pid);
@@ -161,6 +171,12 @@ private:
 	mutable FCriticalSection ProcessMutex;
 	FProcHandle ProcHandle;
 	uint32 ProcId = 0;
+
+	// Windows-only kill-on-close Job Object handle (HANDLE stored as void*; nullptr off Windows / before first
+	// spawn). Created lazily on the first spawn and kept for the manager's lifetime so the OS reaps the server
+	// when the editor process dies by ANY means (graceful quit, hard TerminateProcess, or crash). Closed in the
+	// destructor. See BindProcessToKillOnCloseJob.
+	void* JobHandle = nullptr;
 
 	FThreadSafeBool bStopRequested = false;
 	FThreadSafeBool bStarting = false;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -566,32 +566,34 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildMcpServerCard()
 			[
 				SNew(SBox).MinDesiredWidth(RightControlColumnWidth).HAlign(HAlign_Right)
 				[
-					UnrealMcpStyleWidgets::StyledTextButton("UnrealMcp.Button.Primary", LOCTEXT("Start", "Start"),
-						FOnClicked::CreateLambda([this]()
+					// Issue #95: the MCP-server card's Start/Stop button launches + supervises the LOCAL
+					// gamedev-mcp-server (FUnrealMcpServerManager) via the view-model — REPLACING the interim #94
+					// wiring that (re)started the bridge sidecar. The label toggles Start↔Stop with the live server
+					// state; the action is gated to Custom mode + http transport (ToggleLocalServer no-ops otherwise,
+					// and the button is disabled outside that mode so a stray click can never spawn a server). The
+					// card itself is already Custom-only (visibility predicate below); the IsEnabled guard further
+					// disables it for Custom+stdio. NOT ViewModel->Connect() (the Unreal-side SignalR connect, owned
+					// by the "Unreal: <status>" row) and NOT OnRestartBridge (the footer's bridge restart).
+					SNew(SButton)
+					.ButtonStyle(&FUnrealMcpStyle::Get().GetWidgetStyle<FButtonStyle>("UnrealMcp.Button.Primary"))
+					.HAlign(HAlign_Center)
+					.VAlign(VAlign_Center)
+					// Disabled (so a stray click cannot spawn a server) outside Custom+http; ToggleLocalServer also
+					// no-ops in that case as a second guard.
+					.IsEnabled_Lambda([this]() { return IsViewModelValid() && ViewModel->IsLocalServerLaunchable(); })
+					.OnClicked_Lambda([this]()
+					{
+						if (IsViewModelValid())
+							ViewModel->ToggleLocalServer();
+						return FReply::Handled();
+					})
+					[
+						SNew(STextBlock)
+						.Text_Lambda([this]()
 						{
-							// Issue #93: the MCP-server card's "Start" must start the LOCAL server-side process the
-							// plugin manages — NOT ViewModel->Connect(), which is the Unreal-side SignalR connect
-							// already driven by the "Unreal: <status>" row's Connect/Disconnect button (wiring Start
-							// to Connect() duplicated that control and never touched the server process).
-							//
-							// ARCHITECTURE NOTE (locked decision, docs/ARCHITECTURE.md §7 deviation block ~L94-97):
-							// "there is no in-UI start-local-server control" in this release — the shared
-							// gamedev-mcp-server is acquired + launched by the CLI/§6 layer, NOT by the plugin, so the
-							// view-model exposes no StartServer()/launch path to call. The ONE local server-side
-							// process the plugin DOES own and can (re)start is the .NET sidecar (unreal-mcp-bridge),
-							// which hosts the McpPlugin and dials the MCP server (§1/§6). So Start (re)starts the
-							// sidecar via the same OnRestartBridge delegate the footer/§7 item-7 Restart action uses —
-							// the closest correct, architecture-respecting semantics for "start the local server"
-							// without violating the locked no-in-UI-server-launch decision.
-							//
-							// DEFERRED FOLLOW-UP (separate task/PR — issue #93 scope was deliberately split): a true
-							// in-UI launch of the shared gamedev-mcp-server (§7 item 6) — acquire the binary via the
-							// cli/§6 download layout and spawn/manage its process, gated on Custom mode + http
-							// transport — is intentionally NOT done here. This PR ships the bridge-(re)start as the
-							// interim Start behavior; the real local-server Start/Stop lands in the follow-up.
-							OnRestartBridge.ExecuteIfBound();
-							return FReply::Handled();
-						}))
+							return IsViewModelValid() ? ViewModel->GetLocalServerButtonText() : LOCTEXT("Start", "Start");
+						})
+					]
 				]
 			]
 		]

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -454,6 +454,47 @@ FString FUnrealMcpEditorViewModel::MaskTokenForDisplay(const FString& Token, boo
 	return FString::ChrN(8, TEXT('\x2022')); // U+2022 BULLET
 }
 
+bool FUnrealMcpEditorViewModel::IsLocalServerLaunchable() const
+{
+	// ONLY Custom mode + http transport targets a locally-hosted server (mirrors
+	// FUnrealMcpServerManager::IsLaunchAllowed). Use the connection-AWARE effective transport so Cloud (which
+	// forces Http) still gates OUT on its non-Custom mode rather than slipping through on the locked Http value.
+	return Config.ConnectionMode == EUnrealMcpConnectionMode::Custom
+		&& Config.ResolveEffectiveTransport() == EUnrealMcpTransportMethod::Http;
+}
+
+bool FUnrealMcpEditorViewModel::IsLocalServerRunning() const
+{
+	return IsLocalServerRunningSink ? IsLocalServerRunningSink() : false;
+}
+
+bool FUnrealMcpEditorViewModel::ToggleLocalServer()
+{
+	// Gating guard: a click in Cloud / Custom+stdio must NEVER spawn a server. This is the single choke point
+	// the UI Start button AND the dev-control /control/click "start" both route through.
+	if (!IsLocalServerLaunchable())
+	{
+		UE_LOG(LogUnrealMcp, Verbose,
+			TEXT("[Unreal-MCP] local-server toggle ignored — not launchable (requires Custom mode + http transport)."));
+		return false;
+	}
+
+	if (IsLocalServerRunning())
+	{
+		if (OnStopLocalServer)
+			OnStopLocalServer();
+		return true;
+	}
+	if (OnStartLocalServer)
+		return OnStartLocalServer();
+	return false;
+}
+
+FText FUnrealMcpEditorViewModel::GetLocalServerButtonText() const
+{
+	return IsLocalServerRunning() ? LOCTEXT("ServerBtnStop", "Stop") : LOCTEXT("ServerBtnStart", "Start");
+}
+
 FText FUnrealMcpEditorViewModel::GetButtonText(EUnrealMcpConnectionState State)
 {
 	switch (State)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
@@ -81,6 +81,40 @@ public:
 	 */
 	TFunction<void(const TArray<FString>& /*DisabledTools*/)> OnToolEnablementChanged;
 
+	// --- Local MCP-server (gamedev-mcp-server) control sinks (§7 in-UI Start, issue #95). ---
+
+	/**
+	 * Start the LOCAL gamedev-mcp-server (the MCP-server card's "Start"). Wired by the runtime to
+	 * FUnrealMcpServerManager::Start(); a spec leaves it unset. ONLY invoked when the launch is gated-in
+	 * (Custom mode + http transport) — see IsLocalServerLaunchable / ToggleLocalServer. Returns true on a
+	 * successful (or already-running) start.
+	 */
+	TFunction<bool()> OnStartLocalServer;
+	/** Stop the LOCAL gamedev-mcp-server (the MCP-server card's "Stop"). Wired to FUnrealMcpServerManager::Stop(). */
+	TFunction<void()> OnStopLocalServer;
+	/** Report whether the LOCAL gamedev-mcp-server is currently running. Wired to FUnrealMcpServerManager::IsRunning(); unset → false. */
+	TFunction<bool()> IsLocalServerRunningSink;
+
+	// --- Local MCP-server gating + control (pure view-model surface over the sinks above). ---
+
+	/**
+	 * Whether the in-UI local-server Start affordance is offered at all: ONLY in Custom mode with http transport
+	 * (mirrors FUnrealMcpServerManager::IsLaunchAllowed). In Cloud mode, or Custom+stdio, the Start button is
+	 * hidden/disabled and a click is a no-op — the server is never launched. Pure (reads the config only).
+	 */
+	UNREALMCPEDITOR_API bool IsLocalServerLaunchable() const;
+	/** Whether the local server is currently running (false when no sink is wired). Game-thread only. */
+	UNREALMCPEDITOR_API bool IsLocalServerRunning() const;
+	/**
+	 * The MCP-server card's Start/Stop toggle: when launchable, start the server if stopped, else stop it. A
+	 * NO-OP (returns false, never touches the sinks) when NOT launchable (Cloud / Custom+stdio) — the gating
+	 * guard that guarantees a stray click cannot spawn a server in a non-Custom+http mode. Game-thread only.
+	 * Returns true when an action was taken.
+	 */
+	UNREALMCPEDITOR_API bool ToggleLocalServer();
+	/** The MCP-server card's button label for the current state: "Start" when stopped, "Stop" when running. */
+	UNREALMCPEDITOR_API FText GetLocalServerButtonText() const;
+
 	/**
 	 * Fires whenever a connection-affecting setting changes — connection mode (Cloud↔Custom), Custom host,
 	 * auth option, the Custom/Cloud token. The AI Agent Configurators panel subscribes to this so it can

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -9,6 +9,7 @@
 #include "Dispatch/UnrealMcpGameThreadDispatcher.h"
 #include "Bridge/UnrealMcpBridgeServer.h"
 #include "Sidecar/UnrealMcpSidecarManager.h"
+#include "Server/UnrealMcpServerManager.h"
 #include "Extensions/UnrealMcpExtensionManager.h"
 #include "UI/UnrealMcpEditorViewModel.h"
 #include "UI/UnrealMcpMainWindowTab.h"
@@ -114,6 +115,21 @@ void FUnrealMcpRuntime::Startup()
 	SidecarManager = MakeUnique<FUnrealMcpSidecarManager>();
 	SidecarManager->StartForPort(BoundPort, Token);
 
+	// §7 in-UI local-server (issue #95): create the local gamedev-mcp-server manager. It does NOT auto-start —
+	// the user launches it from the MCP-server card's Start button (Custom+http only). Reattach to a server this
+	// plugin spawned in a previous module load (hot-reload survivor) so a later Stop / editor-quit tears it down
+	// instead of orphaning it — only meaningful in Custom+http.
+	ServerManager = MakeUnique<FUnrealMcpServerManager>();
+	if (FUnrealMcpServerManager::IsLaunchAllowed(
+			Config.ConnectionMode == EUnrealMcpConnectionMode::Custom,
+			Config.ResolveEffectiveTransport() == EUnrealMcpTransportMethod::Http))
+	{
+		const int32 ReattachPort = FUnrealMcpServerManager::ParsePortFromHost(Config.ResolveCustomHost());
+		ServerManager->ReattachIfRunning(
+			ReattachPort, /*PluginTimeoutMs*/ 10000,
+			Config.AuthOption == EUnrealMcpAuthOption::Required, Config.ResolveEffectiveToken());
+	}
+
 	// §7 UI: the main-window view-model owns all UI state; wire its side-effect sinks to the real subsystems.
 	// All config writes go config-store-first (Save) then push the §1.3 `config` to the sidecar (§7 ownership).
 	ViewModel = MakeShared<FUnrealMcpEditorViewModel>();
@@ -139,6 +155,31 @@ void FUnrealMcpRuntime::Startup()
 	{
 		if (!Url.IsEmpty())
 			FPlatformProcess::LaunchURL(*Url, nullptr, nullptr);
+	};
+
+	// §7 in-UI local-server (issue #95): wire the MCP-server card's Start/Stop to the local server manager. The
+	// view-model already gates these to Custom+http (ToggleLocalServer no-ops otherwise) — the sinks just execute.
+	// Re-resolve the §8 config on each Start so the port (from the Custom host), auth, and token reflect what the
+	// user has set right now. The port the agent dials (Custom host) MUST equal the port the server listens on.
+	FUnrealMcpServerManager* ServerPtr = ServerManager.Get();
+	ViewModel->OnStartLocalServer = [ServerPtr]() -> bool
+	{
+		if (!ServerPtr)
+			return false;
+		const FUnrealMcpConfig Live = FUnrealMcpConfig::LoadAndResolve();
+		const int32 ServerPort = FUnrealMcpServerManager::ParsePortFromHost(Live.ResolveCustomHost());
+		return ServerPtr->Start(
+			ServerPort, /*PluginTimeoutMs*/ 10000,
+			Live.AuthOption == EUnrealMcpAuthOption::Required, Live.ResolveEffectiveToken());
+	};
+	ViewModel->OnStopLocalServer = [ServerPtr]()
+	{
+		if (ServerPtr)
+			ServerPtr->Stop(/*bForce*/ false);
+	};
+	ViewModel->IsLocalServerRunningSink = [ServerPtr]() -> bool
+	{
+		return ServerPtr && ServerPtr->IsRunning();
 	};
 	// §7 per-tool enable-map: a Tools-window toggle re-applies the disabled set to the registry and re-pushes the
 	// manifest so the sidecar's tools/list drops/restores the toggled tool over the wire (§2.2). The view-model
@@ -337,6 +378,10 @@ void FUnrealMcpRuntime::Shutdown()
 		ViewModel->OnSendAuth = nullptr;
 		ViewModel->OnOpenBrowser = nullptr;
 		ViewModel->OnToolEnablementChanged = nullptr; // captures the raw registry/bridge pointers freed below
+		// §7 in-UI local-server sinks capture the raw FUnrealMcpServerManager* freed below — null before that.
+		ViewModel->OnStartLocalServer = nullptr;
+		ViewModel->OnStopLocalServer = nullptr;
+		ViewModel->IsLocalServerRunningSink = nullptr;
 	}
 	ViewModel.Reset();
 
@@ -351,6 +396,15 @@ void FUnrealMcpRuntime::Shutdown()
 		SidecarManager->WaitForExit(FTimespan::FromSeconds(3)); // bounded grace for a clean self-exit
 		SidecarManager->Stop();                                 // backstop: TerminateProc if still alive
 		SidecarManager.Reset();
+	}
+
+	// §7 in-UI local-server (issue #95): force-stop the local gamedev-mcp-server on editor shutdown so NO
+	// orphaned server process survives editor close (the DoD "Start then close → server dies" requirement).
+	// bForce blocks (bounded) until the child has actually exited. No-op when one was never started.
+	if (ServerManager.IsValid())
+	{
+		ServerManager->Stop(/*bForce*/ true);
+		ServerManager.Reset();
 	}
 
 	// Unsubscribe from modular-feature events before the registry it mutates is torn down.

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.h
@@ -9,6 +9,7 @@ class FUnrealMcpToolRegistry;
 class FUnrealMcpGameThreadDispatcher;
 class FUnrealMcpBridgeServer;
 class FUnrealMcpSidecarManager;
+class FUnrealMcpServerManager;
 class FUnrealMcpExtensionManager;
 class FUnrealMcpEditorViewModel;
 class FUnrealMcpMainWindowTab;
@@ -43,6 +44,10 @@ private:
 	TUniquePtr<FUnrealMcpGameThreadDispatcher> Dispatcher;
 	TUniquePtr<FUnrealMcpBridgeServer> BridgeServer;
 	TUniquePtr<FUnrealMcpSidecarManager> SidecarManager;
+	// §7 in-UI local-server (issue #95): owns the LOCAL gamedev-mcp-server process (Custom+http only), the
+	// plugin-side analog of Unity's McpServerManager. Distinct from SidecarManager (the always-on bridge).
+	// Force-stopped in Shutdown so no gamedev-mcp-server orphans on editor close.
+	TUniquePtr<FUnrealMcpServerManager> ServerManager;
 	TUniquePtr<FUnrealMcpExtensionManager> ExtensionManager;
 
 	// §7 UI: the main-window view-model (shared so the nomad tab's widget binds to it) and its tab spawner,

--- a/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
+++ b/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
@@ -40,6 +40,11 @@ public class UnrealMcpEditor : ModuleRules
 			"Projects",
 			"EditorSubsystem",
 			"DeveloperSettings",
+			// Local gamedev-mcp-server launch/supervision (FUnrealMcpServerManager, docs/ARCHITECTURE.md §7):
+			//  - HTTP          -> download the pinned server release zip on a cache miss (override/cache first)
+			//  - FileUtilities -> FZipArchiveReader (libzip-backed) to unpack the downloaded release zip
+			"HTTP",
+			"FileUtilities",
 			// Slate main window (docs/ARCHITECTURE.md §7): nomad-tab registration via FGlobalTabmanager
 			// needs WorkspaceMenuStructure (the "AI Game Developer" Window-menu group, applied via
 			// RegisterNomadTabSpawner().SetGroup); the masked-token field reads keystrokes via InputCore;

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDevControlSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDevControlSpec.cpp
@@ -26,6 +26,10 @@ BEGIN_DEFINE_SPEC(FUnrealMcpDevControlSpec, "UnrealMcp.DevControl",
 		int32 PersistCount = 0;
 		int32 PushCount = 0;
 		TArray<FString> AuthSent;
+		// §7 in-UI local-server (issue #95): recording stubs for the server sinks.
+		int32 ServerStartCount = 0;
+		int32 ServerStopCount = 0;
+		bool bServerRunning = false;
 	};
 
 	static TSharedRef<FUnrealMcpEditorViewModel> DevCtlMakeViewModel(TSharedRef<FDevCtlRecording> Rec)
@@ -35,6 +39,9 @@ BEGIN_DEFINE_SPEC(FUnrealMcpDevControlSpec, "UnrealMcp.DevControl",
 		VM->OnPushConfig = [Rec](const FUnrealMcpConfig&) { Rec->PushCount++; };
 		VM->OnSendAuth = [Rec](const FString& Type) -> bool { Rec->AuthSent.Add(Type); return true; };
 		VM->OnOpenBrowser = [](const FString&) {};
+		VM->OnStartLocalServer = [Rec]() -> bool { Rec->ServerStartCount++; Rec->bServerRunning = true; return true; };
+		VM->OnStopLocalServer = [Rec]() { Rec->ServerStopCount++; Rec->bServerRunning = false; };
+		VM->IsLocalServerRunningSink = [Rec]() -> bool { return Rec->bServerRunning; };
 		return VM;
 	}
 
@@ -317,18 +324,77 @@ void FUnrealMcpDevControlSpec::Define()
 			TestEqual("target echoed", Result->GetStringField(TEXT("target")), FString(TEXT("check")));
 		});
 
-		It("click=start (the MCP-server Start button) arms reconnect and goes Connecting", [this]()
+		It("click=start (the MCP-server Start button) launches the local server in Custom+http (issue #95)", [this]()
 		{
 			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
 			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			VM->SetTransportMethod(EUnrealMcpTransportMethod::Http);
 
 			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
 			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
 				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"start\"}")), &VM.Get(), Result);
 
 			TestEqual("status", Status, 200);
-			TestTrue("reconnect armed", VM->IsReconnectArmed());
-			TestEqual("state", VM->GetConnectionState(), EUnrealMcpConnectionState::Connecting);
+			TestEqual("server started (not Connect())", Rec->ServerStartCount, 1);
+			TestTrue("serverRunning echoed true", Result->GetBoolField(TEXT("serverRunning")));
+			TestTrue("serverLaunchable echoed true", Result->GetBoolField(TEXT("serverLaunchable")));
+			// The Start button must NOT touch the SignalR connection (that is the "Unreal:" row's Connect).
+			// Connect() would optimistically drive the state to Connecting; the server-start path must leave the
+			// SignalR connection state untouched (Disconnected here — never started).
+			TestEqual("did not drive the SignalR connection (state untouched)",
+				VM->GetConnectionState(), EUnrealMcpConnectionState::Disconnected);
+		});
+
+		It("click=start-server then stop-server drives a clean server start/stop cycle (Custom+http)", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			VM->SetTransportMethod(EUnrealMcpTransportMethod::Http);
+
+			TSharedRef<FJsonObject> R1 = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"start-server\"}")), &VM.Get(), R1);
+			TestEqual("started once", Rec->ServerStartCount, 1);
+			TestTrue("running after start-server", R1->GetBoolField(TEXT("serverRunning")));
+
+			// Idempotent: a repeat start-server while running does NOT stop it.
+			TSharedRef<FJsonObject> R2 = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"start-server\"}")), &VM.Get(), R2);
+			TestEqual("start-server idempotent (no extra start)", Rec->ServerStartCount, 1);
+			TestEqual("start-server idempotent (no stop)", Rec->ServerStopCount, 0);
+
+			TSharedRef<FJsonObject> R3 = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"stop-server\"}")), &VM.Get(), R3);
+			TestEqual("stopped once", Rec->ServerStopCount, 1);
+			TestFalse("not running after stop-server", R3->GetBoolField(TEXT("serverRunning")));
+		});
+
+		It("click=start-server is a NO-OP that never spawns a server in Cloud / Custom+stdio (gating)", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+
+			// Custom + stdio: gated out.
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			VM->SetTransportMethod(EUnrealMcpTransportMethod::Stdio);
+			TSharedRef<FJsonObject> R1 = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"start-server\"}")), &VM.Get(), R1);
+			TestEqual("no start in Custom+stdio", Rec->ServerStartCount, 0);
+			TestFalse("serverRunning false in Custom+stdio", R1->GetBoolField(TEXT("serverRunning")));
+			TestFalse("serverLaunchable false in Custom+stdio", R1->GetBoolField(TEXT("serverLaunchable")));
+
+			// Cloud: gated out.
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Cloud);
+			TSharedRef<FJsonObject> R2 = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/click"), DevCtlBody(TEXT("{\"target\":\"start-server\"}")), &VM.Get(), R2);
+			TestEqual("no start in Cloud", Rec->ServerStartCount, 0);
+			TestFalse("serverRunning false in Cloud", R2->GetBoolField(TEXT("serverRunning")));
 		});
 
 		It("click=stop (the tri-state Stop button) halts the reconnect loop", [this]()

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
@@ -26,6 +26,11 @@ BEGIN_DEFINE_SPEC(FUnrealMcpEditorViewModelSpec, "UnrealMcp.EditorViewModel",
 		TArray<FString> AuthSent;
 		TArray<FString> OpenedUrls;
 		FUnrealMcpConfig LastPushed;
+		// §7 in-UI local-server (issue #95): the recording stubs for the server sinks. bServerRunning is the
+		// fake live state the IsLocalServerRunningSink reads; OnStart flips it true, OnStop flips it false.
+		int32 ServerStartCount = 0;
+		int32 ServerStopCount = 0;
+		bool bServerRunning = false;
 	};
 
 	static TSharedRef<FUnrealMcpEditorViewModel> MakeViewModel(TSharedRef<FRecording> Rec)
@@ -35,6 +40,9 @@ BEGIN_DEFINE_SPEC(FUnrealMcpEditorViewModelSpec, "UnrealMcp.EditorViewModel",
 		VM->OnPushConfig = [Rec](const FUnrealMcpConfig& Cfg) { Rec->PushCount++; Rec->LastPushed = Cfg; };
 		VM->OnSendAuth = [Rec](const FString& Type) -> bool { Rec->AuthSent.Add(Type); return true; };
 		VM->OnOpenBrowser = [Rec](const FString& Url) { Rec->OpenedUrls.Add(Url); };
+		VM->OnStartLocalServer = [Rec]() -> bool { Rec->ServerStartCount++; Rec->bServerRunning = true; return true; };
+		VM->OnStopLocalServer = [Rec]() { Rec->ServerStopCount++; Rec->bServerRunning = false; };
+		VM->IsLocalServerRunningSink = [Rec]() -> bool { return Rec->bServerRunning; };
 		return VM;
 	}
 
@@ -447,6 +455,66 @@ void FUnrealMcpEditorViewModelSpec::Define()
 			// A stray SetTransportMethod in Cloud is ignored (selector is locked).
 			VM->SetTransportMethod(EUnrealMcpTransportMethod::Stdio);
 			TestEqual("Cloud transport stays Http after stray set", static_cast<int32>(VM->GetEffectiveTransport()), static_cast<int32>(EUnrealMcpTransportMethod::Http));
+		});
+	});
+
+	Describe("Local MCP-server gating + toggle (§7 in-UI Start — issue #95)", [this]()
+	{
+		It("is launchable ONLY in Custom mode + http transport", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			// Custom + http -> launchable.
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			VM->SetTransportMethod(EUnrealMcpTransportMethod::Http);
+			TestTrue("Custom+http launchable", VM->IsLocalServerLaunchable());
+
+			// Custom + stdio -> NOT launchable.
+			VM->SetTransportMethod(EUnrealMcpTransportMethod::Stdio);
+			TestFalse("Custom+stdio not launchable", VM->IsLocalServerLaunchable());
+
+			// Cloud (forces http) -> still NOT launchable (mode gates it out).
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Cloud);
+			TestFalse("Cloud not launchable", VM->IsLocalServerLaunchable());
+		});
+
+		It("ToggleLocalServer starts then stops the server in Custom+http and reports the live state", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			VM->SetTransportMethod(EUnrealMcpTransportMethod::Http);
+
+			TestFalse("starts stopped", VM->IsLocalServerRunning());
+			TestEqual("button label Start when stopped", VM->GetLocalServerButtonText().ToString(), FString(TEXT("Start")));
+
+			TestTrue("toggle acted (start)", VM->ToggleLocalServer());
+			TestEqual("started once", Rec->ServerStartCount, 1);
+			TestTrue("now running", VM->IsLocalServerRunning());
+			TestEqual("button label Stop when running", VM->GetLocalServerButtonText().ToString(), FString(TEXT("Stop")));
+
+			TestTrue("toggle acted (stop)", VM->ToggleLocalServer());
+			TestEqual("stopped once", Rec->ServerStopCount, 1);
+			TestFalse("now stopped", VM->IsLocalServerRunning());
+		});
+
+		It("ToggleLocalServer is a NO-OP (never touches the sinks) outside Custom+http", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			// Custom + stdio: gated out.
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			VM->SetTransportMethod(EUnrealMcpTransportMethod::Stdio);
+			TestFalse("toggle is a no-op in Custom+stdio", VM->ToggleLocalServer());
+			TestEqual("no start in Custom+stdio", Rec->ServerStartCount, 0);
+
+			// Cloud: gated out.
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Cloud);
+			TestFalse("toggle is a no-op in Cloud", VM->ToggleLocalServer());
+			TestEqual("no start in Cloud", Rec->ServerStartCount, 0);
+			TestFalse("server never started", Rec->bServerRunning);
 		});
 	});
 

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpServerManagerSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpServerManagerSpec.cpp
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "HAL/FileManager.h"
+#include "Server/UnrealMcpServerManager.h"
+
+/**
+ * Local gamedev-mcp-server manager specs (docs/ARCHITECTURE.md §7, issue #95). Cover the pure,
+ * host-deterministic helpers — RID mapping (shared with the sidecar + cli), the §6 install-dir layout
+ * (one cache shared with the cli-downloaded binary), the version marker, the Custom-host → listen-port
+ * parse, the Unity-parity launch-arg composition, and the Custom+http launch gate — plus the
+ * UNREAL_MCP_SERVER_PATH override-wins resolution. The live HTTP download + real process spawn /
+ * supervision / orphan-port kill are exercised by the operator dev-control E2E (server_smoke.py /
+ * window_smoke.py), not unit-asserted here (they need a network + a real port + a GUI editor).
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpServerManagerSpec, "UnrealMcp.Server",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	// Spec-unique helper (unity-build ODR rule): write a throwaway file that looks like a server binary so the
+	// override branch's FPaths::FileExists check passes, and return its absolute path.
+	static FString ServerSpecMakeFakeBinary(const FString& Leaf)
+	{
+		const FString Dir = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("UnrealMcpServerSpec"));
+		IFileManager::Get().MakeDirectory(*Dir, /*Tree*/ true);
+		const FString Path = FPaths::ConvertRelativePathToFull(FPaths::Combine(Dir, Leaf));
+		FFileHelper::SaveStringToFile(TEXT("not-a-real-binary"), *Path);
+		return Path;
+	}
+
+	static void ServerSpecCleanup()
+	{
+		const FString Dir = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("UnrealMcpServerSpec"));
+		IFileManager::Get().DeleteDirectory(*Dir, /*RequireExists*/ false, /*Tree*/ true);
+		FPlatformMisc::SetEnvironmentVar(TEXT("UNREAL_MCP_SERVER_PATH"), TEXT(""));
+	}
+
+END_DEFINE_SPEC(FUnrealMcpServerManagerSpec)
+
+void FUnrealMcpServerManagerSpec::Define()
+{
+	Describe("ResolveRid", [this]()
+	{
+		It("maps the host to the documented .NET RID (shared with the sidecar + cli)", [this]()
+		{
+			const FString Rid = FUnrealMcpServerManager::ResolveRid(/*bArm64DirExists*/ true);
+#if PLATFORM_WINDOWS
+			TestEqual(TEXT("Windows -> win-x64"), Rid, FString(TEXT("win-x64")));
+#elif PLATFORM_LINUX
+			TestEqual(TEXT("Linux -> linux-x64"), Rid, FString(TEXT("linux-x64")));
+#elif PLATFORM_MAC
+			TestTrue(TEXT("Mac -> an osx-* rid"), Rid == TEXT("osx-arm64") || Rid == TEXT("osx-x64"));
+#endif
+		});
+	});
+
+	Describe("ServerBinaryBasename", [this]()
+	{
+		It("is platform-correct (.exe on Windows only)", [this]()
+		{
+			const FString Base = FUnrealMcpServerManager::ServerBinaryBasename();
+#if PLATFORM_WINDOWS
+			TestEqual(TEXT("Windows basename"), Base, FString(TEXT("gamedev-mcp-server.exe")));
+#else
+			TestEqual(TEXT("posix basename"), Base, FString(TEXT("gamedev-mcp-server")));
+#endif
+		});
+	});
+
+	Describe("ServerInstallDir / ServerBinaryPathFor", [this]()
+	{
+		It("composes <project>/Intermediate/UnrealMCP/server/<rid> (the §6 cache shared with the cli)", [this]()
+		{
+			const FString Project = TEXT("C:/fake/project");
+			const FString Dir = FUnrealMcpServerManager::ServerInstallDir(Project, TEXT("win-x64"));
+			const FString Expected = FPaths::ConvertRelativePathToFull(
+				FString(Project) / TEXT("Intermediate") / TEXT("UnrealMCP") / TEXT("server") / TEXT("win-x64"));
+			TestEqual(TEXT("install dir matches the §6 layout"), Dir, Expected);
+
+			const FString Bin = FUnrealMcpServerManager::ServerBinaryPathFor(Project, TEXT("win-x64"));
+			TestEqual(TEXT("binary path = installdir/basename"), Bin, Dir / FUnrealMcpServerManager::ServerBinaryBasename());
+		});
+
+		It("returns empty for an empty project dir or rid", [this]()
+		{
+			TestTrue(TEXT("empty project -> empty"), FUnrealMcpServerManager::ServerInstallDir(FString(), TEXT("win-x64")).IsEmpty());
+			TestTrue(TEXT("empty rid -> empty"), FUnrealMcpServerManager::ServerInstallDir(TEXT("C:/p"), FString()).IsEmpty());
+		});
+	});
+
+	Describe("ReadVersionMarker", [this]()
+	{
+		It("reads a trimmed version marker and returns empty when absent", [this]()
+		{
+			const FString Dir = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("UnrealMcpServerSpec"));
+			IFileManager::Get().MakeDirectory(*Dir, /*Tree*/ true);
+			TestTrue(TEXT("missing marker -> empty"), FUnrealMcpServerManager::ReadVersionMarker(Dir).IsEmpty());
+			FFileHelper::SaveStringToFile(TEXT("8.0.0\n"), *(Dir / TEXT("version")));
+			TestEqual(TEXT("marker is trimmed"), FUnrealMcpServerManager::ReadVersionMarker(Dir), FString(TEXT("8.0.0")));
+			ServerSpecCleanup();
+		});
+	});
+
+	Describe("ParsePortFromHost", [this]()
+	{
+		It("extracts an explicit port from the Custom host URL", [this]()
+		{
+			TestEqual(TEXT("http with port"), FUnrealMcpServerManager::ParsePortFromHost(TEXT("http://localhost:8080")), 8080);
+			TestEqual(TEXT("https with port"), FUnrealMcpServerManager::ParsePortFromHost(TEXT("https://127.0.0.1:5244")), 5244);
+			TestEqual(TEXT("trailing path ignored"), FUnrealMcpServerManager::ParsePortFromHost(TEXT("http://localhost:9001/mcp")), 9001);
+			TestEqual(TEXT("bare host:port (no scheme)"), FUnrealMcpServerManager::ParsePortFromHost(TEXT("localhost:7777")), 7777);
+		});
+
+		It("infers the scheme default port when none is given", [this]()
+		{
+			TestEqual(TEXT("http -> 80"), FUnrealMcpServerManager::ParsePortFromHost(TEXT("http://example.com")), 80);
+			TestEqual(TEXT("https -> 443"), FUnrealMcpServerManager::ParsePortFromHost(TEXT("https://example.com")), 443);
+		});
+
+		It("falls back to the supplied default for empty / portless-schemeless input", [this]()
+		{
+			TestEqual(TEXT("empty -> default"), FUnrealMcpServerManager::ParsePortFromHost(TEXT(""), 8080), 8080);
+			TestEqual(TEXT("schemeless host -> default"), FUnrealMcpServerManager::ParsePortFromHost(TEXT("just-a-host"), 1234), 1234);
+		});
+	});
+
+	Describe("BuildLaunchArgs", [this]()
+	{
+		It("composes Unity-parity args with streamableHttp and authorization=none (no token)", [this]()
+		{
+			const FString Args = FUnrealMcpServerManager::BuildLaunchArgs(8080, 10000, /*bAuthRequired*/ false, TEXT(""));
+			TestEqual(TEXT("none-auth args"), Args,
+				FString(TEXT("port=8080 plugin-timeout=10000 client-transport=streamableHttp authorization=none")));
+			TestFalse(TEXT("no token arg when auth is none"), Args.Contains(TEXT("token=")));
+		});
+
+		It("appends token= only when auth is required AND a token is present", [this]()
+		{
+			const FString WithToken = FUnrealMcpServerManager::BuildLaunchArgs(9000, 5000, /*bAuthRequired*/ true, TEXT("secret123"));
+			TestTrue(TEXT("required+token has authorization=required"), WithToken.Contains(TEXT("authorization=required")));
+			TestTrue(TEXT("required+token has token=secret123"), WithToken.Contains(TEXT("token=secret123")));
+
+			// Required but no token -> no token arg (matches Unity BuildArguments).
+			const FString NoToken = FUnrealMcpServerManager::BuildLaunchArgs(9000, 5000, /*bAuthRequired*/ true, TEXT(""));
+			TestTrue(TEXT("required+empty-token still authorization=required"), NoToken.Contains(TEXT("authorization=required")));
+			TestFalse(TEXT("required+empty-token has no token arg"), NoToken.Contains(TEXT("token=")));
+		});
+
+		It("always launches with client-transport=streamableHttp", [this]()
+		{
+			// The agent's stdio/http selection is about how the AGENT reaches the server; the launched server
+			// is always hosted over streamableHttp (Unity parity).
+			TestTrue(TEXT("transport is streamableHttp"),
+				FUnrealMcpServerManager::BuildLaunchArgs(1, 1, false, TEXT("")).Contains(TEXT("client-transport=streamableHttp")));
+		});
+	});
+
+	Describe("IsLaunchAllowed", [this]()
+	{
+		It("permits ONLY Custom mode + http transport", [this]()
+		{
+			TestTrue(TEXT("Custom+http -> allowed"), FUnrealMcpServerManager::IsLaunchAllowed(/*custom*/ true, /*http*/ true));
+			TestFalse(TEXT("Custom+stdio -> denied"), FUnrealMcpServerManager::IsLaunchAllowed(true, false));
+			TestFalse(TEXT("Cloud+http -> denied"), FUnrealMcpServerManager::IsLaunchAllowed(false, true));
+			TestFalse(TEXT("Cloud+stdio -> denied"), FUnrealMcpServerManager::IsLaunchAllowed(false, false));
+		});
+	});
+
+	Describe("ServerVersion", [this]()
+	{
+		It("is pinned to the lockstep value (kept in sync with cli/src/lib/server-version.ts)", [this]()
+		{
+			TestEqual(TEXT("pinned server version"), FString(FUnrealMcpServerManager::ServerVersion), FString(TEXT("8.0.0")));
+		});
+	});
+
+	Describe("ResolveBinaryPath", [this]()
+	{
+		It("returns the UNREAL_MCP_SERVER_PATH override when it points at an existing file", [this]()
+		{
+			const FString Fake = ServerSpecMakeFakeBinary(TEXT("override-server.bin"));
+			FPlatformMisc::SetEnvironmentVar(TEXT("UNREAL_MCP_SERVER_PATH"), *Fake);
+			FUnrealMcpServerManager Manager;
+			TestEqual(TEXT("override wins over cache/download"), Manager.ResolveBinaryPath(), Fake);
+			ServerSpecCleanup();
+		});
+
+		It("ignores a non-existent override and returns empty when no cached binary exists", [this]()
+		{
+			FPlatformMisc::SetEnvironmentVar(TEXT("UNREAL_MCP_SERVER_PATH"), TEXT("Z:/does/not/exist/gamedev-mcp-server.bin"));
+			FUnrealMcpServerManager Manager;
+			// A clean test project has no cached server, so a bogus override degrades to empty (caller downloads).
+			TestTrue(TEXT("bogus override + no cache -> empty"), Manager.ResolveBinaryPath().IsEmpty());
+			ServerSpecCleanup();
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,9 +93,24 @@ Prompts/Resources ship empty-but-wired (§10), as designed.
   (`WorkspaceMenu::GetMenuStructure().GetToolsCategory()`), not the **Window** menu; and the
   **connection timeline** (Unreal → MCP server → AI agent — see §7's Connection section design) — the
   Connection section ships a single status dot / label / button instead. The bridge status string is `Running (restarts: N)` /
-  `Stopped` (no PID/version), the AI agents section lists connected agents only (no config writing),
-  and there is no in-UI start-local-server control. The status table marks §7 "implemented" for the
-  window + 4 aux windows; these affordances are deferred.
+  `Stopped` (no PID/version), the AI agents section lists connected agents only (no config writing).
+  The status table marks §7 "implemented" for the window + 4 aux windows; the deferred affordances
+  above remain deferred.
+- **§7 in-UI local-server Start — LANDED (issue #95, supersedes the prior "no in-UI start-local-server
+  control" decision).** Operator decision 2026-06-15: the MCP-server card's **Start/Stop** button now
+  launches and supervises the LOCAL shared `gamedev-mcp-server` directly from the editor — replacing
+  the interim #94 wiring that (re)started the bridge sidecar. A new plugin-side `FUnrealMcpServerManager`
+  (`Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.{h,cpp}`) owns its lifecycle, the
+  plugin-side C++ analog of Unity's in-process `McpServerManager.cs` (NOT in the bridge): binary
+  resolution (`UNREAL_MCP_SERVER_PATH` override → cached binary → download), spawn via
+  `FPlatformProcess::CreateProc`, startup verification, crash-restart with backoff, orphan-port kill,
+  PID persistence + reattach across module reloads, and graceful-then-force stop on editor shutdown so
+  no `gamedev-mcp-server` orphans on editor close. **Gated to Custom mode + http transport** (Start is
+  hidden/disabled, and a click is a no-op, in Cloud or Custom+stdio). The binary cache shares the CLI's
+  §6 layout `{Project}/Intermediate/UnrealMCP/server/<rid>/`; the consumed server version is pinned in
+  `FUnrealMcpServerManager::ServerVersion`, kept in lockstep with the CLI's
+  `cli/src/lib/server-version.ts` `SERVER_VERSION`. This is distinct from the always-on
+  `unreal-mcp-bridge` sidecar (§6) — two different child processes, two different managers.
 - **§9.1 `.uplugin` `EngineVersion`.** The §9.1 tree comment reads "EngineVersion floor 5.5.0", but
   the shipped `UnrealMCP.uplugin` carries **no `EngineVersion` field at all** — UE treats it as an
   exact-build match (not a floor) and would refuse to load on newer engines. The 5.5+ floor is a
@@ -718,7 +733,10 @@ item 1), not to defer debug affordances entirely:
 5. **Connection alerts** — inline warnings (port conflict, version mismatch, sidecar crash-looped).
 6. **MCP server section** (Custom mode) — local `gamedev-mcp-server` Start/Stop + status, transport
    stdio/http toggle, auth none/required + masked token field + Generate button (crypto-random,
-   restart-on-apply), copyable raw JSON client config snippets (`SetupMcpServerSection`).
+   restart-on-apply), copyable raw JSON client config snippets (`SetupMcpServerSection`). **LANDED
+   (issue #95):** the Start/Stop button drives `FUnrealMcpServerManager` (launch + supervise the local
+   server, gated to Custom + http — see the §7 deviation block above); the button label toggles
+   Start↔Stop with the live server run-state and is disabled outside Custom+http.
 7. **Bridge status** (Unreal-specific, no Unity analog) — sidecar state machine value, PID,
    binary version, restart count, Restart button.
 8. **AI agents** — connected-agent labels + status dot, agent auto-configure list (Claude Code,

--- a/scripts/server_smoke.py
+++ b/scripts/server_smoke.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+server_smoke.py — LIVE end-to-end smoke for the in-UI local gamedev-mcp-server launch (issue #95).
+
+This is the operator complement to window_smoke.py. window_smoke.py asserts the dock-side CONTRACT
+(gating + the start/stop toggle the dev-control bridge exposes) without a real process; THIS script
+drives the REAL launch lifecycle against a live GUI editor and verifies the actual OS process + TCP
+port, covering the parts a contract test cannot:
+
+  (1) Custom+http: Start -> a local gamedev-mcp-server process actually launches and the port LISTENS.
+  (2) Stop -> the server process terminates and the port is FREE again (no orphan).
+  (3) Start, then CLOSE the editor -> the server process is ALSO gone (no orphan after editor exit).
+  (4) Gating: Start is a no-op (no process, no listener) in Cloud mode and in Custom + stdio.
+  (5) Repeated Start/Stop cycles + an external kill leave NO orphaned gamedev-mcp-server processes.
+
+It drives the SAME Start/Stop the Slate button fires, over the dev-control HTTP bridge
+(`/control/click` targets `start-server` / `stop-server`, gated to Custom+http by the view-model).
+
+Requirements
+------------
+- A GUI editor (UnrealEditor.exe, not -Cmd) it launches with UNREAL_MCP_DEV_CONTROL=1 + a port.
+- The Custom host must point at a free local port (the server listens there) — pass --server-port,
+  which this script writes into the dock via /control/server-url before starting.
+- Windows: uses `netstat -ano` + `tasklist` to check the port + process. (Linux/mac: lsof/ps.)
+
+Usage
+-----
+    python scripts/server_smoke.py --project <.uproject> --port 5177 --server-port 5244 \
+        --out-dir tmp/server-smoke
+
+Exit code 0 = every row passed; non-zero = a FAIL or the bridge never came up. NOT a CI gate
+(needs a GUI editor + a real server binary) — it is operator evidence for the issue #95 DoD matrix.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+DEFAULT_EDITOR = r"C:/Program Files/Epic Games/UE_5.7/Engine/Binaries/Win64/UnrealEditor.exe"
+SERVER_PROCESS_NEEDLE = "gamedev-mcp-server"
+
+
+def _req(port: int, method: str, path: str, body: dict | None = None) -> tuple[int, dict]:
+    url = f"http://127.0.0.1:{port}{path}"
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read().decode("utf-8"))
+        except Exception:
+            return e.code, {}
+
+
+def _wait_health(port: int, timeout_s: float) -> bool:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            code, body = _req(port, "GET", "/health")
+            if code == 200 and body.get("ok"):
+                return True
+        except Exception:
+            pass
+        time.sleep(2.0)
+    return False
+
+
+def _is_windows() -> bool:
+    return platform.system() == "Windows"
+
+
+def port_listening(port: int) -> bool:
+    """True when SOME process is LISTENING on the TCP port (cross-platform)."""
+    try:
+        if _is_windows():
+            out = subprocess.run(["netstat", "-ano", "-p", "tcp"], capture_output=True, text=True, timeout=15).stdout
+            suffix = f":{port}"
+            for line in out.splitlines():
+                t = line.strip()
+                if "LISTENING" not in t:
+                    continue
+                parts = t.split()
+                if len(parts) >= 5 and parts[1].endswith(suffix):
+                    return True
+            return False
+        else:
+            r = subprocess.run(["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"], capture_output=True, text=True, timeout=15)
+            return bool(r.stdout.strip())
+    except Exception:
+        return False
+
+
+def server_process_count() -> int:
+    """Count of running processes whose image name contains gamedev-mcp-server."""
+    try:
+        if _is_windows():
+            out = subprocess.run(["tasklist"], capture_output=True, text=True, timeout=15).stdout
+            return sum(1 for ln in out.splitlines() if SERVER_PROCESS_NEEDLE in ln.lower())
+        else:
+            out = subprocess.run(["ps", "-eo", "comm"], capture_output=True, text=True, timeout=15).stdout
+            return sum(1 for ln in out.splitlines() if SERVER_PROCESS_NEEDLE in ln.lower())
+    except Exception:
+        return -1
+
+
+def wait_for(cond, timeout_s: float, interval: float = 1.0) -> bool:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if cond():
+            return True
+        time.sleep(interval)
+    return cond()
+
+
+class Runner:
+    def __init__(self, port: int, server_port: int) -> None:
+        self.port = port
+        self.server_port = server_port
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, cond: bool, detail: str = "") -> None:
+        mark = "PASS" if cond else "FAIL"
+        (setattr(self, "passed", self.passed + 1) if cond else setattr(self, "failed", self.failed + 1))
+        print(f"  [{mark}] {label}" + (f" — {detail}" if detail else ""))
+
+    def set_custom_http(self) -> None:
+        _req(self.port, "POST", "/control/connection-mode", {"mode": "Custom"})
+        _req(self.port, "POST", "/control/server-url", {"url": f"http://127.0.0.1:{self.server_port}"})
+        _req(self.port, "POST", "/control/transport", {"transport": "http"})
+
+    def run(self) -> None:
+        baseline = server_process_count()
+        print(f"Baseline gamedev-mcp-server processes: {baseline}")
+
+        # (4) Gating: Cloud -> Start no-op (no listener, no new process).
+        _req(self.port, "POST", "/control/connection-mode", {"mode": "Cloud"})
+        _, b = _req(self.port, "POST", "/control/click", {"target": "start-server"})
+        time.sleep(2.0)
+        self.check("(4) Cloud: Start is a no-op (port not listening)", not port_listening(self.server_port))
+        self.check("(4) Cloud: no server process spawned", server_process_count() <= max(baseline, 0))
+
+        # (4) Gating: Custom + stdio -> Start no-op.
+        _req(self.port, "POST", "/control/connection-mode", {"mode": "Custom"})
+        _req(self.port, "POST", "/control/transport", {"transport": "stdio"})
+        _, b = _req(self.port, "POST", "/control/click", {"target": "start-server"})
+        time.sleep(2.0)
+        self.check("(4) Custom+stdio: Start is a no-op (port not listening)", not port_listening(self.server_port))
+
+        # (1) Custom + http: Start -> process launches + port listens.
+        self.set_custom_http()
+        _, b = _req(self.port, "POST", "/control/click", {"target": "start-server"})
+        self.check("(1) Start reported serverRunning", b.get("serverRunning") is True, str(b))
+        listening = wait_for(lambda: port_listening(self.server_port), timeout_s=30.0)
+        self.check(f"(1) Custom+http: port {self.server_port} is LISTENING after Start", listening)
+        self.check("(1) a gamedev-mcp-server process is running", server_process_count() > max(baseline, 0))
+
+        # (2) Stop -> process terminates, port freed (no orphan).
+        _, b = _req(self.port, "POST", "/control/click", {"target": "stop-server"})
+        self.check("(2) Stop reported not running", b.get("serverRunning") is False, str(b))
+        freed = wait_for(lambda: not port_listening(self.server_port), timeout_s=20.0)
+        self.check(f"(2) port {self.server_port} FREE after Stop (no orphan)", freed)
+        gone = wait_for(lambda: server_process_count() <= max(baseline, 0), timeout_s=20.0)
+        self.check("(2) gamedev-mcp-server process gone after Stop", gone)
+
+        # (5) Repeated Start/Stop cycles leave no orphan.
+        for i in range(3):
+            _req(self.port, "POST", "/control/click", {"target": "start-server"})
+            wait_for(lambda: port_listening(self.server_port), timeout_s=30.0)
+            _req(self.port, "POST", "/control/click", {"target": "stop-server"})
+            wait_for(lambda: not port_listening(self.server_port), timeout_s=20.0)
+        self.check("(5) repeated Start/Stop: no orphan after 3 cycles",
+                   server_process_count() <= max(baseline, 0))
+
+        # (3) Start, then close the editor -> server dies. (Caller closes the editor after run() returns;
+        # the post-close port/process check happens in main() so we can observe it AFTER editor exit.)
+        _req(self.port, "POST", "/control/click", {"target": "start-server"})
+        self.started_for_close_test = wait_for(lambda: port_listening(self.server_port), timeout_s=30.0)
+        self.check("(3) pre-close: server launched and listening", self.started_for_close_test)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--project", required=True, help="Path to the host .uproject.")
+    ap.add_argument("--port", type=int, required=True, help="UNREAL_MCP_DEV_CONTROL_PORT (from .worktree.env).")
+    ap.add_argument("--server-port", type=int, required=True, help="Local port the gamedev-mcp-server listens on.")
+    ap.add_argument("--editor", default=DEFAULT_EDITOR, help="UnrealEditor.exe (GUI, not -Cmd).")
+    ap.add_argument("--out-dir", default="tmp/server-smoke")
+    ap.add_argument("--boot-timeout", type=float, default=600.0)
+    args = ap.parse_args(argv)
+
+    Path(args.out_dir).mkdir(parents=True, exist_ok=True)
+
+    env = dict(os.environ)
+    env["UNREAL_MCP_DEV_CONTROL"] = "1"
+    env["UNREAL_MCP_DEV_CONTROL_PORT"] = str(args.port)
+    print(f"Launching editor: {args.editor}\n  project={args.project}\n  dev-control={args.port} server-port={args.server_port}")
+    proc = subprocess.Popen([args.editor, args.project], env=env)
+
+    runner = Runner(args.port, args.server_port)
+    try:
+        print(f"Waiting for dev-control /health on {args.port} (up to {args.boot_timeout:.0f}s)...")
+        if not _wait_health(args.port, args.boot_timeout):
+            print("FAIL: dev-control bridge never came up. Is UNREAL_MCP_DEV_CONTROL=1 set and the dock open?")
+            return 2
+        print("Bridge up. Driving server lifecycle...\n")
+        runner.run()
+    finally:
+        print("\nClosing the editor (row 3: server must die with it)...")
+        proc.terminate()
+        try:
+            proc.wait(timeout=60)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=30)
+
+    # (3) After the editor has fully exited, the server it spawned must be gone (force-stop on shutdown).
+    gone = wait_for(lambda: not port_listening(args.server_port), timeout_s=30.0)
+    runner.check(f"(3) post-close: port {args.server_port} FREE (server died with the editor)", gone)
+    runner.check("(3) post-close: no gamedev-mcp-server process survives editor exit",
+                 server_process_count() <= 0)
+
+    print(f"\n=== Summary: {runner.passed} passed, {runner.failed} failed ===")
+    return 0 if runner.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/window_smoke.py
+++ b/scripts/window_smoke.py
@@ -156,7 +156,7 @@ class Driver:
         self.check("generate-token kept a token", s.get("hasCustomToken") is True)
         self.shot("01-custom-required-token")
 
-        # --- Connect / Disconnect / Stop / Start ---
+        # --- Connect / Disconnect / Stop (SignalR connection — the "Unreal: <status>" row) ---
         _req(port, "POST", "/control/click", {"target": "connect"})
         s = self.state()
         self.check("connect -> keepConnected", s.get("keepConnected") is True, s.get("connectionState"))
@@ -164,10 +164,39 @@ class Driver:
         _req(port, "POST", "/control/click", {"target": "stop"})
         s = self.state()
         self.check("stop -> not keepConnected", s.get("keepConnected") is False, s.get("connectionState"))
-        _req(port, "POST", "/control/click", {"target": "start"})
-        s = self.state()
-        self.check("start -> keepConnected", s.get("keepConnected") is True, s.get("connectionState"))
         _req(port, "POST", "/control/click", {"target": "disconnect"})
+
+        # --- Local gamedev-mcp-server Start/Stop (issue #95 — the MCP-server card) + gating matrix ---
+        # The full live launch/reachability + close-editor-kills-it matrix is driven by the operator harness
+        # in scripts/server_smoke.py (it needs a real port + process checks). Here we assert the dock-side
+        # contract the dev-control bridge exposes: gating reflects the mode/transport, and the explicit
+        # start/stop toggle drives the live server state.
+        #
+        # (1) Custom + http -> Start is launchable.
+        _req(port, "POST", "/control/connection-mode", {"mode": "Custom"})
+        _req(port, "POST", "/control/transport", {"transport": "http"})
+        s = self.state()
+        self.check("server launchable in Custom+http", s.get("serverLaunchable") is True, str(s.get("serverLaunchable")))
+        # (4a) Gating: Custom + stdio -> NOT launchable; a start click is a no-op (server stays stopped).
+        _req(port, "POST", "/control/transport", {"transport": "stdio"})
+        s = self.state()
+        self.check("server NOT launchable in Custom+stdio", s.get("serverLaunchable") is False, str(s.get("serverLaunchable")))
+        _, b = _req(port, "POST", "/control/click", {"target": "start-server"})
+        self.check("start-server no-op in Custom+stdio (not running)", b.get("serverRunning") is False, str(b.get("serverRunning")))
+        # (4b) Gating: Cloud -> NOT launchable; a start click is a no-op.
+        _req(port, "POST", "/control/connection-mode", {"mode": "Cloud"})
+        s = self.state()
+        self.check("server NOT launchable in Cloud", s.get("serverLaunchable") is False, str(s.get("serverLaunchable")))
+        _, b = _req(port, "POST", "/control/click", {"target": "start-server"})
+        self.check("start-server no-op in Cloud (not running)", b.get("serverRunning") is False, str(b.get("serverRunning")))
+        # Back to Custom+http and drive an actual launch -> stop cycle (1)+(2)+(5).
+        _req(port, "POST", "/control/connection-mode", {"mode": "Custom"})
+        _req(port, "POST", "/control/transport", {"transport": "http"})
+        _, b = _req(port, "POST", "/control/click", {"target": "start-server"})
+        self.check("start-server -> serverRunning (Custom+http)", b.get("serverRunning") is True, str(b.get("serverRunning")))
+        self.shot("02b-server-running")
+        _, b = _req(port, "POST", "/control/click", {"target": "stop-server"})
+        self.check("stop-server -> serverRunning False (clean stop)", b.get("serverRunning") is False, str(b.get("serverRunning")))
 
         # --- Injected connection-status (status dots/labels readouts) ---
         _req(port, "POST", "/inject/connection-status", {"status": "Connected"})


### PR DESCRIPTION
## Summary
- New plugin-side C++ `FUnrealMcpServerManager` (`Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.{h,cpp}`) that launches + supervises the LOCAL shared `gamedev-mcp-server` — the analog of Unity's in-process `McpServerManager.cs` (NOT in the bridge). Binary resolution (`UNREAL_MCP_SERVER_PATH` override → cached → download), spawn via `FPlatformProcess::CreateProc`, startup verification, crash-restart w/ backoff, orphan-port kill, PID persistence + reattach across module reloads, graceful-then-force stop on editor shutdown (no orphans). Shared §6 cache layout `{Project}/Intermediate/UnrealMCP/server/<rid>/`; pinned `ServerVersion = 8.0.0` in lockstep with `cli/src/lib/server-version.ts`.
- MCP Server card's **Start/Stop** button now drives the local server via the view-model, **replacing the interim #94 bridge-restart wiring**. **Gated to Custom mode + http transport** (disabled + no-op otherwise). Distinct from the always-on `unreal-mcp-bridge` sidecar (§6).
- Dev-control bridge: `start` click now launches the local server; added `start-server`/`stop-server` targets + `serverRunning`/`serverLaunchable` `/state` readouts. New `scripts/server_smoke.py` operator E2E.
- `docs/ARCHITECTURE.md` §7 updated: records the in-UI local-server Start decision, superseding the prior "no in-UI start-local-server control" deviation.

## Security review (requested — new process-spawn + binary-download code)
- **Download source**: HTTPS-only, pinned to `github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v8.0.0/gamedev-mcp-server-<rid>.zip` (same source the CLI uses). Unpacked via `FZipArchiveReader` (libzip); extraction is constrained to the binary's own zip folder, flattened one level (no path traversal outside the install dir).
- **Spawn**: argv carries only non-secrets (`port`, `plugin-timeout`, `client-transport`, `authorization`); the bearer `token=` is appended only when auth is required. No shell; `FPlatformProcess::CreateProc` directly.
- **Orphan-port kill** fails safe: it only terminates a process whose image name contains `gamedev-mcp-server` (never an arbitrary port owner).
- The dev-control bridge that exposes server start/stop remains env-gated (`UNREAL_MCP_DEV_CONTROL=1`) + loopback-only — never listens in a shipped plugin.

## Test plan
- [x] Suite 1 — UBT build of `UnrealTestProjectEditor` (UE 5.7): exit 0.
- [x] Suite 2 — headless boot smoke: `[Unreal-MCP] plugin loaded` confirmed. (The exit-3 `GenericWindow.cpp:113` crash is the pre-existing shutdown-teardown quirk — reproduced unchanged on pristine `origin/main`; not a load failure.)
- [x] Suite 3 — Automation specs (`UnrealMcp.` filter): **130 succeeded, 0 failed** (per-test log; new `UnrealMcp.Server.*` pure-helper specs + view-model gating/toggle + dev-control server-route specs all green).
- [ ] Live dev-control E2E matrix (rows 1–5: Custom+http Start launches a reachable server; Stop clean no-orphan; Start→close-editor kills it; Cloud/Custom+stdio gated no-op; repeated cycles no-orphan) — driven by `scripts/server_smoke.py` against a GUI editor + real server binary (operator step; the dock-side contract is fully spec-covered above).

Closes #95