### PR TITLE
fix(ui): gate plugin window spawns on CanEverRender() so -nullrhi Automation never crashes

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.cpp
@@ -7,6 +7,7 @@
 #include "UI/UnrealMcpEditorViewModel.h"
 #include "UnrealMcpLog.h"
 
+#include "Misc/App.h"
 #include "Framework/Docking/TabManager.h"
 #include "Framework/Application/SlateApplication.h"
 #include "Widgets/Docking/SDockTab.h"
@@ -65,9 +66,19 @@ void FUnrealMcpAuxWindows::Register(
 
 	// Slate may be unavailable in a commandlet / -nullrhi headless run; guard so the Automation/smoke runs
 	// (which load the module) never crash on tab registration (mirrors the main-window tab).
-	if (!FSlateApplication::IsInitialized())
+	//
+	// IsInitialized() alone is NOT enough under `-nullrhi` automation: the editor runs a real (initialized)
+	// FSlateApplication even with no RHI, so this path would proceed and — via the ISettingsModule
+	// RegisterSettings below — eagerly CONSTRUCT a live SUnrealMcpSettingsWindow. Slate then ticks that
+	// widget across the long Automation run and eventually measures its window, hitting GenericWindow's
+	// GetRestoredDimensions, which is fatal with no RHI (issue #103). Also require FApp::CanEverRender()
+	// (false under `-nullrhi`) so the eager-widget path is skipped whenever rendering is unavailable —
+	// the same "rendering present" gate the screenshot family already uses for its GPU-bound branch. The
+	// main-window tab survives on IsInitialized() alone only because it registers a DORMANT spawner that
+	// constructs its widget lazily on invoke; the aux section's eager RegisterSettings widget cannot.
+	if (!FSlateApplication::IsInitialized() || !FApp::CanEverRender())
 	{
-		UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] Slate not initialized; skipping aux-window registration (headless)."));
+		UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] Slate unavailable or rendering disabled; skipping aux-window registration (headless / -nullrhi)."));
 		return;
 	}
 
@@ -218,8 +229,17 @@ TSharedRef<SDockTab> FUnrealMcpAuxWindows::SpawnSerializationCheckTab(const FSpa
 
 bool FUnrealMcpAuxWindows::TryInvokeSerializationCheckTab()
 {
-	if (!FSlateApplication::IsInitialized())
-		return false; // headless / -nullrhi: nothing to open (matches the Register() headless guard)
+	// IsInitialized() alone is too weak under `-nullrhi` automation (the editor runs an initialized
+	// FSlateApplication with no RHI). TryInvokeTab spawns a REAL top-level SWindow regardless of whether the
+	// nomad spawner is registered — if the spawner is missing it falls back to an "unrecognized tab" hosted in
+	// a fresh layout window all the same. Slate then ticks and measures that window via GenericWindow's
+	// GetRestoredDimensions, which is FATAL with no RHI (issue #103: the crash fires on a deferred tick a few
+	// seconds after the invoke, so it lands on whichever spec is running then). Gate on FApp::CanEverRender()
+	// (false under `-nullrhi`) — the same "rendering present" check the screenshot family uses — so the window
+	// is never spawned headless. The DevControl `check` route + the main-window footer button both treat a
+	// false return as a no-op, preserving their headless coverage.
+	if (!FSlateApplication::IsInitialized() || !FApp::CanEverRender())
+		return false; // headless / -nullrhi: nothing to open without a renderer
 
 	FGlobalTabmanager::Get()->TryInvokeTab(SerializationCheckTabId);
 	return true;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.cpp
@@ -6,6 +6,7 @@
 #include "UI/UnrealMcpEditorViewModel.h"
 #include "UnrealMcpLog.h"
 
+#include "Misc/App.h"
 #include "Framework/Docking/TabManager.h"
 #include "Framework/Application/SlateApplication.h"
 #include "Widgets/Docking/SDockTab.h"
@@ -36,10 +37,15 @@ void FUnrealMcpMainWindowTab::Register(
 	ConnectionInfoProvider = MoveTemp(InConnectionInfoProvider);
 
 	// Slate may be unavailable in a commandlet / -nullrhi headless run without a slate application; guard so
-	// the Automation/smoke runs (which load the module) never crash on tab registration.
-	if (!FSlateApplication::IsInitialized())
+	// the Automation/smoke runs (which load the module) never crash on tab registration. IsInitialized() alone
+	// is too weak under `-nullrhi` automation (the editor still runs an initialized FSlateApplication): a
+	// registered nomad spawner can be auto-invoked by the editor's layout restore, spawning a real top-level
+	// SWindow that Slate later measures via GenericWindow::GetRestoredDimensions — fatal with no RHI (#103).
+	// Also require FApp::CanEverRender() (false under `-nullrhi`), the same "rendering present" gate the
+	// screenshot family uses, so no plugin window is registered/spawned on a headless leg.
+	if (!FSlateApplication::IsInitialized() || !FApp::CanEverRender())
 	{
-		UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] Slate not initialized; skipping main-window tab registration (headless)."));
+		UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] Slate unavailable or rendering disabled; skipping main-window tab registration (headless / -nullrhi)."));
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- The now-required `plugin BuildPlugin + Automation (UE 5.7)` CI leg crashed under `-nullrhi` during `Automation RunTests UnrealMcp.` with a fatal `GetRestoredDimensions is not expected to be called on this platform` (GenericWindow.cpp:113), producing no `AutomationReport/index.json`.
- **Root cause:** UI registration / tab-invoke paths guarded only on `FSlateApplication::IsInitialized()` — TRUE under `-nullrhi` (the editor runs an initialized Slate app with no RHI). The trigger is `FUnrealMcpAuxWindows::TryInvokeSerializationCheckTab()` (reached by the `UnrealMcp.DevControl` "click=check" spec): `FGlobalTabmanager::TryInvokeTab` spawns a **real top-level SWindow** even when the spawner is missing (it falls back to an "unrecognized tab" in a fresh layout window). Slate measures that window via `GetRestoredDimensions` on a **deferred tick** a few seconds later → fatal, landing on whichever spec is running then (the timing-dependent "different sub-test each run"). The device-auth specs were innocent bystanders — the crash reproduces with `UnrealMcp.EditorViewModel` fully excluded.
- **Fix:** require `FApp::CanEverRender()` (false under `-nullrhi`), the same gate the screenshot family uses, at every real window spawn/eager-construct site — `TryInvokeSerializationCheckTab()` (the trigger), `FUnrealMcpAuxWindows::Register()` (also eagerly builds an `SUnrealMcpSettingsWindow` via `RegisterSettings` + registers layout-restorable spawners), and `FUnrealMcpMainWindowTab::Register()`. Non-windowed logic coverage is preserved; only the real-window spawn/measure is skipped headless.

## Test plan
- [x] Full `Automation RunTests UnrealMcp.` under `-nullrhi` (the exact CI invocation) completes with **NO fatal**, produces `AutomationReport/index.json`, **0 failed** (295 succeeded + 16 succeededWithWarnings) — verified across **two consecutive runs** (was timing-dependent).
- [x] All `UnrealMcp.EditorViewModel.Cloud device-code auth` specs pass; `UnrealMcp.DevControl ... click=check` passes.
- [x] Headless boot smoke logs `[Unreal-MCP] plugin loaded`; both guards log their headless-skip.
- [x] UBT build (`UnrealTestProjectEditor Win64 Development`) exit 0.

Closes #103