### PR TITLE
fix(bridge): dedupe AI-agents row and clear it on Disconnect

### DIFF
--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -559,6 +559,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         {
             if (!_config.KeepConnected)
             {
+                // §7 (issue #111): the reconnect is disarmed (the user clicked Disconnect / keepConnected=false), so
+                // there will be no live link — clear the cached roster so a later re-arm re-seeds fresh.
+                ClearRoster();
                 await EmitStatusAsync(ResolveConnectionStatusAfterReconnect(keepConnected: false, connected: false), cloudAuthState).ConfigureAwait(false);
                 return;
             }
@@ -600,6 +603,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 try { await plugin.Disconnect(ct).ConfigureAwait(false); }
                 catch (Exception ex) { _logger?.LogDebug("SignalR disconnect failed: {Message}", ex.Message); }
             }
+            // §7 (issue #111): a user Disconnect tears the link down without firing OnClientsChanged, so clear the
+            // cache here too — otherwise a later reconnect would re-seed the agents row from the frozen pre-disconnect
+            // list before SeedRosterAsync pulls the live state.
+            ClearRoster();
             // A superseded disconnect must not emit its now-stale "Disconnected" after the winning transition's
             // status — the newer transition owns the authoritative emit (last-write-wins).
             if (!ct.IsCancellationRequested)
@@ -772,10 +779,29 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         }
 
         /// <summary>
+        /// Clear the cached connected-agent roster (issue #111). Called on every disconnect/teardown path so a later
+        /// reconnect re-seeds fresh from <see cref="SeedRosterAsync"/> rather than from a frozen pre-disconnect list.
+        /// <see cref="EmitStatusAsync"/> already gates a stale cache from leaking under a non-connected state; this
+        /// keeps the in-memory cache itself honest too (guarded by <see cref="_rosterLock"/>).
+        /// </summary>
+        private void ClearRoster()
+        {
+            lock (_rosterLock)
+                _connectedAgents = new List<string>();
+        }
+
+        /// <summary>
         /// Project a roster snapshot to the §7 status labels: keep only connected clients, drop the bridge's own
-        /// self-entry (defensive — the server reports MCP client sessions, not the asking plugin), and format each
-        /// as Unity's exact label <c>"AI agent: {ClientName} ({ClientVersion})"</c>. Pure + static so the bridge
-        /// xUnit suite locks the filter/format/self-exclusion matrix without a live plugin. Null/empty → empty list.
+        /// self-entry (defensive — the server reports MCP client sessions, not the asking plugin), DEDUPE by display
+        /// identity (<c>ClientName</c>,<c>ClientVersion</c>), and format each as Unity's exact label
+        /// <c>"AI agent: {ClientName} ({ClientVersion})"</c>. Pure + static so the bridge xUnit suite locks the
+        /// filter/dedupe/format/self-exclusion matrix without a live plugin. Null/empty → empty list.
+        ///
+        /// Dedupe rationale (issue #111): the server's <c>GetMcpClientData</c>/<c>OnClientsChanged</c> reports one
+        /// <see cref="McpClientData"/> per MCP SESSION (keyed by physicalId), and a single client (e.g. Claude Code)
+        /// commonly holds 2+ live sessions — so without this collapse the row shows duplicate identical labels after
+        /// merely reopening the project. Group by (ClientName, ClientVersion), NOT by SessionId: SessionId is
+        /// per-session and would never collapse the duplicates we are trying to remove.
         /// </summary>
         internal static List<string> BuildAgentLabels(IReadOnlyList<McpClientData>? clients)
         {
@@ -784,6 +810,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             return clients
                 .Where(c => c != null && c.IsConnected)
                 .Where(c => !string.Equals(c.ClientName, SelfClientName, StringComparison.Ordinal))
+                .GroupBy(c => (c.ClientName, c.ClientVersion))
+                .Select(g => g.First())
                 .Select(c => $"AI agent: {c.ClientName} ({c.ClientVersion})")
                 .ToList();
         }
@@ -791,9 +819,22 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         /// <summary>Push a §1.3 <c>status</c> message to the plugin (the §7 live connection indicator).</summary>
         private Task EmitStatusAsync(string connectionState, string? cloudAuthState = null)
         {
+            // §7 clear-on-non-connected invariant (issue #111, mirrors Unity's MainWindowEditor.Connection.cs):
+            // the "AI agents" dot is driven by aiAgents.Num() > 0, so any non-"Connected" transition (Disconnect,
+            // Connecting, Disconnected) MUST ship an EMPTY roster regardless of the cache — otherwise a user
+            // Disconnect (which never fires OnClientsChanged on a torn-down link) leaves the row stale/green. The
+            // disconnect paths ALSO clear _connectedAgents so a later reconnect re-seeds fresh, but this guard is
+            // the authoritative gate: a stale cache can never leak out under a non-connected state.
             List<string> agents;
-            lock (_rosterLock)
-                agents = _connectedAgents.ToList();
+            if (!string.Equals(connectionState, "Connected", StringComparison.Ordinal))
+            {
+                agents = new List<string>();
+            }
+            else
+            {
+                lock (_rosterLock)
+                    agents = _connectedAgents.ToList();
+            }
             var status = new StatusMessage
             {
                 ConnectionState = connectionState,
@@ -857,6 +898,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _ipc.AgentConfigRequestReceived -= HandleAgentConfigRequest;
             try { _clientsChangedSubscription?.Dispose(); } catch { /* ignore */ }
             _clientsChangedSubscription = null;
+            // §7 (issue #111): teardown clears the roster cache so it never outlives the host.
+            ClearRoster();
             try { _authCts?.Cancel(); } catch { /* ignore */ }
             _authCts?.Dispose();
             // Tear down the transition CTS under _transitionLock so a concurrent RunConnectionTransition cannot

--- a/bridge/tests/SidecarHostRosterTests.cs
+++ b/bridge/tests/SidecarHostRosterTests.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common.Model;
@@ -72,6 +73,44 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             Assert.Equal(new[] { "AI agent: Claude (1.0.0)" }, labels);
         }
 
+        // ── (issue #111) dedupe by display identity: one client = one label, distinct identities NOT collapsed ──
+
+        [Fact]
+        public void BuildAgentLabels_DedupesIdenticalNameAndVersion_ToOneLabel()
+        {
+            // A single client (Claude Code) holds two live MCP sessions → the server returns two McpClientData with
+            // identical ClientName/ClientVersion. The row must collapse them to exactly ONE label (issue #111 Bug 1).
+            var labels = SidecarHost.BuildAgentLabels(new[]
+            {
+                Agent("Claude Code", "1.2.3"),
+                Agent("Claude Code", "1.2.3"),
+            });
+
+            Assert.Equal(new[] { "AI agent: Claude Code (1.2.3)" }, labels);
+        }
+
+        [Fact]
+        public void BuildAgentLabels_DoesNotCollapseDistinctNamesOrVersions()
+        {
+            // Distinct display identities must remain separate: a different name OR a different version is a
+            // different entry — only an exact (name, version) match is a duplicate.
+            var labels = SidecarHost.BuildAgentLabels(new[]
+            {
+                Agent("Claude Code", "1.2.3"),
+                Agent("Claude Code", "1.2.4"), // same name, different version → kept
+                Agent("Cursor", "1.2.3"),      // different name, same version → kept
+            });
+
+            Assert.Equal(
+                new[]
+                {
+                    "AI agent: Claude Code (1.2.3)",
+                    "AI agent: Claude Code (1.2.4)",
+                    "AI agent: Cursor (1.2.3)",
+                },
+                labels);
+        }
+
         // ── (1)+(4) OnClientsChanged caches the roster AND re-emits a fresh status carrying it ────────────────
 
         [Fact]
@@ -98,6 +137,95 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             Assert.Empty(host.ConnectedAgentsSnapshot);
             Assert.Equal(2, emitted.Count);
             Assert.Empty(emitted[^1].AiAgents);
+        }
+
+        // ── (issue #111 Bug 1 regression) the connected live-refresh path emits the DEDUPED non-empty list ───
+
+        [Fact]
+        public void OnClientsChanged_WhileConnected_EmitsDedupedNonEmptyList_NoRegression()
+        {
+            using var host = NewHost(out _); // keepConnected defaults to true → "Connected" emits
+            var emitted = new List<StatusMessage>();
+            host.SetStatusEmitterForTest(s => { emitted.Add(s); return Task.CompletedTask; });
+
+            var manager = new FakeMcpManager();
+            var fake = new FakeMcpPlugin(onConnect: _ => Task.FromResult(true), mcpManager: manager);
+            host.SubscribeToClientRoster(fake);
+
+            // Two sessions for the same client (the #111 duplicate) plus a distinct one → deduped to two labels,
+            // and (no #110 regression) the connected path still ships the populated list live.
+            manager.PushClients(new[]
+            {
+                Agent("Claude Code", "1.2.3"),
+                Agent("Claude Code", "1.2.3"),
+                Agent("Cursor", "0.42"),
+            });
+
+            Assert.Equal(new[] { "AI agent: Claude Code (1.2.3)", "AI agent: Cursor (0.42)" }, host.ConnectedAgentsSnapshot);
+            Assert.Single(emitted);
+            Assert.Equal("Connected", emitted[^1].ConnectionState);
+            Assert.Equal(new[] { "AI agent: Claude Code (1.2.3)", "AI agent: Cursor (0.42)" }, emitted[^1].AiAgents);
+        }
+
+        // ── (issue #111 Bug 2) a non-"Connected" emit ships an EMPTY AiAgents list even with a primed cache ──
+
+        [Fact]
+        public void OnClientsChanged_WhileDisarmed_ShipsEmptyAiAgents_EvenThoughCacheIsPrimed()
+        {
+            using var host = NewHost(out _);
+            // Disarm BEFORE the roster push so the OnClientsChanged handler emits "Disconnected" (non-connected).
+            host.ApplyConnectionConfig(new JsonObject { ["mode"] = "Custom", ["host"] = "http://localhost:8500", ["keepConnected"] = false });
+
+            var emitted = new List<StatusMessage>();
+            host.SetStatusEmitterForTest(s => { emitted.Add(s); return Task.CompletedTask; });
+
+            var manager = new FakeMcpManager();
+            var fake = new FakeMcpPlugin(onConnect: _ => Task.FromResult(true), mcpManager: manager);
+            host.SubscribeToClientRoster(fake);
+
+            // The roster cache is primed (UpdateRoster runs regardless of connection state)...
+            manager.PushClients(new[] { Agent("Claude Code", "1.2.3") });
+
+            Assert.Equal(new[] { "AI agent: Claude Code (1.2.3)" }, host.ConnectedAgentsSnapshot); // cache populated
+            Assert.Single(emitted);
+            Assert.Equal("Disconnected", emitted[^1].ConnectionState);
+            Assert.Empty(emitted[^1].AiAgents); // ...but a non-connected status ships EMPTY (the dot stays Offline)
+        }
+
+        // ── (issue #111 Bug 2) a user Disconnect clears the cache AND ships empty AiAgents ────────────────────
+
+        [Fact]
+        public async Task UserDisconnect_ClearsRosterCache_AndShipsEmptyAiAgents()
+        {
+            using var host = NewHost(out _);
+            var manager = new FakeMcpManager();
+            var fake = new FakeMcpPlugin(onConnect: _ => Task.FromResult(true), mcpManager: manager);
+            host.SetPluginForTest(fake);
+            host.SubscribeToClientRoster(fake);
+
+            var disconnectEmitted = new TaskCompletionSource<StatusMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            // Prime the cache while connected, then capture the "Disconnected" status the disconnect transition emits.
+            host.SetStatusEmitterForTest(s =>
+            {
+                if (string.Equals(s.ConnectionState, "Disconnected", System.StringComparison.Ordinal))
+                    disconnectEmitted.TrySetResult(s);
+                return Task.CompletedTask;
+            });
+            manager.PushClients(new[] { Agent("Claude Code", "1.2.3") });
+            Assert.Equal(new[] { "AI agent: Claude Code (1.2.3)" }, host.ConnectedAgentsSnapshot); // primed
+
+            // A user Disconnect = keepConnected true→false config push → HandleDisconnectAsync runs (via the queue).
+            host.OnConfigReceived(new JsonObject
+            {
+                ["type"] = "config",
+                ["mode"] = "Custom",
+                ["host"] = "http://localhost:8500",
+                ["keepConnected"] = false,
+            });
+
+            var status = await disconnectEmitted.Task.WaitAsync(System.TimeSpan.FromSeconds(5));
+            Assert.Empty(status.AiAgents);                 // the emitted Disconnected status carries no agents
+            Assert.Empty(host.ConnectedAgentsSnapshot);    // and the cache itself was cleared (fresh re-seed on reconnect)
         }
 
         // ── connect-time seed via GetMcpClientData(), with retry/backoff when the agent session lags ─────────


### PR DESCRIPTION
## Summary
- **Bug 1 (duplicate entries):** `BuildAgentLabels` now dedupes connected clients by display identity `(ClientName, ClientVersion)` before formatting — the server returns one `McpClientData` per MCP **session**, and one client (e.g. Claude Code) commonly holds 2+ sessions → identical duplicate rows. Dedupe is by name/version, NOT by `SessionId` (per-session — would never collapse the duplicates).
- **Bug 2 (Disconnect left the dot green):** `EmitStatusAsync` now ships an EMPTY `AiAgents` list for any non-`"Connected"` state regardless of cache (mirrors Unity's clear-on-non-connected invariant), and `_connectedAgents` is cleared on every disconnect/teardown path (`HandleDisconnectAsync`, the disarmed reconnect branch, `Dispose`) so a later reconnect re-seeds fresh. The connected-path live refresh is untouched — no #110 regression.

## Test plan
- [x] Bridge build (Debug) + xUnit green: **157/157** passed (was 152; +5 new specs).
- [x] New specs: dedupe-to-one + distinct-not-collapsed; connected path still emits the deduped non-empty list (no #110 regression); disarmed/non-connected emit ships empty despite a primed cache; user-Disconnect clears the cache and ships empty `AiAgents`.
- [ ] Live e2e (one entry per client; Disconnect clears the row): windowed/operator verification pending — not runnable headless in this environment.

Note: if two duplicate sessions ever share the SAME `SessionId`, that's a possible upstream (GameDev-MCP-Server) double-track — not changed here; dedup-by-name resolves the visible symptom regardless.

Closes #111