### PR TITLE
fix(ui): Cloud Authorize starts/awaits the sidecar instead of erroring "No sidecar connected"

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.cpp
@@ -395,6 +395,17 @@ void FUnrealMcpBridgeServer::HandleHandshake(const TSharedPtr<FJsonObject>& Mess
 	}
 
 	StartHeartbeat();
+
+	// Issue #99: notify the §7 view-model (via the game-thread-marshalling sink) that the sidecar is now connected
+	// + handshaken, so a Cloud auth-start queued while the bridge was (re)starting can be flushed exactly here. Copy
+	// the sink under the lock and invoke OUTSIDE it (the sink marshals to the game thread; never hold a lock across).
+	TFunction<void()> HandshakeSinkCopy;
+	{
+		FScopeLock Lock(&StatusSinkMutex);
+		HandshakeSinkCopy = HandshakeSink;
+	}
+	if (HandshakeSinkCopy)
+		HandshakeSinkCopy();
 }
 
 void FUnrealMcpBridgeServer::HandleToolCall(const TSharedPtr<FJsonObject>& Message)
@@ -700,6 +711,12 @@ void FUnrealMcpBridgeServer::SetStatusSink(TFunction<void(const FString&, TShare
 {
 	FScopeLock Lock(&StatusSinkMutex);
 	StatusSink = MoveTemp(InSink);
+}
+
+void FUnrealMcpBridgeServer::SetHandshakeSink(TFunction<void()> InSink)
+{
+	FScopeLock Lock(&StatusSinkMutex);
+	HandshakeSink = MoveTemp(InSink);
 }
 
 void FUnrealMcpBridgeServer::CloseActiveConnection()

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Bridge/UnrealMcpBridgeServer.h
@@ -80,6 +80,15 @@ public:
 	 */
 	void SetStatusSink(TFunction<void(const FString& /*Type*/, TSharedPtr<FJsonObject> /*Message*/)> InSink);
 
+	/**
+	 * Register a sink fired exactly once each time the sidecar completes its handshake (bClientConnected &&
+	 * bHandshakeOk become true — issue #99). Invoked ON THE IPC READER THREAD; the caller (the §7 view-model
+	 * wiring) MUST marshal onto the game thread before touching Slate/view-model state (the M9b rule). Used to
+	 * FLUSH a queued Cloud auth-start the moment a (re)started bridge connects. Pass an unbound TFunction to
+	 * clear it (window close). Thread-safe; the previous sink is replaced.
+	 */
+	void SetHandshakeSink(TFunction<void()> InSink);
+
 	/** Deterministic IPC port for a project path (§1.1): 30000 + sha(path) % 10000. */
 	static int32 ComputeDeterministicPort(const FString& ProjectPath);
 
@@ -140,6 +149,11 @@ private:
 	// open/close), invoked on the reader thread; guarded so a window-close clear cannot race a reader invoke.
 	mutable FCriticalSection StatusSinkMutex;
 	TFunction<void(const FString&, TSharedPtr<FJsonObject>)> StatusSink;
+
+	// Sink fired once per completed handshake (issue #99 — flush a queued Cloud auth-start). Set/cleared on the
+	// game thread (window open/close), invoked on the reader thread from HandleHandshake; shares StatusSinkMutex
+	// (both are reader-thread invokes guarded against a game-thread window-close clear).
+	TFunction<void()> HandshakeSink;
 
 	FThreadSafeBool bStopRequested = false;
 	FThreadSafeBool bClientConnected = false;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
@@ -14,6 +14,7 @@
 #include "HttpPath.h"
 #include "IHttpRouter.h"
 #include "IPAddress.h"
+#include "HAL/PlatformTime.h"
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
 #include "Serialization/JsonReader.h"
@@ -94,6 +95,7 @@ namespace
 	{
 		switch (State)
 		{
+			case EUnrealMcpDeviceAuthState::Connecting: return TEXT("Connecting"); // issue #99 transient starting/awaiting
 			case EUnrealMcpDeviceAuthState::Pending:    return TEXT("Pending");
 			case EUnrealMcpDeviceAuthState::Authorized: return TEXT("Authorized");
 			case EUnrealMcpDeviceAuthState::Failed:     return TEXT("Failed");
@@ -547,7 +549,7 @@ int32 FUnrealMcpDevControlServer::RouteRequest(
 				ViewModelPtr->ToggleLocalServer();
 			bServerTarget = true;
 		}
-		else if (Target.Equals(TEXT("authorize"), ESearchCase::IgnoreCase))        ViewModelPtr->Authorize();
+		else if (Target.Equals(TEXT("authorize"), ESearchCase::IgnoreCase))        ViewModelPtr->Authorize(FPlatformTime::Seconds()); // issue #99: arm the bounded connect timeout (same as the Slate button)
 		else if (Target.Equals(TEXT("cancel"), ESearchCase::IgnoreCase))           ViewModelPtr->CancelAuth();
 		else if (Target.Equals(TEXT("revoke"), ESearchCase::IgnoreCase))           ViewModelPtr->Revoke();
 		else if (Target.Equals(TEXT("generate-token"), ESearchCase::IgnoreCase))   ViewModelPtr->GenerateCustomToken();

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -25,6 +25,7 @@
 #include "Misc/Attribute.h"
 #include "Misc/Paths.h"
 #include "HAL/PlatformProcess.h"
+#include "HAL/PlatformTime.h"
 #include "HAL/PlatformApplicationMisc.h"
 #include "Interfaces/IPluginManager.h"
 
@@ -106,6 +107,19 @@ void SUnrealMcpMainWindow::Construct(const FArguments& InArgs)
 			+ SVerticalBox::Slot().AutoHeight()[ BuildFooterSection() ]
 		]
 	];
+
+	// Issue #99: a low-frequency active timer drives the bounded Cloud-auth Connecting→Failed timeout so the UI never
+	// wedges in the transient "Starting MCP bridge…" state if the sidecar never handshakes. TickAuthTimeout is a no-op
+	// in every state but Connecting, so this is effectively idle (and cheap) the rest of the time. The widget owns the
+	// timer's lifetime — it is unregistered automatically when the widget is destroyed, so no dangling view-model touch.
+	RegisterActiveTimer(0.5f, FWidgetActiveTimerDelegate::CreateSP(this, &SUnrealMcpMainWindow::TickCloudAuthTimeout));
+}
+
+EActiveTimerReturnType SUnrealMcpMainWindow::TickCloudAuthTimeout(double InCurrentTime, float /*InDeltaTime*/)
+{
+	if (IsViewModelValid())
+		ViewModel->TickAuthTimeout(FPlatformTime::Seconds());
+	return EActiveTimerReturnType::Continue;
 }
 
 TSharedRef<SWidget> SUnrealMcpMainWindow::UnderlinedLabel(const TAttribute<FText>& Text)
@@ -475,17 +489,23 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCloudAuthRow()
 			UnrealMcpStyleWidgets::StyledButton("UnrealMcp.Button.Secondary",
 				SNew(STextBlock).Text_Lambda([this]()
 				{
-					return (IsViewModelValid() && ViewModel->GetDeviceAuthState() == EUnrealMcpDeviceAuthState::Pending)
+					// Both Connecting (awaiting the sidecar handshake to flush a queued auth-start, issue #99) and
+					// Pending (device-code in the browser) are in-flight states the user can Cancel.
+					if (!IsViewModelValid())
+						return LOCTEXT("Authorize", "Authorize");
+					const EUnrealMcpDeviceAuthState State = ViewModel->GetDeviceAuthState();
+					return (State == EUnrealMcpDeviceAuthState::Pending || State == EUnrealMcpDeviceAuthState::Connecting)
 						? LOCTEXT("CancelAuth", "Cancel") : LOCTEXT("Authorize", "Authorize");
 				}),
 				FOnClicked::CreateLambda([this]()
 				{
 					if (!IsViewModelValid())
 						return FReply::Handled();
-					if (ViewModel->GetDeviceAuthState() == EUnrealMcpDeviceAuthState::Pending)
+					const EUnrealMcpDeviceAuthState State = ViewModel->GetDeviceAuthState();
+					if (State == EUnrealMcpDeviceAuthState::Pending || State == EUnrealMcpDeviceAuthState::Connecting)
 						ViewModel->CancelAuth();
 					else
-						ViewModel->Authorize();
+						ViewModel->Authorize(FPlatformTime::Seconds()); // issue #99: arm the bounded connect timeout
 					return FReply::Handled();
 				}))
 		];
@@ -532,6 +552,20 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCloudAuthRow()
 						return FReply::Handled();
 					}))
 			]
+		]
+		// Connecting (issue #99): transient "starting/awaiting the MCP bridge" line shown while a queued auth-start
+		// waits for the sidecar handshake to flush. Amber, mirrors the Connecting connection-status colour.
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+		[
+			SNew(STextBlock)
+			.AutoWrapText(true)
+			.ColorAndOpacity(FSlateColor(FUnrealMcpEditorViewModel::GetStatusColor(EUnrealMcpConnectionState::Connecting)))
+			.Visibility_Lambda([this]()
+			{
+				return (IsViewModelValid() && ViewModel->GetDeviceAuthState() == EUnrealMcpDeviceAuthState::Connecting)
+					? EVisibility::Visible : EVisibility::Collapsed;
+			})
+			.Text(LOCTEXT("AuthConnecting", "Starting MCP bridge… authorization will continue once it connects."))
 		]
 		// Authorized indicator.
 		+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
@@ -103,4 +103,8 @@ private:
 	// Common handlers.
 	FReply OnConnectClicked();
 	bool IsViewModelValid() const { return ViewModel.IsValid(); }
+
+	// Issue #99: active-timer callback driving the bounded Cloud-auth Connecting→Failed timeout (no-op unless the
+	// device-auth flow is awaiting a sidecar handshake). Registered in Construct; owned by the widget's lifetime.
+	EActiveTimerReturnType TickCloudAuthTimeout(double InCurrentTime, float InDeltaTime);
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -151,23 +151,85 @@ void FUnrealMcpEditorViewModel::Disconnect()
 	PersistAndPush();
 }
 
-void FUnrealMcpEditorViewModel::Authorize()
+const TCHAR* FUnrealMcpEditorViewModel::BridgeUnavailableMessage()
+{
+	// Actionable, NOT the cryptic "No sidecar connected." — tell the user how to get a working bridge (issue #99).
+	return TEXT("MCP bridge not installed for this platform — reinstall the plugin, or run `unreal-mcp-cli bootstrap-local`.");
+}
+
+void FUnrealMcpEditorViewModel::Authorize(double NowSeconds)
 {
 	DeviceVerificationUrl.Reset();
 	DeviceUserCode.Reset();
 	DeviceAuthError.Reset();
-	// Only enter Pending if the auth-start frame actually reached the sidecar. SendAuthMessage returns false
-	// when no sidecar is connected/handshaken; entering Pending regardless would wedge the UI showing
-	// "Complete authorization in your browser…" with an empty user code until the user manually cancels.
-	const bool bSent = OnSendAuth ? OnSendAuth(TEXT("auth-start")) : false;
-	DeviceAuthState = bSent ? EUnrealMcpDeviceAuthState::Pending : EUnrealMcpDeviceAuthState::Failed;
-	// Surface a reason for the Failed state so the window does not silently collapse the pending instructions.
-	if (!bSent)
-		DeviceAuthError = TEXT("No sidecar connected.");
+	bAuthStartQueued = false;
+
+	// Fast path: a connected + handshaken sidecar takes the auth-start frame immediately → straight to Pending,
+	// then the sidecar drives the device-code feed (verificationUrl / userCode / authorized) over `device-auth`.
+	if (OnSendAuth && OnSendAuth(TEXT("auth-start")))
+	{
+		DeviceAuthState = EUnrealMcpDeviceAuthState::Pending;
+		return;
+	}
+
+	// Robust path (issue #99): the sidecar is not connected/handshaken yet. Do NOT dead-end to Failed — request
+	// it (re)start, QUEUE the auth-start, and enter the transient Connecting state. NotifySidecarHandshakeComplete()
+	// flushes the queued frame the moment the sidecar handshakes; TickAuthTimeout() bounds the wait so the UI never
+	// wedges. Only an unresolvable bridge binary fails fast with an actionable message.
+	const bool bCanStart = OnEnsureSidecarStarted ? OnEnsureSidecarStarted() : false;
+	if (!bCanStart)
+	{
+		// The bridge binary genuinely cannot be resolved/spawned (packaged-without-<rid> / unset dev override).
+		// Awaiting a handshake that will never arrive would be a silent wedge — fail fast, actionably.
+		DeviceAuthState = EUnrealMcpDeviceAuthState::Failed;
+		DeviceAuthError = BridgeUnavailableMessage();
+		return;
+	}
+
+	bAuthStartQueued = true;
+	ConnectingStartedSeconds = NowSeconds;
+	DeviceAuthState = EUnrealMcpDeviceAuthState::Connecting;
+}
+
+void FUnrealMcpEditorViewModel::NotifySidecarHandshakeComplete()
+{
+	// Only meaningful while we are waiting (Connecting) with a queued auth-start. A handshake at any other time
+	// (a normal reconnect, a manual Restart bridge with no auth in flight) must not spuriously start an auth flow.
+	if (DeviceAuthState != EUnrealMcpDeviceAuthState::Connecting || !bAuthStartQueued)
+		return;
+
+	// The sidecar is now connected/handshaken — flush the queued auth-start. On success advance to Pending (the
+	// sidecar's device-auth feed drives the rest); a still-failing send is a transient race, so stay Connecting
+	// and let either a later handshake re-fire this or the timeout fail it actionably.
+	if (OnSendAuth && OnSendAuth(TEXT("auth-start")))
+	{
+		bAuthStartQueued = false;
+		DeviceVerificationUrl.Reset();
+		DeviceUserCode.Reset();
+		DeviceAuthError.Reset();
+		DeviceAuthState = EUnrealMcpDeviceAuthState::Pending;
+	}
+}
+
+void FUnrealMcpEditorViewModel::TickAuthTimeout(double NowSeconds)
+{
+	// Bounded Connecting→Failed: only fires while awaiting the sidecar handshake. Once the wait exceeds the bound,
+	// the bridge plainly is not coming up — fail actionably and clear the queued frame so a late handshake cannot
+	// resurrect a stale auth-start. No-op in every other state (Pending/Authorized/Failed/Idle are driven elsewhere).
+	if (DeviceAuthState != EUnrealMcpDeviceAuthState::Connecting)
+		return;
+	if (NowSeconds - ConnectingStartedSeconds < SidecarConnectTimeoutSeconds)
+		return;
+
+	bAuthStartQueued = false;
+	DeviceAuthState = EUnrealMcpDeviceAuthState::Failed;
+	DeviceAuthError = BridgeUnavailableMessage();
 }
 
 void FUnrealMcpEditorViewModel::CancelAuth()
 {
+	// Cancelling clears any queued/awaiting auth-start (issue #99) so a late handshake/timeout cannot revive it.
+	bAuthStartQueued = false;
 	// Cancelling an in-progress RE-authorize must not hide an already-stored cloud token: InitializeConfig maps
 	// token-present → Authorized, so dropping to Idle here would lose the "Authorized"/Revoke affordance until
 	// restart. Fall back to Authorized when a bearer is still stored; only a token-less cancel returns to Idle.

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
@@ -30,6 +30,12 @@ enum class EUnrealMcpDeviceAuthState : uint8
 {
 	/** No device-code flow in progress. */
 	Idle,
+	/**
+	 * Authorize pressed but the sidecar was not connected/handshaken yet: we have requested it (re)start and are
+	 * awaiting its handshake to FLUSH the queued auth-start (issue #99). A transient, bounded state ("Starting MCP
+	 * bridge…") — it advances to Pending on handshake, or to Failed on the bounded timeout / unresolvable binary.
+	 */
+	Connecting,
 	/** Authorize pressed; awaiting the user to complete verification in their browser. */
 	Pending,
 	/** The device-code flow succeeded and a cloud token was stored. */
@@ -68,9 +74,20 @@ public:
 	/**
 	 * Send a §1.3 auth message (auth-start / auth-cancel / auth-revoke) to the sidecar. Returns true when the
 	 * frame was actually handed to a connected/handshaken sidecar; false when there is no sidecar to send to
-	 * (so Authorize() can avoid wedging the UI in a code-less Pending state). A spec may leave it unset.
+	 * (so Authorize() can queue the auth-start and FLUSH it on handshake rather than wedging — issue #99). A
+	 * spec may leave it unset.
 	 */
 	TFunction<bool(const FString& /*AuthType*/)> OnSendAuth;
+	/**
+	 * Ensure the sidecar (unreal-mcp-bridge) is (re)started so a queued auth-start can be flushed once it
+	 * handshakes (issue #99). Wired by the runtime to FUnrealMcpSidecarManager::StartForPort (via the
+	 * OnRestartBridge-style relaunch). Returns true when the bridge binary resolved and a spawn was attempted
+	 * (or it is already running) — i.e. a handshake is plausibly imminent; false when the binary genuinely
+	 * cannot be resolved (a packaged-without-<rid> install / unset UNREAL_MCP_BRIDGE_PATH in dev), in which case
+	 * Authorize() fails fast with an actionable "install the bridge" message instead of awaiting a handshake that
+	 * will never come. A spec may leave it unset (treated as "cannot start" → actionable Failed).
+	 */
+	TFunction<bool()> OnEnsureSidecarStarted;
 	/** Open a verification URL in the system browser (device-code flow). */
 	TFunction<void(const FString& /*Url*/)> OnOpenBrowser;
 	/**
@@ -197,9 +214,31 @@ public:
 	/** The human-readable failure reason surfaced while the device-code flow is Failed (empty otherwise). */
 	const FString& GetDeviceAuthError() const { return DeviceAuthError; }
 
-	/** Authorize: begin the device-code flow (sends `auth-start`; the sidecar drives the real flow). */
-	UNREALMCPEDITOR_API void Authorize();
-	/** Cancel an in-progress device-code flow (sends `auth-cancel`). */
+	/**
+	 * Authorize: begin the device-code flow (issue #99 robust path). If a sidecar is connected the `auth-start`
+	 * frame is sent immediately and we enter Pending. If it is NOT connected yet, request it (re)start, QUEUE the
+	 * auth-start, enter the transient Connecting state, and arm a bounded timeout — the queued frame is flushed
+	 * automatically by NotifySidecarHandshakeComplete() once the sidecar handshakes. Only an unresolvable binary
+	 * (OnEnsureSidecarStarted returns false) or the timeout transitions to an actionable Failed. The sidecar drives
+	 * the real flow from auth-start onward. @p NowSeconds is the monotonic clock used to arm the timeout (the UI
+	 * passes FPlatformTime::Seconds(); a spec passes a synthetic time).
+	 */
+	UNREALMCPEDITOR_API void Authorize(double NowSeconds = 0.0);
+	/**
+	 * Flush a queued auth-start once the sidecar completes its handshake (issue #99). No-op unless we are in the
+	 * Connecting state with a queued auth-start. Called by the runtime on the game thread when the bridge reports
+	 * bClientConnected && bHandshakeOk. On a successful send we advance to Pending (the sidecar then emits the
+	 * device-auth pending/authorized/failed feed); a still-failing send leaves us Connecting until the timeout.
+	 */
+	UNREALMCPEDITOR_API void NotifySidecarHandshakeComplete();
+	/**
+	 * Drive the bounded Connecting→Failed timeout (issue #99). Call from a UI tick / active timer with the
+	 * monotonic clock; when we have been Connecting (awaiting a handshake to flush the queued auth-start) longer
+	 * than the bound, transition to an actionable Failed so the UI never wedges. No-op in any non-Connecting state.
+	 * @p NowSeconds is FPlatformTime::Seconds() from the UI (a spec passes a synthetic time).
+	 */
+	UNREALMCPEDITOR_API void TickAuthTimeout(double NowSeconds);
+	/** Cancel an in-progress device-code flow (sends `auth-cancel`; also clears a queued/awaiting auth-start). */
 	UNREALMCPEDITOR_API void CancelAuth();
 	/** Revoke + clear the stored cloud token (sends `auth-revoke`, clears CloudToken, persists). */
 	UNREALMCPEDITOR_API void Revoke();
@@ -302,6 +341,16 @@ private:
 	FString DeviceUserCode;
 	FString DeviceAuthError;
 	TArray<FString> AiAgents;
+
+	// --- Issue #99: queue-while-connecting / flush-on-handshake / bounded-timeout for Authorize. ---
+	/** True when an auth-start is queued, awaiting the sidecar handshake to flush it (set in Connecting). */
+	bool bAuthStartQueued = false;
+	/** Monotonic clock (FPlatformTime::Seconds) at which the Connecting state began, for the bounded timeout. */
+	double ConnectingStartedSeconds = 0.0;
+	/** Bounded wait for the sidecar to connect after Authorize before failing actionably (never wedge the UI). */
+	static constexpr double SidecarConnectTimeoutSeconds = 20.0;
+	/** The actionable failure message shown when the bridge binary cannot start / never connects (issue #99). */
+	UNREALMCPEDITOR_API static const TCHAR* BridgeUnavailableMessage();
 
 	// Persist (if a sink is wired) then push the §1.3 config to the sidecar (if a sink is wired).
 	void PersistAndPush();

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpRuntime.cpp
@@ -151,6 +151,21 @@ void FUnrealMcpRuntime::Startup()
 		// connected sidecar to receive the auth-start frame.
 		return BridgeServerPtr ? BridgeServerPtr->SendAuthMessage(AuthType) : false;
 	};
+	// Issue #99: "ensure the sidecar is started" hook. When Cloud Authorize is pressed and no sidecar is connected
+	// yet, the view-model calls this to (re)start the bridge, then QUEUES the auth-start to flush on handshake
+	// (OnSendAuth above eventually succeeds once HandshakeSink fires). Already-running → true (a handshake is
+	// imminent / already happening). Not running → StartForPort spawns it and returns false ONLY when the binary
+	// genuinely cannot be resolved (packaged-without-<rid> / unset UNREAL_MCP_BRIDGE_PATH) — the view-model then
+	// fails fast with an actionable message instead of awaiting a handshake that will never come.
+	FUnrealMcpSidecarManager* SidecarPtrForAuth = SidecarManager.Get();
+	ViewModel->OnEnsureSidecarStarted = [SidecarPtrForAuth, BoundPort, Token]() -> bool
+	{
+		if (!SidecarPtrForAuth)
+			return false;
+		if (SidecarPtrForAuth->IsRunning())
+			return true;
+		return SidecarPtrForAuth->StartForPort(BoundPort, Token);
+	};
 	ViewModel->OnOpenBrowser = [](const FString& Url)
 	{
 		if (!Url.IsEmpty())
@@ -211,6 +226,18 @@ void FUnrealMcpRuntime::Startup()
 					VM->ApplyStatus(Message);
 				else if (Type == TEXT("device-auth"))
 					VM->ApplyDeviceAuth(Message);
+			});
+		});
+
+		// Issue #99: on each sidecar handshake-complete, marshal to the game thread and flush a queued Cloud
+		// auth-start (a no-op unless Authorize is awaiting in the Connecting state). Same M9b marshalling + weak
+		// view-model guard as the status sink so a handshake straddling teardown is a no-op, not a use-after-free.
+		BridgeServerPtr->SetHandshakeSink([WeakViewModel]()
+		{
+			AsyncTask(ENamedThreads::GameThread, [WeakViewModel]()
+			{
+				if (TSharedPtr<FUnrealMcpEditorViewModel> VM = WeakViewModel.Pin())
+					VM->NotifySidecarHandshakeComplete();
 			});
 		});
 	}
@@ -367,7 +394,10 @@ void FUnrealMcpRuntime::Shutdown()
 		MainWindowTab.Reset();
 	}
 	if (BridgeServer.IsValid())
+	{
 		BridgeServer->SetStatusSink(nullptr);
+		BridgeServer->SetHandshakeSink(nullptr); // issue #99: drop the handshake-flush sink before the VM is freed
+	}
 	// Null the view-model's side-effect sinks before destroying the bridge/sidecar below: those sinks capture
 	// raw FUnrealMcpBridgeServer* pointers, so if anything still holds the view-model after the tab close
 	// (a deferred RequestCloseTab, a queued widget event) it cannot dereference the soon-to-be-freed bridge.
@@ -376,6 +406,7 @@ void FUnrealMcpRuntime::Shutdown()
 		ViewModel->OnPersistConfig = nullptr;
 		ViewModel->OnPushConfig = nullptr;
 		ViewModel->OnSendAuth = nullptr;
+		ViewModel->OnEnsureSidecarStarted = nullptr; // issue #99: captures the raw sidecar-manager pointer freed below
 		ViewModel->OnOpenBrowser = nullptr;
 		ViewModel->OnToolEnablementChanged = nullptr; // captures the raw registry/bridge pointers freed below
 		// §7 in-UI local-server sinks capture the raw FUnrealMcpServerManager* freed below — null before that.

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
@@ -26,6 +26,15 @@ BEGIN_DEFINE_SPEC(FUnrealMcpEditorViewModelSpec, "UnrealMcp.EditorViewModel",
 		TArray<FString> AuthSent;
 		TArray<FString> OpenedUrls;
 		FUnrealMcpConfig LastPushed;
+		// Issue #99: the recording hook for "ensure sidecar started". EnsureSidecarStartedCount tracks how many
+		// times Authorize asked the runtime to (re)start the bridge; bSidecarCanStart is the fake binary-resolves
+		// result (true → a handshake is plausibly imminent → enter Connecting+queue; false → actionable Failed).
+		// bSidecarConnected is the fake live send-result the OnSendAuth stub reads: while false, auth-start sends
+		// fail (sidecar not connected yet), so Authorize takes the queue-and-await path; flipping it true then
+		// firing NotifySidecarHandshakeComplete simulates the bridge handshaking and flushes the queued frame.
+		int32 EnsureSidecarStartedCount = 0;
+		bool bSidecarCanStart = true;
+		bool bSidecarConnected = true;
 		// §7 in-UI local-server (issue #95): the recording stubs for the server sinks. bServerRunning is the
 		// fake live state the IsLocalServerRunningSink reads; OnStart flips it true, OnStop flips it false.
 		int32 ServerStartCount = 0;
@@ -38,7 +47,17 @@ BEGIN_DEFINE_SPEC(FUnrealMcpEditorViewModelSpec, "UnrealMcp.EditorViewModel",
 		TSharedRef<FUnrealMcpEditorViewModel> VM = MakeShared<FUnrealMcpEditorViewModel>();
 		VM->OnPersistConfig = [Rec](const FUnrealMcpConfig&) { Rec->PersistCount++; };
 		VM->OnPushConfig = [Rec](const FUnrealMcpConfig& Cfg) { Rec->PushCount++; Rec->LastPushed = Cfg; };
-		VM->OnSendAuth = [Rec](const FString& Type) -> bool { Rec->AuthSent.Add(Type); return true; };
+		// auth-start succeeds only when the fake sidecar is connected (issue #99 robust path); auth-cancel/revoke
+		// always "send" (they are best-effort over whatever connection exists). This lets a spec start disconnected
+		// (auth-start queues) then flip bSidecarConnected + fire the handshake to flush.
+		VM->OnSendAuth = [Rec](const FString& Type) -> bool
+		{
+			Rec->AuthSent.Add(Type);
+			if (Type == TEXT("auth-start"))
+				return Rec->bSidecarConnected;
+			return true;
+		};
+		VM->OnEnsureSidecarStarted = [Rec]() -> bool { Rec->EnsureSidecarStartedCount++; return Rec->bSidecarCanStart; };
 		VM->OnOpenBrowser = [Rec](const FString& Url) { Rec->OpenedUrls.Add(Url); };
 		VM->OnStartLocalServer = [Rec]() -> bool { Rec->ServerStartCount++; Rec->bServerRunning = true; return true; };
 		VM->OnStopLocalServer = [Rec]() { Rec->ServerStopCount++; Rec->bServerRunning = false; };
@@ -253,19 +272,112 @@ void FUnrealMcpEditorViewModelSpec::Define()
 			TestEqual("pushed config carries the cloud token", Rec->LastPushed.CloudToken, FString(TEXT("cloud-bearer-abc")));
 		});
 
-		It("Authorize stays out of Pending when the auth-start frame cannot be sent (no sidecar)", [this]()
+		It("Authorize enters Connecting and QUEUES auth-start when the sidecar is not connected yet (issue #99)", [this]()
 		{
 			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
 			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
-			// A sink that reports the frame could not be delivered (no connected/handshaken sidecar).
-			VM->OnSendAuth = [Rec](const FString& Type) -> bool { Rec->AuthSent.Add(Type); return false; };
+			// Sidecar is NOT connected yet, but its binary CAN start — the robust path: request a (re)start, queue
+			// the auth-start, and enter the transient Connecting state (NOT immediate Failed — the old behavior).
+			Rec->bSidecarConnected = false;
+			Rec->bSidecarCanStart = true;
 
-			VM->Authorize();
+			VM->Authorize(/*NowSeconds*/ 100.0);
 			TestTrue("auth-start attempted", Rec->AuthSent.Contains(TEXT("auth-start")));
-			// Must NOT wedge in a code-less Pending state — fall to Failed so the UI does not show an empty code.
-			TestEqual("not pending when send failed", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Failed));
-			// And surface a reason so the window shows feedback rather than silently collapsing.
-			TestEqual("no-sidecar reason surfaced", VM->GetDeviceAuthError(), FString(TEXT("No sidecar connected.")));
+			TestEqual("ensure-sidecar-started requested once", Rec->EnsureSidecarStartedCount, 1);
+			// Transient connecting/awaiting — NOT Failed, NOT a code-less Pending.
+			TestEqual("connecting while awaiting handshake", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Connecting));
+			// No premature failure message while we wait.
+			TestTrue("no failure reason while connecting", VM->GetDeviceAuthError().IsEmpty());
+		});
+
+		It("flushes the queued auth-start on a simulated handshake-complete (issue #99)", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			Rec->bSidecarConnected = false;
+			Rec->bSidecarCanStart = true;
+
+			VM->Authorize(/*NowSeconds*/ 0.0);
+			TestEqual("connecting after Authorize", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Connecting));
+			const int32 AuthStartsBeforeHandshake = Rec->AuthSent.FilterByPredicate([](const FString& T){ return T == TEXT("auth-start"); }).Num();
+
+			// The sidecar handshakes: flip the fake connection true, then notify. The queued auth-start flushes and
+			// we advance to Pending (the sidecar's device-auth feed then drives the verificationUrl / userCode).
+			Rec->bSidecarConnected = true;
+			VM->NotifySidecarHandshakeComplete();
+			const int32 AuthStartsAfterHandshake = Rec->AuthSent.FilterByPredicate([](const FString& T){ return T == TEXT("auth-start"); }).Num();
+			TestEqual("auth-start re-sent on handshake (flushed)", AuthStartsAfterHandshake, AuthStartsBeforeHandshake + 1);
+			TestEqual("pending after flush", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Pending));
+
+			// A second handshake notification must NOT re-fire the (already-flushed) auth-start.
+			VM->NotifySidecarHandshakeComplete();
+			const int32 AuthStartsAfterSecond = Rec->AuthSent.FilterByPredicate([](const FString& T){ return T == TEXT("auth-start"); }).Num();
+			TestEqual("no double-flush on a second handshake", AuthStartsAfterSecond, AuthStartsAfterHandshake);
+		});
+
+		It("Cancel while awaiting (Connecting) clears the queue and the timeout (issue #99)", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			Rec->bSidecarConnected = false;
+			Rec->bSidecarCanStart = true;
+
+			VM->Authorize(/*NowSeconds*/ 100.0);
+			TestEqual("connecting after Authorize", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Connecting));
+
+			VM->CancelAuth();
+			TestEqual("idle after cancel (no stored token)", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Idle));
+			TestTrue("auth-cancel sent", Rec->AuthSent.Contains(TEXT("auth-cancel")));
+
+			// A late handshake after the cancel must NOT resurrect the cancelled auth-start (queue was cleared).
+			Rec->bSidecarConnected = true;
+			const int32 AuthStartsBefore = Rec->AuthSent.FilterByPredicate([](const FString& T){ return T == TEXT("auth-start"); }).Num();
+			VM->NotifySidecarHandshakeComplete();
+			const int32 AuthStartsAfter = Rec->AuthSent.FilterByPredicate([](const FString& T){ return T == TEXT("auth-start"); }).Num();
+			TestEqual("cancelled queue not flushed by a late handshake", AuthStartsAfter, AuthStartsBefore);
+			TestEqual("still idle after late handshake", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Idle));
+
+			// And a later timeout tick must NOT revive it either.
+			VM->TickAuthTimeout(/*NowSeconds*/ 1000.0);
+			TestEqual("still idle after a post-cancel timeout tick", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Idle));
+		});
+
+		It("times out to an actionable Failed when the sidecar never connects (issue #99)", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			Rec->bSidecarConnected = false;
+			Rec->bSidecarCanStart = true;
+
+			VM->Authorize(/*NowSeconds*/ 100.0);
+			TestEqual("connecting after Authorize", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Connecting));
+
+			// A tick well inside the bound is a no-op (still awaiting).
+			VM->TickAuthTimeout(/*NowSeconds*/ 105.0);
+			TestEqual("still connecting inside the timeout bound", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Connecting));
+
+			// A tick past the bound transitions to Failed with the ACTIONABLE message (not the cryptic old one).
+			VM->TickAuthTimeout(/*NowSeconds*/ 100.0 + 60.0);
+			TestEqual("failed after the timeout", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Failed));
+			TestTrue("actionable failure mentions installing the bridge",
+				VM->GetDeviceAuthError().Contains(TEXT("bootstrap-local")) || VM->GetDeviceAuthError().Contains(TEXT("reinstall")));
+			TestFalse("failure is NOT the cryptic No-sidecar-connected message", VM->GetDeviceAuthError() == TEXT("No sidecar connected."));
+		});
+
+		It("Authorize fails fast actionably when the bridge binary cannot start at all (issue #99)", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			// Sidecar not connected AND its binary cannot be resolved (packaged-without-<rid> / unset dev override).
+			Rec->bSidecarConnected = false;
+			Rec->bSidecarCanStart = false;
+
+			VM->Authorize(/*NowSeconds*/ 100.0);
+			TestEqual("ensure-sidecar-started attempted once", Rec->EnsureSidecarStartedCount, 1);
+			// No point awaiting a handshake that will never arrive — fail fast, actionably (never wedge).
+			TestEqual("failed fast when the binary cannot start", static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Failed));
+			TestTrue("actionable failure surfaced",
+				VM->GetDeviceAuthError().Contains(TEXT("bootstrap-local")) || VM->GetDeviceAuthError().Contains(TEXT("reinstall")));
 		});
 
 		It("surfaces a failed device-auth message and clears it on a fresh Authorize", [this]()

--- a/scripts/window_smoke.py
+++ b/scripts/window_smoke.py
@@ -209,14 +209,16 @@ class Driver:
         _req(port, "POST", "/control/connection-mode", {"mode": "Cloud"})
         _req(port, "POST", "/control/click", {"target": "authorize"})
         s = self.state()
-        # Sidecar-aware: Authorize() only enters Pending when OnSendAuth("auth-start") succeeds, which
-        # needs a connected + handshaken sidecar. A plain live-UI run has no sidecar attached, so the
-        # view-model deliberately falls to Failed (reason "No sidecar connected.") rather than wedging
-        # in a code-less Pending — see UnrealMcpEditorViewModel.cpp::Authorize(). Accept either as the
-        # expected outcome so a sidecar-less run still reports a full pass; the injected device-auth rows
-        # below exercise the Pending/Authorized/Failed readouts directly regardless.
+        # Sidecar-aware (issue #99 robust path): Authorize() reaches Pending immediately only when a connected +
+        # handshaken sidecar takes the auth-start. When the sidecar is not connected yet it enters the transient
+        # Connecting state (queues auth-start, awaits the handshake to flush it), and only an unresolvable bridge
+        # binary or the bounded timeout falls to Failed. A plain live-UI run's outcome therefore depends on whether
+        # a bridge is attached: Pending (connected), Connecting (starting/awaiting), or Failed (no binary / timeout).
+        # Accept all three so both a sidecar-staged run AND a sidecar-less run report a full pass; the injected
+        # device-auth rows below exercise the Pending/Authorized/Failed readouts directly regardless.
         auth_state = s.get("deviceAuthState")
-        self.check("authorize -> Pending (or Failed when no sidecar)", auth_state in ("Pending", "Failed"), auth_state)
+        self.check("authorize -> Pending/Connecting/Failed (sidecar-dependent)",
+                   auth_state in ("Pending", "Connecting", "Failed"), auth_state)
         _req(port, "POST", "/inject/device-auth",
              {"state": "pending", "verificationUrl": "https://ai-game.dev/device", "userCode": "WXYZ-1234"})
         self.shot("04-cloud-pending")


### PR DESCRIPTION
## Summary
- Cloud-mode **Authorize** no longer dead-ends to `Failed` with "No sidecar connected." when the `unreal-mcp-bridge` sidecar is not connected yet. It now requests the sidecar (re)start, enters a transient **Connecting** state ("Starting MCP bridge…"), **queues** the `auth-start`, and **flushes** it automatically once the sidecar handshakes — then proceeds to the normal device-code `Pending` flow driven by the sidecar.
- A **bounded timeout** transitions Connecting→Failed with an **actionable** message (reinstall the plugin / `unreal-mcp-cli bootstrap-local`); an unresolvable bridge binary fails fast with the same message. The UI never wedges. Cancel clears a queued/awaiting auth-start + the timeout.
- Wiring: `UnrealMcpBridgeServer::SetHandshakeSink` (fired on handshake) → `UnrealMcpRuntime` (game-thread marshal → flush) and `OnEnsureSidecarStarted` → `FUnrealMcpSidecarManager`. Slate Cloud auth row renders the Connecting/actionable-failure states; an active timer drives the timeout. Dev-control reports the new `Connecting` label.
- Kept the device-code flow entirely in the sidecar (operator's Option-B decision — no OAuth moved into the plugin). No bridge behavior changed; no version/NuGet bump.

## Test plan
- [x] UBT build (UE 5.7 testbed) — exit 0.
- [x] Automation specs `UnrealMcp.EditorViewModel` — 26/26 Success, 0 failed (new specs: queue→flush-on-handshake, cancel-while-awaiting, timeout→actionable Failed, unresolvable-binary→actionable Failed; revised the old no-sidecar spec to the new behavior).
- [x] Bridge xUnit (unchanged side) — 119 passed, 0 failed.
- [x] Headless boot smoke — `[Unreal-MCP] plugin loaded` (the `GenericWindow.cpp:113` shutdown-teardown crash + missing full-suite `index.json` reproduce identically on pristine `main` — pre-existing, out of scope).
- [x] **Live dev-control verification (bridge staged):** Cloud → Authorize reached `Pending` with **no "No sidecar connected" error**; the real sidecar drove the device-code flow and a real verification page opened in the browser. Screenshots captured (Cloud Authorized + Cloud Pending with verification URL + user code). Clean no-orphan teardown.

Closes #99