### PR TITLE
feat(runtime): UUnrealMcpRuntimeSubsystem opt-in connect (R3)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpRuntimeSubsystemSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpRuntimeSubsystemSpec.cpp
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "UObject/Package.h"
+#include "Engine/World.h"
+#include "Engine/GameInstance.h" // a transient UGameInstance as the subsystem's Outer (ClassWithin=UGameInstance)
+#include "Editor.h" // GEditor — the spec restores the editor world resolver after exercising the runtime one
+
+#include "UnrealMcpRuntimeSubsystem.h"
+#include "UnrealMcpRuntimeSettings.h"
+#include "Tools/UnrealMcpWorldProvider.h"
+
+/**
+ * Specs for the R3 runtime bootstrap (docs/ARCHITECTURE.md §12.4 / §12.6 / §12.8). These exercise the parts
+ * that do NOT require a live UGameInstance + sidecar:
+ *  - the §12.8 #5 loopback-host policy (IsLoopbackHost), the pure gate the host-rejection branch uses;
+ *  - the §12.8 #4 kill-switch and §12.8 #5 host rejection through Connect() on a bare (un-Initialized)
+ *    subsystem object — those two gates run BEFORE the listener-armed gate, so a NewObject suffices to
+ *    prove they reject (and that the security invariant "no connect path without an explicit, gated call"
+ *    holds even for a fully-defaulted project — kill switch off → Connect false);
+ *  - the §12.6 world-provider switching: a runtime-style resolver installs and GetActiveWorld follows it,
+ *    ClearWorldResolver returns to the null (no-resolver) state.
+ *
+ * The live sidecar connect → server → ping wire path is the live-e2e / PIE runbook (test.md Suite 7), not
+ * unit-asserted here (no headless sidecar+server harness in a dev checkout).
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpRuntimeSubsystemSpec, "UnrealMcp.RuntimeSubsystem",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	// Spec-unique helper (unity-build ODR rule): a fresh, un-Initialized subsystem object. Connect()'s
+	// kill-switch + host gates run before the listener gate, so this is enough to assert their rejections.
+	// UUnrealMcpRuntimeSubsystem (a UGameInstanceSubsystem) has ClassWithin=UGameInstance, so it must be
+	// created with a UGameInstance Outer — a transient one suffices; NewObject into the transient PACKAGE
+	// would trip the engine's "created in invalid Outer" ensure. The subsystem is NOT Initialize()'d here
+	// (we never call Initialize), so the transient game instance never drives real bring-up.
+	static UUnrealMcpRuntimeSubsystem* RuntimeSpecMakeSubsystem()
+	{
+		UGameInstance* OuterGI = NewObject<UGameInstance>(GetTransientPackage());
+		return NewObject<UUnrealMcpRuntimeSubsystem>(OuterGI);
+	}
+
+	// Spec-unique helper: set the kill switch and return the previous value so the test can restore it.
+	static bool RuntimeSpecSetKillSwitch(bool bEnabled)
+	{
+		UUnrealMcpRuntimeSettings* Settings = GetMutableDefault<UUnrealMcpRuntimeSettings>();
+		const bool bPrev = Settings->bRuntimeMcpEnabled;
+		Settings->bRuntimeMcpEnabled = bEnabled;
+		return bPrev;
+	}
+
+END_DEFINE_SPEC(FUnrealMcpRuntimeSubsystemSpec)
+
+void FUnrealMcpRuntimeSubsystemSpec::Define()
+{
+	Describe("IsLoopbackHost (§12.8 #5 policy)", [this]()
+	{
+		It("accepts loopback hostnames / addresses (schemed and bare, with and without port)", [this]()
+		{
+			TestTrue(TEXT("localhost"),             UUnrealMcpRuntimeSubsystem::IsLoopbackHost(TEXT("localhost")));
+			TestTrue(TEXT("http://localhost:8080"), UUnrealMcpRuntimeSubsystem::IsLoopbackHost(TEXT("http://localhost:8080")));
+			TestTrue(TEXT("127.0.0.1"),             UUnrealMcpRuntimeSubsystem::IsLoopbackHost(TEXT("127.0.0.1")));
+			TestTrue(TEXT("http://127.0.0.1:9000/"),UUnrealMcpRuntimeSubsystem::IsLoopbackHost(TEXT("http://127.0.0.1:9000/")));
+			TestTrue(TEXT("127.5.5.5 (loopback /8)"),UUnrealMcpRuntimeSubsystem::IsLoopbackHost(TEXT("127.5.5.5")));
+			TestTrue(TEXT("[::1]:8080"),            UUnrealMcpRuntimeSubsystem::IsLoopbackHost(TEXT("http://[::1]:8080")));
+			TestTrue(TEXT("empty -> default localhost"), UUnrealMcpRuntimeSubsystem::IsLoopbackHost(TEXT("")));
+		});
+
+		It("rejects non-loopback hosts", [this]()
+		{
+			TestFalse(TEXT("public IP"),       UUnrealMcpRuntimeSubsystem::IsLoopbackHost(TEXT("203.0.113.7")));
+			TestFalse(TEXT("LAN IP"),          UUnrealMcpRuntimeSubsystem::IsLoopbackHost(TEXT("192.168.1.50")));
+			TestFalse(TEXT("remote hostname"), UUnrealMcpRuntimeSubsystem::IsLoopbackHost(TEXT("http://ai-game.dev")));
+			TestFalse(TEXT("near-127 decoy"),  UUnrealMcpRuntimeSubsystem::IsLoopbackHost(TEXT("128.0.0.1")));
+		});
+	});
+
+	Describe("Connect security gates (§12.8)", [this]()
+	{
+		It("returns false when the kill switch is OFF (§12.8 #4), even for a loopback host", [this]()
+		{
+			const bool bPrev = RuntimeSpecSetKillSwitch(false);
+			UUnrealMcpRuntimeSubsystem* Subsystem = RuntimeSpecMakeSubsystem();
+
+			// Connect logs a Warning (not Error) on rejection, so no AddExpectedError is needed — warnings do
+			// not fail an Automation spec; only the boolean return is asserted.
+			const bool bConnected = Subsystem->Connect(TEXT("http://localhost:8080"));
+			TestFalse(TEXT("kill switch off -> Connect rejects"), bConnected);
+			TestFalse(TEXT("not connected"), Subsystem->IsConnected());
+
+			RuntimeSpecSetKillSwitch(bPrev);
+		});
+
+		It("returns false for a non-loopback host even when the kill switch is ON (§12.8 #5)", [this]()
+		{
+			const bool bPrev = RuntimeSpecSetKillSwitch(true);
+			UUnrealMcpRuntimeSubsystem* Subsystem = RuntimeSpecMakeSubsystem();
+
+			// Rejection is a Warning, not an Error (see above) — assert only the return value.
+			const bool bConnected = Subsystem->Connect(TEXT("http://203.0.113.7:8080"), TEXT(""),
+				EUnrealMcpRuntimeConnectionMode::Custom, /*bAllowRemoteHost*/ false);
+			TestFalse(TEXT("remote host without bAllowRemoteHost -> Connect rejects"), bConnected);
+
+			RuntimeSpecSetKillSwitch(bPrev);
+		});
+
+		It("a bare (un-Initialized) subsystem never reports a connection", [this]()
+		{
+			UUnrealMcpRuntimeSubsystem* Subsystem = RuntimeSpecMakeSubsystem();
+			TestFalse(TEXT("fresh subsystem is not connected"), Subsystem->IsConnected());
+			TestFalse(TEXT("fresh subsystem listener is not armed"), Subsystem->IsListenerArmed());
+		});
+	});
+
+	Describe("World resolver switching (§12.6)", [this]()
+	{
+		// Save + restore the global resolver so these tests do not perturb the editor coordinator's installed
+		// resolver (this spec runs inside a live editor where the coordinator already set the editor resolver).
+		It("a runtime-style resolver is honoured by GetActiveWorld, and ClearWorldResolver returns to null", [this]()
+		{
+			UWorld* FakeWorld = NewObject<UWorld>(GetTransientPackage());
+
+			// Install a runtime-style resolver (the subsystem installs `[this]{ GetGameInstance()->GetWorld() }`;
+			// here we inject a fixed world to assert the provider plumbing follows whatever resolver is set).
+			FUnrealMcpWorldProvider::SetWorldResolver([FakeWorld]() -> UWorld* { return FakeWorld; });
+			TestEqual(TEXT("GetActiveWorld follows the installed resolver"),
+				FUnrealMcpWorldProvider::GetActiveWorld(), FakeWorld);
+
+			FUnrealMcpWorldProvider::ClearWorldResolver();
+			TestNull(TEXT("after Clear, GetActiveWorld is null"), FUnrealMcpWorldProvider::GetActiveWorld());
+
+			// Re-install the editor resolver so the rest of the suite (which may resolve worlds) is unaffected.
+			FUnrealMcpWorldProvider::SetWorldResolver([]() -> UWorld*
+			{
+				return GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+			});
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSettings.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSettings.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpRuntimeSettings.h"
+
+UUnrealMcpRuntimeSettings::UUnrealMcpRuntimeSettings()
+{
+	// Default-off kill switch (§12.8 #4). Explicit here as well as in the header default so a config that
+	// predates the property reads false rather than an uninitialized value.
+	bRuntimeMcpEnabled = false;
+}
+
+FName UUnrealMcpRuntimeSettings::GetCategoryName() const
+{
+	// Group under "Plugins" in Project Settings (UDeveloperSettings default is "Game"). Matches where a
+	// consumer expects to find the Unreal-MCP runtime toggle.
+	return FName(TEXT("Plugins"));
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
@@ -1,0 +1,370 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpRuntimeSubsystem.h"
+#include "UnrealMcpRuntimeSettings.h"
+#include "UnrealMcpLog.h"
+#include "UnrealMcpRuntimeCoreTools.h"
+#include "UnrealMcpToolRegistry.h"
+#include "Config/UnrealMcpConfig.h"
+#include "Dispatch/UnrealMcpGameThreadDispatcher.h"
+#include "Bridge/UnrealMcpBridgeServer.h"
+#include "Sidecar/UnrealMcpSidecarManager.h"
+#include "Extensions/UnrealMcpExtensionManager.h"
+#include "Tools/UnrealMcpWorldProvider.h"
+
+#include "Engine/GameInstance.h"
+#include "Engine/World.h"
+#include "Misc/Paths.h"
+#include "Misc/EngineVersion.h"
+#include "HAL/IConsoleManager.h"
+#include "Interfaces/IPluginManager.h"
+
+// §12.8 #3: build-config gating. The bUnrealMcpAllowShipping Build.cs flag defines this to 0 (default) or 1.
+// With 0, Connect() in a Shipping build logs + returns false. Defaulted here so a build that predates the
+// Build.cs edit (or a foreign target) still compiles with the conservative "off" value.
+#ifndef UNREAL_MCP_ALLOW_SHIPPING
+#define UNREAL_MCP_ALLOW_SHIPPING 0
+#endif
+
+// The runtime-owned machinery, held behind the subsystem's TPimplPtr (see the header note). Defined here,
+// where every member type is complete; TPimplPtr captures a typed deleter at MakePimpl time so destruction
+// is correct even though the header only forward-declares FRuntimeImpl.
+struct UUnrealMcpRuntimeSubsystem::FRuntimeImpl
+{
+	TUniquePtr<FUnrealMcpToolRegistry> Registry;
+	TUniquePtr<FUnrealMcpGameThreadDispatcher> Dispatcher;
+	TUniquePtr<FUnrealMcpBridgeServer> BridgeServer;
+	TUniquePtr<FUnrealMcpSidecarManager> SidecarManager;
+	TUniquePtr<FUnrealMcpExtensionManager> ExtensionManager;
+};
+
+void UUnrealMcpRuntimeSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+
+	// §12.6: install the RUNTIME world resolver BEFORE any tool body can run, so a runtime tool resolves the
+	// live game world (not the editor world). Held weakly via `this` — the subsystem outlives every tool call
+	// (it owns the bridge), and Deinitialize clears the resolver, so the captured `this` never dangles.
+	FUnrealMcpWorldProvider::SetWorldResolver([this]() -> UWorld*
+	{
+		const UGameInstance* GI = GetGameInstance();
+		return GI ? GI->GetWorld() : nullptr;
+	});
+
+	// Build the runtime-owned machinery (mirrors FUnrealMcpEditorCoordinator, §12.3 Model A) — registry +
+	// runtime-safe families + dispatcher + bridge. Editor-only families are NOT registered here (this path
+	// runs in a packaged game where they would not compile/link); R4 adds the remaining runtime-safe families.
+	Impl = MakePimpl<FRuntimeImpl>();
+	Impl->Registry = MakeUnique<FUnrealMcpToolRegistry>();
+	UnrealMcpPingTool::Register(*Impl->Registry);
+
+	Impl->Dispatcher = MakeUnique<FUnrealMcpGameThreadDispatcher>();
+	Impl->BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(*Impl->Registry, *Impl->Dispatcher);
+
+	// Discover §5 extension providers and merge them BEFORE the bridge arms, so the first manifest a sidecar
+	// reads on a later Connect already includes them; a late register/unregister re-pushes the manifest.
+	Impl->ExtensionManager = MakeUnique<FUnrealMcpExtensionManager>(
+		*Impl->Registry,
+		[this]() { if (Impl && Impl->BridgeServer.IsValid()) Impl->BridgeServer->PushManifest(); });
+	Impl->ExtensionManager->Startup();
+
+	const FString ProjectPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
+	const FString EngineVersion = FEngineVersion::Current().ToString();
+
+	FString PluginVersion = TEXT("0.1.0");
+	if (TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("UnrealMCP")))
+		PluginVersion = Plugin->GetDescriptor().VersionName;
+
+	// Generate the one-shot IPC token ONCE (§1.4): the bridge validates the handshake against it and every
+	// Connect hands the SAME token to the sidecar over stdin, so both sides agree across reconnects.
+	IpcToken = FUnrealMcpSidecarManager::GenerateToken();
+
+	// ARM the loopback listener now (the bridge accepts on its own thread) — but DO NOT spawn the sidecar
+	// and DO NOT push a connection config yet. A game that never calls Connect() spawns zero child processes
+	// (§12.4). The effective config is supplied at Connect() time, not here.
+	BoundPort = Impl->BridgeServer->Start(IpcToken, ProjectPath, PluginVersion, EngineVersion, /*EffectiveConfig*/ nullptr);
+	if (BoundPort <= 0)
+	{
+		UE_LOG(LogUnrealMcp, Error,
+			TEXT("[Unreal-MCP] runtime bridge listener failed to arm; Connect() will be rejected until a port binds."));
+	}
+	else
+	{
+		UE_LOG(LogUnrealMcp, Log,
+			TEXT("[Unreal-MCP] runtime subsystem initialized (listener armed on port %d, NOT connected — call Connect() to opt in)."),
+			BoundPort);
+	}
+
+	RegisterConsoleCommands();
+}
+
+void UUnrealMcpRuntimeSubsystem::Deinitialize()
+{
+	UnregisterConsoleCommands();
+
+	if (Impl)
+	{
+		// §1.5 graceful teardown ordering (mirrors the editor coordinator): stop auto-restarts so the bridge's
+		// Bye is not undone by a relaunch, let the bridge send `shutdown`, give the child a bounded grace, then
+		// terminate as a backstop — so closing the game leaves no orphaned sidecar (§12.4 DoD).
+		if (Impl->SidecarManager.IsValid())
+			Impl->SidecarManager->StopRestarts();
+
+		if (Impl->BridgeServer.IsValid())
+		{
+			Impl->BridgeServer->Shutdown(); // sends the §1.5 `shutdown` Bye to a connected sidecar, then tears down
+			Impl->BridgeServer.Reset();
+		}
+
+		if (Impl->SidecarManager.IsValid())
+		{
+			Impl->SidecarManager->WaitForExit(FTimespan::FromSeconds(3)); // bounded grace for a clean self-exit
+			Impl->SidecarManager->Stop();                                 // backstop: TerminateProc if still alive
+			Impl->SidecarManager.Reset();
+		}
+
+		if (Impl->ExtensionManager.IsValid())
+		{
+			Impl->ExtensionManager->Shutdown();
+			Impl->ExtensionManager.Reset();
+		}
+
+		Impl->Dispatcher.Reset();
+		Impl->Registry.Reset();
+		Impl.Reset();
+	}
+	BoundPort = -1;
+
+	// §12.6: drop the runtime world resolver so no stale `this`-capturing lambda survives this subsystem.
+	FUnrealMcpWorldProvider::ClearWorldResolver();
+
+	Super::Deinitialize();
+}
+
+bool UUnrealMcpRuntimeSubsystem::Connect(const FString& Host, const FString& Token,
+	EUnrealMcpRuntimeConnectionMode Mode, bool bAllowRemoteHost)
+{
+	// --- Security gate 4 (§12.8): the kill switch. Default FALSE — a shipped game does not expose its
+	// in-game MCP surface unless the developer turned the setting on. ---
+	const UUnrealMcpRuntimeSettings* Settings = GetDefault<UUnrealMcpRuntimeSettings>();
+	if (!Settings || !Settings->bRuntimeMcpEnabled)
+	{
+		UE_LOG(LogUnrealMcp, Warning,
+			TEXT("[Unreal-MCP] runtime Connect rejected: the runtime kill switch (UUnrealMcpRuntimeSettings::bRuntimeMcpEnabled) is off. ")
+			TEXT("Enable it in Project Settings -> Plugins -> Unreal MCP (Runtime) to opt in."));
+		return false;
+	}
+
+	// --- Security gate 3 (§12.8): build-config gating. In a Shipping build with UNREAL_MCP_ALLOW_SHIPPING==0,
+	// reject regardless of the kill switch. Guarded so the dead branch is stripped from non-Shipping builds. ---
+#if UE_BUILD_SHIPPING && (UNREAL_MCP_ALLOW_SHIPPING == 0)
+	// Host/Token/Mode/bAllowRemoteHost are unused on this branch (the §else branch consumes them); silence the
+	// unused-parameter warning so a Shipping compile stays clean under -WarningsAsErrors.
+	(void)Host; (void)Token; (void)Mode; (void)bAllowRemoteHost;
+	UE_LOG(LogUnrealMcp, Warning,
+		TEXT("[Unreal-MCP] runtime Connect rejected: this is a Shipping build and bUnrealMcpAllowShipping is off ")
+		TEXT("(UNREAL_MCP_ALLOW_SHIPPING=0). Enable the Build.cs flag to permit runtime MCP in Shipping."));
+	return false;
+#else
+
+	// --- Security gate 5 (§12.8): loopback-host default. Reject a non-loopback host unless explicitly allowed. ---
+	if (!bAllowRemoteHost && !IsLoopbackHost(Host))
+	{
+		UE_LOG(LogUnrealMcp, Warning,
+			TEXT("[Unreal-MCP] runtime Connect rejected: host '%s' is not loopback and bAllowRemoteHost is false. ")
+			TEXT("Pass bAllowRemoteHost=true to connect to a remote host (you accept the remote-control exposure)."),
+			*Host);
+		return false;
+	}
+
+	// The listener must be armed (Initialize bound a port) before a sidecar can dial in.
+	if (BoundPort <= 0 || !Impl || !Impl->BridgeServer.IsValid())
+	{
+		UE_LOG(LogUnrealMcp, Error,
+			TEXT("[Unreal-MCP] runtime Connect rejected: the loopback listener is not armed (Initialize failed to bind a port)."));
+		return false;
+	}
+
+	// Build the effective connection config the bridge pushes to the sidecar (§1.3 `config` / handshake-ack).
+	// Start from the resolved §8 config so disk/.env/env defaults apply, then override with the explicit
+	// Connect arguments (the in-game caller's intent wins over persisted config).
+	FUnrealMcpConfig Config = FUnrealMcpConfig::LoadAndResolve();
+	Config.ConnectionMode = (Mode == EUnrealMcpRuntimeConnectionMode::Cloud)
+		? EUnrealMcpConnectionMode::Cloud
+		: EUnrealMcpConnectionMode::Custom;
+	if (Mode == EUnrealMcpRuntimeConnectionMode::Custom)
+	{
+		Config.CustomHost = Host;
+		if (!Token.IsEmpty())
+		{
+			Config.CustomToken = Token;
+			Config.AuthOption = EUnrealMcpAuthOption::Required;
+		}
+	}
+	else
+	{
+		// Cloud: Host overrides the cloud base URL; Token is the cloud bearer.
+		if (!Host.IsEmpty())
+			Config.CloudUrl = Host;
+		if (!Token.IsEmpty())
+			Config.CloudToken = Token;
+	}
+	Config.bKeepConnected = true; // §12.4: the runtime config push carries keepConnected:true
+
+	const TSharedPtr<FJsonObject> EffectiveConfig = Config.BuildEffectiveConnectionConfig();
+	Impl->BridgeServer->SetEffectiveConfig(EffectiveConfig); // also pushes the §1.3 `config` if a sidecar is already up
+
+	// Spawn the sidecar (§12.4: deferred to Connect so a never-connecting game spawns zero child procs). The
+	// sidecar dials the armed loopback port and authenticates with IpcToken over stdin (§1.4).
+	if (!Impl->SidecarManager.IsValid())
+		Impl->SidecarManager = MakeUnique<FUnrealMcpSidecarManager>();
+
+	if (Impl->SidecarManager->IsRunning())
+	{
+		// Already connected/connecting: the SetEffectiveConfig above re-pushed the new config to the live
+		// sidecar. Treat as success (idempotent reconnect with updated target).
+		UE_LOG(LogUnrealMcp, Log,
+			TEXT("[Unreal-MCP] runtime Connect: sidecar already running; pushed updated config (mode=%s, host=%s)."),
+			Mode == EUnrealMcpRuntimeConnectionMode::Cloud ? TEXT("Cloud") : TEXT("Custom"), *Host);
+		return true;
+	}
+
+	const bool bSpawned = Impl->SidecarManager->StartForPort(BoundPort, IpcToken);
+	if (!bSpawned)
+	{
+		UE_LOG(LogUnrealMcp, Error,
+			TEXT("[Unreal-MCP] runtime Connect: bridge sidecar binary could not be resolved (packaged-without-<rid> ")
+			TEXT("or unset UNREAL_MCP_BRIDGE_PATH); no connection established."));
+		return false;
+	}
+
+	UE_LOG(LogUnrealMcp, Log,
+		TEXT("[Unreal-MCP] runtime Connect: sidecar spawned, dialing loopback port %d (mode=%s, host=%s, token=%s)."),
+		BoundPort, Mode == EUnrealMcpRuntimeConnectionMode::Cloud ? TEXT("Cloud") : TEXT("Custom"),
+		*Host, *FUnrealMcpConfig::MaskSecret(Token));
+	return true;
+#endif // UE_BUILD_SHIPPING && UNREAL_MCP_ALLOW_SHIPPING==0
+}
+
+void UUnrealMcpRuntimeSubsystem::Disconnect()
+{
+	if (!Impl || !Impl->SidecarManager.IsValid())
+		return;
+
+	// Tear DOWN the sidecar but leave the bridge listener ARMED, so a later Connect() can re-spawn the sidecar
+	// against the same port/token without a full re-Initialize. (Deinitialize is the one that shuts the bridge.)
+	// §1.5 graceful teardown ordering: stop restarts so the watchdog does not relaunch, bounded grace for a
+	// clean self-exit, then terminate as a backstop. When the sidecar exits, the bridge's reader observes the
+	// dropped connection and bClientConnected falls to false (IsConnected() then reports false).
+	Impl->SidecarManager->StopRestarts();
+	Impl->SidecarManager->WaitForExit(FTimespan::FromSeconds(3));
+	Impl->SidecarManager->Stop();
+	Impl->SidecarManager.Reset();
+
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] runtime Disconnect: sidecar torn down (no orphan); listener still armed."));
+}
+
+bool UUnrealMcpRuntimeSubsystem::IsConnected() const
+{
+	return Impl
+		&& Impl->SidecarManager.IsValid() && Impl->SidecarManager->IsRunning()
+		&& Impl->BridgeServer.IsValid() && Impl->BridgeServer->IsClientConnected();
+}
+
+UUnrealMcpRuntimeSubsystem* UUnrealMcpRuntimeSubsystem::Get(const UObject* WorldContext)
+{
+	if (!WorldContext)
+		return nullptr;
+	const UWorld* World = WorldContext->GetWorld();
+	if (!World)
+		return nullptr;
+	UGameInstance* GI = World->GetGameInstance();
+	return GI ? GI->GetSubsystem<UUnrealMcpRuntimeSubsystem>() : nullptr;
+}
+
+bool UUnrealMcpRuntimeSubsystem::IsLoopbackHost(const FString& Host)
+{
+	if (Host.IsEmpty())
+		return true; // empty host resolves to the default loopback server (§8 DefaultCustomHost is localhost)
+
+	// Extract the hostname from a possibly-schemed URL (e.g. "http://localhost:8080" -> "localhost").
+	FString Work = Host;
+	int32 SchemeIdx;
+	if (Work.FindChar(TEXT(':'), SchemeIdx) && Work.Mid(SchemeIdx).StartsWith(TEXT("://")))
+		Work = Work.RightChop(SchemeIdx + 3);
+
+	// Strip any path / query.
+	int32 SlashIdx;
+	if (Work.FindChar(TEXT('/'), SlashIdx))
+		Work = Work.Left(SlashIdx);
+
+	// Strip a port. IPv6 literals are bracketed ("[::1]:8080"); handle that before the generic colon split.
+	if (Work.StartsWith(TEXT("[")))
+	{
+		int32 CloseIdx;
+		if (Work.FindChar(TEXT(']'), CloseIdx))
+			Work = Work.Mid(1, CloseIdx - 1);
+	}
+	else
+	{
+		int32 ColonIdx;
+		if (Work.FindChar(TEXT(':'), ColonIdx))
+			Work = Work.Left(ColonIdx);
+	}
+
+	Work = Work.TrimStartAndEnd().ToLower();
+	return Work == TEXT("localhost")
+		|| Work == TEXT("127.0.0.1")
+		|| Work.StartsWith(TEXT("127.")) // the whole 127.0.0.0/8 loopback block
+		|| Work == TEXT("::1")
+		|| Work == TEXT("0:0:0:0:0:0:0:1");
+}
+
+void UUnrealMcpRuntimeSubsystem::RegisterConsoleCommands()
+{
+	if (ConnectCommand || DisconnectCommand)
+		return; // idempotent
+
+	// `UnrealMcp.Connect <host> [token]` — QA opt-in without a recompile (§12.4). Loopback-only by default
+	// (the console path never passes bAllowRemoteHost; a remote host is rejected exactly like the API).
+	ConnectCommand = IConsoleManager::Get().RegisterConsoleCommand(
+		TEXT("UnrealMcp.Connect"),
+		TEXT("Connect the runtime MCP bridge: UnrealMcp.Connect <host> [token]. Loopback hosts only."),
+		FConsoleCommandWithArgsDelegate::CreateUObject(this, &UUnrealMcpRuntimeSubsystem::HandleConnectCommand),
+		ECVF_Default);
+
+	DisconnectCommand = IConsoleManager::Get().RegisterConsoleCommand(
+		TEXT("UnrealMcp.Disconnect"),
+		TEXT("Disconnect the runtime MCP bridge and tear down the sidecar."),
+		FConsoleCommandDelegate::CreateUObject(this, &UUnrealMcpRuntimeSubsystem::Disconnect),
+		ECVF_Default);
+}
+
+void UUnrealMcpRuntimeSubsystem::UnregisterConsoleCommands()
+{
+	if (ConnectCommand)
+	{
+		IConsoleManager::Get().UnregisterConsoleObject(ConnectCommand);
+		ConnectCommand = nullptr;
+	}
+	if (DisconnectCommand)
+	{
+		IConsoleManager::Get().UnregisterConsoleObject(DisconnectCommand);
+		DisconnectCommand = nullptr;
+	}
+}
+
+void UUnrealMcpRuntimeSubsystem::HandleConnectCommand(const TArray<FString>& Args)
+{
+	if (Args.Num() < 1)
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] usage: UnrealMcp.Connect <host> [token]"));
+		return;
+	}
+
+	const FString Host = Args[0];
+	const FString Token = Args.Num() >= 2 ? Args[1] : FString();
+	// The console path never passes bAllowRemoteHost — a remote host is rejected exactly like the API (§12.8 #5).
+	Connect(Host, Token, EUnrealMcpRuntimeConnectionMode::Custom, /*bAllowRemoteHost*/ false);
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
@@ -215,6 +215,12 @@ bool UUnrealMcpRuntimeSubsystem::Connect(const FString& Host, const FString& Tok
 	const TSharedPtr<FJsonObject> EffectiveConfig = Config.BuildEffectiveConnectionConfig();
 	Impl->BridgeServer->SetEffectiveConfig(EffectiveConfig); // also pushes the §1.3 `config` if a sidecar is already up
 
+	// Display values for the connection logs below: the mode label, and a host that falls back to a
+	// readable "(default)" when no Host override was passed (Cloud with no override resolves to the
+	// default cloud URL, Custom to the §8 default host) instead of logging an empty string.
+	const TCHAR* const ModeForLog = Mode == EUnrealMcpRuntimeConnectionMode::Cloud ? TEXT("Cloud") : TEXT("Custom");
+	const FString HostForLog = Host.IsEmpty() ? TEXT("(default)") : Host;
+
 	// Spawn the sidecar (§12.4: deferred to Connect so a never-connecting game spawns zero child procs). The
 	// sidecar dials the armed loopback port and authenticates with IpcToken over stdin (§1.4).
 	if (!Impl->SidecarManager.IsValid())
@@ -226,7 +232,7 @@ bool UUnrealMcpRuntimeSubsystem::Connect(const FString& Host, const FString& Tok
 		// sidecar. Treat as success (idempotent reconnect with updated target).
 		UE_LOG(LogUnrealMcp, Log,
 			TEXT("[Unreal-MCP] runtime Connect: sidecar already running; pushed updated config (mode=%s, host=%s)."),
-			Mode == EUnrealMcpRuntimeConnectionMode::Cloud ? TEXT("Cloud") : TEXT("Custom"), *Host);
+			ModeForLog, *HostForLog);
 		return true;
 	}
 
@@ -241,8 +247,7 @@ bool UUnrealMcpRuntimeSubsystem::Connect(const FString& Host, const FString& Tok
 
 	UE_LOG(LogUnrealMcp, Log,
 		TEXT("[Unreal-MCP] runtime Connect: sidecar spawned, dialing loopback port %d (mode=%s, host=%s, token=%s)."),
-		BoundPort, Mode == EUnrealMcpRuntimeConnectionMode::Cloud ? TEXT("Cloud") : TEXT("Custom"),
-		*Host, *FUnrealMcpConfig::MaskSecret(Token));
+		BoundPort, ModeForLog, *HostForLog, *FUnrealMcpConfig::MaskSecret(Token));
 	return true;
 #endif // UE_BUILD_SHIPPING && UNREAL_MCP_ALLOW_SHIPPING==0
 }

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeSettings.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeSettings.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DeveloperSettings.h"
+#include "UnrealMcpRuntimeSettings.generated.h"
+
+/**
+ * Project-level kill switch for the runtime (in-game) MCP connection (docs/ARCHITECTURE.md §12.8 #4).
+ *
+ * Persisted in DefaultGame.ini under [/Script/UnrealMcpRuntime.UnrealMcpRuntimeSettings] and surfaced in
+ * Project Settings → Plugins → "Unreal MCP (Runtime)". The single setting `bRuntimeMcpEnabled` defaults
+ * to FALSE: a shipped/packaged game that ships with the plugin does NOT expose its in-game MCP remote-control
+ * surface unless the developer flips this flag on purpose. UUnrealMcpRuntimeSubsystem::Connect() short-circuits
+ * (returns false + logs) while the flag is off — one of the five layered runtime-security mitigations (the
+ * others: explicit-opt-in-only Connect, loopback IPC + one-shot stdin token, the bUnrealMcpAllowShipping Build
+ * flag, and the loopback-host default that rejects remote hosts without bAllowRemoteHost).
+ *
+ * This is the analog of Unity's runtime opt-in gate. It is a Game-config setting (not Editor) so it travels
+ * into a packaged build, exactly where the gate must take effect.
+ */
+UCLASS(Config = Game, DefaultConfig, meta = (DisplayName = "Unreal MCP (Runtime)"))
+class UNREALMCPRUNTIME_API UUnrealMcpRuntimeSettings : public UDeveloperSettings
+{
+	GENERATED_BODY()
+
+public:
+	UUnrealMcpRuntimeSettings();
+
+	/**
+	 * Master enable for the runtime (in-game) MCP connection. Default FALSE (§12.8 #4): while off, every
+	 * Connect() call is rejected with a log line and no sidecar is spawned. Turning it on does NOT cause an
+	 * auto-connect — a connection still requires an explicit Connect() call (the §12.8 #1 invariant).
+	 */
+	UPROPERTY(Config, EditAnywhere, Category = "Runtime",
+		meta = (DisplayName = "Enable Runtime MCP",
+			ToolTip = "When off (default), in-game UUnrealMcpRuntimeSubsystem::Connect() is rejected. This is a security kill switch; even when on, a connection still requires an explicit Connect() call (the plugin never auto-connects)."))
+	bool bRuntimeMcpEnabled = false;
+
+	/** Settings-category placement helpers (Project Settings → Plugins). */
+	virtual FName GetCategoryName() const override;
+};

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeSubsystem.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeSubsystem.h
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "Templates/PimplPtr.h"
+#include "UnrealMcpRuntimeSubsystem.generated.h"
+
+// The runtime-owned machinery (registry/dispatcher/bridge/sidecar/extensions) is held behind a PImpl
+// (FRuntimeImpl, defined in the .cpp) so this PUBLIC header forward-declares nothing module-private and the
+// TUniquePtr<incomplete-type> members never reach UHT's generated vtable-helper ctor in the .gen.cpp (which,
+// in the Game-target / non-unity BuildPlugin compile, would otherwise C4150 on incomplete member types).
+// TPimplPtr is purpose-built for forward-declared PImpl: it captures a typed deleter at MakePimpl time, so a
+// TPimplPtr<FRuntimeImpl> member destroys correctly even where FRuntimeImpl is incomplete.
+
+/**
+ * Which MCP server a runtime Connect() targets (docs/ARCHITECTURE.md §12.4). Blueprint-exposed analog of
+ * the internal FUnrealMcpConfig EUnrealMcpConnectionMode (which is a plain C++ enum, not UENUM). Custom is
+ * the default for runtime: a game typically dials a developer-supplied loopback server.
+ */
+UENUM(BlueprintType)
+enum class EUnrealMcpRuntimeConnectionMode : uint8
+{
+	/** A developer-supplied server URL (local dev server, self-hosted, …). The runtime default. */
+	Custom,
+	/** The hosted ai-game.dev cloud server. */
+	Cloud
+};
+
+/**
+ * The runtime (in-game) bootstrap for Unreal-MCP (docs/ARCHITECTURE.md §12.4) — the UE analog of Unity's
+ * `UnityMcpPluginRuntime.Initialize().Build().Connect()`. A UGameInstanceSubsystem, so it is auto-instantiated
+ * once per UGameInstance (PIE, Standalone, packaged Development/Shipping) — but it NEVER auto-connects.
+ *
+ * Lifecycle:
+ *  - Initialize(): builds the registry + runtime-safe tool families + game-thread dispatcher + IPC bridge
+ *    server, generates the one-shot token, and ARMS the loopback listener (BridgeServer->Start). It does
+ *    NOT spawn the sidecar and does NOT connect. It also installs the §12.6 RUNTIME world resolver
+ *    (`GetGameInstance()->GetWorld()`) into FUnrealMcpWorldProvider so runtime tool bodies resolve the live
+ *    game world.
+ *  - Connect(): the single explicit opt-in entry point. Spawns the sidecar (SidecarManager->StartForPort)
+ *    and pushes the §1.3 `config` IPC message with keepConnected:true and the resolved host/token/mode.
+ *  - Disconnect(): tears the sidecar down (orphan-safe).
+ *  - Deinitialize(): graceful teardown — stops the sidecar, tears down the bridge, clears the world resolver.
+ *
+ * SECURITY (§12.8 — RCE-class surface if reachable; all mitigations enforced in Connect):
+ *  1. Explicit opt-in only — auto-instantiated, never auto-connecting. NO RuntimeInitializeOnLoadMethod
+ *     auto-dial, NO config-asset auto-connect. (Review-gated invariant.)
+ *  2. Loopback IPC + one-shot stdin token (inherited from FUnrealMcpBridgeServer / FUnrealMcpSidecarManager).
+ *  3. Build-config gating: bUnrealMcpAllowShipping Build.cs flag → UNREAL_MCP_ALLOW_SHIPPING. With 0, Connect
+ *     in a Shipping build logs + returns false.
+ *  4. Kill switch: UUnrealMcpRuntimeSettings::bRuntimeMcpEnabled default FALSE → Connect short-circuits.
+ *  5. Loopback-host default: Connect rejects non-loopback hosts unless bAllowRemoteHost is passed.
+ *
+ * QA convenience without a recompile: the console commands `UnrealMcp.Connect <host> [token]` and
+ * `UnrealMcp.Disconnect` (registered in Initialize, de-registered in Deinitialize) drive Connect/Disconnect
+ * on the active game instance's subsystem.
+ */
+UCLASS()
+class UNREALMCPRUNTIME_API UUnrealMcpRuntimeSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	// UGameInstanceSubsystem ----------------------------------------------------------------------
+	/** Build registry/dispatcher/bridge, arm the listener, install the runtime world resolver. NO connect. */
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	/** Orphan-safe sidecar teardown + bridge shutdown + world-resolver clear. */
+	virtual void Deinitialize() override;
+
+	/**
+	 * Explicit opt-in connect (§12.4) — the ONLY path that spawns the sidecar and connects. Spawns the
+	 * bridge sidecar and pushes the §1.3 `config` (keepConnected:true) with the resolved host/token/mode.
+	 *
+	 * Returns false (and connects nothing) when ANY security gate rejects:
+	 *  - the UUnrealMcpRuntimeSettings kill switch is off (§12.8 #4);
+	 *  - the build is Shipping and UNREAL_MCP_ALLOW_SHIPPING == 0 (§12.8 #3);
+	 *  - @p Host is non-loopback and @p bAllowRemoteHost is false (§12.8 #5);
+	 *  - the listener never armed (Initialize failed to bind a port);
+	 *  - the sidecar binary cannot be resolved (packaged-without-<rid> / unset UNREAL_MCP_BRIDGE_PATH).
+	 *
+	 * @param Host             the server URL to connect to (e.g. "http://localhost:8080").
+	 * @param Token            optional bearer token; empty means anonymous (Custom+None).
+	 * @param Mode             Custom (default) or Cloud.
+	 * @param bAllowRemoteHost set true to permit a non-loopback @p Host (off by default, §12.8 #5).
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Unreal MCP",
+		meta = (AdvancedDisplay = "Token,Mode,bAllowRemoteHost", AutoCreateRefTerm = "Token"))
+	bool Connect(const FString& Host, const FString& Token = TEXT(""),
+		EUnrealMcpRuntimeConnectionMode Mode = EUnrealMcpRuntimeConnectionMode::Custom,
+		bool bAllowRemoteHost = false);
+
+	/** Tear down the sidecar (orphan-safe). Idempotent — a no-op when not connected. */
+	UFUNCTION(BlueprintCallable, Category = "Unreal MCP")
+	void Disconnect();
+
+	/** True when a sidecar is connected and handshaken over the runtime bridge. */
+	UFUNCTION(BlueprintPure, Category = "Unreal MCP")
+	bool IsConnected() const;
+
+	/**
+	 * The runtime subsystem for @p WorldContext's game instance, or null when none (no world / no game
+	 * instance / subsystem not created). Convenience for the §12.4 BeginPlay snippet and console commands.
+	 */
+	UFUNCTION(BlueprintPure, Category = "Unreal MCP", meta = (WorldContext = "WorldContext"))
+	static UUnrealMcpRuntimeSubsystem* Get(const UObject* WorldContext);
+
+	/** Whether the loopback listener armed (a port is bound). False means Initialize failed to bind. */
+	bool IsListenerArmed() const { return BoundPort > 0; }
+
+	/**
+	 * True when @p Host resolves to a loopback address (localhost / the 127.0.0.0/8 block / ::1). Pure +
+	 * static + exported so the §12.8 #5 loopback-host policy is unit-testable without standing up a sidecar.
+	 * An empty host counts as loopback (it resolves to the §8 DefaultCustomHost, which is localhost).
+	 */
+	static bool IsLoopbackHost(const FString& Host);
+
+private:
+	/** Register / unregister the QA console commands (UnrealMcp.Connect / UnrealMcp.Disconnect). */
+	void RegisterConsoleCommands();
+	void UnregisterConsoleCommands();
+
+	/** `UnrealMcp.Connect <host> [token]` handler: parse args and call Connect (loopback-only, Custom mode). */
+	void HandleConnectCommand(const TArray<FString>& Args);
+
+	// Runtime-owned machinery (registry/dispatcher/bridge/sidecar/extensions — mirrors FUnrealMcpEditorCoordinator,
+	// §12.3 Model A) held behind a PImpl defined in the .cpp. See the file-top note for why this is a PImpl and
+	// not a set of forward-declared TUniquePtr members.
+	struct FRuntimeImpl;
+	TPimplPtr<FRuntimeImpl> Impl;
+
+	/** The one-shot IPC token generated in Initialize; reused by every Connect (bridge + sidecar agree, §1.4). */
+	FString IpcToken;
+	/** The bound loopback port from BridgeServer->Start; > 0 once the listener armed. */
+	int32 BoundPort = -1;
+
+	/** The console-command objects (owned by IConsoleManager; we hold them to deregister in Deinitialize). */
+	IConsoleObject* ConnectCommand = nullptr;
+	IConsoleObject* DisconnectCommand = nullptr;
+};

--- a/UnrealMCP/Source/UnrealMcpRuntime/UnrealMcpRuntime.Build.cs
+++ b/UnrealMCP/Source/UnrealMcpRuntime/UnrealMcpRuntime.Build.cs
@@ -17,6 +17,14 @@ public class UnrealMcpRuntime : ModuleRules
 			// that includes them across the .dll boundary (BuildPlugin compiles this module without the editor's
 			// shared PCH, which previously supplied the transitive include). PUBLIC, not Private, for that reason.
 			"Json",
+			// R3 (§12.4): the public headers UnrealMcpRuntimeSubsystem.h / UnrealMcpRuntimeSettings.h are
+			// UObject types. CoreUObject (UCLASS/GENERATED_BODY), Engine (UGameInstanceSubsystem in
+			// Subsystems/GameInstanceSubsystem.h) and DeveloperSettings (UDeveloperSettings, the kill-switch
+			// base) must be PUBLIC so any module including these headers across the .dll boundary (e.g. the
+			// editor module, which depends on UnrealMcpRuntime publicly) compiles + links them.
+			"CoreUObject",
+			"Engine",
+			"DeveloperSettings",
 		});
 
 		// The engine-agnostic, NON-editor machinery the runtime module owns (docs/ARCHITECTURE.md §12.1):
@@ -30,8 +38,7 @@ public class UnrealMcpRuntime : ModuleRules
 		// UnrealMcpEditor.Build.cs. This module must remain GEditor-free (R1 grep gate) and packageable.
 		PrivateDependencyModuleNames.AddRange(new string[]
 		{
-			"CoreUObject",
-			"Engine",
+			// CoreUObject + Engine are PUBLIC deps (above) — the R3 public UObject headers expose them.
 			"Networking",
 			"Sockets",
 			"JsonUtilities",
@@ -40,6 +47,14 @@ public class UnrealMcpRuntime : ModuleRules
 			"RenderCore",
 			"RHI",
 		});
+
+		// R3 (§12.8 #3): the bUnrealMcpAllowShipping Build flag (default false) → UNREAL_MCP_ALLOW_SHIPPING.
+		// With 0, UUnrealMcpRuntimeSubsystem::Connect() in a Shipping build logs + returns false — the
+		// conservative adopted default (Open question 1). A consumer who deliberately wants runtime MCP in a
+		// Shipping build sets bUnrealMcpAllowShipping=true (e.g. via a Target.cs global define or a fork).
+		// PublicDefinitions so the guard value is visible to any module that compiles against this one.
+		bool bUnrealMcpAllowShipping = false;
+		PublicDefinitions.Add("UNREAL_MCP_ALLOW_SHIPPING=" + (bUnrealMcpAllowShipping ? "1" : "0"));
 
 		// NOTE (R2): RuntimeDependencies.Add(.../UnrealMcpBridge/<rid>/*) deliberately stays in
 		// UnrealMcpEditor.Build.cs for now. Moving it here (so the sidecar bundles into packaged GAMES) is


### PR DESCRIPTION
## Summary
- Add `UUnrealMcpRuntimeSubsystem` (UGameInstanceSubsystem, docs/ARCHITECTURE.md §12.4): auto-instantiated per UGameInstance but **never auto-connects**. `Initialize` builds the registry + runtime-safe `ping` family + dispatcher + bridge, arms the loopback listener, and installs the §12.6 runtime world resolver; it does NOT spawn the sidecar. `Connect()` is the single explicit opt-in entry (spawns the sidecar, pushes the §1.3 `config` with `keepConnected:true`). `Disconnect()` / `IsConnected()` / static `Get()` round it out; `Deinitialize` is orphan-safe.
- Security guards (conservative §12.8 defaults): `UUnrealMcpRuntimeSettings` kill switch `bRuntimeMcpEnabled` default **FALSE**; `bUnrealMcpAllowShipping` Build flag default false → `UNREAL_MCP_ALLOW_SHIPPING 0` (Connect in Shipping rejects); Connect rejects non-loopback hosts unless `bAllowRemoteHost`.
- **Hard invariant:** no path connects without an explicit developer call — no `RuntimeInitializeOnLoadMethod` auto-dial, no config-asset auto-connect.
- Blueprint Connect/Disconnect/IsConnected nodes + console commands `UnrealMcp.Connect <host> [token]` / `UnrealMcp.Disconnect` for QA. Editor behaviour unchanged.

## Test plan
- [x] Editor UBT build (Suite 1) — exit 0
- [x] RunUAT BuildPlugin (Suite 1b — Game+Editor, Shipping config, marketplace `-WarningsAsErrors`) — BUILD SUCCESSFUL
- [x] Headless boot smoke (Suite 2) — `[Unreal-MCP] plugin loaded`, clean shutdown
- [x] Automation `UnrealMcp.*` (Suite 3) — 255 succeeded / 0 failed (incl. new `UnrealMcp.RuntimeSubsystem` specs: loopback-host policy, kill-switch + remote-host Connect rejection, world-provider switching)
- [x] Live `-game` console `Connect` → bridge sidecar → `gamedev-mcp-server` handshake successful; game exit → no orphaned sidecar (kill-switch enabled via ini override for the live run; Automation proves the default-off rejection)

Closes #119