### PR TITLE
fix: connection status stays green after mode-switch and after stopping the local server

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -42,10 +42,31 @@ void FUnrealMcpEditorViewModel::SetConnectionMode(EUnrealMcpConnectionMode InMod
 		Config.SetTransportMethod(EUnrealMcpTransportMethod::Http);
 		Config.AuthOption = EUnrealMcpAuthOption::Required;
 	}
+	// Bug #116: a mode switch RETARGETS the connection (Cloud↔Custom dial a different server). If we were showing
+	// Connected/Degraded against the now-abandoned target, the dot must drop off green THE MOMENT the mode flips —
+	// not stay green until the sidecar's re-dial status crosses the wire. PersistAndPush below triggers the bridge's
+	// host-changed re-dial (DecideConfigTransition→Reconnect, which emits Connecting→Connected/etc.), but the UI must
+	// not lag behind it: optimistically reflect the in-flight retarget so no window of stale-green exists.
+	ReflectTargetChangeOptimistically();
 	PersistAndPush();
 	// The resolved connection facts (auth-required, token source, http url, transport) all hinge on the mode, so the
 	// agent configurators must re-resolve their cached config + rebuild their panel (Unity's InvalidateAndReloadAgentUI).
 	OnConnectionSettingsChanged.Broadcast();
+}
+
+void FUnrealMcpEditorViewModel::ReflectTargetChangeOptimistically()
+{
+	// Bug #116 (mode/target switch): when the dial target changes WHILE we are presenting a live/armed link
+	// (Connected or Degraded), the link we are showing is to the OLD target and is about to be torn down + re-dialed
+	// by the sidecar. Optimistically demote to Connecting so the green dot drops immediately; the sidecar's honest
+	// re-dial `status` (Connecting→Connected on success, or Disconnected/Degraded on failure) then converges the UI.
+	// Only meaningful while armed: an unarmed (already Disconnected) view-model has no green to drop, and forcing
+	// Connecting there would falsely claim a connect is in flight when keepConnected=false means none will run.
+	if (Config.bKeepConnected
+		&& (ConnectionState == EUnrealMcpConnectionState::Connected || ConnectionState == EUnrealMcpConnectionState::Degraded))
+	{
+		ConnectionState = EUnrealMcpConnectionState::Connecting;
+	}
 }
 
 void FUnrealMcpEditorViewModel::SetTransportMethod(EUnrealMcpTransportMethod InMethod)
@@ -75,8 +96,19 @@ void FUnrealMcpEditorViewModel::SetCustomHost(const FString& InHost)
 	const bool bChanged = Config.CustomHost != Trimmed;
 	Config.CustomHost = Trimmed;
 	FString Error;
-	if (ValidateServerUrl(Trimmed, Error))
+	if (bChanged && ValidateServerUrl(Trimmed, Error))
 	{
+		// Bug #116: editing the Server URL to a NEW valid target retargets the dial — the sidecar re-dials the new
+		// host (DecideConfigTransition→Reconnect) and the green dot for the OLD host must drop immediately. Mirror
+		// the SetConnectionMode path: optimistically demote off green before the push so no stale-green window exists.
+		// Only on an actual change to a valid host — a malformed edit never changes the dial target (no push, no retarget).
+		ReflectTargetChangeOptimistically();
+		PersistAndPush();
+	}
+	else if (ValidateServerUrl(Trimmed, Error))
+	{
+		// Re-typing the same valid host (bChanged == false): still push for idempotent parity with the prior
+		// behavior, but there is no retarget — the dial target is unchanged, so the connection state must not churn.
 		PersistAndPush();
 	}
 	// Refresh the configurators on any host change (even before it validates) so the previewed HTTP url tracks
@@ -545,6 +577,17 @@ bool FUnrealMcpEditorViewModel::ToggleLocalServer()
 	{
 		if (OnStopLocalServer)
 			OnStopLocalServer();
+		// Bug #116 (stop local server while connected): the server the editor's transport is connected to has just
+		// gone away — the SignalR link is now dead even though no explicit Disconnect was clicked. The dot must not
+		// stay green. Optimistically demote off Connected/Degraded so the UI reflects the drop immediately; the
+		// bridge's transport-drop status (issue #116, ConnectionState→non-Connected) then converges it. We stay armed
+		// (keepConnected unchanged): the user STOPPED the server, not the connection — re-Starting it should resume
+		// without re-arming. While armed, a torn-down link reads as Degraded (background-retry), matching ParseConnectionState.
+		if (Config.bKeepConnected
+			&& (ConnectionState == EUnrealMcpConnectionState::Connected || ConnectionState == EUnrealMcpConnectionState::Connecting))
+		{
+			ConnectionState = EUnrealMcpConnectionState::Degraded;
+		}
 		return true;
 	}
 	if (OnStartLocalServer)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -584,7 +584,9 @@ bool FUnrealMcpEditorViewModel::ToggleLocalServer()
 		// (keepConnected unchanged): the user STOPPED the server, not the connection — re-Starting it should resume
 		// without re-arming. While armed, a torn-down link reads as Degraded (background-retry), matching ParseConnectionState.
 		if (Config.bKeepConnected
-			&& (ConnectionState == EUnrealMcpConnectionState::Connected || ConnectionState == EUnrealMcpConnectionState::Connecting))
+			&& (ConnectionState == EUnrealMcpConnectionState::Connected
+				|| ConnectionState == EUnrealMcpConnectionState::Connecting
+				|| ConnectionState == EUnrealMcpConnectionState::Degraded))
 		{
 			ConnectionState = EUnrealMcpConnectionState::Degraded;
 		}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
@@ -354,4 +354,14 @@ private:
 
 	// Persist (if a sink is wired) then push the §1.3 config to the sidecar (if a sink is wired).
 	void PersistAndPush();
+
+	/**
+	 * Bug #116: a connection-target change (mode switch Cloud↔Custom, or editing the Custom Server URL to a new
+	 * valid host) RETARGETS the dial — the bridge re-dials the new target (DecideConfigTransition→Reconnect). If we
+	 * are presenting a live/armed link (Connected/Degraded) to the OLD target, optimistically demote to Connecting so
+	 * the green dot drops the instant the target flips, instead of lagging until the sidecar's honest re-dial `status`
+	 * arrives. No-op when unarmed (keepConnected=false → no green to drop and no re-dial will run). The sidecar's
+	 * subsequent `status` (Connecting→Connected on success, Disconnected/Degraded on failure) converges the UI.
+	 */
+	void ReflectTargetChangeOptimistically();
 };

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
@@ -650,6 +650,174 @@ void FUnrealMcpEditorViewModelSpec::Define()
 			TestEqual("two agents", VM->GetAiAgents().Num(), 2);
 		});
 	});
+
+	Describe("Connection-status lifecycle (issue #116)", [this]()
+	{
+		// Drive the view-model into a live, green "Connected" state the way the runtime does: arm via Connect()
+		// then apply a Connected `status` from the sidecar. Returns a VM presenting Connected + armed.
+		auto MakeConnectedVM = [](TSharedRef<FRecording> Rec) -> TSharedRef<FUnrealMcpEditorViewModel>
+		{
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			VM->Connect();
+			TSharedPtr<FJsonObject> Status = MakeShared<FJsonObject>();
+			Status->SetStringField(TEXT("connectionState"), TEXT("Connected"));
+			Status->SetBoolField(TEXT("keepConnected"), true);
+			VM->ApplyStatus(Status);
+			return VM;
+		};
+
+		It("Bug 1: switching connection mode while connected drops the green Connected state immediately", [this, MakeConnectedVM]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			// Default config mode is Cloud — connect green in Cloud, then switch to Custom (a retarget).
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeConnectedVM(Rec);
+			TestEqual("green before the switch", static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connected));
+
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			// The dot must leave green the INSTANT the target changes — not wait for the sidecar's re-dial status.
+			TestNotEqual("no longer Connected after the mode switch",
+				static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connected));
+			TestEqual("optimistically Connecting to the new target",
+				static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connecting));
+			// Still armed: the user retargeted, they did not Disconnect — a re-dial to the new target is expected.
+			TestTrue("still armed after the retarget", VM->IsReconnectArmed());
+			// And it pushed the new config so the sidecar re-dials the new target.
+			TestTrue("pushed the retargeted config", Rec->PushCount >= 1);
+		});
+
+		It("Bug 1: the symmetric Custom->Cloud switch also drops the green state", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			// Enter Custom, connect green there, then switch back to Cloud.
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			VM->Connect();
+			TSharedPtr<FJsonObject> Status = MakeShared<FJsonObject>();
+			Status->SetStringField(TEXT("connectionState"), TEXT("Connected"));
+			Status->SetBoolField(TEXT("keepConnected"), true);
+			VM->ApplyStatus(Status);
+			TestEqual("green in Custom", static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connected));
+
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Cloud);
+			TestEqual("Connecting after Custom->Cloud",
+				static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connecting));
+		});
+
+		It("Bug 1: editing the Server URL to a new valid host while connected drops the green state", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			VM->SetCustomHost(TEXT("http://localhost:5244"));
+			VM->Connect();
+			TSharedPtr<FJsonObject> Status = MakeShared<FJsonObject>();
+			Status->SetStringField(TEXT("connectionState"), TEXT("Connected"));
+			Status->SetBoolField(TEXT("keepConnected"), true);
+			VM->ApplyStatus(Status);
+			TestEqual("green before the host edit", static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connected));
+
+			// Edit to a DIFFERENT valid host: retargets the dial → drop off green.
+			VM->SetCustomHost(TEXT("http://localhost:9999"));
+			TestEqual("Connecting after the host retarget",
+				static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connecting));
+		});
+
+		It("Bug 1: re-typing the SAME host (no retarget) does NOT churn the Connected state", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			VM->SetCustomHost(TEXT("http://localhost:5244"));
+			VM->Connect();
+			TSharedPtr<FJsonObject> Status = MakeShared<FJsonObject>();
+			Status->SetStringField(TEXT("connectionState"), TEXT("Connected"));
+			Status->SetBoolField(TEXT("keepConnected"), true);
+			VM->ApplyStatus(Status);
+
+			// Same host value — the dial target is unchanged, so the live Connected state must be preserved.
+			VM->SetCustomHost(TEXT("http://localhost:5244"));
+			TestEqual("still Connected after a no-retarget host set",
+				static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connected));
+		});
+
+		It("Bug 1: an invalid host edit while connected does NOT drop green (no retarget happens)", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			VM->SetCustomHost(TEXT("http://localhost:5244"));
+			VM->Connect();
+			TSharedPtr<FJsonObject> Status = MakeShared<FJsonObject>();
+			Status->SetStringField(TEXT("connectionState"), TEXT("Connected"));
+			Status->SetBoolField(TEXT("keepConnected"), true);
+			VM->ApplyStatus(Status);
+
+			// A malformed URL never becomes the dial target (no push) — so the live link to the OLD valid host stands.
+			VM->SetCustomHost(TEXT("not-a-url"));
+			TestEqual("still Connected after a malformed host edit",
+				static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connected));
+		});
+
+		It("Bug 1: a mode switch while DISCONNECTED does not fabricate a Connecting state", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			// Never connected (unarmed, Disconnected). A retarget must not claim a connect is in flight.
+			TestEqual("starts Disconnected", static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Disconnected));
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			TestEqual("stays Disconnected (no green to drop, no re-dial armed)",
+				static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Disconnected));
+		});
+
+		It("Bug 2: stopping the local server while connected drives the state off Connected", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			// Custom + http = launchable; start the local server, then connect green to it.
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			VM->SetTransportMethod(EUnrealMcpTransportMethod::Http);
+			VM->ToggleLocalServer(); // start
+			TestTrue("server running", VM->IsLocalServerRunning());
+			VM->Connect();
+			TSharedPtr<FJsonObject> Status = MakeShared<FJsonObject>();
+			Status->SetStringField(TEXT("connectionState"), TEXT("Connected"));
+			Status->SetBoolField(TEXT("keepConnected"), true);
+			VM->ApplyStatus(Status);
+			TestEqual("green before stopping the server", static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connected));
+
+			// Stop the server the editor is connected to: the dot must leave green WITHOUT a manual Disconnect.
+			VM->ToggleLocalServer(); // stop
+			TestEqual("server stopped once", Rec->ServerStopCount, 1);
+			TestFalse("server no longer running", VM->IsLocalServerRunning());
+			TestNotEqual("no longer Connected after stopping the server",
+				static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connected));
+			// Stays armed (the user stopped the SERVER, not the connection) — a re-Start should resume; while armed a
+			// torn-down link reads as Degraded (background retry), so the action button leaves "Disconnect".
+			TestEqual("Degraded after the server stop", static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Degraded));
+			TestTrue("still armed", VM->IsReconnectArmed());
+		});
+
+		It("Bug 2: the action button label updates off 'Disconnect' once the server-stop drops the link", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+			VM->SetTransportMethod(EUnrealMcpTransportMethod::Http);
+			VM->ToggleLocalServer();
+			VM->Connect();
+			TSharedPtr<FJsonObject> Status = MakeShared<FJsonObject>();
+			Status->SetStringField(TEXT("connectionState"), TEXT("Connected"));
+			Status->SetBoolField(TEXT("keepConnected"), true);
+			VM->ApplyStatus(Status);
+			TestEqual("button is Disconnect while Connected",
+				FUnrealMcpEditorViewModel::GetButtonText(VM->GetConnectionState()).ToString(), FString(TEXT("Disconnect")));
+
+			VM->ToggleLocalServer(); // stop
+			// Degraded → the tri-state maps to "Stop" (the user can halt the background retry) — no longer "Disconnect".
+			TestEqual("button updated off Disconnect after the server stop",
+				FUnrealMcpEditorViewModel::GetButtonText(VM->GetConnectionState()).ToString(), FString(TEXT("Stop")));
+		});
+	});
 }
 
 #endif // WITH_DEV_AUTOMATION_TESTS

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -746,9 +746,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         /// an R3 <c>ReadOnlyReactiveProperty&lt;HubConnectionState&gt;</c>). On a transition AWAY from
         /// <see cref="HubConnectionState.Connected"/> (the link dropped — most importantly because the user stopped the
         /// local server the editor was connected to), emit a FRESH non-green <c>status</c> so the plugin's dot leaves
-        /// green and the action button updates, WITHOUT requiring an editor-initiated config push. While still armed the
-        /// drop reads as "Connecting" (the client is auto-retrying = the plugin's Degraded once keepConnected is applied,
-        /// see ParseConnectionState); a disarmed drop reads as "Disconnected". A transition INTO Connected re-emits a
+        /// green and the action button updates, WITHOUT requiring an editor-initiated config push. The drop emits
+        /// "Disconnected", which the plugin's ParseConnectionState folds into amber Degraded while armed (the client is
+        /// auto-retrying) and a true Disconnected when disarmed. A transition INTO Connected re-emits a
         /// Connected status so a transport-level recovery (the client reconnected on its own) also refreshes the dot.
         /// Internal + plugin-injected so the bridge xUnit suite drives it with a fake whose ConnectionState it controls.
         /// Idempotent: a second subscribe (a re-Build) replaces the prior subscription.
@@ -776,7 +776,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         /// bug-2 trigger) or a RECOVERY back into Connected — never on the baseline first observation (<paramref
         /// name="previous"/> &lt; 0) or a same-state re-publish, so a property that re-emits its current value on
         /// subscribe does not spam a redundant status. Pure + static so the bridge xUnit suite locks the matrix without a
-        /// live client. The shipped string is mode-agnostic ("Connecting"/"Connected"); <see cref="EmitStatusAsync"/>
+        /// live client. The shipped string is mode-agnostic ("Disconnected"/"Connected"); <see cref="EmitStatusAsync"/>
         /// stamps the live <c>keepConnected</c>, which the plugin's ParseConnectionState folds into Degraded while armed.
         /// </summary>
         internal static bool ShouldEmitOnConnectionStateChange(int previous, int current, out string connectionState)
@@ -791,9 +791,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
             if (wasConnected && !nowConnected)
             {
-                // The link the editor was on just dropped (stopped local server / network loss). Report "Connecting"
-                // — the McpPlugin client auto-retries while armed; the plugin maps that to its amber Degraded dot.
-                connectionState = "Connecting";
+                // The link the editor was on just dropped (stopped local server / network loss). Report "Disconnected"
+                // — while armed the plugin's ParseConnectionState folds Disconnected into its amber Degraded dot (the
+                // client auto-retries in the background), matching the ViewModel's optimistic post-Stop Degraded so the
+                // dot drops straight to amber with no amber→blue flip; a disarmed drop reads as a true Disconnected.
+                connectionState = "Disconnected";
                 return true;
             }
             if (!wasConnected && nowConnected)

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -24,6 +24,7 @@ using com.IvanMurzak.Unreal.MCP.Bridge.AgentConfig;
 using com.IvanMurzak.Unreal.MCP.Bridge.Auth;
 using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
 using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Logging;
 using R3;
 using McpVersion = com.IvanMurzak.McpPlugin.Common.Version;
@@ -101,6 +102,19 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         private readonly object _rosterLock = new();
         private List<string> _connectedAgents = new();
         private IDisposable? _clientsChangedSubscription;
+
+        // Bug #116: subscription to the transport-level SignalR connection state (IConnection.ConnectionState, an R3
+        // ReadOnlyReactiveProperty<HubConnectionState>). When the link the editor is connected to drops — e.g. the user
+        // stops the LOCAL gamedev-mcp-server the editor was connected to — McpPlugin's client transitions Connected →
+        // Reconnecting/Disconnected WITHOUT any editor-initiated config push, so none of the existing status-emit paths
+        // (config transition, device-auth, roster) fire and the plugin's dot stays stale-green. This subscription makes
+        // that drop observable: on a transition AWAY from Connected (while still armed) it emits a fresh non-green
+        // `status` so the dot leaves green and the action button updates. Replaced on re-Build; disposed in Dispose().
+        private IDisposable? _connectionStateSubscription;
+        // The last HubConnectionState we OBSERVED, so we only react to genuine Connected→non-Connected DROPS (not every
+        // tick of a property that may re-publish its current value on subscribe). HubConnectionState lives in
+        // Microsoft.AspNetCore.SignalR.Client; stored as the enum's int to avoid leaking the type across this field.
+        private int _lastObservedConnectionState = -1;
 
         // The bridge's OWN SignalR client label (Version.Environment). Used to defensively drop a self-entry from
         // the roster: the server's GetMcpClientData/OnClientsChanged report MCP client (AI-agent) sessions, NOT the
@@ -232,6 +246,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             // refreshes live. OnClientsChanged fires with the full active-client list on every agent join/leave;
             // cache the formatted labels and push a FRESH status so the editor updates without a reconnect.
             SubscribeToClientRoster(_plugin);
+
+            // Bug #116: subscribe to the transport-level connection state so a link DROP (e.g. the user stopped the
+            // local server the editor was connected to) demotes the plugin's dot off green even though no editor
+            // config push fired. This is the "subscribe to the McpPlugin connection-lost/reconnecting event and emit a
+            // fresh status" half of the bug-2 fix; the ViewModel optimistic demote on Stop is the other half.
+            SubscribeToConnectionState(_plugin);
 
             _ipc.HandshakeAccepted += OnHandshakeAccepted;
             _ipc.ConfigReceived += OnConfigReceived;
@@ -722,6 +742,84 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         }
 
         /// <summary>
+        /// Bug #116: subscribe to the transport-level SignalR connection state (<see cref="IConnection.ConnectionState"/>,
+        /// an R3 <c>ReadOnlyReactiveProperty&lt;HubConnectionState&gt;</c>). On a transition AWAY from
+        /// <see cref="HubConnectionState.Connected"/> (the link dropped — most importantly because the user stopped the
+        /// local server the editor was connected to), emit a FRESH non-green <c>status</c> so the plugin's dot leaves
+        /// green and the action button updates, WITHOUT requiring an editor-initiated config push. While still armed the
+        /// drop reads as "Connecting" (the client is auto-retrying = the plugin's Degraded once keepConnected is applied,
+        /// see ParseConnectionState); a disarmed drop reads as "Disconnected". A transition INTO Connected re-emits a
+        /// Connected status so a transport-level recovery (the client reconnected on its own) also refreshes the dot.
+        /// Internal + plugin-injected so the bridge xUnit suite drives it with a fake whose ConnectionState it controls.
+        /// Idempotent: a second subscribe (a re-Build) replaces the prior subscription.
+        /// </summary>
+        internal void SubscribeToConnectionState(IMcpPlugin plugin)
+        {
+            _connectionStateSubscription?.Dispose();
+            // Reset the observed-state latch so the first value the property publishes establishes the baseline rather
+            // than being mis-read as a drop from a stale prior subscription's last value.
+            _lastObservedConnectionState = -1;
+            _connectionStateSubscription = plugin.ConnectionState
+                .Subscribe(state =>
+                {
+                    var previous = _lastObservedConnectionState;
+                    _lastObservedConnectionState = (int)state;
+                    // Fire-and-forget; never throw out of the R3 callback (it runs on a client thread).
+                    if (ShouldEmitOnConnectionStateChange(previous, (int)state, out var connectionState))
+                        _ = EmitConnectionStateStatusAsync(connectionState);
+                });
+        }
+
+        /// <summary>
+        /// Decide whether a transport-level <see cref="HubConnectionState"/> transition warrants a fresh <c>status</c>
+        /// emit, and what connection-state string to ship. We emit on a genuine EDGE only — a DROP off Connected (the
+        /// bug-2 trigger) or a RECOVERY back into Connected — never on the baseline first observation (<paramref
+        /// name="previous"/> &lt; 0) or a same-state re-publish, so a property that re-emits its current value on
+        /// subscribe does not spam a redundant status. Pure + static so the bridge xUnit suite locks the matrix without a
+        /// live client. The shipped string is mode-agnostic ("Connecting"/"Connected"); <see cref="EmitStatusAsync"/>
+        /// stamps the live <c>keepConnected</c>, which the plugin's ParseConnectionState folds into Degraded while armed.
+        /// </summary>
+        internal static bool ShouldEmitOnConnectionStateChange(int previous, int current, out string connectionState)
+        {
+            connectionState = string.Empty;
+            // No prior observation (baseline) or no actual change — nothing to report.
+            if (previous < 0 || previous == current)
+                return false;
+
+            var nowConnected = current == (int)HubConnectionState.Connected;
+            var wasConnected = previous == (int)HubConnectionState.Connected;
+
+            if (wasConnected && !nowConnected)
+            {
+                // The link the editor was on just dropped (stopped local server / network loss). Report "Connecting"
+                // — the McpPlugin client auto-retries while armed; the plugin maps that to its amber Degraded dot.
+                connectionState = "Connecting";
+                return true;
+            }
+            if (!wasConnected && nowConnected)
+            {
+                // A transport-level recovery (the client reconnected on its own) — refresh the dot back to green.
+                connectionState = "Connected";
+                return true;
+            }
+            // Connecting↔Reconnecting and other non-Connected churn: no edge that changes the green/non-green dot.
+            return false;
+        }
+
+        /// <summary>
+        /// Emit a <c>status</c> for a transport-level connection-state edge (Bug #116). A non-Connected drop must ALSO
+        /// clear the cached roster so a later reconnect re-seeds fresh and the "AI agents" row does not linger from the
+        /// dropped link (mirrors the disconnect paths' <see cref="ClearRoster"/>). <see cref="EmitStatusAsync"/> already
+        /// ships an empty roster under any non-Connected state, but clearing the cache keeps it honest for the next seed.
+        /// </summary>
+        private Task EmitConnectionStateStatusAsync(string connectionState)
+        {
+            if (!string.Equals(connectionState, "Connected", StringComparison.Ordinal))
+                ClearRoster();
+            return EmitStatusAsync(connectionState);
+        }
+
+        /// <summary>
         /// Seed the roster on connect via <see cref="IMcpManagerHub.GetMcpClientData"/> (pull), with a small
         /// retry/backoff (Unity uses 3×/3s) because an agent's MCP session can lag the plugin's SignalR connect —
         /// an immediate pull can return empty even though an agent is about to join. Each successful pull updates
@@ -898,6 +996,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _ipc.AgentConfigRequestReceived -= HandleAgentConfigRequest;
             try { _clientsChangedSubscription?.Dispose(); } catch { /* ignore */ }
             _clientsChangedSubscription = null;
+            // Bug #116: drop the transport connection-state subscription so a late R3 callback cannot touch a
+            // half-disposed host.
+            try { _connectionStateSubscription?.Dispose(); } catch { /* ignore */ }
+            _connectionStateSubscription = null;
             // §7 (issue #111): teardown clears the roster cache so it never outlives the host.
             ClearRoster();
             try { _authCts?.Cancel(); } catch { /* ignore */ }

--- a/bridge/tests/Fakes.cs
+++ b/bridge/tests/Fakes.cs
@@ -48,6 +48,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         private readonly IMcpManager? _mcpManager;
         private readonly IMcpManagerHub? _mcpManagerHub;
 
+        // Bug #116: a controllable transport connection-state property so the connection-drop subscription path is
+        // drivable without a live SignalR client. Tests push transitions via PushConnectionState; the property is
+        // seeded Disconnected. The transition tests never read it (R3 lets it lie dormant), so they are unaffected.
+        private readonly ReactiveProperty<HubConnectionState> _connectionState = new(HubConnectionState.Disconnected);
+
         public FakeMcpPlugin(
             Func<CancellationToken, Task<bool>> onConnect,
             Func<CancellationToken, Task>? onDisconnect = null,
@@ -59,6 +64,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             _mcpManager = mcpManager;
             _mcpManagerHub = mcpManagerHub;
         }
+
+        /// <summary>Bug #116: drive a transport connection-state transition through <see cref="ConnectionState"/>.</summary>
+        public void PushConnectionState(HubConnectionState state) => _connectionState.Value = state;
 
         public Task<bool> Connect(CancellationToken cancellationToken = default)
         {
@@ -81,7 +89,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         // Unused surface — the transition orchestration under test never reads these. Throwing keeps the fake
         // honest: if a future change starts depending on one, the test fails loudly instead of silently.
         public ReadOnlyReactiveProperty<bool> KeepConnected => throw new NotSupportedException();
-        public ReadOnlyReactiveProperty<HubConnectionState> ConnectionState => throw new NotSupportedException();
+        // Bug #116: a real (controllable) ConnectionState so the connection-drop subscription is testable; the
+        // transition tests never subscribe, so seeding it does not perturb them.
+        public ReadOnlyReactiveProperty<HubConnectionState> ConnectionState => _connectionState;
         public Observable<Unit> OnAuthorizationRejected => throw new NotSupportedException();
         public ILogger Logger => throw new NotSupportedException();
         // Roster path (issue #109): return the injected fakes when supplied; otherwise throw to keep the

--- a/bridge/tests/SidecarHostConnectionDropTests.cs
+++ b/bridge/tests/SidecarHostConnectionDropTests.cs
@@ -43,17 +43,19 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         // ── the pure edge-decision matrix ────────────────────────────────────────────────────────────────────
 
         [Fact]
-        public void ShouldEmit_OnDropOffConnected_EmitsConnecting()
+        public void ShouldEmit_OnDropOffConnected_EmitsDisconnected()
         {
+            // A drop off Connected emits "Disconnected" — the plugin's ParseConnectionState folds that into amber
+            // Degraded while armed (no amber→blue flip vs. the editor's optimistic post-Stop Degraded).
             var emit = SidecarHost.ShouldEmitOnConnectionStateChange(
                 (int)HubConnectionState.Connected, (int)HubConnectionState.Reconnecting, out var state);
             Assert.True(emit);
-            Assert.Equal("Connecting", state);
+            Assert.Equal("Disconnected", state);
 
             // A hard drop to Disconnected is also an off-Connected edge.
             Assert.True(SidecarHost.ShouldEmitOnConnectionStateChange(
                 (int)HubConnectionState.Connected, (int)HubConnectionState.Disconnected, out var state2));
-            Assert.Equal("Connecting", state2);
+            Assert.Equal("Disconnected", state2);
         }
 
         [Fact]
@@ -111,7 +113,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             fake.PushConnectionState(HubConnectionState.Reconnecting);
             Assert.Equal(2, emitted.Count);
             Assert.NotEqual("Connected", emitted[^1].ConnectionState);
-            Assert.Equal("Connecting", emitted[^1].ConnectionState);
+            Assert.Equal("Disconnected", emitted[^1].ConnectionState);
         }
 
         [Fact]

--- a/bridge/tests/SidecarHostConnectionDropTests.cs
+++ b/bridge/tests/SidecarHostConnectionDropTests.cs
@@ -1,0 +1,156 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using com.IvanMurzak.Unreal.MCP.Bridge.Host;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>
+    /// Regression specs for issue #116 bug 2 (bridge half): "stopping the local MCP server doesn't disconnect the
+    /// editor". Before the fix the sidecar re-emitted <c>status</c> only on the editor's OWN connection/auth
+    /// transitions (config push, device-auth) and on roster changes — so a transport-level DROP (the user stopped the
+    /// local gamedev-mcp-server the editor was connected to → McpPlugin's SignalR client falls Connected →
+    /// Reconnecting/Disconnected with no config push) never reached the plugin, leaving the "Unreal" dot stale-green.
+    /// The fix subscribes to <see cref="IConnection.ConnectionState"/> and emits a fresh non-green <c>status</c> on a
+    /// drop. These lock both the pure edge-decision matrix and the wired emit through a fake whose ConnectionState the
+    /// test drives (no live SignalR client).
+    /// </summary>
+    public class SidecarHostConnectionDropTests
+    {
+        private static SidecarHost NewHost(out IpcClient ipc)
+        {
+            // Port is never dialed — the fake plugin replaces the real SignalR client, so no socket opens.
+            ipc = new IpcClient("127.0.0.1", 39996, token: "ipc-token", sidecarVersion: "0.1.0");
+            return new SidecarHost(ipc, "0.1.0");
+        }
+
+        private static FakeMcpPlugin NewFake() =>
+            new(onConnect: _ => Task.FromResult(true));
+
+        // ── the pure edge-decision matrix ────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void ShouldEmit_OnDropOffConnected_EmitsConnecting()
+        {
+            var emit = SidecarHost.ShouldEmitOnConnectionStateChange(
+                (int)HubConnectionState.Connected, (int)HubConnectionState.Reconnecting, out var state);
+            Assert.True(emit);
+            Assert.Equal("Connecting", state);
+
+            // A hard drop to Disconnected is also an off-Connected edge.
+            Assert.True(SidecarHost.ShouldEmitOnConnectionStateChange(
+                (int)HubConnectionState.Connected, (int)HubConnectionState.Disconnected, out var state2));
+            Assert.Equal("Connecting", state2);
+        }
+
+        [Fact]
+        public void ShouldEmit_OnRecoveryIntoConnected_EmitsConnected()
+        {
+            Assert.True(SidecarHost.ShouldEmitOnConnectionStateChange(
+                (int)HubConnectionState.Reconnecting, (int)HubConnectionState.Connected, out var state));
+            Assert.Equal("Connected", state);
+        }
+
+        [Fact]
+        public void ShouldEmit_OnBaselineOrSameStateOrNonConnectedChurn_DoesNotEmit()
+        {
+            // Baseline first observation (previous < 0): the property publishes its current value on subscribe — this
+            // establishes the latch, it is NOT a drop.
+            Assert.False(SidecarHost.ShouldEmitOnConnectionStateChange(-1, (int)HubConnectionState.Disconnected, out _));
+            Assert.False(SidecarHost.ShouldEmitOnConnectionStateChange(-1, (int)HubConnectionState.Connected, out _));
+
+            // Same-state re-publish: no edge.
+            Assert.False(SidecarHost.ShouldEmitOnConnectionStateChange(
+                (int)HubConnectionState.Connected, (int)HubConnectionState.Connected, out _));
+
+            // Non-Connected churn (Connecting↔Reconnecting): the green/non-green dot does not change.
+            Assert.False(SidecarHost.ShouldEmitOnConnectionStateChange(
+                (int)HubConnectionState.Connecting, (int)HubConnectionState.Reconnecting, out _));
+            Assert.False(SidecarHost.ShouldEmitOnConnectionStateChange(
+                (int)HubConnectionState.Disconnected, (int)HubConnectionState.Connecting, out _));
+        }
+
+        // ── the wired subscription: a real drop emits a fresh non-green status ────────────────────────────────
+
+        [Fact]
+        public void TransportDrop_AfterConnected_EmitsAFreshNonGreenStatus()
+        {
+            using var host = NewHost(out _);
+            var fake = NewFake();
+            host.SetPluginForTest(fake);
+
+            var emitted = new List<StatusMessage>();
+            host.SetStatusEmitterForTest(s => { emitted.Add(s); return Task.CompletedTask; });
+
+            // Subscribe AFTER wiring the capture. The property seeds Disconnected → that first publish establishes the
+            // baseline latch and must NOT emit a status (it is not a drop from Connected).
+            host.SubscribeToConnectionState(fake);
+            Assert.Empty(emitted);
+
+            // The editor connects: Disconnected → Connected. This recovery-into-Connected edge refreshes the dot green.
+            fake.PushConnectionState(HubConnectionState.Connected);
+            Assert.Single(emitted);
+            Assert.Equal("Connected", emitted[^1].ConnectionState);
+
+            // The user STOPS the local server the editor was connected to: the SignalR client falls Connected →
+            // Reconnecting with NO editor config push. Pre-fix: nothing emitted, dot stays green. Post-fix: a fresh
+            // non-green status drops the dot.
+            fake.PushConnectionState(HubConnectionState.Reconnecting);
+            Assert.Equal(2, emitted.Count);
+            Assert.NotEqual("Connected", emitted[^1].ConnectionState);
+            Assert.Equal("Connecting", emitted[^1].ConnectionState);
+        }
+
+        [Fact]
+        public void TransportDrop_ShipsAnEmptyAgentRoster()
+        {
+            using var host = NewHost(out _);
+            var fake = NewFake();
+            host.SetPluginForTest(fake);
+
+            var emitted = new List<StatusMessage>();
+            host.SetStatusEmitterForTest(s => { emitted.Add(s); return Task.CompletedTask; });
+
+            host.SubscribeToConnectionState(fake);
+            fake.PushConnectionState(HubConnectionState.Connected);
+            fake.PushConnectionState(HubConnectionState.Disconnected);
+
+            // The §7 clear-on-non-connected invariant (issue #111) holds for this path too: a dropped link must ship an
+            // empty "AI agents" row so the dot/list does not linger from the now-dead connection.
+            Assert.Empty(emitted[^1].AiAgents);
+        }
+
+        [Fact]
+        public void ConnectionStateSubscription_IsIdempotentAcrossReSubscribe()
+        {
+            using var host = NewHost(out _);
+            var fake = NewFake();
+            host.SetPluginForTest(fake);
+
+            var emitted = new List<StatusMessage>();
+            host.SetStatusEmitterForTest(s => { emitted.Add(s); return Task.CompletedTask; });
+
+            host.SubscribeToConnectionState(fake);
+            host.SubscribeToConnectionState(fake); // a re-Build replaces the prior subscription — must not double-emit
+
+            fake.PushConnectionState(HubConnectionState.Connected);
+            fake.PushConnectionState(HubConnectionState.Reconnecting);
+
+            // Exactly one Connected + one drop status — the superseded first subscription is disposed, so no duplicates.
+            Assert.Equal(2, emitted.Count);
+        }
+    }
+}

--- a/bridge/tests/SidecarHostTransitionTests.cs
+++ b/bridge/tests/SidecarHostTransitionTests.cs
@@ -9,6 +9,8 @@
 */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
@@ -152,6 +154,75 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
 
             await disconnectCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5)); // token threaded in AND cancelled on supersede
             await laterRan.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        // ── issue #116 bug 1 (bridge half): a mode/host change while connected re-dials the NEW target ──────────
+
+        [Fact]
+        public void DecideConfigTransition_HostChangeWhileArmed_ReDials()
+        {
+            // The crux of bug 1 on the bridge: a user switching Cloud↔Custom or editing the Server URL while connected
+            // (keepConnected stays true) changes the resolved host → DecideConfigTransition MUST return Reconnect so
+            // SignalR re-dials the new target instead of staying bound to the abandoned one (UI then converges off the
+            // optimistic Connecting the ViewModel set).
+            Assert.Equal(SidecarHost.ConfigTransition.Reconnect,
+                SidecarHost.DecideConfigTransition(wasKeepConnected: true, nowKeepConnected: true, hostOrTokenChanged: true));
+            // No host/token change while armed → no churn.
+            Assert.Equal(SidecarHost.ConfigTransition.None,
+                SidecarHost.DecideConfigTransition(wasKeepConnected: true, nowKeepConnected: true, hostOrTokenChanged: false));
+        }
+
+        [Fact]
+        public async Task ModeSwitchWhileConnected_TearsDownTheOldLink_AndReDialsTheNewTarget()
+        {
+            using var host = NewHost(out _);
+
+            // Track BOTH the disconnect of the old link and the dial of the new target. The bug-1 contract on the
+            // bridge: a mode/host change while armed must NOT leave SignalR bound to the abandoned target — it
+            // disconnects the current link and re-dials the NEW host. (The optimistic "drop the green dot immediately"
+            // is the ViewModel's job; the bridge's job is to actually retarget the transport, then emit the honest
+            // resulting status — never a stale "Connected" against the old target.)
+            var newTargetDialed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var fake = new FakeMcpPlugin(
+                onConnect: _ =>
+                {
+                    // ReconnectAsync reads the freshly-applied Host before dialing — exactly the live ConnectionManager
+                    // behavior. Only the NEW (localhost) target should ever be dialed after the switch.
+                    if ((host.Config.Host ?? "").Contains("localhost", StringComparison.OrdinalIgnoreCase))
+                        newTargetDialed.TrySetResult();
+                    return Task.FromResult(true);
+                },
+                onDisconnect: _ => Task.CompletedTask);
+            host.SetPluginForTest(fake);
+
+            // Armed + connected in Cloud (the state right after the user connected in Cloud).
+            host.ApplyConnectionConfig(Cfg("Cloud", cloudUrl: "https://ai-game.dev"));
+
+            var emitted = new List<StatusMessage>();
+            host.SetStatusEmitterForTest(s => { lock (emitted) emitted.Add(s); return Task.CompletedTask; });
+
+            // The user switches to Custom (a host change while armed) → OnConfigReceived issues a Reconnect transition.
+            host.OnConfigReceived(Cfg("Custom", host: "http://localhost:8500", token: ""));
+
+            // The new (localhost) target was dialed — SignalR did not stay pinned to the abandoned Cloud target.
+            await newTargetDialed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            // The old link was torn down before the re-dial (ReconnectAsync disconnects first).
+            Assert.True(fake.DisconnectCalls >= 1);
+            // The honest post-redial status is Connected against the NEW target — never a stale Connected emitted
+            // without a re-dial having happened.
+            await WaitUntilAsync(() => { lock (emitted) return emitted.Any(s => s.ConnectionState == "Connected"); },
+                TimeSpan.FromSeconds(5));
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                if (condition()) return;
+                await Task.Delay(20).ConfigureAwait(false);
+            }
+            Assert.True(condition(), "condition not met within timeout");
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- **Bug 1 (mode/target switch leaves stale green):** the ViewModel now optimistically demotes a live/armed `Connected`/`Degraded` state to `Connecting` the instant the dial target changes — a `SetConnectionMode` switch (Cloud↔Custom) or a valid-host `SetCustomHost` edit. The sidecar's host-changed re-dial (`DecideConfigTransition`→`Reconnect`, which tears down the old link first) then converges the honest status. No-retarget host re-types, malformed edits, and unarmed/Disconnected view-models are guarded against spurious churn.
- **Bug 2 (stopping the local server leaves green):** stopping the local server the editor is connected to (Custom+http) now demotes off `Connected` without a manual Disconnect (ViewModel half), and the bridge subscribes to `IConnection.ConnectionState` and emits a fresh non-green `status` on a transport-level drop so the dot leaves green even with no editor config push (sidecar half).
- McpPlugin pin stays **6.10.0** (no NuGet bump). Scope limited to `UnrealMcpEditor` ViewModel + `bridge/**`.

## Test plan
- [x] bridge `dotnet build` + `dotnet test` — 165 passed, 0 failed (extends `SidecarHostTransitionTests`, adds `SidecarHostConnectionDropTests`).
- [x] UE plugin UBT build (exit 0) + headless boot smoke (`[Unreal-MCP] plugin loaded`).
- [x] UE Automation `UnrealMcp.` specs — 251 succeeded, 0 failed; 8 new `UnrealMcp.EditorViewModel` regression specs for both bugs.

Closes #116