### PR TITLE
feat(ui): AI-agents status row in the Connection timeline; configurator to its own section (#97)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
@@ -362,10 +362,20 @@ int32 FUnrealMcpDevControlServer::RouteRequest(
 		TSharedPtr<FJsonObject> StatusJson = MakeShared<FJsonObject>();
 		StatusJson->SetStringField(TEXT("connectionState"), StatusLabel);
 		StatusJson->SetBoolField(TEXT("keepConnected"), bKeepConnected);
+		// Issue #97: forward an optional `aiAgents` array verbatim so a smoke test (and the live window screenshot)
+		// can drive the §7 AI-agents status row's connected-agents list + its rail dot. Optional — when omitted the
+		// list stays whatever ApplyStatus last set (a §1.3 status with no aiAgents key clears it to empty per
+		// ApplyStatus's contract, so the empty state is still exercisable by injecting a status without the field).
+		const TArray<TSharedPtr<FJsonValue>>* InAgents = nullptr;
+		if (Body->TryGetArrayField(TEXT("aiAgents"), InAgents) && InAgents)
+		{
+			StatusJson->SetArrayField(TEXT("aiAgents"), *InAgents);
+		}
 		ViewModelPtr->ApplyStatus(StatusJson);
 
 		OutResult->SetBoolField(TEXT("ok"), true);
 		OutResult->SetStringField(TEXT("connectionState"), DevControlConnectionStateLabel(ViewModelPtr->GetConnectionState()));
+		OutResult->SetNumberField(TEXT("aiAgentCount"), ViewModelPtr->GetAiAgents().Num());
 		return 200;
 	}
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentWidgets.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentWidgets.h
@@ -285,6 +285,93 @@ namespace UnrealMcpStyleWidgets
 	}
 
 	/**
+	 * A single connection-timeline ROW: a self-contained 20px rail cell on the LEFT (its status dot pinned to the
+	 * TOP, then a FillHeight connecting-line segment that fills the rest of THIS row's height) beside the row's
+	 * CONTENT on the right. The two cells share the row's AutoHeight, so the dot sits on the content's FIRST line
+	 * (its label) and the line spans from just below the dot to the row's bottom edge.
+	 *
+	 * Stacking these rows in an SVerticalBox yields BOTH properties the single-column TimelineRail could not give
+	 * at once: (1) each dot is anchored to the TOP of its OWN content row — i.e. centred on its label — instead of
+	 * floating at the even-split midpoint of the whole cluster (which dragged the 2nd/3rd dots down into the middle
+	 * of tall rows like the MCP card); and (2) the line is still continuous, because each row's line runs from its
+	 * dot down to the row bottom, which is exactly where the next row's dot begins. @p bIsLast collapses the line
+	 * (the last point has none — Unity's .timeline-point-last). @p DotTopPadding is a small per-row nudge to centre
+	 * the 14px dot on its label's text line (labels differ slightly in cap-height / leading).
+	 *
+	 * @p bLineAbove draws a short connecting-line segment ABOVE the dot, filling the DotTopPadding gap between the
+	 * row's top edge and the (possibly nudged-down) dot — so the line arrives flush at the dot regardless of how
+	 * far DotTopPadding pushes it down (the MCP row nudges its dot ~14px to reach the card-header label; without
+	 * this the previous row's line would stop at the row boundary and leave a visible gap above the MCP dot). Pass
+	 * false for the FIRST row (nothing is above it). The above-segment uses the row's own DotState visibility-free
+	 * connecting brush; it is collapsed when the dot itself is collapsed.
+	 *
+	 * Width 20px + dot/line centred horizontally mirror Unity's .timeline-indicator (20px column, line at x=9px).
+	 */
+	inline TSharedRef<SWidget> TimelineRow(
+		const FTimelineRailDot& Point,
+		const TSharedRef<SWidget>& Content,
+		bool bIsLast,
+		bool bLineAbove)
+	{
+		// LEFT: the rail cell. When bLineAbove, a fixed-height connecting segment fills the DotTopPadding gap so the
+		// line meets the dot flush (uniform spacing into every dot); otherwise the dot just carries its top padding.
+		TSharedRef<SVerticalBox> RailCell = SNew(SVerticalBox);
+		if (bLineAbove && Point.DotTopPadding > 0.0f)
+		{
+			// The 2px-gap below mirrors the inter-dot line's 2px top gap, so the visible spacing dot↔line is uniform
+			// at every dot. The segment height = DotTopPadding - 2 (clamped >= 1) so the dot still lands at its label.
+			const float AboveHeight = FMath::Max(1.0f, Point.DotTopPadding - 2.0f);
+			RailCell->AddSlot().AutoHeight().HAlign(HAlign_Center)
+			[
+				SNew(SBox).WidthOverride(2.0f).HeightOverride(AboveHeight).Visibility(Point.DotVisibility)
+				[
+					SNew(SImage).Image(FUnrealMcpStyle::Get().GetBrush("UnrealMcp.ConnectingLine"))
+				]
+			];
+			RailCell->AddSlot().AutoHeight().HAlign(HAlign_Center).Padding(0, 2, 0, 0)
+			[
+				SNew(SBox).Visibility(Point.DotVisibility)
+				[
+					StatusDot(Point.DotState)
+				]
+			];
+		}
+		else
+		{
+			RailCell->AddSlot().AutoHeight().HAlign(HAlign_Center).Padding(0, Point.DotTopPadding, 0, 0)
+			[
+				SNew(SBox).Visibility(Point.DotVisibility)
+				[
+					StatusDot(Point.DotState)
+				]
+			];
+		}
+		if (!bIsLast)
+		{
+			RailCell->AddSlot().FillHeight(1.0f).HAlign(HAlign_Center).Padding(0, 2, 0, 0)
+			[
+				TimelineLineSegment(Point.LineBelowVisibility)
+			];
+		}
+
+		return SNew(SHorizontalBox)
+			// The rail cell — VAlign_Fill so its FillHeight line stretches to the full row height (down to the next
+			// row's dot). Fixed 20px column, 8px gutter to the content (matches the old cluster's rail->content gap).
+			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Fill).Padding(0, 0, 8, 0)
+			[
+				SNew(SBox).WidthOverride(20.0f)
+				[
+					RailCell
+				]
+			]
+			// The content — its first line (the row's label) is what the top-pinned dot aligns to.
+			+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Fill)
+			[
+				Content
+			];
+	}
+
+	/**
 	 * A tab-like segmented control (Unity .segmented-control): a rounded track holding N toggle segments;
 	 * the selected segment renders its text teal. Each segment is a toggle-style SCheckBox bound to the
 	 * shared IsSelected/OnSelect lambdas so it stays a thin view over the caller's state.

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -306,8 +306,18 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildConnectionCluster()
 	UnrealPoint.DotTopPadding = 6.0f;
 
 	// Point 2 — MCP server (Custom-only; second row).
+	// Issue #97 (operator follow-up): drive the dot from the LIVE local-server run-state instead of a hardcoded
+	// EDot::Offline — Online (green) when the local gamedev-mcp-server (#95/#96 FUnrealMcpServerManager, surfaced
+	// via ViewModel->IsLocalServerRunning()) is running, else Offline. Mirrors how UnrealPoint reads
+	// GetConnectionState() and AgentsPoint reads GetAiAgents(). There is no separate "starting/launching" transient
+	// in the view-model (IsLocalServerRunning is a single bool sink), so no EDot::Ring state — Online/Offline only,
+	// no new plumbing. This dot only renders in Custom mode (the whole MCP row collapses in Cloud — see below),
+	// which matches the local-server feature's Custom+http-only gating.
 	UnrealMcpStyleWidgets::FTimelineRailDot McpPoint;
-	McpPoint.DotState = EDot::Offline;
+	McpPoint.DotState = TAttribute<EDot>::Create([this]()
+	{
+		return (IsViewModelValid() && ViewModel->IsLocalServerRunning()) ? EDot::Online : EDot::Offline;
+	});
 	McpPoint.DotVisibility = EVisibility::Visible; // the whole row collapses in Cloud mode (see below), so the dot is always visible WITHIN the row.
 	// The line below the MCP-server dot runs DOWN to the AI-agents row.
 	McpPoint.LineBelowVisibility = EVisibility::Visible;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -89,10 +89,17 @@ void SUnrealMcpMainWindow::Construct(const FArguments& InArgs)
 			SNew(SVerticalBox)
 			+ SVerticalBox::Slot().AutoHeight()[ BuildHeaderSection() ]
 			+ SVerticalBox::Slot().AutoHeight().Padding(0, 10)[ UnrealMcpStyleWidgets::Divider() ]
-			// The AI Agent Configurators panel is no longer a standalone top-level section — issue #93 moved it
-			// INSIDE the Connection cluster (BuildConnectionCluster), directly after the MCP-server element, so the
-			// connection timeline reads Unreal → MCP server → AI agents per ARCHITECTURE §7.
+			// The Connection section is the 3-item status timeline (Unreal → MCP server → AI agents). Issue #97:
+			// the AI-agents element inside the cluster is now a READ-ONLY status row (BuildAiAgentsStatusRow) listing
+			// the connected agents, NOT the configurator — mirroring Unity's TimelinePointAiAgent. The configurator
+			// dropdown is a separate section below (next slot).
 			+ SVerticalBox::Slot().AutoHeight()[ BuildConnectionSection() ]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 10)[ UnrealMcpStyleWidgets::Divider() ]
+			// The AI Agent Configurators panel — its own standalone top-level section BELOW the Connection section
+			// (issue #97 restored the pre-#93 placement). It is the agent-picker/configurator dropdown, distinct
+			// from the AI-agents STATUS row inside the Connection timeline above; the connection dots do not anchor
+			// to it. Mirrors Unity's separate "AI agent" dropdown section below the connection timeline.
+			+ SVerticalBox::Slot().AutoHeight()[ BuildAgentConfiguratorsSection() ]
 			+ SVerticalBox::Slot().AutoHeight().Padding(0, 10)[ UnrealMcpStyleWidgets::Divider() ]
 			+ SVerticalBox::Slot().AutoHeight()[ BuildExtensionsSection() ]
 			+ SVerticalBox::Slot().AutoHeight().Padding(0, 10)[ UnrealMcpStyleWidgets::Divider() ]
@@ -302,12 +309,18 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildConnectionCluster()
 	McpPoint.DotTopPadding = 8.0f;
 
 	// Point 3 — AI agents (always present; last in the rail, so no line below it — Unity's .timeline-point-last).
+	// Issue #97: the dot is driven by live data — Online when any agent is connected (GetAiAgents().Num() > 0),
+	// else Offline — mirroring how UnrealPoint's dot reflects GetConnectionState() and Unity's aiAgentStatusCircle
+	// flips connected/disconnected from the agent list. Replaces the previous hardcoded EDot::Offline.
 	UnrealMcpStyleWidgets::FTimelineRailDot AgentsPoint;
-	AgentsPoint.DotState = EDot::Offline;
+	AgentsPoint.DotState = TAttribute<EDot>::Create([this]()
+	{
+		return (IsViewModelValid() && ViewModel->GetAiAgents().Num() > 0) ? EDot::Online : EDot::Offline;
+	});
 	AgentsPoint.DotVisibility = EVisibility::Visible;
 	AgentsPoint.LineBelowVisibility = EVisibility::Collapsed;
-	// Nudge to centre the dot on the "AI agent" header inside the carded panel (8px card padding + ~half a line).
-	AgentsPoint.DotTopPadding = 8.0f;
+	// Nudge to centre the dot on the "AI agents" underlined label's text line (mirrors the Unreal-status row's 2px).
+	AgentsPoint.DotTopPadding = 2.0f;
 
 	return SNew(SHorizontalBox)
 		// LEFT column: the continuous timeline rail owning all three dots + the lines between them. VAlign_Fill so
@@ -324,10 +337,10 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildConnectionCluster()
 			+ SVerticalBox::Slot().AutoHeight()[ BuildUnrealStatusRow() ]
 			// (2) MCP-server card body (Custom-only) — aligns with the MCP-server dot.
 			+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)[ BuildMcpServerCard() ]
-			// (3) AI agents (connected-agent list + configurators) — aligns with the AI-agents dot. Moved here from
-			// its former standalone top-level section (issue #93) so it sits inside the Connection cluster, directly
-			// after the MCP-server element, per the §7 connection-timeline order.
-			+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)[ BuildAgentConfiguratorsSection() ]
+			// (3) AI agents STATUS row — aligns with the AI-agents dot. Issue #97: this is a READ-ONLY readout of the
+			// connected-agents list (BuildAiAgentsStatusRow), mirroring Unity's TimelinePointAiAgent, NOT the
+			// configurator. The configurator dropdown moved back out to its own standalone section below Connection.
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)[ BuildAiAgentsStatusRow() ]
 		];
 }
 
@@ -360,6 +373,41 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildUnrealStatusRow()
 					}),
 					FOnClicked::CreateSP(this, &SUnrealMcpMainWindow::OnConnectClicked))
 			]
+		];
+}
+
+TSharedRef<SWidget> SUnrealMcpMainWindow::BuildAiAgentsStatusRow()
+{
+	// Issue #97: the "AI agents" connection-timeline content row — the read-only STATUS readout of the agents
+	// currently connected (mirrors Unity's TimelinePointAiAgent / aiAgentLabelsContainer). NOT the configurator
+	// (which is now its own standalone section below the Connection section). The dot for this row lives in the
+	// shared rail (BuildConnectionCluster) and is driven Online when GetAiAgents().Num() > 0; this row carries
+	// only the underlined label + the agent-name list (or an empty-state line).
+	//
+	// The label uses UnderlinedLabel (same style as the "Unreal: <status>" and "MCP server" rows) so the rail dot
+	// pins to the top of its text line. Below the label, one Description line per connected agent name, or a single
+	// "No agents connected" Description line when the list is empty (Unity shows the placeholder "AI agent" label;
+	// we use an explicit empty-state line per the task brief). The list is rebuilt every frame from the live
+	// view-model via a Description bound to a lambda — there is no per-agent interactive widget, so a single joined
+	// text block (one name per line) is the simplest faithful readout and stays a thin view over GetAiAgents().
+	return SNew(SVerticalBox)
+		// Underlined "AI agents" label — spans only the text (matches the other timeline labels).
+		+ SVerticalBox::Slot().AutoHeight()
+		[
+			UnderlinedLabel(LOCTEXT("AiAgentsLabel", "AI agents"))
+		]
+		// The connected-agent list (one name per line) or the empty state, as a dimmed Description block.
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
+		[
+			UnrealMcpStyleWidgets::Description(TAttribute<FText>::Create([this]()
+			{
+				if (!IsViewModelValid())
+					return LOCTEXT("NoAgents", "No agents connected");
+				const TArray<FString>& Agents = ViewModel->GetAiAgents();
+				if (Agents.Num() == 0)
+					return LOCTEXT("NoAgents", "No agents connected");
+				return FText::FromString(FString::Join(Agents, TEXT("\n")));
+			}))
 		];
 }
 
@@ -716,9 +764,12 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCustomAuthSelector()
 
 TSharedRef<SWidget> SUnrealMcpMainWindow::BuildAgentConfiguratorsSection()
 {
-	// The AI Agent Configurators panel (§7/§8). It keeps its own framed card (Unity reserves the blue frame for the
-	// AI-agent block) — one of the few elements that stays carded per issue #80 item 6. Bound to the shared
-	// view-model + the runtime connection-info provider.
+	// The AI Agent Configurators panel (§7/§8) — the agent-picker dropdown + per-agent configuration. Issue #97
+	// moved it back OUT of the Connection cluster to its OWN standalone top-level section below the Connection
+	// section (its pre-#93 placement); the connection status dots no longer anchor to it. It keeps its own framed
+	// card (Unity reserves the blue frame for the AI-agent block) — one of the few elements that stays carded per
+	// issue #80 item 6. Bound to the shared view-model + the runtime connection-info provider. This is distinct
+	// from BuildAiAgentsStatusRow (the read-only connected-agents readout inside the Connection timeline).
 	return SNew(SUnrealMcpAgentConfigurators)
 		.ViewModel(ViewModel)
 		.ConnectionInfoProvider(ConnectionInfoProvider);

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -285,30 +285,38 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildConnectionCluster()
 
 	// Issue #93: the connection timeline must read top-to-bottom EXACTLY as ARCHITECTURE §7 specifies —
 	// "Unreal point → MCP server point → AI-agent point" (the pre-#93 cluster had MCP-server ABOVE Unreal and
-	// omitted the AI-agent point entirely). The three content rows below are stacked in the same order, each
-	// aligned to its dot in the shared rail.
+	// omitted the AI-agent point entirely).
+	//
+	// Issue #97 (operator alignment pass): the timeline is now built ROW-BY-ROW via TimelineRow rather than as a
+	// single rail column beside a single content column. The old two-column split positioned every dot via two
+	// even-weight FillHeight line segments, so the 2nd/3rd dots floated to the cluster's vertical midpoint and
+	// landed in the MIDDLE of tall rows (the MCP dot sat at "Authorization"; the AI-agents dot sat at "Copilot")
+	// instead of on their header labels. TimelineRow keeps each dot pinned to the TOP of its OWN row's content
+	// (its label) while still drawing a continuous line (each row's line runs from its dot to the row bottom =
+	// the next row's dot). DotTopPadding is now only a small per-label centring nudge, not a coarse positioner.
 
-	// Point 1 — Unreal status (always present; first in the rail).
+	// Point 1 — Unreal status (always present; first row).
 	UnrealMcpStyleWidgets::FTimelineRailDot UnrealPoint;
 	UnrealPoint.DotState = UnrealDot;
 	UnrealPoint.DotVisibility = EVisibility::Visible;
-	// The line runs DOWN from the Unreal dot toward the next point. Always present (a point always follows:
-	// the MCP-server point in Custom mode, or the AI-agents point in Cloud mode).
+	// The line runs DOWN from the Unreal dot to the next row (the MCP row in Custom mode, or — when the MCP row is
+	// collapsed in Cloud mode — straight on to the AI-agents row).
 	UnrealPoint.LineBelowVisibility = EVisibility::Visible;
-	// Small nudge to centre the dot on the "Unreal: <status>" label's text line.
-	UnrealPoint.DotTopPadding = 2.0f;
+	// Centre the 14px dot on the "Unreal: <status>" underlined label's text line.
+	UnrealPoint.DotTopPadding = 6.0f;
 
-	// Point 2 — MCP server (Custom-only; second in the rail).
+	// Point 2 — MCP server (Custom-only; second row).
 	UnrealMcpStyleWidgets::FTimelineRailDot McpPoint;
 	McpPoint.DotState = EDot::Offline;
-	McpPoint.DotVisibility = CustomOnly;
-	// The line below the MCP-server dot runs DOWN to the AI-agents dot — present only in Custom mode (the dot
-	// itself is Custom-only). In Cloud mode this whole point collapses and the Unreal line connects to AI-agents.
-	McpPoint.LineBelowVisibility = CustomOnly;
-	// Nudge the dot down to centre it on the "MCP server" label inside the card (8px card padding + ~half a line).
-	McpPoint.DotTopPadding = 8.0f;
+	McpPoint.DotVisibility = EVisibility::Visible; // the whole row collapses in Cloud mode (see below), so the dot is always visible WITHIN the row.
+	// The line below the MCP-server dot runs DOWN to the AI-agents row.
+	McpPoint.LineBelowVisibility = EVisibility::Visible;
+	// The MCP content is a card whose header label sits below the card's own 8px border padding; nudge the dot down
+	// to centre it on that "MCP server" header text (was a coarse 8px positioner in the old rail; here it only
+	// accounts for the card border + label leading).
+	McpPoint.DotTopPadding = 14.0f;
 
-	// Point 3 — AI agents (always present; last in the rail, so no line below it — Unity's .timeline-point-last).
+	// Point 3 — AI agents (always present; last row, so no line below it — Unity's .timeline-point-last).
 	// Issue #97: the dot is driven by live data — Online when any agent is connected (GetAiAgents().Num() > 0),
 	// else Offline — mirroring how UnrealPoint's dot reflects GetConnectionState() and Unity's aiAgentStatusCircle
 	// flips connected/disconnected from the agent list. Replaces the previous hardcoded EDot::Offline.
@@ -319,28 +327,32 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildConnectionCluster()
 	});
 	AgentsPoint.DotVisibility = EVisibility::Visible;
 	AgentsPoint.LineBelowVisibility = EVisibility::Collapsed;
-	// Nudge to centre the dot on the "AI agents" underlined label's text line (mirrors the Unreal-status row's 2px).
-	AgentsPoint.DotTopPadding = 2.0f;
+	// Centre the dot on the "AI agents" underlined label's text line (same label shape as the Unreal-status row).
+	AgentsPoint.DotTopPadding = 6.0f;
 
-	return SNew(SHorizontalBox)
-		// LEFT column: the continuous timeline rail owning all three dots + the lines between them. VAlign_Fill so
-		// the rail matches the content column's height and each FillHeight line slot absorbs the inter-dot slack.
-		+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Fill).Padding(0, 0, 8, 0)
+	// The MCP-server row is Custom-only: in Cloud mode the WHOLE row (its rail cell + the card) collapses, so the
+	// Unreal row's line connects straight to the AI-agents row with no dangling MCP segment.
+	TSharedRef<SWidget> McpRow = UnrealMcpStyleWidgets::TimelineRow(McpPoint, BuildMcpServerCard(), /*bIsLast*/ false, /*bLineAbove*/ true);
+	McpRow->SetVisibility(CustomOnly);
+
+	return SNew(SVerticalBox)
+		// (1) Unreal status row — dot pinned to the "Unreal: <status>" label. First row, so no line above it.
+		+ SVerticalBox::Slot().AutoHeight()
 		[
-			UnrealMcpStyleWidgets::TimelineRail({ UnrealPoint, McpPoint, AgentsPoint })
+			UnrealMcpStyleWidgets::TimelineRow(UnrealPoint, BuildUnrealStatusRow(), /*bIsLast*/ false, /*bLineAbove*/ false)
 		]
-		// RIGHT column: the stacked content rows, one per dot, in the §7 order. Each row's top aligns with its dot.
-		+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Fill)
+		// (2) MCP-server card row (Custom-only) — dot pinned to the "MCP server" card header. bLineAbove fills the
+		// dot's ~14px top nudge so the connector meets the dot flush (uniform spacing, issue #97 alignment pass).
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)
 		[
-			SNew(SVerticalBox)
-			// (1) Unreal status row — aligns with the Unreal dot.
-			+ SVerticalBox::Slot().AutoHeight()[ BuildUnrealStatusRow() ]
-			// (2) MCP-server card body (Custom-only) — aligns with the MCP-server dot.
-			+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)[ BuildMcpServerCard() ]
-			// (3) AI agents STATUS row — aligns with the AI-agents dot. Issue #97: this is a READ-ONLY readout of the
-			// connected-agents list (BuildAiAgentsStatusRow), mirroring Unity's TimelinePointAiAgent, NOT the
-			// configurator. The configurator dropdown moved back out to its own standalone section below Connection.
-			+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)[ BuildAiAgentsStatusRow() ]
+			McpRow
+		]
+		// (3) AI agents STATUS row — dot pinned to the "AI agents" label. Issue #97: this is a READ-ONLY readout of
+		// the connected-agents list (BuildAiAgentsStatusRow), mirroring Unity's TimelinePointAiAgent, NOT the
+		// configurator. The configurator dropdown moved back out to its own standalone section below Connection.
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)
+		[
+			UnrealMcpStyleWidgets::TimelineRow(AgentsPoint, BuildAiAgentsStatusRow(), /*bIsLast*/ true, /*bLineAbove*/ true)
 		];
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
@@ -13,8 +13,8 @@
  * The "AI Game Developer" main window (docs/ARCHITECTURE.md §7), a pure-Slate compound widget — NO UMG /
  * editor-utility dependency. Hosted in the nomad dockable tab registered by FUnrealMcpMainWindowTab. Every
  * widget binds (via TAttribute lambdas) to the shared FUnrealMcpEditorViewModel, which owns all state; this
- * widget is a thin view. Sections, top to bottom: header/settings, connection panel, connection-mode toggle,
- * Cloud device-code auth, Custom server auth, bridge status, AI agents, footer.
+ * widget is a thin view. Sections, top to bottom: header/settings, the Connection timeline (Unreal status →
+ * MCP server → AI-agents status readout), the AI Agent Configurators section, Extensions, footer.
  *
  * Lifetime: the view-model outlives the widget (it is owned by the runtime); the widget keeps only a weak-ish
  * shared ref and reads it under IsValid guards. The status feed is marshalled to the game thread by the
@@ -50,10 +50,11 @@ private:
 
 	// Section builders (each returns a Slate widget; kept separate so §7's ordering reads top-to-bottom).
 	// The window now mirrors the Unity-MCP reference (issue #78): a header card with base config (Log Level /
-	// Timeout / Version) + the AI-cube logo, a unified Connection timeline card (Custom/Cloud segmented in the
-	// header row, status dots + connecting line + underlined labels, teal Start / red Revoke / masked token +
-	// New, stdio/http + none/required segmented), the AI Agent Configurators panel, an Extensions card, and a
-	// styled footer (Discord / GitHub bug-report / gold GitHub Star).
+	// Timeout / Version) + the AI-cube logo, a unified Connection timeline (Custom/Cloud segmented in the header
+	// row, status dots + connecting line + underlined labels, teal Start / red Revoke / masked token + New,
+	// stdio/http + none/required segmented) whose three points are Unreal status → MCP server → AI-agents status
+	// readout (issue #97), then the AI Agent Configurators panel as its own section below, an Extensions section,
+	// and a styled footer (Discord / GitHub bug-report / gold GitHub Star).
 	TSharedRef<SWidget> BuildHeaderSection();
 	TSharedRef<SWidget> BuildConnectionSection();
 	// The connection cluster (Unity's .connection-timeline): a 2-column layout — a continuous vertical rail
@@ -69,10 +70,17 @@ private:
 	TSharedRef<SWidget> BuildMcpServerCard();
 	// The "Unreal: <status>" content row (underlined label + Connect/Disconnect/Stop) — its dot lives in the rail.
 	TSharedRef<SWidget> BuildUnrealStatusRow();
+	// The "AI agents" connection-timeline content row (issue #97): an underlined "AI agents" label + the read-only
+	// list of currently-connected agents from ViewModel->GetAiAgents() (empty-state line when none). A STATUS
+	// readout (mirrors BuildUnrealStatusRow), NOT the configurator — its dot lives in the shared rail.
+	TSharedRef<SWidget> BuildAiAgentsStatusRow();
 	// The Custom-mode transport selector (stdio/http) segmented control.
 	TSharedRef<SWidget> BuildTransportSelector();
 	// The Custom-mode authorization selector (none/required) + masked token + New.
 	TSharedRef<SWidget> BuildCustomAuthSelector();
+	// The AI Agent Configurators panel (the SUnrealMcpAgentConfigurators dropdown). Issue #97 moved it back OUT of
+	// the Connection cluster to its own standalone top-level section BELOW the Connection section (where it lived
+	// before #93) — the connection status dots no longer anchor to it.
 	TSharedRef<SWidget> BuildAgentConfiguratorsSection();
 	TSharedRef<SWidget> BuildExtensionsSection();
 	TSharedRef<SWidget> BuildFooterSection();

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDevControlSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDevControlSpec.cpp
@@ -209,6 +209,49 @@ void FUnrealMcpDevControlSpec::Define()
 			TestEqual("status", Status, 400);
 			TestFalse("not ok", Result->GetBoolField(TEXT("ok")));
 		});
+
+		It("forwards an optional aiAgents array into the view-model (issue #97 AI-agents status row)", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/inject/connection-status"),
+				DevCtlBody(TEXT("{\"status\":\"Connected\",\"aiAgents\":[\"Claude Code\",\"Cursor\"]}")),
+				&VM.Get(), Result);
+
+			TestEqual("status", Status, 200);
+			TestTrue("ok", Result->GetBoolField(TEXT("ok")));
+			TestEqual("aiAgentCount in response", (int32)Result->GetNumberField(TEXT("aiAgentCount")), 2);
+			// The view-model's live list (which the §7 AI-agents status row + its rail dot read) reflects the inject.
+			TestEqual("view-model agent count", VM->GetAiAgents().Num(), 2);
+			if (VM->GetAiAgents().Num() == 2)
+			{
+				TestEqual("agent[0]", VM->GetAiAgents()[0], FString(TEXT("Claude Code")));
+				TestEqual("agent[1]", VM->GetAiAgents()[1], FString(TEXT("Cursor")));
+			}
+		});
+
+		It("clears the aiAgents list when a status omits the field (empty-state path)", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+
+			// First populate, then inject a status with no aiAgents key — the list must reset to empty so the
+			// AI-agents status row falls back to its "No agents connected" empty state.
+			TSharedRef<FJsonObject> First = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/inject/connection-status"),
+				DevCtlBody(TEXT("{\"status\":\"Connected\",\"aiAgents\":[\"Claude Code\"]}")), &VM.Get(), First);
+			TestEqual("populated", VM->GetAiAgents().Num(), 1);
+
+			TSharedRef<FJsonObject> Second = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/inject/connection-status"),
+				DevCtlBody(TEXT("{\"status\":\"Connected\"}")), &VM.Get(), Second);
+			TestEqual("cleared to empty", VM->GetAiAgents().Num(), 0);
+		});
 	});
 
 	Describe("Control mutators", [this]()

--- a/scripts/window_smoke.py
+++ b/scripts/window_smoke.py
@@ -234,6 +234,21 @@ class Driver:
         self.check("cancel -> Idle", s.get("deviceAuthState") == "Idle", s.get("deviceAuthState"))
         _req(port, "POST", "/control/connection-mode", {"mode": "Custom"})
 
+        # --- AI agents status row (issue #97) — the read-only connected-agents readout in the Connection timeline ---
+        # Inject a populated list, then clear it, asserting the view-model list the §7 AI-agents row + its rail dot
+        # render. The populated screenshot is the live evidence the row lists agents; the empty one shows the
+        # "No agents connected" empty state.
+        _req(port, "POST", "/inject/connection-status",
+             {"status": "Connected", "aiAgents": ["Claude Code", "Cursor", "Copilot"]})
+        s = self.state()
+        self.check("ai-agents populated -> /state count", s.get("aiAgentCount") == 3, str(s.get("aiAgentCount")))
+        self.check("ai-agents list reflected", s.get("aiAgents") == ["Claude Code", "Cursor", "Copilot"], str(s.get("aiAgents")))
+        self.shot("06a-ai-agents-connected")
+        _req(port, "POST", "/inject/connection-status", {"status": "Connected"})
+        s = self.state()
+        self.check("ai-agents cleared -> empty state", s.get("aiAgentCount") == 0, str(s.get("aiAgentCount")))
+        self.shot("06b-ai-agents-empty")
+
         # --- Agent selector ---
         _req(port, "POST", "/control/select-agent", {"agentId": "claude-code"})
         s = self.state()


### PR DESCRIPTION
## Summary
- The Connection section is now a true 3-item status timeline (Unreal -> MCP server -> AI agents) matching Unity-MCP. The "AI agents" element is a read-only status row listing the connected agents from `ViewModel->GetAiAgents()` (with a "No agents connected" empty state); its rail dot is driven Online when any agent is connected, else Offline (replacing the hardcoded `EDot::Offline`).
- The AI agent configurator (`SUnrealMcpAgentConfigurators` dropdown) moved back OUT of the Connection cluster to its own standalone section below Connection (its pre-#93 placement); the connection dots no longer anchor to it.
- Dev-control `/inject/connection-status` forwards an optional `aiAgents` array (+ echoes `aiAgentCount`) so the live smoke harness can drive the row and its dot; two new `UnrealMcpDevControlSpec` cases and a `window_smoke.py` block cover the populated + empty states.

## Test plan
- [x] Suite 1 — UBT `UnrealTestProjectEditor Win64 Development` exit 0.
- [x] Suite 2 — headless boot smoke: `[Unreal-MCP] plugin loaded`. (The `GenericWindow.cpp:113` teardown crash on `QUIT_EDITOR` reproduces unchanged on pristine `main` — pre-existing, out of scope.)
- [x] Suite 3 — Automation `UnrealMcp.` specs: 129 succeeded / 0 failed (log authoritative; the same pre-existing teardown crash prevents the `index.json` flush, reproduced identically on `main`).
- [x] LIVE GUI window smoke (`scripts/window_smoke.py`, dev-control bridge): 34/34 passed; screenshots confirm the 3-item Connection timeline (Unreal / MCP server / AI agents with dots), the AI-agents row listing `Claude Code / Cursor / Copilot` (and the "No agents connected" empty state with an offline dot), and the configurator as a separate section below Connection — visual parity with the Unity-MCP reference.

Follow-up to #93/#94.

Closes #97