### PR TITLE
feat(bridge): populate + live-refresh the connected AI-agents list

### DIFF
--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -9,6 +9,8 @@
 */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,12 +18,14 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.ReflectorNet;
 using com.IvanMurzak.Unreal.MCP.Bridge.AgentConfig;
 using com.IvanMurzak.Unreal.MCP.Bridge.Auth;
 using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
 using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
 using Microsoft.Extensions.Logging;
+using R3;
 using McpVersion = com.IvanMurzak.McpPlugin.Common.Version;
 
 namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
@@ -86,6 +90,36 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         // a Custom-mode bearer is a LOCAL token, not a cloud authorization, so it must not light "Authorized".
         private bool _isCloudMode;
 
+        // §7 connected-AI-agent roster (issue #109). The plugin's "AI agents" status row reflects
+        // StatusMessage.AiAgents; before this it was hardcoded empty. The roster is the formatted label list
+        // ("AI agent: {ClientName} ({ClientVersion})") for the currently-connected MCP clients, sourced from
+        // McpManager.OnClientsChanged (push) and seeded via McpManagerHub.GetMcpClientData() (pull). Guarded by
+        // _rosterLock: OnClientsChanged fires on an R3 callback thread while EmitStatusAsync reads it from the
+        // transition queue / connect path, so the read and write must not race. A fresh status is emitted from the
+        // OnClientsChanged handler so the editor refreshes live on agent join/leave — today status fired only on
+        // the editor's own connection/auth transitions.
+        private readonly object _rosterLock = new();
+        private List<string> _connectedAgents = new();
+        private IDisposable? _clientsChangedSubscription;
+
+        // The bridge's OWN SignalR client label (Version.Environment). Used to defensively drop a self-entry from
+        // the roster: the server's GetMcpClientData/OnClientsChanged report MCP client (AI-agent) sessions, NOT the
+        // asking plugin, so in practice no self-entry appears — but excluding by name keeps the row honest if a
+        // future server build ever surfaces the plugin's own session. (McpClientData in the pinned McpPlugin 6.10.0
+        // exposes no ClientType discriminator, so name-equality is the available self-filter — see issue #109.)
+        private const string SelfClientName = "Unreal-MCP-Bridge";
+
+        // §7 retry/backoff for the roster seed (mirrors Unity's 3×/3s): an agent's MCP session can lag the plugin's
+        // SignalR connect, so an immediate GetMcpClientData() can return empty even though an agent is about to join.
+        // Internal so the bridge xUnit suite can drive the seed without waiting real seconds (override to 0 delay).
+        internal int RosterSeedRetryCount = 3;
+        internal int RosterSeedRetryDelayMs = 3000;
+
+        // Test seam: the status emitter. Defaults to the IPC send; the bridge xUnit suite swaps it for a capture so
+        // it can assert AiAgents population + the live re-emit on a roster change without a live socket. Never null
+        // after construction.
+        private Func<StatusMessage, Task> _statusEmitter;
+
         // Serialize SignalR connect/disconnect transitions so rapid Connect/Disconnect toggles (or a device-auth
         // reconnect racing a config-driven disconnect) apply in submission order — last-write-wins — instead of
         // two in-flight plugin.Connect()/Disconnect() calls interleaving and landing in the wrong final state.
@@ -111,6 +145,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _fallbackHost = fallbackHost;
             _fallbackToken = fallbackToken;
             _clientLabel = clientLabel;
+            // Default to the real IPC send; SetStatusEmitterForTest swaps it in the xUnit suite.
+            _statusEmitter = status => _ipc.SendToPluginAsync(status, CancellationToken.None);
             _agentConfig = new AgentConfigService(loggerProvider?.CreateLogger(nameof(AgentConfigService)));
             if (authenticator != null)
             {
@@ -135,6 +171,20 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         /// repro — without standing up a live SignalR endpoint.
         /// </summary>
         internal void SetPluginForTest(IMcpPlugin plugin) => _plugin = plugin;
+
+        /// <summary>
+        /// Test seam: replace the status emitter (default: IPC send) with a capture so the bridge xUnit suite can
+        /// assert <see cref="StatusMessage.AiAgents"/> population and the live re-emit on a roster change without a
+        /// live socket. The captured emitter is invoked for EVERY status the host pushes.
+        /// </summary>
+        internal void SetStatusEmitterForTest(Func<StatusMessage, Task> emitter) =>
+            _statusEmitter = emitter ?? throw new ArgumentNullException(nameof(emitter));
+
+        /// <summary>Test seam: the current cached connected-agent roster (the labels surfaced in StatusMessage.AiAgents).</summary>
+        internal IReadOnlyList<string> ConnectedAgentsSnapshot
+        {
+            get { lock (_rosterLock) return _connectedAgents.ToList(); }
+        }
 
         /// <summary>
         /// Build the plugin (empty tool set) + reflector, wire the manifest registrar to the live
@@ -177,6 +227,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
             // Wire the registrar BEFORE the IPC loop can deliver a manifest.
             _ipc.Registrar = _registrar;
+
+            // §7 (issue #109): subscribe to the connected-AI-agent roster so the plugin's "AI agents" status row
+            // refreshes live. OnClientsChanged fires with the full active-client list on every agent join/leave;
+            // cache the formatted labels and push a FRESH status so the editor updates without a reconnect.
+            SubscribeToClientRoster(_plugin);
+
             _ipc.HandshakeAccepted += OnHandshakeAccepted;
             _ipc.ConfigReceived += OnConfigReceived;
             _ipc.AuthMessageReceived += HandleAuthMessage;
@@ -516,6 +572,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 if (ct.IsCancellationRequested)
                     return; // superseded — the newer transition owns the authoritative status emit
                 await EmitStatusAsync(ResolveConnectionStatusAfterReconnect(keepConnected: true, connected), cloudAuthState).ConfigureAwait(false);
+                // §7 (issue #109): a re-dial (config host/token change or device-auth commit) re-establishes the
+                // SignalR link — re-seed the roster so the agents row reflects the post-reconnect state.
+                if (connected)
+                    _ = SeedRosterAsync();
             }).ConfigureAwait(false);
         }
 
@@ -632,16 +692,116 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             return queued;
         }
 
+        /// <summary>
+        /// Subscribe to <see cref="IMcpManager.OnClientsChanged"/> so the §7 "AI agents" status row tracks the live
+        /// roster (issue #109). On each change: cache the formatted labels and emit a FRESH <c>status</c> so the
+        /// editor refreshes on agent join/leave (today status fired only on the editor's own connection/auth
+        /// transitions). Internal + plugin-injected so the bridge xUnit suite can drive it with a fake manager whose
+        /// observable it controls. Idempotent: a second subscribe (e.g. a re-Build) replaces the prior subscription.
+        /// </summary>
+        internal void SubscribeToClientRoster(IMcpPlugin plugin)
+        {
+            // Replace any prior subscription so a re-wire does not leak / double-emit.
+            _clientsChangedSubscription?.Dispose();
+            _clientsChangedSubscription = plugin.McpManager.OnClientsChanged
+                .Subscribe(clients =>
+                {
+                    UpdateRoster(clients);
+                    // Emit a fresh status carrying the new roster. The connection state is unchanged by a roster
+                    // change, so report the resolved current state (armed → Connected once a link exists; the plugin
+                    // latches the dot from aiAgents anyway). Fire-and-forget — never throw out of the R3 callback.
+                    _ = EmitStatusAsync(_config.KeepConnected ? "Connected" : "Disconnected");
+                });
+        }
+
+        /// <summary>
+        /// Seed the roster on connect via <see cref="IMcpManagerHub.GetMcpClientData"/> (pull), with a small
+        /// retry/backoff (Unity uses 3×/3s) because an agent's MCP session can lag the plugin's SignalR connect —
+        /// an immediate pull can return empty even though an agent is about to join. Each successful pull updates
+        /// the cache and emits a fresh status; if the pull yields no connected agent and retries remain (and we are
+        /// still armed), it waits <see cref="RosterSeedRetryDelayMs"/> and tries again. Never throws (runs on a
+        /// background task). Internal so the bridge xUnit suite can drive it directly.
+        /// </summary>
+        internal async Task SeedRosterAsync(CancellationToken ct = default)
+        {
+            var hub = _plugin?.McpManagerHub;
+            if (hub == null)
+                return;
+
+            for (var attempt = 0; ; attempt++)
+            {
+                if (ct.IsCancellationRequested)
+                    return;
+
+                McpClientData[]? clients = null;
+                try
+                {
+                    var task = hub.GetMcpClientData();
+                    if (task != null)
+                        clients = await task.ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogDebug("Roster seed pull failed: {Message}", ex.Message);
+                }
+
+                if (clients != null)
+                {
+                    UpdateRoster(clients);
+                    await EmitStatusAsync(_config.KeepConnected ? "Connected" : "Disconnected").ConfigureAwait(false);
+                }
+
+                var anyConnected = clients != null && clients.Any(c => c.IsConnected);
+                // Retry only while no agent is connected yet, retries remain, and we are still armed — exactly
+                // Unity's condition (an agent is expected to re-establish its session shortly after we connect).
+                if (anyConnected || attempt >= RosterSeedRetryCount || !_config.KeepConnected)
+                    return;
+
+                _logger?.LogDebug("No AI agent in roster yet; retrying seed ({RetriesLeft} left).", RosterSeedRetryCount - attempt);
+                try { await Task.Delay(RosterSeedRetryDelayMs, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { return; }
+            }
+        }
+
+        /// <summary>Recompute + cache the connected-agent labels from a roster snapshot (under <see cref="_rosterLock"/>).</summary>
+        private void UpdateRoster(IReadOnlyList<McpClientData>? clients)
+        {
+            var labels = BuildAgentLabels(clients);
+            lock (_rosterLock)
+                _connectedAgents = labels;
+        }
+
+        /// <summary>
+        /// Project a roster snapshot to the §7 status labels: keep only connected clients, drop the bridge's own
+        /// self-entry (defensive — the server reports MCP client sessions, not the asking plugin), and format each
+        /// as Unity's exact label <c>"AI agent: {ClientName} ({ClientVersion})"</c>. Pure + static so the bridge
+        /// xUnit suite locks the filter/format/self-exclusion matrix without a live plugin. Null/empty → empty list.
+        /// </summary>
+        internal static List<string> BuildAgentLabels(IReadOnlyList<McpClientData>? clients)
+        {
+            if (clients == null)
+                return new List<string>();
+            return clients
+                .Where(c => c != null && c.IsConnected)
+                .Where(c => !string.Equals(c.ClientName, SelfClientName, StringComparison.Ordinal))
+                .Select(c => $"AI agent: {c.ClientName} ({c.ClientVersion})")
+                .ToList();
+        }
+
         /// <summary>Push a §1.3 <c>status</c> message to the plugin (the §7 live connection indicator).</summary>
         private Task EmitStatusAsync(string connectionState, string? cloudAuthState = null)
         {
+            List<string> agents;
+            lock (_rosterLock)
+                agents = _connectedAgents.ToList();
             var status = new StatusMessage
             {
                 ConnectionState = connectionState,
                 KeepConnected = _config.KeepConnected,
                 CloudAuthState = cloudAuthState,
+                AiAgents = agents,
             };
-            return _ipc.SendToPluginAsync(status, CancellationToken.None);
+            return _statusEmitter(status);
         }
 
         // Internal (not private) so the bridge xUnit suite can assert the initial connect is routed through the
@@ -672,6 +832,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                     // "Authorized — cloud token stored" indicator (ApplyStatus latches it and never demotes).
                     var cloudAuthState = _isCloudMode && !string.IsNullOrEmpty(_config.Token) ? "Authorized" : null;
                     await EmitStatusAsync(ok ? "Connected" : "Connecting", cloudAuthState).ConfigureAwait(false);
+                    // §7 (issue #109): once connected, seed the AI-agent roster (with retry/backoff) so the row is
+                    // populated even before the first OnClientsChanged push. Fire-and-forget on a background task —
+                    // it has its own retry delays and must not block the transition queue.
+                    if (ok)
+                        _ = SeedRosterAsync();
                 }
                 catch (OperationCanceledException)
                 {
@@ -690,6 +855,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _ipc.ConfigReceived -= OnConfigReceived;
             _ipc.AuthMessageReceived -= HandleAuthMessage;
             _ipc.AgentConfigRequestReceived -= HandleAgentConfigRequest;
+            try { _clientsChangedSubscription?.Dispose(); } catch { /* ignore */ }
+            _clientsChangedSubscription = null;
             try { _authCts?.Cancel(); } catch { /* ignore */ }
             _authCts?.Dispose();
             // Tear down the transition CTS under _transitionLock so a concurrent RunConnectionTransition cannot

--- a/bridge/tests/Fakes.cs
+++ b/bridge/tests/Fakes.cs
@@ -14,7 +14,9 @@ using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.Common.Hub.Server;
 using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.ReflectorNet;
 using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
 using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -41,10 +43,21 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         public int ConnectCalls;
         public int DisconnectCalls;
 
-        public FakeMcpPlugin(Func<CancellationToken, Task<bool>> onConnect, Func<CancellationToken, Task>? onDisconnect = null)
+        // Roster surface (issue #109). Supplied only by tests that exercise the AI-agent roster path; left null by
+        // the connection-transition tests, which never touch McpManager/McpManagerHub.
+        private readonly IMcpManager? _mcpManager;
+        private readonly IMcpManagerHub? _mcpManagerHub;
+
+        public FakeMcpPlugin(
+            Func<CancellationToken, Task<bool>> onConnect,
+            Func<CancellationToken, Task>? onDisconnect = null,
+            IMcpManager? mcpManager = null,
+            IMcpManagerHub? mcpManagerHub = null)
         {
             _onConnect = onConnect;
             _onDisconnect = onDisconnect;
+            _mcpManager = mcpManager;
+            _mcpManagerHub = mcpManagerHub;
         }
 
         public Task<bool> Connect(CancellationToken cancellationToken = default)
@@ -71,8 +84,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         public ReadOnlyReactiveProperty<HubConnectionState> ConnectionState => throw new NotSupportedException();
         public Observable<Unit> OnAuthorizationRejected => throw new NotSupportedException();
         public ILogger Logger => throw new NotSupportedException();
-        public IMcpManager McpManager => throw new NotSupportedException();
-        public IMcpManagerHub? McpManagerHub => throw new NotSupportedException();
+        // Roster path (issue #109): return the injected fakes when supplied; otherwise throw to keep the
+        // connection-transition tests honest (they must never depend on the roster surface).
+        public IMcpManager McpManager => _mcpManager ?? throw new NotSupportedException();
+        public IMcpManagerHub? McpManagerHub => _mcpManagerHub;
         public McpVersion Version => throw new NotSupportedException();
         public VersionHandshakeResponse? VersionHandshakeStatus => throw new NotSupportedException();
         public bool GenerateSkillFiles(string? path = null) => throw new NotSupportedException();
@@ -140,5 +155,78 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             Enabled[name] = enabled;
             return true;
         }
+    }
+
+    /// <summary>
+    /// A controllable <see cref="IMcpManager"/> for driving the connected-AI-agent roster path (issue #109): the
+    /// test pushes new rosters through <see cref="PushClients"/> (an R3 <see cref="Subject{T}"/> backing
+    /// <see cref="OnClientsChanged"/>), and the host's subscription caches + re-emits status. Only the roster
+    /// surface is meaningful — the rest of the interface throws so an accidental new dependency surfaces loudly.
+    /// </summary>
+    internal sealed class FakeMcpManager : IMcpManager
+    {
+        private readonly Subject<IReadOnlyList<McpClientData>> _onClientsChanged = new();
+
+        /// <summary>Push a roster snapshot through <see cref="OnClientsChanged"/> (an agent join/leave event).</summary>
+        public void PushClients(IReadOnlyList<McpClientData> clients) => _onClientsChanged.OnNext(clients);
+
+        public Observable<IReadOnlyList<McpClientData>> OnClientsChanged => _onClientsChanged;
+
+        public void Dispose() => _onClientsChanged.Dispose();
+
+        // Unused surface — the roster wiring under test never reads these.
+        public Reflector Reflector => throw new NotSupportedException();
+        public IReadOnlyList<McpClientData> ActiveClients => throw new NotSupportedException();
+        public Observable<Unit> OnForceDisconnect => throw new NotSupportedException();
+        public Observable<McpClientData> OnClientConnected => throw new NotSupportedException();
+        public Observable<McpClientData> OnClientDisconnected => throw new NotSupportedException();
+        public IToolManager? ToolManager => throw new NotSupportedException();
+        public IPromptManager? PromptManager => throw new NotSupportedException();
+        public IResourceManager? ResourceManager => throw new NotSupportedException();
+        public ISystemToolManager? SystemToolManager => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A controllable <see cref="IMcpManagerHub"/> for the roster SEED path (issue #109): each
+    /// <see cref="GetMcpClientData"/> call returns the next scripted snapshot (or the last one once the script is
+    /// exhausted), letting a test model "empty, then an agent appears on retry". Only that one method is
+    /// meaningful; the (large) inherited hub surface throws.
+    /// </summary>
+    internal sealed class FakeMcpManagerHub : IMcpManagerHub
+    {
+        private readonly Queue<McpClientData[]> _scripted;
+        private McpClientData[] _last;
+        public int GetMcpClientDataCalls { get; private set; }
+
+        public FakeMcpManagerHub(params McpClientData[][] scriptedSnapshots)
+        {
+            _scripted = new Queue<McpClientData[]>(scriptedSnapshots);
+            _last = scriptedSnapshots.Length > 0 ? scriptedSnapshots[^1] : Array.Empty<McpClientData>();
+        }
+
+        public Task<McpClientData[]> GetMcpClientData()
+        {
+            GetMcpClientDataCalls++;
+            var snapshot = _scripted.Count > 0 ? _scripted.Dequeue() : _last;
+            return Task.FromResult(snapshot);
+        }
+
+        public void Dispose() { }
+
+        // Unused inherited surface (IConnectServerHub / IServerMcpManager / IServer*Hub).
+        public VersionHandshakeResponse VersionHandshakeStatus => throw new NotSupportedException();
+        public Task<bool> Connect(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task Disconnect(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public void DisconnectImmediate() => throw new NotSupportedException();
+        public bool WaitForImmediateTeardown(TimeSpan timeout) => throw new NotSupportedException();
+        public ReadOnlyReactiveProperty<bool> KeepConnected => throw new NotSupportedException();
+        public ReadOnlyReactiveProperty<HubConnectionState> ConnectionState => throw new NotSupportedException();
+        public Observable<Unit> OnAuthorizationRejected => throw new NotSupportedException();
+        public Task<VersionHandshakeResponse> PerformVersionHandshake(RequestVersionHandshake request) => throw new NotSupportedException();
+        public Task<McpServerData> GetMcpServerData() => throw new NotSupportedException();
+        public Task<ResponseData> NotifyAboutUpdatedTools(RequestToolsUpdated request) => throw new NotSupportedException();
+        public Task<ResponseData> NotifyToolRequestCompleted(RequestToolCompletedData request) => throw new NotSupportedException();
+        public Task<ResponseData> NotifyAboutUpdatedPrompts(RequestPromptsUpdated request) => throw new NotSupportedException();
+        public Task<ResponseData> NotifyAboutUpdatedResources(RequestResourcesUpdated request) => throw new NotSupportedException();
     }
 }

--- a/bridge/tests/SidecarHostRosterTests.cs
+++ b/bridge/tests/SidecarHostRosterTests.cs
@@ -1,0 +1,142 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.Unreal.MCP.Bridge.Host;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>
+    /// Specs for the connected-AI-agent roster (issue #109): before this, <c>StatusMessage.AiAgents</c> was
+    /// hardcoded empty and <c>status</c> was re-pushed only on the editor's own connect/auth transitions, so an
+    /// external agent joining never reached the editor. These lock the four behaviors the fix adds — (1) AiAgents
+    /// populated from a roster, (2) empty when none, (3) the bridge's own self-entry excluded, (4) a fresh status
+    /// re-emitted on an <c>OnClientsChanged</c> event — plus the connect-time seed (with retry/backoff). The pure
+    /// label projection is tested directly; the wiring is driven through fakes (no live SignalR / editor).
+    /// </summary>
+    public class SidecarHostRosterTests
+    {
+        private static SidecarHost NewHost(out IpcClient ipc)
+        {
+            // Port is never dialed — the fake plugin replaces the real SignalR client, so no socket opens.
+            ipc = new IpcClient("127.0.0.1", 39997, token: "ipc-token", sidecarVersion: "0.1.0");
+            return new SidecarHost(ipc, "0.1.0");
+        }
+
+        private static McpClientData Agent(string name, string version = "1.0.0", bool connected = true) =>
+            new() { IsConnected = connected, ClientName = name, ClientVersion = version };
+
+        // ── (1)+(2)+(3) the pure projection: filter IsConnected, exclude self, Unity label format ────────────
+
+        [Fact]
+        public void BuildAgentLabels_PopulatesFromRoster_WithUnityLabelFormat()
+        {
+            var labels = SidecarHost.BuildAgentLabels(new[] { Agent("Claude", "1.2.3"), Agent("Cursor", "0.42") });
+
+            Assert.Equal(
+                new[] { "AI agent: Claude (1.2.3)", "AI agent: Cursor (0.42)" },
+                labels);
+        }
+
+        [Fact]
+        public void BuildAgentLabels_EmptyWhenNoConnectedClients()
+        {
+            Assert.Empty(SidecarHost.BuildAgentLabels(null));
+            Assert.Empty(SidecarHost.BuildAgentLabels(new List<McpClientData>()));
+            // A roster of only-disconnected entries projects to empty.
+            Assert.Empty(SidecarHost.BuildAgentLabels(new[] { Agent("Claude", connected: false) }));
+        }
+
+        [Fact]
+        public void BuildAgentLabels_ExcludesTheBridgeSelfEntry()
+        {
+            var labels = SidecarHost.BuildAgentLabels(new[]
+            {
+                Agent("Unreal-MCP-Bridge", "0.1.0"), // the plugin's own SignalR client label — must be dropped
+                Agent("Claude", "1.0.0"),
+            });
+
+            Assert.Equal(new[] { "AI agent: Claude (1.0.0)" }, labels);
+        }
+
+        // ── (1)+(4) OnClientsChanged caches the roster AND re-emits a fresh status carrying it ────────────────
+
+        [Fact]
+        public void OnClientsChanged_CachesRoster_AndReEmitsStatusWithAiAgents()
+        {
+            using var host = NewHost(out _);
+            var emitted = new List<StatusMessage>();
+            host.SetStatusEmitterForTest(s => { emitted.Add(s); return Task.CompletedTask; });
+
+            var manager = new FakeMcpManager();
+            var fake = new FakeMcpPlugin(onConnect: _ => Task.FromResult(true), mcpManager: manager);
+            host.SubscribeToClientRoster(fake);
+
+            // An agent joins → OnClientsChanged fires with the full active-client list.
+            manager.PushClients(new[] { Agent("Claude", "1.0.0") });
+
+            // The cache reflects the join, and a FRESH status was emitted carrying the roster (the live-refresh path).
+            Assert.Equal(new[] { "AI agent: Claude (1.0.0)" }, host.ConnectedAgentsSnapshot);
+            Assert.Single(emitted);
+            Assert.Equal(new[] { "AI agent: Claude (1.0.0)" }, emitted[^1].AiAgents);
+
+            // The agent leaves → a second status with an empty roster (live clear on disconnect).
+            manager.PushClients(new List<McpClientData>());
+            Assert.Empty(host.ConnectedAgentsSnapshot);
+            Assert.Equal(2, emitted.Count);
+            Assert.Empty(emitted[^1].AiAgents);
+        }
+
+        // ── connect-time seed via GetMcpClientData(), with retry/backoff when the agent session lags ─────────
+
+        [Fact]
+        public async Task SeedRosterAsync_SeedsFromGetMcpClientData_AndPopulatesAiAgents()
+        {
+            using var host = NewHost(out _);
+            var emitted = new List<StatusMessage>();
+            host.SetStatusEmitterForTest(s => { emitted.Add(s); return Task.CompletedTask; });
+
+            var hub = new FakeMcpManagerHub(new[] { Agent("Claude", "1.0.0") });
+            var fake = new FakeMcpPlugin(onConnect: _ => Task.FromResult(true), mcpManagerHub: hub);
+            host.SetPluginForTest(fake);
+
+            await host.SeedRosterAsync(CancellationToken.None);
+
+            Assert.Equal(1, hub.GetMcpClientDataCalls); // an agent was present on the first pull → no retry
+            Assert.Equal(new[] { "AI agent: Claude (1.0.0)" }, host.ConnectedAgentsSnapshot);
+            Assert.Equal(new[] { "AI agent: Claude (1.0.0)" }, emitted[^1].AiAgents);
+        }
+
+        [Fact]
+        public async Task SeedRosterAsync_RetriesWhenNoAgentYet_ThenPicksUpTheLateJoiner()
+        {
+            using var host = NewHost(out _);
+            var emitted = new List<StatusMessage>();
+            host.SetStatusEmitterForTest(s => { emitted.Add(s); return Task.CompletedTask; });
+
+            // First pull empty (agent session lags the plugin connect), second pull has the agent — Unity's repro.
+            var hub = new FakeMcpManagerHub(System.Array.Empty<McpClientData>(), new[] { Agent("Claude", "1.0.0") });
+            var fake = new FakeMcpPlugin(onConnect: _ => Task.FromResult(true), mcpManagerHub: hub);
+            host.SetPluginForTest(fake);
+            host.RosterSeedRetryDelayMs = 0; // no real wait in the test
+
+            await host.SeedRosterAsync(CancellationToken.None);
+
+            Assert.True(hub.GetMcpClientDataCalls >= 2); // retried past the empty first pull
+            Assert.Equal(new[] { "AI agent: Claude (1.0.0)" }, host.ConnectedAgentsSnapshot);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- The editor's "AI agents" status row always showed "No agents connected": `SidecarHost.EmitStatusAsync` never set `status.AiAgents`, and `status` was re-pushed only on the editor's own connect/auth transitions, so an external agent joining never reached the editor.
- Mirror Unity-MCP's `MainWindowEditor.McpFeatures`: subscribe `McpManager.OnClientsChanged` (cache + re-emit a fresh status live on join/leave), seed on connect via `McpManagerHub.GetMcpClientData()` with a 3×/3s retry/backoff, and set `status.AiAgents` from the cached roster.
- Labels use Unity's exact `"AI agent: {ClientName} ({ClientVersion})"`, filter `IsConnected`, and defensively drop the bridge's own self-entry by name (McpClientData in the pinned McpPlugin 6.10.0 exposes no `ClientType` discriminator).

## Scope
`bridge/**` only — no C++ plugin, CLI, or upstream changes. No NuGet/version bumps.

## Test plan
- [x] `dotnet build` + `dotnet test` green for the bridge solution (152 tests; +6 new in `SidecarHostRosterTests`).
- [x] New xUnit coverage: AiAgents populated from a roster, empty when none, self-entry excluded, status re-emitted on `OnClientsChanged`, connect-time seed with no-agent-yet retry.
- [ ] Live e2e (server ⇄ bridge ⇄ headless editor, Custom mode) asserting `aiAgents` non-empty with a real connected agent — pending operator/CI; requires a live AI-agent MCP client in the chain.

Closes #109