### PR TITLE
chore(bridge): bump McpPlugin pin to 6.10.0 for Troubleshooting/Docker agent sections

### DIFF
--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -51,21 +51,25 @@
 
   <!--
     Reused NuGet pins, kept in lockstep with Godot-MCP (Godot-MCP.csproj):
-    McpPlugin 6.9.0 + ReflectorNet 5.3.1. The MCP/reflection stack is NOT forked —
+    McpPlugin 6.10.0 + ReflectorNet 5.3.1. The MCP/reflection stack is NOT forked —
     pins are owned by the upstream release pipelines. The 6.8.0 bump consumed the new
     shared engine-agnostic com.IvanMurzak.McpPlugin.AgentConfig module (the AI-agent
     configurators + the AgentConfiguratorDescription UI-DTO) so the sidecar hosts the
     AI-agent configuration service instead of the duplicated C++ Agents/ implementation.
-    6.9.0 carries the AgentConfig parity fix (Kilo/Zoo: disabled=false + HTTP
+    6.9.0 carried the AgentConfig parity fix (Kilo/Zoo: disabled=false + HTTP
     type="streamable-http") plus the AgentConfiguratorDescription DTO extension — the new
     ConfigurationItemKind.Link + ConfigurationItem.Url (clickable open-URL items), the
     ConfiguratorStatus tri-state (NotConfigured/Configured/ReconfigureNeeded) on a Status
     field, and a Links collection (with a prepended "Reconfiguration Required" Alert when
-    stale). 6.9.0 keeps the ReflectorNet 5.3.1 dependency, so the lockstep with Godot-MCP holds.
+    stale). 6.10.0 extends AgentConfiguratorDescription.Sections further — per-agent
+    "Troubleshooting" sections and the Custom agent's Docker command content. Both flow
+    through the existing generic Sections passthrough in AgentConfigService.Describe (no
+    code change needed). 6.10.0 keeps the ReflectorNet 5.3.1 dependency, so the lockstep
+    with Godot-MCP holds.
   -->
   <ItemGroup>
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.9.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.10.0" />
   </ItemGroup>
 
   <!-- The xUnit suite exercises a couple of internal helpers (e.g. ProxyTool.CalculateTokenCount). -->

--- a/bridge/tests/AgentConfigServiceTests.cs
+++ b/bridge/tests/AgentConfigServiceTests.cs
@@ -101,6 +101,49 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         }
 
         [Fact]
+        public void Status_CarriesTheTroubleshootingSection_ThroughTheDto()
+        {
+            // 6.10.0 AgentConfig extension: most built-in agents gained a per-agent "Troubleshooting" section.
+            // The sidecar's Describe() serializes description.Sections generically (no heading/kind filter), so the
+            // new section must surface in the emitted DTO without any passthrough change. claude-code carries one.
+            var result = _service.HandleStatus(new AgentStatusRequestMessage
+            {
+                RequestId = "r2t", AgentId = "claude-code", Transport = "streamableHttp", Settings = Settings(),
+            });
+
+            Assert.True(result.Ok);
+            var d = result.Description!;
+            var troubleshooting = d.Sections.FirstOrDefault(s => s.Heading == "Troubleshooting");
+            Assert.NotNull(troubleshooting);
+            // The section's guidance lines come through as Description-kind items with non-empty text.
+            Assert.NotEmpty(troubleshooting!.Items);
+            Assert.Contains(troubleshooting.Items, i => i.Kind == "Description" && !string.IsNullOrEmpty(i.Text));
+        }
+
+        [Fact]
+        public void Status_CustomAgent_CarriesTheDockerCommands_ThroughTheDto()
+        {
+            // 6.10.0 AgentConfig extension: the Custom (other-custom) agent's Configuration section now spells out
+            // the Docker lifecycle (run / start / stop / rm) as ReadOnlyField command items. The generic Sections
+            // passthrough must carry those command strings into the DTO verbatim so the Slate panel can show them.
+            var result = _service.HandleStatus(new AgentStatusRequestMessage
+            {
+                RequestId = "r2d", AgentId = "other-custom", Transport = "streamableHttp", Settings = Settings(),
+            });
+
+            Assert.True(result.Ok);
+            var d = result.Description!;
+            var commandTexts = d.Sections
+                .SelectMany(s => s.Items)
+                .Where(i => i.Kind == "ReadOnlyField")
+                .Select(i => i.Text ?? string.Empty)
+                .ToList();
+            // The Docker run command (with the resolved port) and the start command must both be present verbatim.
+            Assert.Contains(commandTexts, t => t.StartsWith("docker run") && t.Contains("12345"));
+            Assert.Contains(commandTexts, t => t.StartsWith("docker start"));
+        }
+
+        [Fact]
         public void Status_CarriesTheTriStateStatus_AndTopLevelLinks()
         {
             // 6.9.0 DTO extension: the description carries the ConfiguratorStatus tri-state and a top-level Links

--- a/bridge/tests/Fakes.cs
+++ b/bridge/tests/Fakes.cs
@@ -60,6 +60,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         }
 
         public void DisconnectImmediate() { }
+        // McpPlugin 6.10.0 added IConnection.WaitForImmediateTeardown(TimeSpan) — the immediate-teardown
+        // path is not exercised by the transition orchestration under test, so report "torn down".
+        public bool WaitForImmediateTeardown(TimeSpan timeout) => true;
         public void Dispose() { }
 
         // Unused surface — the transition orchestration under test never reads these. Throwing keeps the fake


### PR DESCRIPTION
## Summary
- Bump `bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj` `com.IvanMurzak.McpPlugin` **6.9.0 → 6.10.0** so the shared `AgentConfig` library supplies the per-agent **Troubleshooting** sections and the **Custom agent's Docker** lifecycle commands (`docker run/start/stop/rm`). ReflectorNet stays **5.3.1** (Godot lockstep). Authorized one-pin override of the profile's frozen-pins invariant.
- **No passthrough change needed**: `AgentConfigService.Describe()` serializes `AgentConfiguratorDescription.Sections` (and each item) generically, with no heading/kind filter — the new sections flow through the IPC DTO automatically. Verified the C++ Slate panel (`UnrealMcpAgentConfigModels.cpp` parse + `SUnrealMcpAgentConfigurators.cpp` render) also walks every section/item generically, so no plugin change either.
- Added two `AgentConfigServiceTests` asserting the emitted DTO now carries a `Troubleshooting` section (claude-code) and the Custom agent's `docker run`/`docker start` command items.
- Implemented the new `IConnection.WaitForImmediateTeardown(TimeSpan)` member (added in 6.10.0) on the test `FakeMcpPlugin` so the test project compiles.

## Test plan
- [x] Bridge: `dotnet restore` + `build` + `test` on `bridge/Unreal-MCP-Bridge.sln` — **146/146 passing** (2 new), 0 errors.
- [x] UE plugin build (UBT, testbed junction → this worktree) — exit 0.
- [x] Headless boot smoke — `[Unreal-MCP] plugin loaded` confirmed in the Saved log.
- [x] Automation `UnrealMcp.` suite — `index.json` `failed: 0`, `succeeded: 243` (+16 with warnings), 259 tests. Proves the agent-config IPC round-trip path compiles + boots against the 6.10.0 bridge.

Closes #105