### PR TITLE
Runtime-safe tool families (actor spawn branch, console/reflection, screenshot, level-get-data) (#121)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpEditorTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpEditorTools.cpp
@@ -4,11 +4,9 @@
 #include "UnrealMcpCoreTools.h"
 #include "UnrealMcpToolRegistry.h"
 #include "Tools/UnrealMcpObjectRef.h"
-#include "Tools/UnrealMcpLogCollector.h"
 
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
-#include "JsonObjectConverter.h"
 #include "Editor.h"
 #include "Editor/EditorEngine.h"
 #include "Engine/Engine.h"
@@ -16,28 +14,23 @@
 #include "Engine/World.h"
 #include "GameFramework/Actor.h"
 #include "Misc/PackageName.h"
-#include "Misc/StringOutputDevice.h"
 #include "PlayInEditorDataTypes.h"
 #include "ScopedTransaction.h"
-#include "UObject/Class.h"
-#include "UObject/Script.h"
-#include "UObject/UnrealType.h"
-#include "UObject/UObjectIterator.h"
 
 /**
- * The editor / console / reflection tool family (docs/ARCHITECTURE.md §10 "editor/reflection family").
- *
- * Nine native C++ tools, all declared via the §3.3 builder and run ON the game thread (the bridge
- * dispatches Registry.Execute through FUnrealMcpGameThreadDispatcher, §4):
+ * The editor-application / selection tool family (docs/ARCHITECTURE.md §10 "editor/reflection family"
+ * editor-only subset, issue #19). Four native C++ EDITOR-ONLY tools, all declared via the §3.3 builder
+ * and run ON the game thread (the bridge dispatches Registry.Execute through
+ * FUnrealMcpGameThreadDispatcher, §4):
  *   - editor-application-get-state / editor-application-set-state — PIE state snapshot + start/stop/
  *     pause/resume. Transitions are LATENT (RequestPlaySession/RequestEndPlayMap fire next tick), so
  *     set-state returns an honest `pending` rather than a false "done".
  *   - editor-selection-get / editor-selection-set — actor selection read/write via §3.2 refs.
- *   - console-get-logs / console-clear-logs — filtered/paginated slices of the FUnrealMcpLogCollector
- *     GLog ring buffer (registered at module startup), and a clear.
- *   - console-run-command — GEngine->Exec with captured output.
- *   - reflection-method-find / reflection-method-call — UFunction discovery + safety-gated invocation
- *     (ProcessEvent over a constructed param frame; §3.2 JSON arg mapping).
+ *
+ * The RUNTIME-SAFE subset of the original editor/reflection family — console-get-logs / console-clear-logs,
+ * console-run-command, reflection-method-find / reflection-method-call — moved DOWN into the runtime
+ * module's UnrealMcpConsoleReflectionTools in R4 (§12.7). These four tools stay editor-only because they
+ * depend on GEditor (PIE control, the editor selection set), which does not exist in a packaged game.
  */
 namespace
 {
@@ -54,17 +47,6 @@ namespace
 		if (!Desc.IsEmpty())
 			Schema->SetStringField(TEXT("description"), Desc);
 		Schema->SetObjectField(TEXT("items"), Items);
-		return Schema;
-	}
-
-	/** A free-form `{ key: value }` argument bag (reflection-method-call's `args`). */
-	TSharedPtr<FJsonObject> MakeArgsBagSchema(const FString& Desc)
-	{
-		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
-		Schema->SetStringField(TEXT("type"), TEXT("object"));
-		if (!Desc.IsEmpty())
-			Schema->SetStringField(TEXT("description"), Desc);
-		Schema->SetBoolField(TEXT("additionalProperties"), true);
 		return Schema;
 	}
 
@@ -101,103 +83,10 @@ namespace
 		return Out;
 	}
 
-	/** The §3.2 JSON-schema type token for a reflected FProperty (best-effort, for discovery output). */
-	FString PropertyTypeName(const FProperty* Prop)
-	{
-		if (!Prop) return TEXT("null");
-		if (Prop->IsA<FBoolProperty>()) return TEXT("boolean");
-		if (Prop->IsA<FFloatProperty>() || Prop->IsA<FDoubleProperty>()) return TEXT("number");
-		if (Prop->IsA<FByteProperty>() || Prop->IsA<FIntProperty>() || Prop->IsA<FInt64Property>()
-			|| Prop->IsA<FUInt32Property>() || Prop->IsA<FInt8Property>() || Prop->IsA<FInt16Property>()
-			|| Prop->IsA<FUInt16Property>() || Prop->IsA<FUInt64Property>())
-			return TEXT("integer");
-		if (Prop->IsA<FEnumProperty>()) return TEXT("string");
-		if (Prop->IsA<FStrProperty>() || Prop->IsA<FNameProperty>() || Prop->IsA<FTextProperty>()) return TEXT("string");
-		if (Prop->IsA<FObjectPropertyBase>() || Prop->IsA<FClassProperty>() || Prop->IsA<FSoftObjectProperty>()) return TEXT("string");
-		if (Prop->IsA<FArrayProperty>() || Prop->IsA<FSetProperty>()) return TEXT("array");
-		if (Prop->IsA<FStructProperty>() || Prop->IsA<FMapProperty>()) return TEXT("object");
-		return TEXT("string");
-	}
-
-	/** Whether @p Function is safe to invoke from a tool (the §10 safety gate). */
-	bool IsCallableFunction(const UFunction* Function)
-	{
-		if (!Function)
-			return false;
-		if (Function->HasAnyFunctionFlags(FUNC_BlueprintCallable))
-			return true;
-#if WITH_EDITORONLY_DATA
-		// CallInEditor UFUNCTIONs are explicitly editor-invocable even when not BlueprintCallable.
-		if (Function->GetBoolMetaData(TEXT("CallInEditor")))
-			return true;
-#endif
-		return false;
-	}
-
-	/**
-	 * Whether @p Function may be invoked on a class CDO (the 'class' path of reflection-method-call).
-	 * Only static or CallInEditor functions are safe there: a plain instance method run on the default
-	 * object mutates the shared class defaults (CDO pollution that serializes into new instances) and a
-	 * world-dependent instance method can crash on a world-less CDO. Instance methods must go via 'target'.
-	 */
-	bool IsCdoCallableFunction(const UFunction* Function)
-	{
-		if (!Function)
-			return false;
-		if (Function->HasAnyFunctionFlags(FUNC_Static))
-			return true;
-#if WITH_EDITORONLY_DATA
-		if (Function->GetBoolMetaData(TEXT("CallInEditor")))
-			return true;
-#endif
-		return false;
-	}
-
 	/** JSON identity for one selected actor (§3.2 ref shape; reuses the actor-family identity block). */
 	TSharedPtr<FJsonObject> SelectionIdentity(const AActor* Actor)
 	{
 		return FUnrealMcpObjectRef::ActorIdentity(Actor);
-	}
-
-	/** Build the per-function discovery descriptor for reflection-method-find. */
-	TSharedPtr<FJsonObject> DescribeFunction(UFunction* Function)
-	{
-		TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
-		Json->SetStringField(TEXT("name"), Function->GetName());
-		Json->SetStringField(TEXT("class"), Function->GetOwnerClass() ? Function->GetOwnerClass()->GetName() : FString());
-		Json->SetBoolField(TEXT("isStatic"), Function->HasAnyFunctionFlags(FUNC_Static));
-		Json->SetBoolField(TEXT("isBlueprintCallable"), Function->HasAnyFunctionFlags(FUNC_BlueprintCallable));
-		Json->SetBoolField(TEXT("isPure"), Function->HasAnyFunctionFlags(FUNC_BlueprintPure));
-		Json->SetBoolField(TEXT("isNative"), Function->HasAnyFunctionFlags(FUNC_Native));
-#if WITH_EDITORONLY_DATA
-		Json->SetBoolField(TEXT("isCallInEditor"), Function->GetBoolMetaData(TEXT("CallInEditor")));
-#else
-		Json->SetBoolField(TEXT("isCallInEditor"), false);
-#endif
-		Json->SetBoolField(TEXT("isCallable"), IsCallableFunction(Function));
-
-		TArray<TSharedPtr<FJsonValue>> Params;
-		TSharedPtr<FJsonObject> ReturnParam;
-		for (TFieldIterator<FProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
-		{
-			FProperty* Prop = *It;
-			TSharedPtr<FJsonObject> P = MakeShared<FJsonObject>();
-			P->SetStringField(TEXT("name"), Prop->GetName());
-			P->SetStringField(TEXT("type"), PropertyTypeName(Prop));
-			P->SetStringField(TEXT("cppType"), Prop->GetCPPType());
-			const bool bReturn = Prop->HasAnyPropertyFlags(CPF_ReturnParm);
-			const bool bOut = Prop->HasAnyPropertyFlags(CPF_OutParm);
-			P->SetBoolField(TEXT("isReturn"), bReturn);
-			P->SetBoolField(TEXT("isOut"), bOut && !bReturn);
-			if (bReturn)
-				ReturnParam = P;
-			else
-				Params.Add(MakeShared<FJsonValueObject>(P));
-		}
-		Json->SetArrayField(TEXT("params"), Params);
-		if (ReturnParam.IsValid())
-			Json->SetObjectField(TEXT("returnType"), ReturnParam);
-		return Json;
 	}
 }
 
@@ -394,313 +283,6 @@ namespace UnrealMcpEditorTools
 				return FUnrealMcpToolResult::Success(
 					bClear ? TEXT("Selection cleared.")
 					       : FString::Printf(TEXT("Selected %d actor(s)."), Resolved.Num()), S);
-			});
-
-		// ============================================================================================
-		// console-get-logs — filtered/paginated ring-buffer slice.
-		// ============================================================================================
-		Registry.Tool(TEXT("console-get-logs"))
-			.Title(TEXT("Get Console Logs"))
-			.Description(TEXT("Read recent engine log lines captured by the plugin's GLog ring buffer "
-			                  "(capped at 10000). Filter by minimum severity ('Fatal'|'Error'|'Warning'|"
-			                  "'Display'|'Log'|'Verbose'|'VeryVerbose'|'All'), exact category, and a message "
-			                  "substring; 'limit' returns the most-recent N after filtering. Read-only."))
-			.ParamString(TEXT("verbosity"), TEXT("Minimum severity to include (default 'All')."))
-			.ParamString(TEXT("category"), TEXT("Exact log category (e.g. 'LogTemp'); empty = all."))
-			.ParamString(TEXT("search"), TEXT("Case-insensitive message substring; empty = all."))
-			.ParamInt(TEXT("limit"), TEXT("Max entries to return (most-recent first-trimmed); default 100, <=0 = all."))
-			.ReadOnlyHint(true)
-			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
-			{
-				ELogVerbosity::Type MinVerbosity = ELogVerbosity::All;
-				if (Call.Has(TEXT("verbosity")))
-				{
-					const FString Token = Call.GetString(TEXT("verbosity"));
-					if (!Token.IsEmpty() && !FUnrealMcpLogCollector::ParseVerbosity(Token, MinVerbosity))
-						return FUnrealMcpToolResult::Error(FString::Printf(
-							TEXT("Unknown verbosity '%s'. Use Fatal/Error/Warning/Display/Log/Verbose/VeryVerbose/All."), *Token));
-				}
-				const FString Category = Call.GetString(TEXT("category"));
-				const FString Search = Call.GetString(TEXT("search"));
-				const int32 Limit = (int32)Call.GetInt(TEXT("limit"), 100);
-
-				const FUnrealMcpLogCollector& Collector = FUnrealMcpLogCollector::Get();
-				const TArray<FUnrealMcpLogEntry> Slice = Collector.Snapshot(MinVerbosity, Category, Search, Limit);
-
-				TArray<TSharedPtr<FJsonValue>> Lines;
-				for (const FUnrealMcpLogEntry& Entry : Slice)
-				{
-					TSharedPtr<FJsonObject> L = MakeShared<FJsonObject>();
-					L->SetStringField(TEXT("timestamp"), Entry.Timestamp.ToIso8601());
-					L->SetStringField(TEXT("verbosity"), FUnrealMcpLogCollector::VerbosityToString(Entry.Verbosity));
-					L->SetStringField(TEXT("category"), Entry.Category.ToString());
-					L->SetStringField(TEXT("message"), Entry.Message);
-					Lines.Add(MakeShared<FJsonValueObject>(L));
-				}
-
-				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
-				S->SetNumberField(TEXT("count"), Lines.Num());
-				S->SetNumberField(TEXT("totalBuffered"), Collector.Num());
-				S->SetArrayField(TEXT("logs"), Lines);
-				return FUnrealMcpToolResult::Success(
-					FString::Printf(TEXT("Returned %d log line(s) (%d buffered)."), Lines.Num(), Collector.Num()), S);
-			});
-
-		// ============================================================================================
-		// console-clear-logs — empty the ring buffer.
-		// ============================================================================================
-		Registry.Tool(TEXT("console-clear-logs"))
-			.Title(TEXT("Clear Console Logs"))
-			.Description(TEXT("Clear the plugin's GLog ring buffer. Returns how many entries were dropped."))
-			.DestructiveHint(true)
-			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
-			{
-				const int32 Removed = FUnrealMcpLogCollector::Get().Clear();
-				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
-				S->SetNumberField(TEXT("cleared"), Removed);
-				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Cleared %d log entry(ies)."), Removed), S);
-			});
-
-		// ============================================================================================
-		// console-run-command — GEngine->Exec with captured output.
-		// ============================================================================================
-		Registry.Tool(TEXT("console-run-command"))
-			.Title(TEXT("Run Console Command"))
-			.Description(TEXT("Execute an Unreal console command (incl. CVars, e.g. 'stat fps', 'r.ScreenPercentage 80') "
-			                  "via GEngine->Exec against the editor world, returning any captured output text."))
-			.ParamString(TEXT("command"), TEXT("The console command line to execute."), EUnrealMcpParamRequirement::Required)
-			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
-			{
-				const FString Command = Call.GetString(TEXT("command"));
-				if (Command.IsEmpty())
-					return FUnrealMcpToolResult::Error(TEXT("Missing required 'command'."));
-				if (!GEngine)
-					return FUnrealMcpToolResult::Error(TEXT("No engine available."));
-
-				UWorld* World = FUnrealMcpObjectRef::GetEditorWorld();
-
-				FStringOutputDevice Output;
-				Output.SetAutoEmitLineTerminator(true);
-				const bool bHandled = GEngine->Exec(World, *Command, Output);
-
-				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
-				S->SetStringField(TEXT("command"), Command);
-				S->SetBoolField(TEXT("handled"), bHandled);
-				S->SetStringField(TEXT("output"), Output);
-				return FUnrealMcpToolResult::Success(
-					FString::Printf(TEXT("Ran '%s' (%s)."), *Command, bHandled ? TEXT("handled") : TEXT("not handled")), S);
-			});
-
-		// ============================================================================================
-		// reflection-method-find — UFunction discovery by class (+ optional name filter).
-		// ============================================================================================
-		Registry.Tool(TEXT("reflection-method-find"))
-			.Title(TEXT("Find Reflection Method"))
-			.Description(TEXT("Discover UFunctions on a class (native class path, short name, or Blueprint asset/"
-			                  "generated-class path, §3.2). Returns signatures: params (name/type), return type, "
-			                  "and flags (static/instance, BlueprintCallable, pure, CallInEditor, callable). "
-			                  "Optional 'name' filters by case-insensitive substring. Read-only."))
-			.ParamString(TEXT("class"), TEXT("Class ref to search (native path/name or Blueprint path)."), EUnrealMcpParamRequirement::Required)
-			.ParamString(TEXT("name"), TEXT("Optional case-insensitive substring to match the function name."))
-			.ParamInt(TEXT("limit"), TEXT("Max functions to return; default 100, <=0 = all."))
-			.ReadOnlyHint(true)
-			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
-			{
-				const FString ClassRef = Call.GetString(TEXT("class"));
-				UClass* Class = FUnrealMcpObjectRef::ResolveClass(ClassRef);
-				if (!Class)
-					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Class '%s' was not found."), *ClassRef));
-
-				const FString NameFilter = Call.GetString(TEXT("name"));
-				const int32 Limit = (int32)Call.GetInt(TEXT("limit"), 100);
-
-				TArray<TSharedPtr<FJsonValue>> Methods;
-				int32 Matched = 0;
-				TSet<FName> SeenNames;
-				for (TFieldIterator<UFunction> It(Class, EFieldIteratorFlags::IncludeSuper); It; ++It)
-				{
-					UFunction* Function = *It;
-					// IncludeSuper walks most-derived first, so an override appears once per declaring class
-					// in the hierarchy. Keep only the first (most-derived) occurrence of each name.
-					bool bAlreadySeen = false;
-					SeenNames.Add(Function->GetFName(), &bAlreadySeen);
-					if (bAlreadySeen)
-						continue;
-					if (!NameFilter.IsEmpty() && !Function->GetName().Contains(NameFilter, ESearchCase::IgnoreCase))
-						continue;
-					++Matched;
-					if (Limit > 0 && Methods.Num() >= Limit)
-						continue; // keep counting Matched for an honest total, but stop materializing
-					Methods.Add(MakeShared<FJsonValueObject>(DescribeFunction(Function)));
-				}
-
-				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
-				S->SetStringField(TEXT("class"), Class->GetPathName());
-				S->SetNumberField(TEXT("matched"), Matched);
-				S->SetNumberField(TEXT("returned"), Methods.Num());
-				S->SetArrayField(TEXT("methods"), Methods);
-				return FUnrealMcpToolResult::Success(
-					FString::Printf(TEXT("Found %d method(s) on '%s' (returned %d)."), Matched, *Class->GetName(), Methods.Num()), S);
-			});
-
-		// ============================================================================================
-		// reflection-method-call — safety-gated ProcessEvent over a constructed param frame.
-		// ============================================================================================
-		Registry.Tool(TEXT("reflection-method-call"))
-			.Title(TEXT("Call Reflection Method"))
-			.Description(TEXT("Invoke a UFunction by name. Provide EITHER 'target' (an object/actor ref, §3.2 — "
-			                  "the function is resolved and called on it) OR 'class' (the function is called on "
-			                  "that class's CDO — use for static/CallInEditor functions). 'args' is a JSON object "
-			                  "mapping parameter names to values (§3.2). SAFETY: only BlueprintCallable or "
-			                  "CallInEditor functions may be called; anything else is rejected — and the 'class' "
-			                  "(CDO) path additionally requires static/CallInEditor (instance methods must use "
-			                  "'target'). ACCEPTED RISK: callable functions can still be destructive (QuitGame, "
-			                  "console exec, DestroyActor), consistent with console-run-command. Returns the "
-			                  "function's return value and any out-params."))
-			.ParamString(TEXT("target"), TEXT("Object/actor ref to call the method on (instance methods)."))
-			.ParamString(TEXT("class"), TEXT("Class ref whose CDO to call on (static/CallInEditor methods)."))
-			.ParamString(TEXT("method"), TEXT("The UFunction name to invoke."), EUnrealMcpParamRequirement::Required)
-			.Param(TEXT("args"), TEXT("object"), TEXT("Parameter name -> value map (§3.2)."), EUnrealMcpParamRequirement::Optional, MakeArgsBagSchema(TEXT("Parameter name -> value map.")))
-			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
-			{
-				const FString MethodName = Call.GetString(TEXT("method"));
-				if (MethodName.IsEmpty())
-					return FUnrealMcpToolResult::Error(TEXT("Missing required 'method'."));
-
-				const FString TargetRef = Call.GetString(TEXT("target"));
-				const FString ClassRef = Call.GetString(TEXT("class"));
-				if (TargetRef.IsEmpty() && ClassRef.IsEmpty())
-					return FUnrealMcpToolResult::Error(TEXT("Provide either 'target' (instance) or 'class' (CDO/static)."));
-				// The receiver is EITHER/OR — reject an ambiguous pair instead of silently preferring one.
-				if (!TargetRef.IsEmpty() && !ClassRef.IsEmpty())
-					return FUnrealMcpToolResult::Error(TEXT("Provide EITHER 'target' (instance) OR 'class' (CDO/static), not both."));
-
-				// Resolve the receiving object: an explicit instance ref, else the class CDO.
-				const bool bViaCDO = TargetRef.IsEmpty();
-				UObject* Target = nullptr;
-				if (!TargetRef.IsEmpty())
-				{
-					Target = FUnrealMcpObjectRef::ResolveObject(TargetRef);
-					if (!Target)
-						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Target '%s' was not found."), *TargetRef));
-				}
-				else
-				{
-					UClass* Class = FUnrealMcpObjectRef::ResolveClass(ClassRef);
-					if (!Class)
-						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Class '%s' was not found."), *ClassRef));
-					Target = Class->GetDefaultObject();
-					if (!Target)
-						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Class '%s' has no default object."), *ClassRef));
-				}
-
-				UFunction* Function = Target->FindFunction(FName(*MethodName));
-				if (!Function)
-					return FUnrealMcpToolResult::Error(FString::Printf(
-						TEXT("Method '%s' was not found on '%s'."), *MethodName, *Target->GetClass()->GetName()));
-
-				// SAFETY GATE (§10): reject anything that is not explicitly callable. An unguarded ProcessEvent
-				// surface would let an agent invoke arbitrary native engine functions — a security finding.
-				// ACCEPTED RISK: BlueprintCallable/CallInEditor still includes destructive functions
-				// (UKismetSystemLibrary::QuitGame, ExecuteConsoleCommand, AActor::K2_DestroyActor, the editor
-				// scripting libraries). console-run-command already grants equivalent power, so this is in
-				// keeping with the family's purpose rather than a separate escalation — gated by intent, not
-				// by an allow-list of individual functions.
-				if (!IsCallableFunction(Function))
-					return FUnrealMcpToolResult::Error(FString::Printf(
-						TEXT("Method '%s' is not BlueprintCallable or CallInEditor; refusing to call it."), *MethodName));
-
-				// The 'class' path runs on the CDO, which is only safe for static / CallInEditor functions
-				// (see IsCdoCallableFunction). Reject a plain instance method here and steer it to 'target'.
-				if (bViaCDO && !IsCdoCallableFunction(Function))
-					return FUnrealMcpToolResult::Error(FString::Printf(
-						TEXT("Method '%s' is an instance method; call it via 'target' (an instance), not 'class' "
-						     "(whose CDO is only for static/CallInEditor functions)."), *MethodName));
-
-				// 'args' is optional; absent -> an empty bag (every param defaults). But a PRESENT-but-non-object
-				// 'args' (e.g. an array or a bare string) is a malformed call — error rather than silently
-				// dropping it to an empty bag, which would zero every parameter without telling the caller.
-				const TSharedPtr<FJsonObject>* ArgsPtr = nullptr;
-				if (Call.Arguments->HasField(TEXT("args")) && !(Call.Arguments->TryGetObjectField(TEXT("args"), ArgsPtr) && ArgsPtr))
-					return FUnrealMcpToolResult::Error(TEXT("'args' must be a JSON object mapping parameter names to values."));
-				TSharedPtr<FJsonObject> Args = ArgsPtr ? *ArgsPtr : MakeShared<FJsonObject>();
-
-				// Build + own a parameter frame for the duration of the call (init -> import -> call -> read -> destroy).
-				TArray<uint8> ParmFrame;
-				ParmFrame.SetNumZeroed(FMath::Max<int32>(Function->ParmsSize, 1));
-				uint8* Frame = ParmFrame.GetData();
-
-				for (TFieldIterator<FProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
-					It->InitializeValue_InContainer(Frame);
-
-				// Import inputs (everything that is not the return value; out-params may also be seeded).
-				FString ImportError;
-				for (TFieldIterator<FProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
-				{
-					FProperty* Prop = *It;
-					if (Prop->HasAnyPropertyFlags(CPF_ReturnParm))
-						continue;
-					const TSharedPtr<FJsonValue> Field = Args->TryGetField(Prop->GetName());
-					if (!Field.IsValid())
-						continue; // absent -> zero/default; UE handles optional/defaulted params
-					void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(Frame);
-					FText Fail;
-					if (!FJsonObjectConverter::JsonValueToUProperty(Field, Prop, ValuePtr, 0, 0, false, &Fail))
-					{
-						ImportError = FString::Printf(TEXT("Failed to convert argument '%s': %s"), *Prop->GetName(), *Fail.ToString());
-						break;
-					}
-				}
-
-				if (ImportError.IsEmpty())
-				{
-					// AActor::ProcessEvent gates script execution in the editor: for an actor in the editor
-					// world (not PIE, not a CDO) a plain BlueprintCallable (non-CallInEditor) function is
-					// SILENTLY SKIPPED unless GAllowActorScriptExecutionInEditor is set — the tool would
-					// otherwise return Success with a zeroed return/out-params. Scope the call in the same
-					// guard the editor's own details-panel / CallInEditor invocations use (it also resets the
-					// runaway-loop counter). The §10 safety gate above remains the authorization layer; this
-					// only lets an already-authorized call actually run.
-					FEditorScriptExecutionGuard ScriptGuard;
-					Target->ProcessEvent(Function, Frame);
-				}
-
-				// Read the return value + any out-params back into JSON (before destroying the frame).
-				TSharedPtr<FJsonObject> Returned = MakeShared<FJsonObject>();
-				TSharedPtr<FJsonValue> ReturnValue;
-				if (ImportError.IsEmpty())
-				{
-					for (TFieldIterator<FProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
-					{
-						FProperty* Prop = *It;
-						const bool bReturn = Prop->HasAnyPropertyFlags(CPF_ReturnParm);
-						const bool bOut = Prop->HasAnyPropertyFlags(CPF_OutParm);
-						if (!bReturn && !bOut)
-							continue;
-						const void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(Frame);
-						TSharedPtr<FJsonValue> JV = FJsonObjectConverter::UPropertyToJsonValue(Prop, ValuePtr);
-						if (bReturn)
-							ReturnValue = JV;
-						else
-							Returned->SetField(Prop->GetName(), JV);
-					}
-				}
-
-				// Always destroy the frame (init succeeded for every param above).
-				for (TFieldIterator<FProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
-					It->DestroyValue_InContainer(Frame);
-
-				if (!ImportError.IsEmpty())
-					return FUnrealMcpToolResult::Error(ImportError);
-
-				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
-				S->SetStringField(TEXT("method"), MethodName);
-				S->SetStringField(TEXT("target"), Target->GetPathName());
-				if (ReturnValue.IsValid())
-					S->SetField(TEXT("returnValue"), ReturnValue);
-				S->SetObjectField(TEXT("outParams"), Returned);
-				return FUnrealMcpToolResult::Success(
-					FString::Printf(TEXT("Called '%s' on '%s'."), *MethodName, *Target->GetName()), S);
 			});
 	}
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLevelTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLevelTools.cpp
@@ -4,7 +4,6 @@
 #include "UnrealMcpCoreTools.h"
 #include "UnrealMcpToolRegistry.h"
 #include "Tools/UnrealMcpObjectRef.h"
-#include "Tools/UnrealMcpPropertyJson.h"
 
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
@@ -20,10 +19,11 @@
 #include "UObject/Package.h"
 
 /**
- * The level / map tool family (docs/ARCHITECTURE.md §10 "level family", the Unity Scene.* analog),
- * declared via §3.3. Seven native C++ tools over the world / map editor surface:
- *   level-create, level-open, level-save, level-get-data, level-list-loaded, level-set-current,
- *   level-unload-sublevel.
+ * The editor level / map tool family (docs/ARCHITECTURE.md §10 "level family", the Unity Scene.* analog),
+ * declared via §3.3. Six native C++ EDITOR-ONLY tools over the world / map editor surface:
+ *   level-create, level-open, level-save, level-list-loaded, level-set-current, level-unload-sublevel.
+ * (The read-only level-get-data moved to the runtime module's UnrealMcpRuntimeLevelTools in R4, §12.7 —
+ * it needs no UnrealEd, so it works over a runtime connection too.)
  *
  * Headless-safety (the binding lesson carried from the actor family, issue #16):
  *   - UEditorActorSubsystem AND ULevelEditorSubsystem (LevelEditor module) are avoided. We touch the
@@ -39,57 +39,10 @@
  *
  * Every Handle() body runs ON the game thread (the dispatcher marshals Registry.Execute, §4), so the
  * bodies touch the editor world / UObject graph directly. Reuses FUnrealMcpObjectRef (§3.2 path-or-name
- * refs) and FUnrealMcpPropertyJson (scoped reads) from the actor family for level-get-data.
+ * refs) from the actor family.
  */
 namespace
 {
-	/** An `array` of strings — the §3.2 scoped-read `paths` filter (mirrors the actor family's local schema).
-	 *  Uniquely named (Level-prefixed): the UE unity build concatenates this TU with the other tool
-	 *  families' TUs, so a bare `MakeStringArraySchema` would ODR-collide with the actor family's copy. */
-	TSharedPtr<FJsonObject> LevelMakeStringArraySchema(const FString& Desc)
-	{
-		TSharedPtr<FJsonObject> Items = MakeShared<FJsonObject>();
-		Items->SetStringField(TEXT("type"), TEXT("string"));
-
-		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
-		Schema->SetStringField(TEXT("type"), TEXT("array"));
-		if (!Desc.IsEmpty())
-			Schema->SetStringField(TEXT("description"), Desc);
-		Schema->SetObjectField(TEXT("items"), Items);
-		return Schema;
-	}
-
-	/**
-	 * Read a string array argument (the scoped-read `paths` filter); empty when absent or not an array.
-	 * A non-string entry is reported via OutError (and the array is left empty) rather than silently
-	 * dropped — a dropped entry would otherwise flip the scoped read to "identity only" (the opposite of
-	 * the requested scope) with no signal to the caller. Same contract as the actor family's helper.
-	 * Uniquely named (Level-prefixed) to avoid a unity-build ODR collision with the actor family's copy.
-	 */
-	TArray<FString> LevelGetStringArray(const FUnrealMcpToolCall& Call, const FString& Key, FString& OutError)
-	{
-		TArray<FString> Out;
-		const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
-		if (Call.Arguments->TryGetArrayField(Key, Arr) && Arr)
-		{
-			for (const TSharedPtr<FJsonValue>& V : *Arr)
-			{
-				FString S;
-				if (V.IsValid() && V->TryGetString(S))
-				{
-					Out.Add(S);
-				}
-				else
-				{
-					OutError = FString::Printf(TEXT("'%s' must be an array of strings; a non-string entry was provided."), *Key);
-					Out.Reset();
-					return Out;
-				}
-			}
-		}
-		return Out;
-	}
-
 	/** Long package name of a level's outermost package (e.g. /Game/Maps/Arena); empty when null. */
 	FString LevelPackageName(const ULevel* Level)
 	{
@@ -421,77 +374,10 @@ namespace UnrealMcpLevelTools
 					FString::Printf(TEXT("Saved the current level '%s'."), *LevelShortName(World->GetCurrentLevel())));
 			});
 
-		// ----------------------------------------------------------------------------------------
-		// level-get-data — actor-tree snapshot of the loaded world; scoped reads via 'paths' (§3.2).
-		// ----------------------------------------------------------------------------------------
-		Registry.Tool(TEXT("level-get-data"))
-			.Title(TEXT("Get Level Data"))
-			.Description(TEXT("Read an actor-tree snapshot of the loaded editor world. Returns each actor's "
-			                  "identity, optionally including reflected data scoped to the dotted 'paths' filter "
-			                  "(§3.2) to save tokens. Pass 'actor' to scope the read to a single actor instead of "
-			                  "the whole world."))
-			.ParamString(TEXT("actor"), TEXT("Label / name / path of a single actor to read. Omit to snapshot the whole world."))
-			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include per actor (scoped read). Identity only when omitted."), EUnrealMcpParamRequirement::Optional, LevelMakeStringArraySchema(TEXT("Dotted property paths to include per actor (scoped read).")))
-			.ParamInt(TEXT("limit"), TEXT("Maximum number of actors to return for a world snapshot. Defaults to 200; pass 0 or a negative value for no limit."))
-			.ReadOnlyHint(true)
-			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
-			{
-				UWorld* World = GetWorldOrNull();
-				if (!World)
-					return FUnrealMcpToolResult::Error(TEXT("No editor world available."));
-
-				FString PathsError;
-				const TArray<FString> Paths = LevelGetStringArray(Call, TEXT("paths"), PathsError);
-				if (!PathsError.IsEmpty())
-					return FUnrealMcpToolResult::Error(PathsError);
-
-				// Single-actor scope.
-				const FString ActorRef = Call.GetString(TEXT("actor"));
-				if (!ActorRef.IsEmpty())
-				{
-					AActor* Actor = FUnrealMcpObjectRef::ResolveActor(ActorRef, World);
-					if (!Actor)
-						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No actor matched '%s' (by label/name/path)."), *ActorRef));
-
-					TSharedPtr<FJsonObject> Entry = FUnrealMcpObjectRef::ActorIdentity(Actor);
-					// Attach reflected data only when a scoped 'paths' filter is given — matching the whole-world
-					// branch and the "Identity only when omitted" contract (an empty Paths returns the full dump).
-					if (Paths.Num() > 0)
-						Entry->SetObjectField(TEXT("data"), FUnrealMcpPropertyJson::SerializeObject(Actor, Paths));
-					return FUnrealMcpToolResult::Success(
-						FString::Printf(TEXT("Read actor '%s'."), *Actor->GetActorLabel()), Entry);
-				}
-
-				// Whole-world snapshot.
-				const int32 Limit = static_cast<int32>(Call.GetInt(TEXT("limit"), 200));
-				TArray<TSharedPtr<FJsonValue>> Actors;
-				int32 Total = 0;
-				for (TActorIterator<AActor> It(World); It; ++It)
-				{
-					AActor* Actor = *It;
-					if (!Actor)
-						continue;
-					++Total;
-					if (Limit > 0 && Actors.Num() >= Limit)
-						continue; // keep counting the total, stop materializing entries
-
-					TSharedPtr<FJsonObject> Entry = FUnrealMcpObjectRef::ActorIdentity(Actor);
-					if (Paths.Num() > 0)
-						Entry->SetObjectField(TEXT("data"), FUnrealMcpPropertyJson::SerializeObject(Actor, Paths));
-					Actors.Add(MakeShared<FJsonValueObject>(Entry));
-				}
-
-				TSharedPtr<FJsonObject> Structured = LevelIdentity(World->GetCurrentLevel(), World);
-				Structured->SetStringField(TEXT("world"), World->GetName());
-				Structured->SetBoolField(TEXT("isPartitionedWorld"), World->IsPartitionedWorld());
-				Structured->SetNumberField(TEXT("levelCount"), World->GetLevels().Num());
-				Structured->SetNumberField(TEXT("count"), Actors.Num());
-				Structured->SetNumberField(TEXT("total"), Total);
-				Structured->SetArrayField(TEXT("actors"), Actors);
-				return FUnrealMcpToolResult::Success(
-					FString::Printf(TEXT("Snapshot of world '%s': %d actor(s) (returned %d)."), *World->GetName(), Total, Actors.Num()),
-					Structured);
-			});
+		// NOTE (§12.7, R4): the read-only `level-get-data` tool moved DOWN into the runtime module's
+		// UnrealMcpRuntimeLevelTools so it works over a runtime connection (PIE / packaged game) too — it
+		// touches only Engine UWorld surface, no UnrealEd. The remaining level tools below stay editor-only
+		// (they need UEditorLoadingAndSavingUtils / UEditorLevelUtils for level create/open/save/sublevel ops).
 
 		// ----------------------------------------------------------------------------------------
 		// level-list-loaded — persistent + streaming sublevels, World-Partition aware (read-only).

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpScreenshotTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpScreenshotTools.cpp
@@ -26,15 +26,15 @@
 #include "Camera/CameraComponent.h"
 
 /**
- * The screenshot / viewport-capture tool family (docs/ARCHITECTURE.md §10 "screenshot family", issue
- * #17). Four kebab-case CORE tools that return a base64 PNG as MCP image content:
+ * The editor screenshot / viewport-capture tool family (docs/ARCHITECTURE.md §10 "screenshot family",
+ * issue #17, §12.7). Two kebab-case EDITOR-ONLY tools that return a base64 PNG as MCP image content:
  *
- *  - `screenshot-viewport`   — active editor viewport via FViewport::ReadPixels.
- *  - `screenshot-game-view`  — PIE/game view via the PIE FViewport; structured error when no PIE session.
- *  - `screenshot-camera`     — render from a §3.2-resolved camera actor through a transient
- *                              USceneCaptureComponent2D into a render target, then read back.
+ *  - `screenshot-viewport`   — active editor viewport via FViewport::ReadPixels (GEditor->GetActiveViewport).
  *  - `screenshot-isolated`   — isolated actor render: transient SceneCapture2D + show-only list +
  *                              neutral background (the Godot SubViewport pattern mapped to UE).
+ *
+ * The runtime-safe subset — `screenshot-game-view` (live game viewport) and `screenshot-camera` —
+ * moved DOWN into the runtime module's UnrealMcpRuntimeScreenshotTools in R4 (§12.7).
  *
  * Every handler runs ON the game thread (the dispatcher guarantees it, §4). Captures are dimension-
  * capped (default 1024, hard cap 2048 per side; width/height clamped). Actual pixel capture needs a
@@ -385,72 +385,6 @@ namespace UnrealMcpScreenshotTools
 					return FUnrealMcpToolResult::Error(TEXT("No active editor viewport. Focus a level editor viewport and retry."));
 
 				return CaptureFromViewport(Call, Viewport, TEXT("editor viewport"));
-			});
-
-		// screenshot-game-view — PIE/game view; structured error when no PIE session is active.
-		Registry.Tool(TEXT("screenshot-game-view"))
-			.Title(TEXT("Screenshot Game View"))
-			.Description(FString(TEXT("Capture the Play-In-Editor game view. Errors when no PIE session is active.")) + SizeCapNote())
-			.ParamInt(TEXT("width"), TEXT("Optional output width in pixels (clamped to [1, 2048]); when only 'height' is given the width is derived from the native aspect ratio, and the native game-view width is used when both are omitted."))
-			.ParamInt(TEXT("height"), TEXT("Optional output height in pixels (clamped to [1, 2048]); when only 'width' is given the height is derived from the native aspect ratio, and the native game-view height is used when both are omitted."))
-			.ReadOnlyHint(true)
-			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
-			{
-				// Validate the PIE precondition FIRST (GPU-free, headless-spec-covered).
-				const bool bPlaySessionActive = GEditor && GEditor->PlayWorld != nullptr;
-				FViewport* PieViewport = GEditor ? GEditor->GetPIEViewport() : nullptr;
-				if (!bPlaySessionActive || !PieViewport)
-					return FUnrealMcpToolResult::Error(TEXT("No Play-In-Editor session is active. Start PIE before calling screenshot-game-view."));
-
-				FString Error;
-				if (!EnsureRenderingAvailable(Error))
-					return FUnrealMcpToolResult::Error(Error);
-
-				return CaptureFromViewport(Call, PieViewport, TEXT("PIE game view"));
-			});
-
-		// screenshot-camera — render from a resolved camera actor via SceneCapture2D.
-		Registry.Tool(TEXT("screenshot-camera"))
-			.Title(TEXT("Screenshot Camera"))
-			.Description(FString(TEXT("Render the scene from a chosen camera actor (resolved by label/name/path) and capture it.")) + SizeCapNote())
-			.ParamString(TEXT("camera"), TEXT("Camera actor reference (label, object name, or path) to render from."), EUnrealMcpParamRequirement::Required)
-			.ParamInt(TEXT("width"), TEXT("Optional output width in pixels (clamped to [1, 2048]); default 1024."))
-			.ParamInt(TEXT("height"), TEXT("Optional output height in pixels (clamped to [1, 2048]); default 1024."))
-			.ParamNumber(TEXT("fov"), TEXT("Optional horizontal field-of-view override in degrees (clamped to [5, 170]); defaults to the camera component's FOV (or 90)."))
-			.ReadOnlyHint(true)
-			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
-			{
-				// Validate arguments + resolve the camera FIRST (GPU-free, headless-spec-covered).
-				if (!Call.Has(TEXT("camera")))
-					return FUnrealMcpToolResult::Error(TEXT("'camera' is required."));
-
-				UWorld* World = FUnrealMcpObjectRef::GetEditorWorld();
-				if (!World)
-					return FUnrealMcpToolResult::Error(TEXT("No editor world is available."));
-
-				const FString CameraRef = Call.GetString(TEXT("camera"));
-				AActor* CameraActor = FUnrealMcpObjectRef::ResolveActor(CameraRef, World);
-				if (!CameraActor)
-					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No actor matched camera reference '%s'."), *CameraRef));
-
-				UCameraComponent* CameraComponent = CameraActor->FindComponentByClass<UCameraComponent>();
-				// Clamp once at parse time to a sane perspective range; a degenerate FOV (<= 0 or >= 180)
-				// yields a NaN/garbage projection matrix rather than a usable render.
-				const float Fov = FMath::Clamp(Call.Has(TEXT("fov"))
-					? (float)Call.GetNumber(TEXT("fov"))
-					: (CameraComponent ? CameraComponent->FieldOfView : 90.0f), 5.0f, 170.0f);
-				const FTransform CaptureXform = CameraComponent
-					? CameraComponent->GetComponentTransform()
-					: CameraActor->GetActorTransform();
-
-				FString Error;
-				if (!EnsureRenderingAvailable(Error))
-					return FUnrealMcpToolResult::Error(Error);
-
-				const int32 Width = ResolveCaptureDimension(Call.GetInt(TEXT("width"), 0));
-				const int32 Height = ResolveCaptureDimension(Call.GetInt(TEXT("height"), 0));
-				const FString Source = FString::Printf(TEXT("camera '%s'"), *CameraActor->GetActorNameOrLabel());
-				return CaptureWithSceneCapture(World, CaptureXform, Fov, Width, Height, Source, nullptr, nullptr);
 			});
 
 		// screenshot-isolated — isolated actor render (transient SceneCapture2D + show-only list + background).

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
@@ -55,13 +55,21 @@ void FUnrealMcpEditorCoordinator::Startup()
 	FUnrealMcpLogCollector::Get().Startup();
 
 	Registry = MakeUnique<FUnrealMcpToolRegistry>();
+	// §12.3 Model A: the editor coordinator registers BOTH the runtime-safe families (which also work over a
+	// runtime connection — they live in the runtime module) AND the editor-only families on top of the SAME
+	// registry. The runtime bootstrap subsystem (R3) registers ONLY the runtime-safe subset in a packaged game.
+	// --- Runtime-safe families (UnrealMcpRuntimeCoreTools.h, §12.7) ---
 	UnrealMcpPingTool::Register(*Registry);
-	UnrealMcpActorTools::Register(*Registry);
+	UnrealMcpActorTools::Register(*Registry); // §10 actor / component family — runtime-safe (World->SpawnActor + WITH_EDITOR guards)
+	UnrealMcpConsoleReflectionTools::Register(*Registry); // §10 console + reflection runtime subset (console-*, reflection-method-*)
+	UnrealMcpRuntimeScreenshotTools::Register(*Registry); // §10 screenshot runtime subset (screenshot-game-view, screenshot-camera)
+	UnrealMcpRuntimeLevelTools::Register(*Registry); // §10 read-only level-get-data (runtime-safe)
+	// --- Editor-only families (UnrealMcpCoreTools.h) ---
 	UnrealMcpBlueprintTools::Register(*Registry); // §10 flagship Blueprint family (CORE)
 	UnrealMcpAssetTools::Register(*Registry); // §10 asset / Content-Browser family (issue #10)
-	UnrealMcpEditorTools::Register(*Registry); // §10 editor / console / reflection family (issue #19)
-	UnrealMcpLevelTools::Register(*Registry); // §10 level / map family (issue #16, Unity Scene.* analog)
-	UnrealMcpScreenshotTools::Register(*Registry); // §10 screenshot / viewport-capture family (issue #17)
+	UnrealMcpEditorTools::Register(*Registry); // §10 editor-application / selection family (issue #19, editor-only subset)
+	UnrealMcpLevelTools::Register(*Registry); // §10 level / map WRITE family (issue #16, Unity Scene.* analog)
+	UnrealMcpScreenshotTools::Register(*Registry); // §10 editor screenshot subset (screenshot-viewport, screenshot-isolated)
 	UnrealMcpSourceTools::Register(*Registry); // §10 C++ source / script family (issue #18)
 
 	Dispatcher = MakeUnique<FUnrealMcpGameThreadDispatcher>();

--- a/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpCoreTools.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Public/UnrealMcpCoreTools.h
@@ -10,22 +10,11 @@ class FUnrealMcpToolRegistry;
 /**
  * Registration entry points for the EDITOR-only core tool families (docs/ARCHITECTURE.md §10). Exported
  * so the editor coordinator wires them on boot AND the Automation specs can register + exercise them in
- * isolation. The runtime-safe `ping` family moved to the runtime module (UnrealMcpRuntimeCoreTools.h,
- * §12.1); the other families below are editor-only until their runtime subset migrates in R4.
+ * isolation. The runtime-safe families moved to the runtime module (UnrealMcpRuntimeCoreTools.h): `ping`
+ * (R1), and in R4 the actor/component family, the runtime console/reflection subset, the runtime
+ * screenshot subset (screenshot-game-view + screenshot-camera), and read-only level-get-data. The
+ * families below are the editor-only remainder.
  */
-
-/**
- * The actor & component tool family (docs/ARCHITECTURE.md §10 "actor family"): actor lifecycle
- * (create/destroy/duplicate), scoped reads + FProperty writes (find/modify), parent/attachment,
- * component management (add/destroy/get/modify/list-all), and generic UObject access
- * (object-get-data/object-modify). ~13 native C++ tools, all declared via the §3.3 builder and run
- * on the GameThread dispatcher. Exported so the runtime wires it on boot AND the Automation specs
- * can register + exercise it in isolation.
- */
-namespace UnrealMcpActorTools
-{
-	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry);
-}
 
 /**
  * The Blueprint tool family (docs/ARCHITECTURE.md §10 — FLAGSHIP, Unreal-unique). MVP floor: a closed
@@ -49,11 +38,12 @@ namespace UnrealMcpAssetTools
 }
 
 /**
- * The editor / console / reflection tool family (docs/ARCHITECTURE.md §10 "editor/reflection family",
- * issue #19): ~9 kebab-case tools — editor-application-get/set-state (PIE), editor-selection-get/set,
- * console-get/clear-logs (backed by the module-startup FUnrealMcpLogCollector GLog ring buffer),
- * console-run-command, and reflection-method-find/call (safety-gated UFunction discovery + ProcessEvent).
- * Registered in the boot path alongside the other CORE families; also exercised in isolation by specs.
+ * The editor-application / selection tool family (docs/ARCHITECTURE.md §10 "editor/reflection family"
+ * editor-only subset, issue #19): four kebab-case EDITOR-ONLY tools — editor-application-get/set-state
+ * (PIE control) and editor-selection-get/set (editor actor selection). The runtime-safe subset of this
+ * family (console-get/clear-logs, console-run-command, reflection-method-find/-call) moved to the
+ * runtime module's UnrealMcpConsoleReflectionTools in R4 (§12.7). Registered in the editor boot path;
+ * also exercised in isolation by Automation specs.
  */
 namespace UnrealMcpEditorTools
 {
@@ -62,9 +52,10 @@ namespace UnrealMcpEditorTools
 
 /**
  * The level / map tool family (docs/ARCHITECTURE.md §10 "level family", issue #16 — the Unity Scene.*
- * analog): level-create / level-open / level-save (save-as via optional path) / level-get-data (scoped
- * actor-tree reads) / level-list-loaded (persistent + streaming sublevels, World-Partition aware,
- * read-only) / level-set-current / level-unload-sublevel. 7 native C++ tools over the editor UWorld +
+ * analog): level-create / level-open / level-save (save-as via optional path) / level-list-loaded
+ * (persistent + streaming sublevels, World-Partition aware, read-only) / level-set-current /
+ * level-unload-sublevel. 6 native C++ EDITOR-ONLY tools over the editor UWorld +
+ * (read-only level-get-data moved to the runtime module's UnrealMcpRuntimeLevelTools in R4, §12.7).
  * UEditorLoadingAndSavingUtils + UEditorLevelUtils (Engine/UnrealEd only — no LevelEditor module, no
  * UEditorActorSubsystem, so every body is headless-safe under -nullrhi). Registered in the boot path
  * alongside the other core families; also exercised in isolation by Automation specs.
@@ -75,14 +66,15 @@ namespace UnrealMcpLevelTools
 }
 
 /**
- * The screenshot / viewport-capture tool family (docs/ARCHITECTURE.md §10 "screenshot family", issue
- * #17). Four kebab-case CORE tools that return a base64 PNG as MCP image content so an LLM can directly
- * inspect what the editor/game is rendering: `screenshot-viewport` (active editor viewport),
- * `screenshot-game-view` (PIE/game view), `screenshot-camera` (render from a resolved camera actor via
- * USceneCaptureComponent2D), `screenshot-isolated` (transient SceneCapture2D + show-only list).
- * Captures are dimension-capped (default 1024, hard cap 2048 per side, width/height clamped). Every
- * handler runs ON the game thread (the dispatcher guarantees it, §4). Exported so the runtime wires it
- * on boot AND the Automation specs can register + exercise the GPU-free logic in isolation.
+ * The editor screenshot / viewport-capture tool family (docs/ARCHITECTURE.md §10 "screenshot family",
+ * issue #17). Two kebab-case EDITOR-ONLY tools that return a base64 PNG as MCP image content so an LLM
+ * can directly inspect what the editor is rendering: `screenshot-viewport` (active editor viewport, via
+ * GEditor->GetActiveViewport) and `screenshot-isolated` (transient SceneCapture2D + show-only list).
+ * The runtime-safe subset (`screenshot-game-view`, `screenshot-camera`) moved to the runtime module's
+ * UnrealMcpRuntimeScreenshotTools in R4 (§12.7). Captures are dimension-capped (default 1024, hard cap
+ * 2048 per side, width/height clamped). Every handler runs ON the game thread (the dispatcher guarantees
+ * it, §4). Exported so the editor coordinator wires it on boot AND the Automation specs can register +
+ * exercise the GPU-free logic in isolation.
  *
  * Actual pixel capture needs a GPU-backed editor — headless `-nullrhi` cannot render, so the capture
  * paths return a structured error there and are LIVE-VERIFIED WINDOWED; the logic/clamp/error branches

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpActorToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpActorToolsSpec.cpp
@@ -5,7 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "Misc/AutomationTest.h"
-#include "UnrealMcpCoreTools.h"
+#include "UnrealMcpRuntimeCoreTools.h" // §12.7: the actor/component family moved to the runtime module (R4)
 #include "UnrealMcpToolRegistry.h"
 #include "Dom/JsonObject.h"
 #include "Editor.h"

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConsoleReflectionToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConsoleReflectionToolsSpec.cpp
@@ -1,0 +1,292 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "UnrealMcpRuntimeCoreTools.h" // §12.7: the console + reflection runtime subset lives in the runtime module (R4)
+#include "UnrealMcpToolRegistry.h"
+#include "Tools/UnrealMcpLogCollector.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+
+/**
+ * Console + reflection tool family specs (docs/ARCHITECTURE.md §10 "editor/reflection family" runtime
+ * subset, §12.7). The runtime-safe console-* and reflection-method-* tools moved DOWN into the runtime
+ * module in R4; these specs register UnrealMcpConsoleReflectionTools and exercise the same happy/error
+ * paths the original editor-family specs covered. Executed in EditorContext so GEditor + the editor
+ * world are live (the family also works over a runtime connection, but the headless editor is the
+ * convenient harness; the world is the editor world via FUnrealMcpWorldProvider).
+ *
+ * RUNTIME GATE DIFFERENCE: the runtime safety gate accepts BlueprintCallable (instance/target) and
+ * additionally Static (CDO/class) functions ONLY — the editor family's CallInEditor allowance is
+ * excluded (the metadata is editor-only). The non-callable / instance-on-CDO probes below therefore
+ * key off BlueprintCallable/Static, not CallInEditor.
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpConsoleReflectionToolsSpec, "UnrealMcp.Tools.ConsoleReflection",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	static TSharedPtr<FJsonObject> Args() { return MakeShared<FJsonObject>(); }
+
+	FUnrealMcpToolResult Run(FUnrealMcpToolRegistry& Reg, const FString& Tool, const TSharedPtr<FJsonObject>& A)
+	{
+		return Reg.Execute(Tool, FUnrealMcpToolCall(A));
+	}
+
+	/** A throwaway actor in the editor world, cleaned up by the caller. */
+	AActor* SpawnTemp(const FString& Label)
+	{
+		UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+		if (!World) return nullptr;
+		AActor* Actor = World->SpawnActor<AActor>();
+		if (Actor) Actor->SetActorLabel(Label);
+		return Actor;
+	}
+
+END_DEFINE_SPEC(FUnrealMcpConsoleReflectionToolsSpec)
+
+void FUnrealMcpConsoleReflectionToolsSpec::Define()
+{
+	Describe("registration", [this]()
+	{
+		It("registers the console + reflection family as core tools and bumps the revision", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			const int32 Before = Registry.GetRevision();
+			UnrealMcpConsoleReflectionTools::Register(Registry);
+
+			const TCHAR* const Expected[] = {
+				TEXT("console-get-logs"), TEXT("console-clear-logs"), TEXT("console-run-command"),
+				TEXT("reflection-method-find"), TEXT("reflection-method-call")
+			};
+			for (const TCHAR* Name : Expected)
+				TestTrue(FString::Printf(TEXT("has %s"), Name), Registry.HasTool(Name));
+
+			TestEqual(TEXT("tool count"), Registry.Num(), (int32)UE_ARRAY_COUNT(Expected));
+			TestTrue(TEXT("revision bumped"), Registry.GetRevision() > Before);
+
+			const FUnrealMcpRegisteredTool* GetLogs = Registry.Find(TEXT("console-get-logs"));
+			TestTrue(TEXT("get-logs found"), GetLogs != nullptr);
+			if (GetLogs)
+			{
+				TestEqual(TEXT("core extension id"), GetLogs->ExtensionId, FString(TEXT("core")));
+				TestFalse(TEXT("schema hash non-empty"), GetLogs->SchemaHash.IsEmpty());
+				TestTrue(TEXT("get-logs is read-only"), GetLogs->bReadOnlyHint);
+			}
+		});
+	});
+
+	Describe("console", [this]()
+	{
+		It("runs a console command and captures handled/output", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpConsoleReflectionTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("command"), TEXT("r.ScreenPercentage")); // read-only CVar query — prints its value
+			const FUnrealMcpToolResult R = Run(Registry, TEXT("console-run-command"), A);
+			TestTrue(TEXT("command runs"), R.bSuccess);
+			TestTrue(TEXT("missing command is rejected"), !Run(Registry, TEXT("console-run-command"), Args()).bSuccess);
+		});
+
+		It("captures GLog lines into the ring buffer, filters them, and clears", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpConsoleReflectionTools::Register(Registry);
+
+			// Drive the collector directly (the runtime that normally Startup()s it is not running in specs).
+			// NOTE: the collector is a process-wide singleton. Running this spec inside a LIVE editor session
+			// (rather than a throwaway -nullrhi automation process) is DESTRUCTIVE to the runtime's buffered
+			// logs — the Clear() below and console-clear-logs wipe the shared buffer. Registration state is
+			// snapshotted/restored at the end, but buffer CONTENTS are not. Acceptable for automation; do not
+			// run against a session whose captured logs you need to keep.
+			FUnrealMcpLogCollector& Collector = FUnrealMcpLogCollector::Get();
+			const bool bWasRegistered = Collector.IsRegistered();
+			Collector.Startup();
+			Collector.Clear();
+
+			const FString Needle = TEXT("McpLogProbe_4d9f");
+			UE_LOG(LogTemp, Display, TEXT("%s once"), *Needle);
+			GLog->Flush();
+
+			TSharedPtr<FJsonObject> GetArgs = Args();
+			GetArgs->SetStringField(TEXT("search"), Needle);
+			const FUnrealMcpToolResult GetR = Run(Registry, TEXT("console-get-logs"), GetArgs);
+			TestTrue(TEXT("get-logs succeeds"), GetR.bSuccess);
+			int32 Found = 0;
+			if (GetR.Structured.IsValid())
+			{
+				double C = 0; GetR.Structured->TryGetNumberField(TEXT("count"), C); Found = (int32)C;
+			}
+			TestTrue(TEXT("probe line captured"), Found >= 1);
+
+			const FUnrealMcpToolResult ClearR = Run(Registry, TEXT("console-clear-logs"), Args());
+			TestTrue(TEXT("clear succeeds"), ClearR.bSuccess);
+			TestEqual(TEXT("buffer empty after clear"), Collector.Num(), 0);
+
+			// Restore the registration state we found (don't leave a dangling GLog device across specs).
+			if (!bWasRegistered)
+				Collector.Shutdown();
+		});
+	});
+
+	Describe("reflection", [this]()
+	{
+		It("discovers a known BlueprintCallable static method with signature + flags", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpConsoleReflectionTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("class"), TEXT("KismetMathLibrary"));
+			A->SetStringField(TEXT("name"), TEXT("Add_IntInt"));
+			const FUnrealMcpToolResult R = Run(Registry, TEXT("reflection-method-find"), A);
+			TestTrue(TEXT("find succeeds"), R.bSuccess);
+
+			int32 Matched = 0;
+			if (R.Structured.IsValid())
+			{
+				double M = 0; R.Structured->TryGetNumberField(TEXT("matched"), M); Matched = (int32)M;
+			}
+			TestTrue(TEXT("at least one Add_IntInt match"), Matched >= 1);
+		});
+
+		It("invokes a safe pure BlueprintCallable static method and returns its result", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpConsoleReflectionTools::Register(Registry);
+			TSharedPtr<FJsonObject> CallArgs = Args();
+			CallArgs->SetStringField(TEXT("class"), TEXT("KismetMathLibrary"));
+			CallArgs->SetStringField(TEXT("method"), TEXT("Add_IntInt"));
+			TSharedPtr<FJsonObject> Inner = MakeShared<FJsonObject>();
+			Inner->SetNumberField(TEXT("A"), 2);
+			Inner->SetNumberField(TEXT("B"), 3);
+			CallArgs->SetObjectField(TEXT("args"), Inner);
+
+			const FUnrealMcpToolResult R = Run(Registry, TEXT("reflection-method-call"), CallArgs);
+			TestTrue(TEXT("call succeeds"), R.bSuccess);
+			if (R.Structured.IsValid())
+			{
+				double Ret = 0; R.Structured->TryGetNumberField(TEXT("returnValue"), Ret);
+				TestEqual(TEXT("2 + 3 == 5"), (int32)Ret, 5);
+			}
+		});
+
+		It("invokes an INSTANCE BlueprintCallable method on an editor-world actor and gets a real (non-default) result", [this]()
+		{
+			// Regression guard for the FEditorScriptExecutionGuard around ProcessEvent (editor build of the
+			// runtime family). An editor-world actor's BlueprintCallable INSTANCE method is silently skipped by
+			// AActor::ProcessEvent unless script execution in the editor is enabled — without the guard the call
+			// would still report success but return the zero-initialized default (false here). Proving a 'true'
+			// result proves the method actually executed.
+			FUnrealMcpToolRegistry Registry; UnrealMcpConsoleReflectionTools::Register(Registry);
+
+			AActor* Actor = SpawnTemp(TEXT("McpReflectInstance"));
+			TestTrue(TEXT("spawned a target actor"), Actor != nullptr);
+			if (!Actor) return;
+			Actor->Tags.Add(FName(TEXT("McpReflectProbe")));
+
+			TSharedPtr<FJsonObject> CallArgs = Args();
+			CallArgs->SetStringField(TEXT("target"), TEXT("McpReflectInstance"));
+			CallArgs->SetStringField(TEXT("method"), TEXT("ActorHasTag")); // BlueprintCallable instance method, bool return
+			TSharedPtr<FJsonObject> Inner = MakeShared<FJsonObject>();
+			Inner->SetStringField(TEXT("Tag"), TEXT("McpReflectProbe"));
+			CallArgs->SetObjectField(TEXT("args"), Inner);
+
+			const FUnrealMcpToolResult R = Run(Registry, TEXT("reflection-method-call"), CallArgs);
+			TestTrue(TEXT("instance call succeeds"), R.bSuccess);
+			bool bRet = false;
+			if (R.Structured.IsValid())
+				R.Structured->TryGetBoolField(TEXT("returnValue"), bRet);
+			TestTrue(TEXT("ActorHasTag returned true (method ran under the editor script guard)"), bRet);
+
+			Actor->Destroy();
+		});
+
+		It("rejects a non-object 'args' argument instead of silently zeroing every parameter", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpConsoleReflectionTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("class"), TEXT("KismetMathLibrary"));
+			A->SetStringField(TEXT("method"), TEXT("Add_IntInt"));
+			TArray<TSharedPtr<FJsonValue>> ArgsArr; ArgsArr.Add(MakeShared<FJsonValueNumber>(1));
+			A->SetArrayField(TEXT("args"), ArgsArr); // present but an array, not an object
+			TestFalse(TEXT("non-object 'args' is an error"), Run(Registry, TEXT("reflection-method-call"), A).bSuccess);
+		});
+
+		It("refuses to call a non-BlueprintCallable function (runtime safety gate)", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpConsoleReflectionTools::Register(Registry);
+
+			// Find a concrete non-BlueprintCallable UFunction on AActor (deterministic: lifecycle/native
+			// helpers exist that are not BlueprintCallable) and prove the runtime gate rejects it BEFORE any
+			// ProcessEvent runs. (The runtime gate is BlueprintCallable-only — no CallInEditor allowance.)
+			UClass* ActorClass = AActor::StaticClass();
+			FString TargetName;
+			for (TFieldIterator<UFunction> It(ActorClass, EFieldIteratorFlags::IncludeSuper); It; ++It)
+			{
+				UFunction* Fn = *It;
+				if (!Fn->HasAnyFunctionFlags(FUNC_BlueprintCallable)) { TargetName = Fn->GetName(); break; }
+			}
+			TestTrue(TEXT("found a non-callable function to probe the gate with"), !TargetName.IsEmpty());
+			if (TargetName.IsEmpty()) return;
+
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("class"), TEXT("Actor"));
+			A->SetStringField(TEXT("method"), TargetName);
+			const FUnrealMcpToolResult R = Run(Registry, TEXT("reflection-method-call"), A);
+			TestFalse(TEXT("non-callable function is rejected"), R.bSuccess);
+		});
+
+		It("errors on a missing method and on a missing target/class", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpConsoleReflectionTools::Register(Registry);
+
+			TSharedPtr<FJsonObject> NoTarget = Args();
+			NoTarget->SetStringField(TEXT("method"), TEXT("Add_IntInt"));
+			TestFalse(TEXT("no target/class is an error"), Run(Registry, TEXT("reflection-method-call"), NoTarget).bSuccess);
+
+			TSharedPtr<FJsonObject> BadMethod = Args();
+			BadMethod->SetStringField(TEXT("class"), TEXT("KismetMathLibrary"));
+			BadMethod->SetStringField(TEXT("method"), TEXT("NoSuchMethod_zzz"));
+			TestFalse(TEXT("unknown method is an error"), Run(Registry, TEXT("reflection-method-call"), BadMethod).bSuccess);
+		});
+
+		It("rejects an ambiguous target+class pair instead of silently preferring one", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpConsoleReflectionTools::Register(Registry);
+			TSharedPtr<FJsonObject> Both = Args();
+			Both->SetStringField(TEXT("class"), TEXT("KismetMathLibrary"));
+			Both->SetStringField(TEXT("target"), TEXT("AnyObject"));
+			Both->SetStringField(TEXT("method"), TEXT("Add_IntInt"));
+			TestFalse(TEXT("both target and class is an error"), Run(Registry, TEXT("reflection-method-call"), Both).bSuccess);
+		});
+
+		It("refuses an instance method on the class CDO path (steer to 'target')", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpConsoleReflectionTools::Register(Registry);
+
+			// Find a BlueprintCallable, non-static UFunction on AActor — exactly the case the CDO path must
+			// refuse at runtime (it would mutate the shared class defaults / need a world). The runtime CDO
+			// gate accepts only Static functions.
+			UClass* ActorClass = AActor::StaticClass();
+			FString InstanceName;
+			for (TFieldIterator<UFunction> It(ActorClass, EFieldIteratorFlags::IncludeSuper); It; ++It)
+			{
+				UFunction* Fn = *It;
+				if (!Fn->HasAnyFunctionFlags(FUNC_BlueprintCallable) || Fn->HasAnyFunctionFlags(FUNC_Static))
+					continue;
+				InstanceName = Fn->GetName();
+				break;
+			}
+			TestTrue(TEXT("found a BlueprintCallable instance method to probe the CDO gate"), !InstanceName.IsEmpty());
+			if (InstanceName.IsEmpty()) return;
+
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("class"), TEXT("Actor"));
+			A->SetStringField(TEXT("method"), InstanceName);
+			TestFalse(TEXT("instance method via 'class' is rejected"), Run(Registry, TEXT("reflection-method-call"), A).bSuccess);
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorToolsSpec.cpp
@@ -7,7 +7,6 @@
 #include "Misc/AutomationTest.h"
 #include "UnrealMcpCoreTools.h"
 #include "UnrealMcpToolRegistry.h"
-#include "Tools/UnrealMcpLogCollector.h"
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
 #include "Editor.h"
@@ -15,15 +14,17 @@
 #include "GameFramework/Actor.h"
 
 /**
- * Editor / console / reflection tool family specs (docs/ARCHITECTURE.md §10, issue #19). Registration
- * shape + per-tool happy/error paths, executed in EditorContext so GEditor + the editor world are live.
+ * Editor-application / selection tool family specs (docs/ARCHITECTURE.md §10, issue #19, editor-only
+ * subset). Registration shape + per-tool happy/error paths, executed in EditorContext so GEditor + the
+ * editor world are live. The runtime-safe console + reflection subset moved to the runtime module in R4
+ * (§12.7); its specs live in UnrealMcpConsoleReflectionToolsSpec.cpp.
  *
  * PIE state TRANSITIONS are NOT driven here: starting a play session under headless `-nullrhi` automation
  * emits engine Errors (which count as Automation failures) and cannot tick to completion. Only the
  * deterministic validation/error branches of editor-application-set-state are asserted; the real PIE
  * paths are proven honestly in the live bridge e2e (see targets/unreal-mcp/test.md Suite 7).
  */
-BEGIN_DEFINE_SPEC(FUnrealMcpEditorToolsSpec, "UnrealMcp.Tools.EditorReflection",
+BEGIN_DEFINE_SPEC(FUnrealMcpEditorToolsSpec, "UnrealMcp.Tools.EditorApplication",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
 
 	static TSharedPtr<FJsonObject> Args() { return MakeShared<FJsonObject>(); }
@@ -49,7 +50,7 @@ void FUnrealMcpEditorToolsSpec::Define()
 {
 	Describe("registration", [this]()
 	{
-		It("registers the full editor/console/reflection family as core tools and bumps the revision", [this]()
+		It("registers the editor-application / selection family as core tools and bumps the revision", [this]()
 		{
 			FUnrealMcpToolRegistry Registry;
 			const int32 Before = Registry.GetRevision();
@@ -57,9 +58,7 @@ void FUnrealMcpEditorToolsSpec::Define()
 
 			const TCHAR* const Expected[] = {
 				TEXT("editor-application-get-state"), TEXT("editor-application-set-state"),
-				TEXT("editor-selection-get"), TEXT("editor-selection-set"),
-				TEXT("console-get-logs"), TEXT("console-clear-logs"), TEXT("console-run-command"),
-				TEXT("reflection-method-find"), TEXT("reflection-method-call")
+				TEXT("editor-selection-get"), TEXT("editor-selection-set")
 			};
 			for (const TCHAR* Name : Expected)
 				TestTrue(FString::Printf(TEXT("has %s"), Name), Registry.HasTool(Name));
@@ -177,222 +176,6 @@ void FUnrealMcpEditorToolsSpec::Define()
 			// Neither 'actors' nor clear=true: must be an explicit error, not a silent SelectNone reported
 			// as success — deselecting the whole selection requires the explicit clear=true intent.
 			TestFalse(TEXT("empty no-arg call is an error"), Run(Registry, TEXT("editor-selection-set"), Args()).bSuccess);
-		});
-	});
-
-	Describe("console", [this]()
-	{
-		It("runs a console command and captures handled/output", [this]()
-		{
-			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
-			TSharedPtr<FJsonObject> A = Args();
-			A->SetStringField(TEXT("command"), TEXT("r.ScreenPercentage")); // read-only CVar query — prints its value
-			const FUnrealMcpToolResult R = Run(Registry, TEXT("console-run-command"), A);
-			TestTrue(TEXT("command runs"), R.bSuccess);
-			TestTrue(TEXT("missing command is rejected"), !Run(Registry, TEXT("console-run-command"), Args()).bSuccess);
-		});
-
-		It("captures GLog lines into the ring buffer, filters them, and clears", [this]()
-		{
-			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
-
-			// Drive the collector directly (the runtime that normally Startup()s it is not running in specs).
-			// NOTE: the collector is a process-wide singleton. Running this spec inside a LIVE editor session
-			// (rather than a throwaway -nullrhi automation process) is DESTRUCTIVE to the runtime's buffered
-			// logs — the Clear() below and console-clear-logs wipe the shared buffer. Registration state is
-			// snapshotted/restored at the end, but buffer CONTENTS are not. Acceptable for automation; do not
-			// run against a session whose captured logs you need to keep.
-			FUnrealMcpLogCollector& Collector = FUnrealMcpLogCollector::Get();
-			const bool bWasRegistered = Collector.IsRegistered();
-			Collector.Startup();
-			Collector.Clear();
-
-			const FString Needle = TEXT("McpLogProbe_4d9f");
-			UE_LOG(LogTemp, Display, TEXT("%s once"), *Needle);
-			GLog->Flush();
-
-			TSharedPtr<FJsonObject> GetArgs = Args();
-			GetArgs->SetStringField(TEXT("search"), Needle);
-			const FUnrealMcpToolResult GetR = Run(Registry, TEXT("console-get-logs"), GetArgs);
-			TestTrue(TEXT("get-logs succeeds"), GetR.bSuccess);
-			int32 Found = 0;
-			if (GetR.Structured.IsValid())
-			{
-				double C = 0; GetR.Structured->TryGetNumberField(TEXT("count"), C); Found = (int32)C;
-			}
-			TestTrue(TEXT("probe line captured"), Found >= 1);
-
-			const FUnrealMcpToolResult ClearR = Run(Registry, TEXT("console-clear-logs"), Args());
-			TestTrue(TEXT("clear succeeds"), ClearR.bSuccess);
-			TestEqual(TEXT("buffer empty after clear"), Collector.Num(), 0);
-
-			// Restore the registration state we found (don't leave a dangling GLog device across specs).
-			if (!bWasRegistered)
-				Collector.Shutdown();
-		});
-	});
-
-	Describe("reflection", [this]()
-	{
-		It("discovers a known BlueprintCallable static method with signature + flags", [this]()
-		{
-			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
-			TSharedPtr<FJsonObject> A = Args();
-			A->SetStringField(TEXT("class"), TEXT("KismetMathLibrary"));
-			A->SetStringField(TEXT("name"), TEXT("Add_IntInt"));
-			const FUnrealMcpToolResult R = Run(Registry, TEXT("reflection-method-find"), A);
-			TestTrue(TEXT("find succeeds"), R.bSuccess);
-
-			int32 Matched = 0;
-			if (R.Structured.IsValid())
-			{
-				double M = 0; R.Structured->TryGetNumberField(TEXT("matched"), M); Matched = (int32)M;
-			}
-			TestTrue(TEXT("at least one Add_IntInt match"), Matched >= 1);
-		});
-
-		It("invokes a safe pure BlueprintCallable method and returns its result", [this]()
-		{
-			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
-			TSharedPtr<FJsonObject> CallArgs = Args();
-			CallArgs->SetStringField(TEXT("class"), TEXT("KismetMathLibrary"));
-			CallArgs->SetStringField(TEXT("method"), TEXT("Add_IntInt"));
-			TSharedPtr<FJsonObject> Inner = MakeShared<FJsonObject>();
-			Inner->SetNumberField(TEXT("A"), 2);
-			Inner->SetNumberField(TEXT("B"), 3);
-			CallArgs->SetObjectField(TEXT("args"), Inner);
-
-			const FUnrealMcpToolResult R = Run(Registry, TEXT("reflection-method-call"), CallArgs);
-			TestTrue(TEXT("call succeeds"), R.bSuccess);
-			if (R.Structured.IsValid())
-			{
-				double Ret = 0; R.Structured->TryGetNumberField(TEXT("returnValue"), Ret);
-				TestEqual(TEXT("2 + 3 == 5"), (int32)Ret, 5);
-			}
-		});
-
-		It("invokes an INSTANCE BlueprintCallable method on an editor-world actor and gets a real (non-default) result", [this]()
-		{
-			// Regression guard for the FEditorScriptExecutionGuard around ProcessEvent. An editor-world actor's
-			// BlueprintCallable (non-CallInEditor) INSTANCE method is silently skipped by AActor::ProcessEvent
-			// unless script execution in the editor is enabled — without the guard the call would still report
-			// success but return the zero-initialized default (false here). Proving a 'true' result proves the
-			// method actually executed. (The static-via-CDO path above bypasses this gate, so it can't catch it.)
-			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
-
-			AActor* Actor = SpawnTemp(TEXT("McpReflectInstance"));
-			TestTrue(TEXT("spawned a target actor"), Actor != nullptr);
-			if (!Actor) return;
-			Actor->Tags.Add(FName(TEXT("McpReflectProbe")));
-
-			TSharedPtr<FJsonObject> CallArgs = Args();
-			CallArgs->SetStringField(TEXT("target"), TEXT("McpReflectInstance"));
-			CallArgs->SetStringField(TEXT("method"), TEXT("ActorHasTag")); // BlueprintCallable instance method, bool return
-			TSharedPtr<FJsonObject> Inner = MakeShared<FJsonObject>();
-			Inner->SetStringField(TEXT("Tag"), TEXT("McpReflectProbe"));
-			CallArgs->SetObjectField(TEXT("args"), Inner);
-
-			const FUnrealMcpToolResult R = Run(Registry, TEXT("reflection-method-call"), CallArgs);
-			TestTrue(TEXT("instance call succeeds"), R.bSuccess);
-			bool bRet = false;
-			if (R.Structured.IsValid())
-				R.Structured->TryGetBoolField(TEXT("returnValue"), bRet);
-			TestTrue(TEXT("ActorHasTag returned true (method ran under the editor script guard)"), bRet);
-
-			Actor->Destroy();
-		});
-
-		It("rejects a non-object 'args' argument instead of silently zeroing every parameter", [this]()
-		{
-			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
-			TSharedPtr<FJsonObject> A = Args();
-			A->SetStringField(TEXT("class"), TEXT("KismetMathLibrary"));
-			A->SetStringField(TEXT("method"), TEXT("Add_IntInt"));
-			TArray<TSharedPtr<FJsonValue>> ArgsArr; ArgsArr.Add(MakeShared<FJsonValueNumber>(1));
-			A->SetArrayField(TEXT("args"), ArgsArr); // present but an array, not an object
-			TestFalse(TEXT("non-object 'args' is an error"), Run(Registry, TEXT("reflection-method-call"), A).bSuccess);
-		});
-
-		It("refuses to call a non-BlueprintCallable / non-CallInEditor function (safety gate)", [this]()
-		{
-			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
-
-			// Find a concrete non-callable UFunction on AActor at runtime (deterministic: lifecycle/native
-			// helpers exist that are neither BlueprintCallable nor CallInEditor) and prove the gate rejects
-			// it BEFORE any ProcessEvent runs.
-			UClass* ActorClass = AActor::StaticClass();
-			FString TargetName;
-			for (TFieldIterator<UFunction> It(ActorClass, EFieldIteratorFlags::IncludeSuper); It; ++It)
-			{
-				UFunction* Fn = *It;
-				const bool bCallable = Fn->HasAnyFunctionFlags(FUNC_BlueprintCallable)
-#if WITH_EDITORONLY_DATA
-					|| Fn->GetBoolMetaData(TEXT("CallInEditor"))
-#endif
-					;
-				if (!bCallable) { TargetName = Fn->GetName(); break; }
-			}
-			TestTrue(TEXT("found a non-callable function to probe the gate with"), !TargetName.IsEmpty());
-			if (TargetName.IsEmpty()) return;
-
-			TSharedPtr<FJsonObject> A = Args();
-			A->SetStringField(TEXT("class"), TEXT("Actor"));
-			A->SetStringField(TEXT("method"), TargetName);
-			const FUnrealMcpToolResult R = Run(Registry, TEXT("reflection-method-call"), A);
-			TestFalse(TEXT("non-callable function is rejected"), R.bSuccess);
-		});
-
-		It("errors on a missing method and on a missing target/class", [this]()
-		{
-			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
-
-			TSharedPtr<FJsonObject> NoTarget = Args();
-			NoTarget->SetStringField(TEXT("method"), TEXT("Add_IntInt"));
-			TestFalse(TEXT("no target/class is an error"), Run(Registry, TEXT("reflection-method-call"), NoTarget).bSuccess);
-
-			TSharedPtr<FJsonObject> BadMethod = Args();
-			BadMethod->SetStringField(TEXT("class"), TEXT("KismetMathLibrary"));
-			BadMethod->SetStringField(TEXT("method"), TEXT("NoSuchMethod_zzz"));
-			TestFalse(TEXT("unknown method is an error"), Run(Registry, TEXT("reflection-method-call"), BadMethod).bSuccess);
-		});
-
-		It("rejects an ambiguous target+class pair instead of silently preferring one", [this]()
-		{
-			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
-			TSharedPtr<FJsonObject> Both = Args();
-			Both->SetStringField(TEXT("class"), TEXT("KismetMathLibrary"));
-			Both->SetStringField(TEXT("target"), TEXT("AnyObject"));
-			Both->SetStringField(TEXT("method"), TEXT("Add_IntInt"));
-			TestFalse(TEXT("both target and class is an error"), Run(Registry, TEXT("reflection-method-call"), Both).bSuccess);
-		});
-
-		It("refuses an instance method on the class CDO path (steer to 'target')", [this]()
-		{
-			FUnrealMcpToolRegistry Registry; UnrealMcpEditorTools::Register(Registry);
-
-			// Find a BlueprintCallable, non-static, non-CallInEditor UFunction on AActor — exactly the
-			// case the CDO path must refuse (it would mutate the shared class defaults / need a world).
-			UClass* ActorClass = AActor::StaticClass();
-			FString InstanceName;
-			for (TFieldIterator<UFunction> It(ActorClass, EFieldIteratorFlags::IncludeSuper); It; ++It)
-			{
-				UFunction* Fn = *It;
-				if (!Fn->HasAnyFunctionFlags(FUNC_BlueprintCallable) || Fn->HasAnyFunctionFlags(FUNC_Static))
-					continue;
-#if WITH_EDITORONLY_DATA
-				if (Fn->GetBoolMetaData(TEXT("CallInEditor")))
-					continue;
-#endif
-				InstanceName = Fn->GetName();
-				break;
-			}
-			TestTrue(TEXT("found a BlueprintCallable instance method to probe the CDO gate"), !InstanceName.IsEmpty());
-			if (InstanceName.IsEmpty()) return;
-
-			TSharedPtr<FJsonObject> A = Args();
-			A->SetStringField(TEXT("class"), TEXT("Actor"));
-			A->SetStringField(TEXT("method"), InstanceName);
-			TestFalse(TEXT("instance method via 'class' is rejected"), Run(Registry, TEXT("reflection-method-call"), A).bSuccess);
 		});
 	});
 }

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpLevelToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpLevelToolsSpec.cpp
@@ -11,12 +11,14 @@
 #include "Dom/JsonValue.h"
 
 /**
- * Level / map tool family specs (docs/ARCHITECTURE.md §10, issue #16 — Unity Scene.* analog).
+ * Editor level / map tool family specs (docs/ARCHITECTURE.md §10, issue #16 — Unity Scene.* analog, §12.7).
+ * Covers the six EDITOR-ONLY level tools. The read-only level-get-data moved to the runtime module in R4;
+ * its specs live in UnrealMcpRuntimeLevelToolsSpec.cpp.
  *
  * Three groups:
  *  - registration   — every declared tool is present with a kebab-case id + correct hints (no live editor).
  *  - error paths     — each tool's required-arg / not-found guard returns an error result.
- *  - live round-trip — a real in-editor lifecycle (create -> list-loaded -> get-data -> set-current),
+ *  - live round-trip — a real in-editor lifecycle (create -> list-loaded -> set-current),
  *    driven entirely through GEditor->NewMap() (the level-create no-'path' branch), so NOTHING is
  *    written to disk and the testbed working tree stays clean. Disk save / open is proven separately by
  *    the live bridge e2e (which saves under a temp content path and cleans up).
@@ -43,14 +45,14 @@ void FUnrealMcpLevelToolsSpec::Define()
 {
 	Describe("registration", [this]()
 	{
-		It("registers all seven level tools with kebab-case ids", [this]()
+		It("registers all six editor level tools with kebab-case ids", [this]()
 		{
 			FUnrealMcpToolRegistry Registry;
 			UnrealMcpLevelTools::Register(Registry);
 
 			const TArray<FString> Expected = {
 				TEXT("level-create"), TEXT("level-open"), TEXT("level-save"),
-				TEXT("level-get-data"), TEXT("level-list-loaded"), TEXT("level-set-current"),
+				TEXT("level-list-loaded"), TEXT("level-set-current"),
 				TEXT("level-unload-sublevel")
 			};
 			for (const FString& Name : Expected)
@@ -58,7 +60,9 @@ void FUnrealMcpLevelToolsSpec::Define()
 				TestTrue(FString::Printf(TEXT("has %s"), *Name), Registry.HasTool(Name));
 				TestTrue(FString::Printf(TEXT("%s is valid kebab id"), *Name), FUnrealMcpToolRegistry::IsValidToolName(Name));
 			}
-			TestEqual(TEXT("exactly seven tools"), Registry.Num(), Expected.Num());
+			TestEqual(TEXT("exactly six tools"), Registry.Num(), Expected.Num());
+			// level-get-data moved to the runtime module (R4, §12.7) — it must NOT be in the editor level family.
+			TestFalse(TEXT("level-get-data is no longer in the editor level family"), Registry.HasTool(TEXT("level-get-data")));
 		});
 
 		It("marks read-only and destructive tools correctly", [this]()
@@ -67,14 +71,11 @@ void FUnrealMcpLevelToolsSpec::Define()
 			UnrealMcpLevelTools::Register(Registry);
 			// Find() returns nullptr for an unregistered id; null-check before dereferencing so a registration
 			// regression fails this assertion cleanly instead of crashing the whole automation run.
-			const FUnrealMcpRegisteredTool* GetData = Registry.Find(TEXT("level-get-data"));
 			const FUnrealMcpRegisteredTool* ListLoaded = Registry.Find(TEXT("level-list-loaded"));
 			const FUnrealMcpRegisteredTool* Unload = Registry.Find(TEXT("level-unload-sublevel"));
-			if (!TestNotNull(TEXT("level-get-data registered"), GetData) ||
-				!TestNotNull(TEXT("level-list-loaded registered"), ListLoaded) ||
+			if (!TestNotNull(TEXT("level-list-loaded registered"), ListLoaded) ||
 				!TestNotNull(TEXT("level-unload-sublevel registered"), Unload))
 				return;
-			TestTrue(TEXT("get-data read-only"), GetData->bReadOnlyHint);
 			TestTrue(TEXT("list-loaded read-only"), ListLoaded->bReadOnlyHint);
 			TestTrue(TEXT("unload-sublevel destructive"), Unload->bDestructiveHint);
 		});
@@ -122,17 +123,6 @@ void FUnrealMcpLevelToolsSpec::Define()
 		{
 			FUnrealMcpToolRegistry Registry; UnrealMcpLevelTools::Register(Registry);
 			TestFalse(TEXT("not success"), RunLevel(Registry, TEXT("level-unload-sublevel"), Args()).bSuccess);
-		});
-
-		It("level-get-data errors on a non-string paths entry", [this]()
-		{
-			FUnrealMcpToolRegistry Registry; UnrealMcpLevelTools::Register(Registry);
-			TSharedPtr<FJsonObject> A = Args();
-			// An object entry is genuinely non-stringable — unlike a JSON number, which UE's
-			// FJsonValue::TryGetString coerces to its text form ("42") and would NOT trip the guard.
-			TArray<TSharedPtr<FJsonValue>> Paths; Paths.Add(MakeShared<FJsonValueObject>(MakeShared<FJsonObject>()));
-			A->SetArrayField(TEXT("paths"), Paths);
-			TestFalse(TEXT("not success"), RunLevel(Registry, TEXT("level-get-data"), A).bSuccess);
 		});
 	});
 
@@ -187,21 +177,6 @@ void FUnrealMcpLevelToolsSpec::Define()
 						if (V.IsValid() && V->AsObject().IsValid() && V->AsObject()->GetBoolField(TEXT("isPersistent")))
 							bSawPersistent = true;
 				TestTrue(TEXT("persistent level present in list"), bSawPersistent);
-			}
-
-			// level-get-data whole-world snapshot: an actors array + numeric total.
-			{
-				const FUnrealMcpToolResult R = RunLevel(Registry, TEXT("level-get-data"), Args());
-				TestTrue(TEXT("get-data ok"), R.bSuccess);
-				if (!R.Structured.IsValid())
-				{
-					AddError(TEXT("level-get-data returned no structured payload"));
-					return;
-				}
-				const TArray<TSharedPtr<FJsonValue>>* Actors = nullptr;
-				TestTrue(TEXT("get-data has actors array"), R.Structured->TryGetArrayField(TEXT("actors"), Actors) && Actors);
-				double Total = -1;
-				TestTrue(TEXT("get-data has total"), R.Structured->TryGetNumberField(TEXT("total"), Total) && Total >= 0.0);
 			}
 
 			// level-set-current on the persistent level: already current -> success (idempotent).

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpRuntimeLevelToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpRuntimeLevelToolsSpec.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "UnrealMcpRuntimeCoreTools.h" // §12.7: read-only level-get-data lives in the runtime module (R4)
+#include "UnrealMcpToolRegistry.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+
+/**
+ * Runtime level-data tool specs (docs/ARCHITECTURE.md §10 "level family" read-only runtime subset, §12.7).
+ * Covers the single runtime-safe tool, level-get-data, moved DOWN into the runtime module in R4. Runs in
+ * EditorContext so the editor world resolver the editor coordinator installs (FUnrealMcpWorldProvider) is
+ * live — the whole-world snapshot reads that editor world (the same code path serves the live game world
+ * over a runtime connection).
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpRuntimeLevelToolsSpec, "UnrealMcp.Tools.RuntimeLevel",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+	TSharedPtr<FJsonObject> Args() const { return MakeShared<FJsonObject>(); }
+END_DEFINE_SPEC(FUnrealMcpRuntimeLevelToolsSpec)
+
+namespace
+{
+	// Uniquely named (not a bare `Run`): the tests module UNITY-builds every *Spec.cpp into one TU, so an
+	// anonymous-namespace `Run` with the same signature as another spec's would ODR-collide.
+	FUnrealMcpToolResult RunRuntimeLevel(FUnrealMcpToolRegistry& Registry, const FString& Name, const TSharedPtr<FJsonObject>& Args)
+	{
+		return Registry.Execute(Name, FUnrealMcpToolCall(Args));
+	}
+}
+
+void FUnrealMcpRuntimeLevelToolsSpec::Define()
+{
+	Describe("registration", [this]()
+	{
+		It("registers level-get-data as a read-only core tool and bumps the revision", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			const int32 Before = Registry.GetRevision();
+			UnrealMcpRuntimeLevelTools::Register(Registry);
+
+			TestTrue(TEXT("has level-get-data"), Registry.HasTool(TEXT("level-get-data")));
+			TestTrue(TEXT("level-get-data is a valid kebab id"), FUnrealMcpToolRegistry::IsValidToolName(TEXT("level-get-data")));
+			TestEqual(TEXT("exactly one tool"), Registry.Num(), 1);
+			TestTrue(TEXT("revision bumped"), Registry.GetRevision() > Before);
+
+			const FUnrealMcpRegisteredTool* GetData = Registry.Find(TEXT("level-get-data"));
+			if (TestNotNull(TEXT("level-get-data registered"), GetData))
+			{
+				TestEqual(TEXT("core extension id"), GetData->ExtensionId, FString(TEXT("core")));
+				TestFalse(TEXT("schema hash non-empty"), GetData->SchemaHash.IsEmpty());
+				TestTrue(TEXT("get-data read-only"), GetData->bReadOnlyHint);
+			}
+		});
+	});
+
+	Describe("error paths", [this]()
+	{
+		It("level-get-data errors on a non-string paths entry", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpRuntimeLevelTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			// An object entry is genuinely non-stringable — unlike a JSON number, which UE's
+			// FJsonValue::TryGetString coerces to its text form ("42") and would NOT trip the guard.
+			TArray<TSharedPtr<FJsonValue>> Paths; Paths.Add(MakeShared<FJsonValueObject>(MakeShared<FJsonObject>()));
+			A->SetArrayField(TEXT("paths"), Paths);
+			TestFalse(TEXT("not success"), RunRuntimeLevel(Registry, TEXT("level-get-data"), A).bSuccess);
+		});
+
+		It("level-get-data errors for an unresolved single-actor ref", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpRuntimeLevelTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("actor"), TEXT("__definitely_missing_actor__"));
+			TestFalse(TEXT("not success"), RunRuntimeLevel(Registry, TEXT("level-get-data"), A).bSuccess);
+		});
+	});
+
+	Describe("whole-world snapshot", [this]()
+	{
+		It("returns an actors array + numeric total for the resolved world", [this]()
+		{
+			// The editor coordinator installed the editor-world resolver on plugin startup, so GetEditorWorld()
+			// resolves the live editor world here (the same path serves the game world over a runtime connection).
+			FUnrealMcpToolRegistry Registry; UnrealMcpRuntimeLevelTools::Register(Registry);
+			const FUnrealMcpToolResult R = RunRuntimeLevel(Registry, TEXT("level-get-data"), Args());
+			TestTrue(TEXT("get-data ok"), R.bSuccess);
+			if (!R.Structured.IsValid())
+			{
+				AddError(TEXT("level-get-data returned no structured payload"));
+				return;
+			}
+			const TArray<TSharedPtr<FJsonValue>>* Actors = nullptr;
+			TestTrue(TEXT("get-data has actors array"), R.Structured->TryGetArrayField(TEXT("actors"), Actors) && Actors);
+			double Total = -1;
+			TestTrue(TEXT("get-data has total"), R.Structured->TryGetNumberField(TEXT("total"), Total) && Total >= 0.0);
+			FString World;
+			TestTrue(TEXT("get-data names the world"), R.Structured->TryGetStringField(TEXT("world"), World) && !World.IsEmpty());
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpRuntimeScreenshotToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpRuntimeScreenshotToolsSpec.cpp
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/App.h"
+#include "Misc/AutomationTest.h"
+#include "UnrealMcpRuntimeCoreTools.h" // §12.7: the runtime screenshot subset lives in the runtime module (R4)
+#include "UnrealMcpToolRegistry.h"
+#include "Dom/JsonObject.h"
+
+/**
+ * Runtime screenshot subset specs (docs/ARCHITECTURE.md §10, issue #17, §12.7). Covers the two
+ * runtime-safe tools — screenshot-game-view, screenshot-camera — moved DOWN into the runtime module in
+ * R4. GPU-free: registration, the dimension clamp/cap logic, and every argument / precondition error
+ * branch (missing 'camera', unresolved camera ref, no active game viewport). The real pixel-capture
+ * paths are LIVE-VERIFIED WINDOWED over the bridge (no GPU under `-nullrhi`); the headless harness asserts
+ * a clean error (never a crash) when rendering is unavailable.
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpRuntimeScreenshotToolsSpec, "UnrealMcp.Tools.RuntimeScreenshot",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+	TSharedPtr<FJsonObject> Args() const { return MakeShared<FJsonObject>(); }
+END_DEFINE_SPEC(FUnrealMcpRuntimeScreenshotToolsSpec)
+
+namespace
+{
+	FUnrealMcpToolResult RunRuntimeScreenshot(FUnrealMcpToolRegistry& Registry, const FString& Name, const TSharedPtr<FJsonObject>& Args)
+	{
+		return Registry.Execute(Name, FUnrealMcpToolCall(Args));
+	}
+}
+
+void FUnrealMcpRuntimeScreenshotToolsSpec::Define()
+{
+	Describe("registration", [this]()
+	{
+		It("registers the two runtime screenshot tools with kebab-case ids", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpRuntimeScreenshotTools::Register(Registry);
+
+			const TArray<FString> Expected = {
+				TEXT("screenshot-game-view"), TEXT("screenshot-camera")
+			};
+			for (const FString& Name : Expected)
+			{
+				TestTrue(FString::Printf(TEXT("has %s"), *Name), Registry.HasTool(Name));
+				TestTrue(FString::Printf(TEXT("%s is a valid kebab id"), *Name), FUnrealMcpToolRegistry::IsValidToolName(Name));
+			}
+			TestEqual(TEXT("exactly two tools"), Registry.Num(), Expected.Num());
+		});
+
+		It("marks every runtime screenshot tool read-only (capture never mutates the scene)", [this]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			UnrealMcpRuntimeScreenshotTools::Register(Registry);
+			const TArray<FString> Names = {
+				TEXT("screenshot-game-view"), TEXT("screenshot-camera")
+			};
+			for (const FString& Name : Names)
+			{
+				const FUnrealMcpRegisteredTool* Tool = Registry.Find(Name);
+				TestNotNull(FString::Printf(TEXT("%s present"), *Name), Tool);
+				if (Tool)
+					TestTrue(FString::Printf(TEXT("%s read-only"), *Name), Tool->bReadOnlyHint);
+			}
+		});
+	});
+
+	Describe("dimension logic", [this]()
+	{
+		It("ResolveCaptureDimension clamps to [1, 2048] and defaults unset to 1024", [this]()
+		{
+			TestEqual(TEXT("zero -> default"), UnrealMcpRuntimeScreenshotTools::ResolveCaptureDimension(0), (int32)UnrealMcpRuntimeScreenshotTools::DefaultCaptureDimension);
+			TestEqual(TEXT("negative -> default"), UnrealMcpRuntimeScreenshotTools::ResolveCaptureDimension(-7), (int32)UnrealMcpRuntimeScreenshotTools::DefaultCaptureDimension);
+			TestEqual(TEXT("one stays one"), UnrealMcpRuntimeScreenshotTools::ResolveCaptureDimension(1), 1);
+			TestEqual(TEXT("mid passes through"), UnrealMcpRuntimeScreenshotTools::ResolveCaptureDimension(800), 800);
+			TestEqual(TEXT("at cap"), UnrealMcpRuntimeScreenshotTools::ResolveCaptureDimension(2048), 2048);
+			TestEqual(TEXT("over cap clamps"), UnrealMcpRuntimeScreenshotTools::ResolveCaptureDimension(5000), (int32)UnrealMcpRuntimeScreenshotTools::MaxCaptureDimension);
+		});
+
+		It("CapToMaxDimension downscales proportionally only when the longest side exceeds the cap", [this]()
+		{
+			int32 W = 0, H = 0;
+			UnrealMcpRuntimeScreenshotTools::CapToMaxDimension(1920, 1080, W, H);
+			TestEqual(TEXT("within cap width unchanged"), W, 1920);
+			TestEqual(TEXT("within cap height unchanged"), H, 1080);
+
+			UnrealMcpRuntimeScreenshotTools::CapToMaxDimension(4096, 2048, W, H);
+			TestEqual(TEXT("over cap width = 2048"), W, 2048);
+			TestEqual(TEXT("over cap height scaled"), H, 1024);
+
+			UnrealMcpRuntimeScreenshotTools::CapToMaxDimension(0, 0, W, H);
+			TestEqual(TEXT("zero floors to 1 width"), W, 1);
+			TestEqual(TEXT("zero floors to 1 height"), H, 1);
+		});
+	});
+
+	Describe("error paths (GPU-free)", [this]()
+	{
+		It("screenshot-camera errors when 'camera' is missing", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpRuntimeScreenshotTools::Register(Registry);
+			TestFalse(TEXT("not success"), RunRuntimeScreenshot(Registry, TEXT("screenshot-camera"), Args()).bSuccess);
+		});
+
+		It("screenshot-camera errors for an unresolved camera reference", [this]()
+		{
+			FUnrealMcpToolRegistry Registry; UnrealMcpRuntimeScreenshotTools::Register(Registry);
+			TSharedPtr<FJsonObject> A = Args();
+			A->SetStringField(TEXT("camera"), TEXT("__definitely_missing_camera__"));
+			TestFalse(TEXT("not success"), RunRuntimeScreenshot(Registry, TEXT("screenshot-camera"), A).bSuccess);
+		});
+
+		It("screenshot-game-view errors with no active game viewport", [this]()
+		{
+			// No PIE / game viewport runs under the Automation harness, so this is the documented
+			// no-game-viewport error branch (validated before the GPU guard).
+			FUnrealMcpToolRegistry Registry; UnrealMcpRuntimeScreenshotTools::Register(Registry);
+			TestFalse(TEXT("not success"), RunRuntimeScreenshot(Registry, TEXT("screenshot-game-view"), Args()).bSuccess);
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpRuntimeSubsystemSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpRuntimeSubsystemSpec.cpp
@@ -13,6 +13,8 @@
 #include "UnrealMcpRuntimeSubsystem.h"
 #include "UnrealMcpRuntimeSettings.h"
 #include "Tools/UnrealMcpWorldProvider.h"
+#include "UnrealMcpRuntimeCoreTools.h" // runtime-safe families (§12.7) — for the runtime-manifest-separation check
+#include "UnrealMcpToolRegistry.h"      // FUnrealMcpToolRegistry — the registry the separation check builds against
 
 /**
  * Specs for the R3 runtime bootstrap (docs/ARCHITECTURE.md §12.4 / §12.6 / §12.8). These exercise the parts
@@ -137,6 +139,69 @@ void FUnrealMcpRuntimeSubsystemSpec::Define()
 			{
 				return GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
 			});
+		});
+	});
+
+	Describe("runtime manifest separation (§12.7 R4 DoD)", [this]()
+	{
+		// Build a registry with EXACTLY the runtime-safe families the runtime bootstrap subsystem registers
+		// (UnrealMcpRuntimeSubsystem::Initialize: ping + actor/component + console/reflection + screenshot
+		// subset + level-get-data). This is the authoritative headless proxy for the packaged-game runtime
+		// manifest: the subsystem builds its registry privately inside Initialize() (which needs a live
+		// UGameInstance + bridge), so asserting against the SAME registration list here proves the manifest's
+		// shape without the live harness — and is what makes "editor-only tools absent from the runtime
+		// manifest" a deterministic CI gate rather than a flaky live-e2e step.
+		auto BuildRuntimeRegistry = [](FUnrealMcpToolRegistry& Registry)
+		{
+			UnrealMcpPingTool::Register(Registry);
+			UnrealMcpActorTools::Register(Registry);
+			UnrealMcpConsoleReflectionTools::Register(Registry);
+			UnrealMcpRuntimeScreenshotTools::Register(Registry);
+			UnrealMcpRuntimeLevelTools::Register(Registry);
+		};
+
+		It("includes the runtime-safe tools and EXCLUDES every editor-only tool", [this, BuildRuntimeRegistry]()
+		{
+			FUnrealMcpToolRegistry Registry;
+			BuildRuntimeRegistry(Registry);
+
+			// --- Runtime-safe tools MUST be present (the family also works over a runtime connection). ---
+			const TCHAR* const RuntimeExpected[] = {
+				TEXT("ping"),
+				// actor / component family (13)
+				TEXT("actor-create"), TEXT("actor-destroy"), TEXT("actor-duplicate"), TEXT("actor-find"),
+				TEXT("actor-modify"), TEXT("actor-set-parent"), TEXT("actor-component-add"),
+				TEXT("actor-component-destroy"), TEXT("actor-component-get"), TEXT("actor-component-modify"),
+				TEXT("actor-component-list-all"), TEXT("object-get-data"), TEXT("object-modify"),
+				// console + reflection runtime subset (5)
+				TEXT("console-get-logs"), TEXT("console-clear-logs"), TEXT("console-run-command"),
+				TEXT("reflection-method-find"), TEXT("reflection-method-call"),
+				// screenshot runtime subset (2)
+				TEXT("screenshot-game-view"), TEXT("screenshot-camera"),
+				// read-only level data (1)
+				TEXT("level-get-data")
+			};
+			for (const TCHAR* Name : RuntimeExpected)
+				TestTrue(FString::Printf(TEXT("runtime manifest HAS %s"), Name), Registry.HasTool(Name));
+
+			// The runtime set is exactly these (1 + 13 + 5 + 2 + 1 = 22).
+			TestEqual(TEXT("runtime tool count == 22"), Registry.Num(), (int32)UE_ARRAY_COUNT(RuntimeExpected));
+
+			// --- Editor-only tools MUST be ABSENT from the runtime manifest. ---
+			const TCHAR* const EditorOnlyForbidden[] = {
+				// editor-application / selection
+				TEXT("editor-application-get-state"), TEXT("editor-application-set-state"),
+				TEXT("editor-selection-get"), TEXT("editor-selection-set"),
+				// editor screenshot subset
+				TEXT("screenshot-viewport"), TEXT("screenshot-isolated"),
+				// level WRITE + editor list
+				TEXT("level-create"), TEXT("level-open"), TEXT("level-save"),
+				TEXT("level-list-loaded"), TEXT("level-set-current"), TEXT("level-unload-sublevel"),
+				// representative asset / blueprint / source family members
+				TEXT("asset-find"), TEXT("blueprint-create"), TEXT("source-compile")
+			};
+			for (const TCHAR* Name : EditorOnlyForbidden)
+				TestFalse(FString::Printf(TEXT("runtime manifest does NOT have editor-only %s"), Name), Registry.HasTool(Name));
 		});
 	});
 }

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpScreenshotToolsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpScreenshotToolsSpec.cpp
@@ -15,10 +15,13 @@
 #include "GameFramework/Actor.h"
 
 /**
- * Screenshot / viewport-capture tool family specs (docs/ARCHITECTURE.md §10, issue #17).
+ * Editor screenshot / viewport-capture tool family specs (docs/ARCHITECTURE.md §10, issue #17, §12.7).
+ * Covers the two EDITOR-ONLY tools — screenshot-viewport, screenshot-isolated. The runtime-safe subset
+ * (screenshot-game-view, screenshot-camera) moved to the runtime module in R4; its specs live in
+ * UnrealMcpRuntimeScreenshotToolsSpec.cpp.
  *
  * These are GPU-free: they cover registration, the dimension clamp/cap logic, and every argument /
- * precondition error branch (missing 'camera'/'actor', unresolved refs, no PIE session). The actual
+ * precondition error branch (missing 'actor', unresolved refs, malformed background hex). The actual
  * pixel-capture paths CANNOT run headless (`-nullrhi` has no GPU) — those are LIVE-VERIFIED WINDOWED
  * over the bridge. To keep the suite green headless, the capture branch is asserted to return a clean
  * "rendering unavailable" error (never a crash) when FApp::CanEverRender() is false, rather than being
@@ -41,21 +44,20 @@ void FUnrealMcpScreenshotToolsSpec::Define()
 {
 	Describe("registration", [this]()
 	{
-		It("registers all four screenshot tools with kebab-case ids", [this]()
+		It("registers the two editor screenshot tools with kebab-case ids", [this]()
 		{
 			FUnrealMcpToolRegistry Registry;
 			UnrealMcpScreenshotTools::Register(Registry);
 
 			const TArray<FString> Expected = {
-				TEXT("screenshot-viewport"), TEXT("screenshot-game-view"),
-				TEXT("screenshot-camera"), TEXT("screenshot-isolated")
+				TEXT("screenshot-viewport"), TEXT("screenshot-isolated")
 			};
 			for (const FString& Name : Expected)
 			{
 				TestTrue(FString::Printf(TEXT("has %s"), *Name), Registry.HasTool(Name));
 				TestTrue(FString::Printf(TEXT("%s is a valid kebab id"), *Name), FUnrealMcpToolRegistry::IsValidToolName(Name));
 			}
-			TestEqual(TEXT("exactly four tools"), Registry.Num(), Expected.Num());
+			TestEqual(TEXT("exactly two tools"), Registry.Num(), Expected.Num());
 		});
 
 		It("marks every screenshot tool read-only (capture never mutates the scene)", [this]()
@@ -63,8 +65,7 @@ void FUnrealMcpScreenshotToolsSpec::Define()
 			FUnrealMcpToolRegistry Registry;
 			UnrealMcpScreenshotTools::Register(Registry);
 			const TArray<FString> Names = {
-				TEXT("screenshot-viewport"), TEXT("screenshot-game-view"),
-				TEXT("screenshot-camera"), TEXT("screenshot-isolated")
+				TEXT("screenshot-viewport"), TEXT("screenshot-isolated")
 			};
 			for (const FString& Name : Names)
 			{
@@ -107,20 +108,6 @@ void FUnrealMcpScreenshotToolsSpec::Define()
 
 	Describe("error paths (GPU-free)", [this]()
 	{
-		It("screenshot-camera errors when 'camera' is missing", [this]()
-		{
-			FUnrealMcpToolRegistry Registry; UnrealMcpScreenshotTools::Register(Registry);
-			TestFalse(TEXT("not success"), RunScreenshot(Registry, TEXT("screenshot-camera"), Args()).bSuccess);
-		});
-
-		It("screenshot-camera errors for an unresolved camera reference", [this]()
-		{
-			FUnrealMcpToolRegistry Registry; UnrealMcpScreenshotTools::Register(Registry);
-			TSharedPtr<FJsonObject> A = Args();
-			A->SetStringField(TEXT("camera"), TEXT("__definitely_missing_camera__"));
-			TestFalse(TEXT("not success"), RunScreenshot(Registry, TEXT("screenshot-camera"), A).bSuccess);
-		});
-
 		It("screenshot-isolated errors when 'actor' is missing", [this]()
 		{
 			FUnrealMcpToolRegistry Registry; UnrealMcpScreenshotTools::Register(Registry);
@@ -133,14 +120,6 @@ void FUnrealMcpScreenshotToolsSpec::Define()
 			TSharedPtr<FJsonObject> A = Args();
 			A->SetStringField(TEXT("actor"), TEXT("__definitely_missing_actor__"));
 			TestFalse(TEXT("not success"), RunScreenshot(Registry, TEXT("screenshot-isolated"), A).bSuccess);
-		});
-
-		It("screenshot-game-view errors with no active PIE session", [this]()
-		{
-			// No Play-In-Editor session runs under the Automation harness, so this is the documented
-			// no-PIE error branch (validated before the GPU guard).
-			FUnrealMcpToolRegistry Registry; UnrealMcpScreenshotTools::Register(Registry);
-			TestFalse(TEXT("not success"), RunScreenshot(Registry, TEXT("screenshot-game-view"), Args()).bSuccess);
 		});
 
 		It("screenshot-isolated rejects a malformed background hex after the actor resolves", [this]()

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Tools/UnrealMcpActorTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Tools/UnrealMcpActorTools.cpp
@@ -1,15 +1,13 @@
 // Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the repository root for more information.
 
-#include "UnrealMcpCoreTools.h"
+#include "UnrealMcpRuntimeCoreTools.h"
 #include "UnrealMcpToolRegistry.h"
 #include "Tools/UnrealMcpObjectRef.h"
 #include "Tools/UnrealMcpPropertyJson.h"
 
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
-#include "Editor.h"
-#include "ScopedTransaction.h"      // FScopedTransaction — gives the per-handler Modify() snapshots an open transaction to record into
 #include "EngineUtils.h"            // TActorIterator
 #include "Engine/World.h"
 #include "GameFramework/Actor.h"
@@ -19,20 +17,85 @@
 #include "UObject/UObjectGlobals.h"   // StaticFindObjectFast
 
 /**
- * The actor & component tool family (docs/ARCHITECTURE.md §10 "actor family", declared via §3.3).
+ * The actor & component tool family (docs/ARCHITECTURE.md §10 "actor family", declared via §3.3, §12.7).
  *
  * ~13 native C++ tools over UClass/FProperty reflection. Object references are resolved through
  * FUnrealMcpObjectRef (§3.2: label → FindObject → soft-path load); scoped reads + FProperty/transform
  * writes go through FUnrealMcpPropertyJson. Every Handle() body runs ON the game thread — the bridge
  * dispatches Registry.Execute through FUnrealMcpGameThreadDispatcher (§4), so the bodies below touch
- * the editor world / UObject graph directly without any extra marshalling.
+ * the resolved world / UObject graph directly without any extra marshalling.
+ *
+ * RUNTIME-SAFE (§12.7, R4): this family lives in the Type=Runtime module so it works over a runtime
+ * connection in PIE and packaged Development builds as well as the editor. The world is resolved via
+ * FUnrealMcpObjectRef::GetEditorWorld() (the FUnrealMcpWorldProvider seam — editor world in the editor,
+ * live game world at runtime); actors spawn through the engine `UWorld::SpawnActor` path (never the
+ * editor-only UEditorActorSubsystem; today's editor code already used the engine path, so this is a
+ * straight move). The editor-only conveniences — undo transactions (FScopedTransaction), unique-label
+ * assignment (FActorLabelUtilities), the friendly actor label (GetActorLabel), and EditorDestroyActor —
+ * are handled behind the small seam helpers below: in the editor they preserve today's mutation
+ * behaviour; in a non-editor Game build they compile down to the plain runtime equivalents
+ * (GetActorNameOrLabel, World->DestroyActor).
  */
 namespace
 {
+	// --- Undo-transaction seam (runtime-safe, no-op) ---------------------------------------------
+	//
+	// The editor family wrapped each mutating op in an FScopedTransaction for editor undo. FScopedTransaction
+	// lives in the UnrealEd MODULE — which this Type=Runtime module deliberately does NOT depend on (depending
+	// on it would break the non-editor BuildPlugin Game target, the whole point of §12). A WITH_EDITOR guard is
+	// not enough: in the editor build of the runtime module WITH_EDITOR is true, so referencing FScopedTransaction
+	// produces an UNRESOLVED-SYMBOL link error against UnrealEd. So the transaction is a no-op RAII object in BOTH
+	// configs. The actor ops still mutate correctly and still call AActor/UActorComponent::Modify() +
+	// MarkPackageDirty() where they did before (those are Engine, WITH_EDITOR), so the editor's undo system can
+	// still capture them via whatever transaction is open at call time — the family simply no longer OPENS its own
+	// named undo step. Cancel() is therefore a no-op. (Trade-off recorded in the §12.7 R4 design_notes: moving the
+	// actor family into the runtime module costs the per-op named undo grouping; the mutations themselves are
+	// unchanged.) A family-unique name (FActorScopedTransaction) per the unity-build ODR rule.
+	struct FActorScopedTransaction
+	{
+		explicit FActorScopedTransaction(const FText& /*SessionName*/) {}
+		void Cancel() {}
+	};
+
+	/**
+	 * Assign an actor's label (editor) or no-op (runtime). Uses AActor::SetActorLabel, which is in the Engine
+	 * module (ENGINE_API, WITH_EDITOR) — NOT FActorLabelUtilities::SetActorLabelUnique, which lives in UnrealEd
+	 * and is therefore unlinkable from this Type=Runtime module. SetActorLabel does not auto-disambiguate a
+	 * colliding label the way SetActorLabelUnique did; ResolveActor's case-insensitive match simply returns the
+	 * first actor with that label, so a duplicate label resolves to one of them deterministically (the spawn
+	 * still succeeds). At runtime labels do not exist, so this compiles out — the actor keeps its engine-assigned
+	 * object name, its only stable identifier there and what ResolveActor matches outside the editor.
+	 */
+	void ActorAssignLabelUnique(AActor* Actor, const FString& Label)
+	{
+#if WITH_EDITOR
+		if (Actor && !Label.IsEmpty())
+			Actor->SetActorLabel(Label);
+#endif
+	}
+
+	// (Actor display name is read inline via AActor::GetActorNameOrLabel() — runtime-safe: the friendly
+	// label in the editor, the object name at runtime; AActor::GetActorLabel() itself is WITH_EDITOR-only.)
+
+	/**
+	 * Destroy an actor from its world. EditorDestroyActor (with undo + level-dirty bookkeeping) in the
+	 * editor; the plain UWorld::DestroyActor at runtime. Returns whether the destroy took.
+	 */
+	bool ActorDestroyInWorld(UWorld* World, AActor* Actor)
+	{
+		if (!World || !Actor)
+			return false;
+#if WITH_EDITOR
+		return World->EditorDestroyActor(Actor, /*bShouldModifyLevel*/ true);
+#else
+		return World->DestroyActor(Actor);
+#endif
+	}
+
 	// --- Local schema builders (the typed builder helpers don't cover rotators / property bags / lists) ---
 
 	/** `{pitch,yaw,roll: number}` — the §3.2 FRotator mapping (degrees). Read back via FUnrealMcpToolCall::GetRotator. */
-	TSharedPtr<FJsonObject> MakeRotatorSchema(const FString& Desc)
+	TSharedPtr<FJsonObject> ActorMakeRotatorSchema(const FString& Desc)
 	{
 		auto Num = []() { TSharedPtr<FJsonObject> N = MakeShared<FJsonObject>(); N->SetStringField(TEXT("type"), TEXT("number")); return N; };
 		TSharedPtr<FJsonObject> Props = MakeShared<FJsonObject>();
@@ -49,7 +112,7 @@ namespace
 	}
 
 	/** A free-form `{ key: value }` property bag — arbitrary FProperty writes (§3.2), additionalProperties allowed. */
-	TSharedPtr<FJsonObject> MakePropertyBagSchema(const FString& Desc)
+	TSharedPtr<FJsonObject> ActorMakePropertyBagSchema(const FString& Desc)
 	{
 		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
 		Schema->SetStringField(TEXT("type"), TEXT("object"));
@@ -60,7 +123,7 @@ namespace
 	}
 
 	/** An `array` of strings — used for the §3.2 scoped-read `paths` filter. */
-	TSharedPtr<FJsonObject> MakeStringArraySchema(const FString& Desc)
+	TSharedPtr<FJsonObject> ActorMakeStringArraySchema(const FString& Desc)
 	{
 		TSharedPtr<FJsonObject> Items = MakeShared<FJsonObject>();
 		Items->SetStringField(TEXT("type"), TEXT("string"));
@@ -81,7 +144,7 @@ namespace
 	 * dropped — a dropped entry would otherwise flip the scoped read to "identity only" / "full object"
 	 * (the opposite extremes of the requested scope) with no signal to the caller.
 	 */
-	TArray<FString> GetStringArray(const FUnrealMcpToolCall& Call, const FString& Key, FString& OutError)
+	TArray<FString> ActorGetStringArray(const FUnrealMcpToolCall& Call, const FString& Key, FString& OutError)
 	{
 		TArray<FString> Out;
 		const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
@@ -106,7 +169,7 @@ namespace
 	}
 
 	/** The 'properties' object argument (the write property bag); null when absent. */
-	TSharedPtr<FJsonObject> GetPropertiesArg(const FUnrealMcpToolCall& Call)
+	TSharedPtr<FJsonObject> ActorGetPropertiesArg(const FUnrealMcpToolCall& Call)
 	{
 		const TSharedPtr<FJsonObject>* Obj = nullptr;
 		if (Call.Arguments->TryGetObjectField(TEXT("properties"), Obj) && Obj && Obj->IsValid())
@@ -115,7 +178,7 @@ namespace
 	}
 
 	/** Resolve an actor by ref or produce a uniform error result. Returns null + fills OutError on miss. */
-	AActor* ResolveActorOrError(const FString& Ref, FUnrealMcpToolResult& OutError, bool& bFailed)
+	AActor* ActorResolveActorOrError(const FString& Ref, FUnrealMcpToolResult& OutError, bool& bFailed)
 	{
 		bFailed = false;
 		if (Ref.IsEmpty())
@@ -134,7 +197,7 @@ namespace
 	}
 
 	/** Build a `{ applied, errors:[...] }` structured result for the *-modify tools. */
-	FUnrealMcpToolResult MakeModifyResult(const FString& Subject, int32 Applied, const TArray<FString>& Errors)
+	FUnrealMcpToolResult ActorMakeModifyResult(const FString& Subject, int32 Applied, const TArray<FString>& Errors)
 	{
 		TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
 		Structured->SetNumberField(TEXT("applied"), Applied);
@@ -154,27 +217,27 @@ namespace
 
 namespace UnrealMcpActorTools
 {
-	UNREALMCPEDITOR_API void Register(FUnrealMcpToolRegistry& Registry)
+	UNREALMCPRUNTIME_API void Register(FUnrealMcpToolRegistry& Registry)
 	{
 		// ----------------------------------------------------------------------------------------
 		// actor-create — spawn from a class path / Blueprint asset path.
 		// ----------------------------------------------------------------------------------------
 		Registry.Tool(TEXT("actor-create"))
 			.Title(TEXT("Create Actor"))
-			.Description(TEXT("Spawn a new actor in the current editor level from a native class path "
+			.Description(TEXT("Spawn a new actor in the current world (editor level, or the live game world over a runtime connection) from a native class path "
 			                  "(e.g. '/Script/Engine.StaticMeshActor', 'PointLight') or a Blueprint asset "
 			                  "path. Optionally set label, location, rotation, and a parent actor to attach to."))
 			.ParamString(TEXT("classPath"), TEXT("Native class or Blueprint asset path/name."), EUnrealMcpParamRequirement::Required)
 			.ParamString(TEXT("name"), TEXT("Actor label. Auto-generated when omitted."))
 			.ParamVector(TEXT("location"), TEXT("World location {x,y,z}. Defaults to origin."))
-			.Param(TEXT("rotation"), TEXT("object"), TEXT("World rotation {pitch,yaw,roll} in degrees."), EUnrealMcpParamRequirement::Optional, MakeRotatorSchema(TEXT("World rotation {pitch,yaw,roll} in degrees.")))
+			.Param(TEXT("rotation"), TEXT("object"), TEXT("World rotation {pitch,yaw,roll} in degrees."), EUnrealMcpParamRequirement::Optional, ActorMakeRotatorSchema(TEXT("World rotation {pitch,yaw,roll} in degrees.")))
 			.ParamString(TEXT("parentActor"), TEXT("Label/path of an actor to attach the new actor to."))
 			.DestructiveHint(false)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
 				UWorld* World = FUnrealMcpObjectRef::GetEditorWorld();
 				if (!World)
-					return FUnrealMcpToolResult::Error(TEXT("No editor world available (not running in the editor)."));
+					return FUnrealMcpToolResult::Error(TEXT("No active world available (no editor world and no live game world)."));
 
 				const FString ClassPath = Call.GetString(TEXT("classPath"));
 				UClass* Class = FUnrealMcpObjectRef::ResolveClass(ClassPath);
@@ -204,7 +267,7 @@ namespace UnrealMcpActorTools
 				// Spawn through the engine UWorld path (not UEditorActorSubsystem): the actor still lands in
 				// the editor world (outliner-visible), and this avoids the editor viewport-snapping code that
 				// is unsafe under headless -nullrhi automation. SpawnParameters get a transactional, dirtyable actor.
-				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorCreate", "MCP: Create Actor"));
+				const FActorScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorCreate", "MCP: Create Actor"));
 				FActorSpawnParameters SpawnParams;
 				SpawnParams.ObjectFlags |= RF_Transactional;
 				AActor* Actor = World->SpawnActor<AActor>(Class, Location, Rotation, SpawnParams);
@@ -217,7 +280,7 @@ namespace UnrealMcpActorTools
 					// SetActorLabelUnique (not SetActorLabel): a user-supplied label that collides with an
 					// existing actor's label would otherwise make both ambiguous to ResolveActor.
 					if (!Label.IsEmpty())
-						FActorLabelUtilities::SetActorLabelUnique(Actor, Label);
+						ActorAssignLabelUnique(Actor, Label);
 				}
 
 				FString AttachNote;
@@ -232,11 +295,11 @@ namespace UnrealMcpActorTools
 					if (Actor->GetAttachParentActor() != Parent)
 						AttachNote = FString::Printf(
 							TEXT(" (warning: could not attach to parent '%s' — the spawned actor has no root component)"),
-							*Parent->GetActorLabel());
+							*Parent->GetActorNameOrLabel());
 				}
 
 				return FUnrealMcpToolResult::Success(
-					FString::Printf(TEXT("Spawned %s '%s'.%s"), *Class->GetName(), *Actor->GetActorLabel(), *AttachNote),
+					FString::Printf(TEXT("Spawned %s '%s'.%s"), *Class->GetName(), *Actor->GetActorNameOrLabel(), *AttachNote),
 					FUnrealMcpObjectRef::ActorIdentity(Actor));
 			});
 
@@ -245,23 +308,23 @@ namespace UnrealMcpActorTools
 		// ----------------------------------------------------------------------------------------
 		Registry.Tool(TEXT("actor-destroy"))
 			.Title(TEXT("Destroy Actor"))
-			.Description(TEXT("Remove an actor from the current editor level. Identify it by label, object "
+			.Description(TEXT("Remove an actor from the current world (editor level or live game world). Identify it by label, object "
 			                  "name, or full path."))
 			.ParamString(TEXT("actor"), TEXT("Actor label / name / path to destroy."), EUnrealMcpParamRequirement::Required)
 			.DestructiveHint(true)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
 				FUnrealMcpToolResult Err; bool bFailed = false;
-				AActor* Actor = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				AActor* Actor = ActorResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
 				if (bFailed) return Err;
 
 				UWorld* World = Actor->GetWorld();
 				if (!World)
 					return FUnrealMcpToolResult::Error(TEXT("Actor has no world."));
 
-				FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorDestroy", "MCP: Destroy Actor"));
-				const FString Label = Actor->GetActorLabel();
-				if (!World->EditorDestroyActor(Actor, /*bShouldModifyLevel*/ true))
+				FActorScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorDestroy", "MCP: Destroy Actor"));
+				const FString Label = Actor->GetActorNameOrLabel();
+				if (!ActorDestroyInWorld(World, Actor))
 				{
 					Transaction.Cancel(); // do not leave a dangling no-op entry on the undo stack
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to destroy actor '%s'."), *Label));
@@ -283,7 +346,7 @@ namespace UnrealMcpActorTools
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
 				FUnrealMcpToolResult Err; bool bFailed = false;
-				AActor* Source = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				AActor* Source = ActorResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
 				if (bFailed) return Err;
 
 				UWorld* World = Source->GetWorld();
@@ -292,7 +355,7 @@ namespace UnrealMcpActorTools
 
 				// Duplicate by spawning the same class with the source as a property template (engine path,
 				// headless-safe), then apply the requested location offset.
-				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorDuplicate", "MCP: Duplicate Actor"));
+				const FActorScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorDuplicate", "MCP: Duplicate Actor"));
 				const FVector Offset = Call.GetVector(TEXT("offset"), FVector::ZeroVector);
 				FActorSpawnParameters SpawnParams;
 				SpawnParams.Template = Source;
@@ -300,15 +363,15 @@ namespace UnrealMcpActorTools
 				const FTransform DupXform(Source->GetActorRotation(), Source->GetActorLocation() + Offset, Source->GetActorScale3D());
 				AActor* Dup = World->SpawnActor<AActor>(Source->GetClass(), DupXform, SpawnParams);
 				if (!Dup)
-					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to duplicate actor '%s'."), *Source->GetActorLabel()));
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to duplicate actor '%s'."), *Source->GetActorNameOrLabel()));
 
 				const FString NameArg = Call.GetString(TEXT("name"));
 				// The spawn template copies the source's label verbatim, so two actors would share a label and
 				// ResolveActor could not disambiguate them. SetActorLabelUnique guarantees a unique label whether
 				// the caller supplied one explicitly or we fall back to the source's label.
-				FActorLabelUtilities::SetActorLabelUnique(Dup, NameArg.IsEmpty() ? Source->GetActorLabel() : NameArg);
+				ActorAssignLabelUnique(Dup, NameArg.IsEmpty() ? Source->GetActorNameOrLabel() : NameArg);
 				return FUnrealMcpToolResult::Success(
-					FString::Printf(TEXT("Duplicated '%s' as '%s'."), *Source->GetActorLabel(), *Dup->GetActorLabel()),
+					FString::Printf(TEXT("Duplicated '%s' as '%s'."), *Source->GetActorNameOrLabel(), *Dup->GetActorNameOrLabel()),
 					FUnrealMcpObjectRef::ActorIdentity(Dup));
 			});
 
@@ -317,26 +380,26 @@ namespace UnrealMcpActorTools
 		// ----------------------------------------------------------------------------------------
 		Registry.Tool(TEXT("actor-find"))
 			.Title(TEXT("Find Actors"))
-			.Description(TEXT("List actors in the current level filtered by label substring, path substring, "
+			.Description(TEXT("List actors in the current world (editor level or live game world) filtered by label substring, path substring, "
 			                  "and/or class. Optionally include each actor's reflected data, scoped to the "
 			                  "dotted 'paths' filter to save tokens."))
 			.ParamString(TEXT("labelFilter"), TEXT("Case-insensitive substring matched against actor labels."))
 			.ParamString(TEXT("pathFilter"), TEXT("Case-insensitive substring matched against full actor paths."))
 			.ParamString(TEXT("classFilter"), TEXT("Class path/name; matches actors of this class or a subclass."))
-			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include per actor (scoped read). Identity only when omitted."), EUnrealMcpParamRequirement::Optional, MakeStringArraySchema(TEXT("Dotted property paths to include per actor (scoped read).")))
+			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include per actor (scoped read). Identity only when omitted."), EUnrealMcpParamRequirement::Optional, ActorMakeStringArraySchema(TEXT("Dotted property paths to include per actor (scoped read).")))
 			.ParamInt(TEXT("limit"), TEXT("Maximum number of actors to return. Defaults to 100."))
 			.ReadOnlyHint(true)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
 				UWorld* World = FUnrealMcpObjectRef::GetEditorWorld();
 				if (!World)
-					return FUnrealMcpToolResult::Error(TEXT("No editor world available."));
+					return FUnrealMcpToolResult::Error(TEXT("No active world available."));
 
 				const FString LabelFilter = Call.GetString(TEXT("labelFilter"));
 				const FString PathFilter = Call.GetString(TEXT("pathFilter"));
 				const FString ClassFilter = Call.GetString(TEXT("classFilter"));
 				FString PathsError;
-				const TArray<FString> Paths = GetStringArray(Call, TEXT("paths"), PathsError);
+				const TArray<FString> Paths = ActorGetStringArray(Call, TEXT("paths"), PathsError);
 				if (!PathsError.IsEmpty())
 					return FUnrealMcpToolResult::Error(PathsError);
 				const int32 Limit = static_cast<int32>(Call.GetInt(TEXT("limit"), 100));
@@ -354,7 +417,7 @@ namespace UnrealMcpActorTools
 						continue;
 					if (FilterClass && !Actor->IsA(FilterClass))
 						continue;
-					if (!LabelFilter.IsEmpty() && !Actor->GetActorLabel().Contains(LabelFilter, ESearchCase::IgnoreCase))
+					if (!LabelFilter.IsEmpty() && !Actor->GetActorNameOrLabel().Contains(LabelFilter, ESearchCase::IgnoreCase))
 						continue;
 					if (!PathFilter.IsEmpty() && !Actor->GetPathName().Contains(PathFilter, ESearchCase::IgnoreCase))
 						continue;
@@ -386,22 +449,22 @@ namespace UnrealMcpActorTools
 			                  "'rotation' {pitch,yaw,roll}, and 'scale' {x,y,z} are routed to the transform "
 			                  "APIs; all other keys are set by name through FProperty reflection."))
 			.ParamString(TEXT("actor"), TEXT("Actor label / name / path to modify."), EUnrealMcpParamRequirement::Required)
-			.Param(TEXT("properties"), TEXT("object"), TEXT("Property bag of name -> value to write (incl. transform keys)."), EUnrealMcpParamRequirement::Required, MakePropertyBagSchema(TEXT("Property bag of name -> value to write.")))
+			.Param(TEXT("properties"), TEXT("object"), TEXT("Property bag of name -> value to write (incl. transform keys)."), EUnrealMcpParamRequirement::Required, ActorMakePropertyBagSchema(TEXT("Property bag of name -> value to write.")))
 			.DestructiveHint(false)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
 				FUnrealMcpToolResult Err; bool bFailed = false;
-				AActor* Actor = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				AActor* Actor = ActorResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
 				if (bFailed) return Err;
 
-				TSharedPtr<FJsonObject> Props = GetPropertiesArg(Call);
+				TSharedPtr<FJsonObject> Props = ActorGetPropertiesArg(Call);
 				if (!Props.IsValid())
 					return FUnrealMcpToolResult::Error(TEXT("Missing required 'properties' object."));
 
-				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorModify", "MCP: Modify Actor"));
+				const FActorScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorModify", "MCP: Modify Actor"));
 				TArray<FString> Errors;
 				const int32 Applied = FUnrealMcpPropertyJson::ApplyProperties(Actor, Props, Errors);
-				return MakeModifyResult(FString::Printf(TEXT("actor '%s'"), *Actor->GetActorLabel()), Applied, Errors);
+				return ActorMakeModifyResult(FString::Printf(TEXT("actor '%s'"), *Actor->GetActorNameOrLabel()), Applied, Errors);
 			});
 
 		// ----------------------------------------------------------------------------------------
@@ -419,7 +482,7 @@ namespace UnrealMcpActorTools
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
 				FUnrealMcpToolResult Err; bool bFailed = false;
-				AActor* Child = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				AActor* Child = ActorResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
 				if (bFailed) return Err;
 
 				const bool bKeepWorld = Call.GetBool(TEXT("keepWorldTransform"), true);
@@ -427,11 +490,11 @@ namespace UnrealMcpActorTools
 
 				if (ParentRef.IsEmpty())
 				{
-					const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorDetach", "MCP: Detach Actor"));
+					const FActorScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorDetach", "MCP: Detach Actor"));
 					Child->DetachFromActor(bKeepWorld
 						? FDetachmentTransformRules::KeepWorldTransform
 						: FDetachmentTransformRules::KeepRelativeTransform);
-					return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Detached '%s' from its parent."), *Child->GetActorLabel()));
+					return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Detached '%s' from its parent."), *Child->GetActorNameOrLabel()));
 				}
 
 				AActor* Parent = FUnrealMcpObjectRef::ResolveActor(ParentRef);
@@ -443,11 +506,11 @@ namespace UnrealMcpActorTools
 				if (Parent->IsAttachedTo(Child))
 					return FUnrealMcpToolResult::Error(FString::Printf(
 						TEXT("Cannot attach '%s' to '%s': '%s' is already a descendant (would create a cycle)."),
-						*Child->GetActorLabel(), *Parent->GetActorLabel(), *Parent->GetActorLabel()));
+						*Child->GetActorNameOrLabel(), *Parent->GetActorNameOrLabel(), *Parent->GetActorNameOrLabel()));
 
 				// Open the transaction only AFTER validation: the resolve/self/cycle error paths above would
 				// otherwise leave an empty "MCP: Set Actor Parent" entry on the editor undo stack.
-				FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorSetParent", "MCP: Set Actor Parent"));
+				FActorScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ActorSetParent", "MCP: Set Actor Parent"));
 				const FAttachmentTransformRules Rules = bKeepWorld
 					? FAttachmentTransformRules::KeepWorldTransform
 					: FAttachmentTransformRules::KeepRelativeTransform;
@@ -461,10 +524,10 @@ namespace UnrealMcpActorTools
 					Transaction.Cancel();
 					return FUnrealMcpToolResult::Error(FString::Printf(
 						TEXT("Engine rejected attaching '%s' to '%s' (missing root component or invalid attachment)."),
-						*Child->GetActorLabel(), *Parent->GetActorLabel()));
+						*Child->GetActorNameOrLabel(), *Parent->GetActorNameOrLabel()));
 				}
 				return FUnrealMcpToolResult::Success(
-					FString::Printf(TEXT("Attached '%s' to '%s'."), *Child->GetActorLabel(), *Parent->GetActorLabel()));
+					FString::Printf(TEXT("Attached '%s' to '%s'."), *Child->GetActorNameOrLabel(), *Parent->GetActorNameOrLabel()));
 			});
 
 		// ----------------------------------------------------------------------------------------
@@ -481,7 +544,7 @@ namespace UnrealMcpActorTools
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
 				FUnrealMcpToolResult Err; bool bFailed = false;
-				AActor* Actor = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				AActor* Actor = ActorResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
 				if (bFailed) return Err;
 
 				const FString ClassRef = Call.GetString(TEXT("componentClass"));
@@ -506,10 +569,10 @@ namespace UnrealMcpActorTools
 					if (StaticFindObjectFast(nullptr, Actor, CompName))
 						return FUnrealMcpToolResult::Error(FString::Printf(
 							TEXT("A component named '%s' already exists on '%s'; choose a different name."),
-							*NameArg, *Actor->GetActorLabel()));
+							*NameArg, *Actor->GetActorNameOrLabel()));
 				}
 
-				FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ComponentAdd", "MCP: Add Component"));
+				FActorScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ComponentAdd", "MCP: Add Component"));
 				Actor->Modify();
 				UActorComponent* NewComp = NewObject<UActorComponent>(Actor, CompClass, CompName, RF_Transactional);
 				if (!NewComp)
@@ -531,7 +594,7 @@ namespace UnrealMcpActorTools
 				Actor->MarkPackageDirty();
 
 				return FUnrealMcpToolResult::Success(
-					FString::Printf(TEXT("Added %s '%s' to '%s'."), *CompClass->GetName(), *NewComp->GetName(), *Actor->GetActorLabel()),
+					FString::Printf(TEXT("Added %s '%s' to '%s'."), *CompClass->GetName(), *NewComp->GetName(), *Actor->GetActorNameOrLabel()),
 					FUnrealMcpObjectRef::ComponentIdentity(NewComp));
 			});
 
@@ -547,13 +610,13 @@ namespace UnrealMcpActorTools
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
 				FUnrealMcpToolResult Err; bool bFailed = false;
-				AActor* Actor = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				AActor* Actor = ActorResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
 				if (bFailed) return Err;
 
 				const FString CompRef = Call.GetString(TEXT("component"));
 				UActorComponent* Comp = FUnrealMcpObjectRef::ResolveComponent(Actor, CompRef);
 				if (!Comp)
-					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No component matched '%s' on '%s'."), *CompRef, *Actor->GetActorLabel()));
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No component matched '%s' on '%s'."), *CompRef, *Actor->GetActorNameOrLabel()));
 
 				// Only instance components can be destroyed cleanly: a native/inherited component would no-op
 				// RemoveInstanceComponent yet still proceed to DestroyComponent, leaving a broken (possibly
@@ -561,15 +624,15 @@ namespace UnrealMcpActorTools
 				if (!Actor->GetInstanceComponents().Contains(Comp))
 					return FUnrealMcpToolResult::Error(FString::Printf(
 						TEXT("Component '%s' on '%s' is not an instance component (native/inherited components cannot be destroyed this way)."),
-						*CompRef, *Actor->GetActorLabel()));
+						*CompRef, *Actor->GetActorNameOrLabel()));
 
-				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ComponentDestroy", "MCP: Destroy Component"));
+				const FActorScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ComponentDestroy", "MCP: Destroy Component"));
 				const FString CompName = Comp->GetName();
 				Actor->Modify();
 				Actor->RemoveInstanceComponent(Comp);
 				Comp->DestroyComponent();
 				Actor->MarkPackageDirty();
-				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Destroyed component '%s' on '%s'."), *CompName, *Actor->GetActorLabel()));
+				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Destroyed component '%s' on '%s'."), *CompName, *Actor->GetActorNameOrLabel()));
 			});
 
 		// ----------------------------------------------------------------------------------------
@@ -580,21 +643,21 @@ namespace UnrealMcpActorTools
 			.Description(TEXT("Read a component's reflected properties, optionally scoped to the dotted 'paths' filter."))
 			.ParamString(TEXT("actor"), TEXT("Owning actor label / name / path."), EUnrealMcpParamRequirement::Required)
 			.ParamString(TEXT("component"), TEXT("Component name to read."), EUnrealMcpParamRequirement::Required)
-			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include (scoped read). Full object when omitted."), EUnrealMcpParamRequirement::Optional, MakeStringArraySchema(TEXT("Dotted property paths to include (scoped read).")))
+			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include (scoped read). Full object when omitted."), EUnrealMcpParamRequirement::Optional, ActorMakeStringArraySchema(TEXT("Dotted property paths to include (scoped read).")))
 			.ReadOnlyHint(true)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
 				FUnrealMcpToolResult Err; bool bFailed = false;
-				AActor* Actor = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				AActor* Actor = ActorResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
 				if (bFailed) return Err;
 
 				const FString CompRef = Call.GetString(TEXT("component"));
 				UActorComponent* Comp = FUnrealMcpObjectRef::ResolveComponent(Actor, CompRef);
 				if (!Comp)
-					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No component matched '%s' on '%s'."), *CompRef, *Actor->GetActorLabel()));
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No component matched '%s' on '%s'."), *CompRef, *Actor->GetActorNameOrLabel()));
 
 				FString PathsError;
-				const TArray<FString> Paths = GetStringArray(Call, TEXT("paths"), PathsError);
+				const TArray<FString> Paths = ActorGetStringArray(Call, TEXT("paths"), PathsError);
 				if (!PathsError.IsEmpty())
 					return FUnrealMcpToolResult::Error(PathsError);
 				TSharedPtr<FJsonObject> Data = FUnrealMcpObjectRef::ComponentIdentity(Comp);
@@ -612,27 +675,27 @@ namespace UnrealMcpActorTools
 			                  "'relativeScale3D' {x,y,z} routed to the relative-transform APIs."))
 			.ParamString(TEXT("actor"), TEXT("Owning actor label / name / path."), EUnrealMcpParamRequirement::Required)
 			.ParamString(TEXT("component"), TEXT("Component name to modify."), EUnrealMcpParamRequirement::Required)
-			.Param(TEXT("properties"), TEXT("object"), TEXT("Property bag of name -> value to write."), EUnrealMcpParamRequirement::Required, MakePropertyBagSchema(TEXT("Property bag of name -> value to write.")))
+			.Param(TEXT("properties"), TEXT("object"), TEXT("Property bag of name -> value to write."), EUnrealMcpParamRequirement::Required, ActorMakePropertyBagSchema(TEXT("Property bag of name -> value to write.")))
 			.DestructiveHint(false)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
 				FUnrealMcpToolResult Err; bool bFailed = false;
-				AActor* Actor = ResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
+				AActor* Actor = ActorResolveActorOrError(Call.GetString(TEXT("actor")), Err, bFailed);
 				if (bFailed) return Err;
 
 				const FString CompRef = Call.GetString(TEXT("component"));
 				UActorComponent* Comp = FUnrealMcpObjectRef::ResolveComponent(Actor, CompRef);
 				if (!Comp)
-					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No component matched '%s' on '%s'."), *CompRef, *Actor->GetActorLabel()));
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No component matched '%s' on '%s'."), *CompRef, *Actor->GetActorNameOrLabel()));
 
-				TSharedPtr<FJsonObject> Props = GetPropertiesArg(Call);
+				TSharedPtr<FJsonObject> Props = ActorGetPropertiesArg(Call);
 				if (!Props.IsValid())
 					return FUnrealMcpToolResult::Error(TEXT("Missing required 'properties' object."));
 
-				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ComponentModify", "MCP: Modify Component"));
+				const FActorScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ComponentModify", "MCP: Modify Component"));
 				TArray<FString> Errors;
 				const int32 Applied = FUnrealMcpPropertyJson::ApplyProperties(Comp, Props, Errors);
-				return MakeModifyResult(FString::Printf(TEXT("component '%s'"), *Comp->GetName()), Applied, Errors);
+				return ActorMakeModifyResult(FString::Printf(TEXT("component '%s'"), *Comp->GetName()), Applied, Errors);
 			});
 
 		// ----------------------------------------------------------------------------------------
@@ -694,7 +757,7 @@ namespace UnrealMcpActorTools
 			                  "('/Game/Folder/Asset.Asset') or, for scene objects, by actor label. Optionally "
 			                  "scoped to the dotted 'paths' filter."))
 			.ParamString(TEXT("object"), TEXT("Object path or actor label/name/path."), EUnrealMcpParamRequirement::Required)
-			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include (scoped read). Full object when omitted."), EUnrealMcpParamRequirement::Optional, MakeStringArraySchema(TEXT("Dotted property paths to include (scoped read).")))
+			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include (scoped read). Full object when omitted."), EUnrealMcpParamRequirement::Optional, ActorMakeStringArraySchema(TEXT("Dotted property paths to include (scoped read).")))
 			.ReadOnlyHint(true)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
@@ -707,7 +770,7 @@ namespace UnrealMcpActorTools
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No object matched '%s'."), *Ref));
 
 				FString PathsError;
-				const TArray<FString> Paths = GetStringArray(Call, TEXT("paths"), PathsError);
+				const TArray<FString> Paths = ActorGetStringArray(Call, TEXT("paths"), PathsError);
 				if (!PathsError.IsEmpty())
 					return FUnrealMcpToolResult::Error(PathsError);
 				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
@@ -726,7 +789,7 @@ namespace UnrealMcpActorTools
 			.Description(TEXT("Write reflected properties on any UObject resolved by object path or actor label. "
 			                  "Transform keys are honored when the object is an actor or scene component."))
 			.ParamString(TEXT("object"), TEXT("Object path or actor label/name/path."), EUnrealMcpParamRequirement::Required)
-			.Param(TEXT("properties"), TEXT("object"), TEXT("Property bag of name -> value to write."), EUnrealMcpParamRequirement::Required, MakePropertyBagSchema(TEXT("Property bag of name -> value to write.")))
+			.Param(TEXT("properties"), TEXT("object"), TEXT("Property bag of name -> value to write."), EUnrealMcpParamRequirement::Required, ActorMakePropertyBagSchema(TEXT("Property bag of name -> value to write.")))
 			.DestructiveHint(false)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
@@ -738,14 +801,14 @@ namespace UnrealMcpActorTools
 				if (!Object)
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No object matched '%s'."), *Ref));
 
-				TSharedPtr<FJsonObject> Props = GetPropertiesArg(Call);
+				TSharedPtr<FJsonObject> Props = ActorGetPropertiesArg(Call);
 				if (!Props.IsValid())
 					return FUnrealMcpToolResult::Error(TEXT("Missing required 'properties' object."));
 
-				const FScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ObjectModify", "MCP: Modify Object"));
+				const FActorScopedTransaction Transaction(NSLOCTEXT("UnrealMcp", "ObjectModify", "MCP: Modify Object"));
 				TArray<FString> Errors;
 				const int32 Applied = FUnrealMcpPropertyJson::ApplyProperties(Object, Props, Errors);
-				return MakeModifyResult(FString::Printf(TEXT("object '%s'"), *Object->GetName()), Applied, Errors);
+				return ActorMakeModifyResult(FString::Printf(TEXT("object '%s'"), *Object->GetName()), Applied, Errors);
 			});
 	}
 }

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Tools/UnrealMcpConsoleReflectionTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Tools/UnrealMcpConsoleReflectionTools.cpp
@@ -1,0 +1,457 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpRuntimeCoreTools.h"
+#include "UnrealMcpToolRegistry.h"
+#include "Tools/UnrealMcpObjectRef.h"
+#include "Tools/UnrealMcpLogCollector.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "JsonObjectConverter.h"
+#include "Engine/Engine.h"
+#include "Engine/World.h"
+#include "Misc/StringOutputDevice.h"
+#include "UObject/Class.h"
+#include "UObject/Script.h"
+#include "UObject/UnrealType.h"      // FBoolProperty/FIntProperty/... full definitions for FProperty::IsA<>
+#include "UObject/TextProperty.h"    // FTextProperty is its own header; the editor PCH supplied it transitively, the Game target needs it explicitly
+#include "UObject/EnumProperty.h"    // FEnumProperty — same lost-transitive-include reason in the Game build
+
+/**
+ * The runtime console / reflection tool family (docs/ARCHITECTURE.md §10 "editor/reflection family"
+ * runtime subset, §12.7). The runtime-safe half of the original editor/reflection family, moved DOWN
+ * into the Type=Runtime module so it works over a runtime connection in PIE and packaged Development
+ * builds as well as the editor:
+ *
+ *   - console-get-logs / console-clear-logs — filtered/paginated slices of the FUnrealMcpLogCollector
+ *     GLog ring buffer (the collector is started by whichever bootstrap owns the plugin: the editor
+ *     coordinator in the editor, the runtime subsystem in a game), and a clear.
+ *   - console-run-command — GEngine->Exec against the resolved world (editor world in the editor, the
+ *     live game world at runtime). GEngine + UWorld::Exec are runtime-available.
+ *   - reflection-method-find / reflection-method-call — UFunction discovery + safety-gated invocation
+ *     (ProcessEvent over a constructed param frame; §3.2 JSON arg mapping).
+ *
+ * RUNTIME-SAFE differences from the editor family (§12.7): the CallInEditor allowance is EXCLUDED. The
+ * editor family treated a `CallInEditor` UFUNCTION as callable even when not BlueprintCallable, reading
+ * `GetBoolMetaData("CallInEditor")` behind `WITH_EDITORONLY_DATA` — that metadata does not exist in a
+ * non-editor build, so the runtime gate accepts ONLY FUNC_BlueprintCallable (for the instance/`target`
+ * path) and additionally FUNC_Static (for the CDO/`class` path). The editor-only ProcessEvent script
+ * guard (FEditorScriptExecutionGuard) is likewise WITH_EDITOR-guarded — at runtime BlueprintCallable
+ * functions execute without it. Every Handle() body runs ON the game thread (the §4 dispatcher).
+ */
+namespace
+{
+	// --- Local schema builders (family-unique names per the unity-build ODR rule) -----------------
+
+	/** A free-form `{ key: value }` argument bag (reflection-method-call's `args`). */
+	TSharedPtr<FJsonObject> ConsoleReflectionMakeArgsBagSchema(const FString& Desc)
+	{
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), TEXT("object"));
+		if (!Desc.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Desc);
+		Schema->SetBoolField(TEXT("additionalProperties"), true);
+		return Schema;
+	}
+
+	/** The §3.2 JSON-schema type token for a reflected FProperty (best-effort, for discovery output). */
+	FString ConsoleReflectionPropertyTypeName(const FProperty* Prop)
+	{
+		if (!Prop) return TEXT("null");
+		if (Prop->IsA<FBoolProperty>()) return TEXT("boolean");
+		if (Prop->IsA<FFloatProperty>() || Prop->IsA<FDoubleProperty>()) return TEXT("number");
+		if (Prop->IsA<FByteProperty>() || Prop->IsA<FIntProperty>() || Prop->IsA<FInt64Property>()
+			|| Prop->IsA<FUInt32Property>() || Prop->IsA<FInt8Property>() || Prop->IsA<FInt16Property>()
+			|| Prop->IsA<FUInt16Property>() || Prop->IsA<FUInt64Property>())
+			return TEXT("integer");
+		if (Prop->IsA<FEnumProperty>()) return TEXT("string");
+		if (Prop->IsA<FStrProperty>() || Prop->IsA<FNameProperty>() || Prop->IsA<FTextProperty>()) return TEXT("string");
+		if (Prop->IsA<FObjectPropertyBase>() || Prop->IsA<FClassProperty>() || Prop->IsA<FSoftObjectProperty>()) return TEXT("string");
+		if (Prop->IsA<FArrayProperty>() || Prop->IsA<FSetProperty>()) return TEXT("array");
+		if (Prop->IsA<FStructProperty>() || Prop->IsA<FMapProperty>()) return TEXT("object");
+		return TEXT("string");
+	}
+
+	/**
+	 * Whether @p Function is safe to invoke from a runtime tool (the §10 safety gate, §12.7 runtime
+	 * variant). RUNTIME: only FUNC_BlueprintCallable is accepted — the editor family's CallInEditor
+	 * allowance is excluded because the `CallInEditor` metadata is WITH_EDITORONLY_DATA and a packaged
+	 * game has none; gating on it there would be a no-op anyway. BlueprintCallable is the engine-agnostic
+	 * "designed to be invoked from script" signal, available identically in editor and game.
+	 */
+	bool ConsoleReflectionIsCallableFunction(const UFunction* Function)
+	{
+		return Function && Function->HasAnyFunctionFlags(FUNC_BlueprintCallable);
+	}
+
+	/**
+	 * Whether @p Function may be invoked on a class CDO (the 'class' path of reflection-method-call).
+	 * Only static functions are safe there at runtime: a plain instance method run on the default object
+	 * mutates the shared class defaults (CDO pollution that serializes into new instances) and a
+	 * world-dependent instance method can crash on a world-less CDO. Instance methods must go via 'target'.
+	 * (The editor family also accepted CallInEditor here; excluded at runtime — see the header note.)
+	 */
+	bool ConsoleReflectionIsCdoCallableFunction(const UFunction* Function)
+	{
+		return Function && Function->HasAnyFunctionFlags(FUNC_Static);
+	}
+
+	/** Build the per-function discovery descriptor for reflection-method-find. */
+	TSharedPtr<FJsonObject> ConsoleReflectionDescribeFunction(UFunction* Function)
+	{
+		TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+		Json->SetStringField(TEXT("name"), Function->GetName());
+		Json->SetStringField(TEXT("class"), Function->GetOwnerClass() ? Function->GetOwnerClass()->GetName() : FString());
+		Json->SetBoolField(TEXT("isStatic"), Function->HasAnyFunctionFlags(FUNC_Static));
+		Json->SetBoolField(TEXT("isBlueprintCallable"), Function->HasAnyFunctionFlags(FUNC_BlueprintCallable));
+		Json->SetBoolField(TEXT("isPure"), Function->HasAnyFunctionFlags(FUNC_BlueprintPure));
+		Json->SetBoolField(TEXT("isNative"), Function->HasAnyFunctionFlags(FUNC_Native));
+#if WITH_EDITORONLY_DATA
+		Json->SetBoolField(TEXT("isCallInEditor"), Function->GetBoolMetaData(TEXT("CallInEditor")));
+#else
+		Json->SetBoolField(TEXT("isCallInEditor"), false);
+#endif
+		// Runtime callability reflects the runtime gate (BlueprintCallable only); CallInEditor-only
+		// functions are reported isCallable=false here even though the editor family would call them.
+		Json->SetBoolField(TEXT("isCallable"), ConsoleReflectionIsCallableFunction(Function));
+
+		TArray<TSharedPtr<FJsonValue>> Params;
+		TSharedPtr<FJsonObject> ReturnParam;
+		for (TFieldIterator<FProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
+		{
+			FProperty* Prop = *It;
+			TSharedPtr<FJsonObject> P = MakeShared<FJsonObject>();
+			P->SetStringField(TEXT("name"), Prop->GetName());
+			P->SetStringField(TEXT("type"), ConsoleReflectionPropertyTypeName(Prop));
+			P->SetStringField(TEXT("cppType"), Prop->GetCPPType());
+			const bool bReturn = Prop->HasAnyPropertyFlags(CPF_ReturnParm);
+			const bool bOut = Prop->HasAnyPropertyFlags(CPF_OutParm);
+			P->SetBoolField(TEXT("isReturn"), bReturn);
+			P->SetBoolField(TEXT("isOut"), bOut && !bReturn);
+			if (bReturn)
+				ReturnParam = P;
+			else
+				Params.Add(MakeShared<FJsonValueObject>(P));
+		}
+		Json->SetArrayField(TEXT("params"), Params);
+		if (ReturnParam.IsValid())
+			Json->SetObjectField(TEXT("returnType"), ReturnParam);
+		return Json;
+	}
+}
+
+namespace UnrealMcpConsoleReflectionTools
+{
+	UNREALMCPRUNTIME_API void Register(FUnrealMcpToolRegistry& Registry)
+	{
+		// ============================================================================================
+		// console-get-logs — filtered/paginated ring-buffer slice.
+		// ============================================================================================
+		Registry.Tool(TEXT("console-get-logs"))
+			.Title(TEXT("Get Console Logs"))
+			.Description(TEXT("Read recent engine log lines captured by the plugin's GLog ring buffer "
+			                  "(capped at 10000). Filter by minimum severity ('Fatal'|'Error'|'Warning'|"
+			                  "'Display'|'Log'|'Verbose'|'VeryVerbose'|'All'), exact category, and a message "
+			                  "substring; 'limit' returns the most-recent N after filtering. Read-only."))
+			.ParamString(TEXT("verbosity"), TEXT("Minimum severity to include (default 'All')."))
+			.ParamString(TEXT("category"), TEXT("Exact log category (e.g. 'LogTemp'); empty = all."))
+			.ParamString(TEXT("search"), TEXT("Case-insensitive message substring; empty = all."))
+			.ParamInt(TEXT("limit"), TEXT("Max entries to return (most-recent first-trimmed); default 100, <=0 = all."))
+			.ReadOnlyHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				ELogVerbosity::Type MinVerbosity = ELogVerbosity::All;
+				if (Call.Has(TEXT("verbosity")))
+				{
+					const FString Token = Call.GetString(TEXT("verbosity"));
+					if (!Token.IsEmpty() && !FUnrealMcpLogCollector::ParseVerbosity(Token, MinVerbosity))
+						return FUnrealMcpToolResult::Error(FString::Printf(
+							TEXT("Unknown verbosity '%s'. Use Fatal/Error/Warning/Display/Log/Verbose/VeryVerbose/All."), *Token));
+				}
+				const FString Category = Call.GetString(TEXT("category"));
+				const FString Search = Call.GetString(TEXT("search"));
+				const int32 Limit = (int32)Call.GetInt(TEXT("limit"), 100);
+
+				const FUnrealMcpLogCollector& Collector = FUnrealMcpLogCollector::Get();
+				const TArray<FUnrealMcpLogEntry> Slice = Collector.Snapshot(MinVerbosity, Category, Search, Limit);
+
+				TArray<TSharedPtr<FJsonValue>> Lines;
+				for (const FUnrealMcpLogEntry& Entry : Slice)
+				{
+					TSharedPtr<FJsonObject> L = MakeShared<FJsonObject>();
+					L->SetStringField(TEXT("timestamp"), Entry.Timestamp.ToIso8601());
+					L->SetStringField(TEXT("verbosity"), FUnrealMcpLogCollector::VerbosityToString(Entry.Verbosity));
+					L->SetStringField(TEXT("category"), Entry.Category.ToString());
+					L->SetStringField(TEXT("message"), Entry.Message);
+					Lines.Add(MakeShared<FJsonValueObject>(L));
+				}
+
+				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
+				S->SetNumberField(TEXT("count"), Lines.Num());
+				S->SetNumberField(TEXT("totalBuffered"), Collector.Num());
+				S->SetArrayField(TEXT("logs"), Lines);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Returned %d log line(s) (%d buffered)."), Lines.Num(), Collector.Num()), S);
+			});
+
+		// ============================================================================================
+		// console-clear-logs — empty the ring buffer.
+		// ============================================================================================
+		Registry.Tool(TEXT("console-clear-logs"))
+			.Title(TEXT("Clear Console Logs"))
+			.Description(TEXT("Clear the plugin's GLog ring buffer. Returns how many entries were dropped."))
+			.DestructiveHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const int32 Removed = FUnrealMcpLogCollector::Get().Clear();
+				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
+				S->SetNumberField(TEXT("cleared"), Removed);
+				return FUnrealMcpToolResult::Success(FString::Printf(TEXT("Cleared %d log entry(ies)."), Removed), S);
+			});
+
+		// ============================================================================================
+		// console-run-command — GEngine->Exec with captured output.
+		// ============================================================================================
+		Registry.Tool(TEXT("console-run-command"))
+			.Title(TEXT("Run Console Command"))
+			.Description(TEXT("Execute an Unreal console command (incl. CVars, e.g. 'stat fps', 'r.ScreenPercentage 80') "
+			                  "via GEngine->Exec against the active world (editor world in the editor, the live game "
+			                  "world over a runtime connection), returning any captured output text."))
+			.ParamString(TEXT("command"), TEXT("The console command line to execute."), EUnrealMcpParamRequirement::Required)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const FString Command = Call.GetString(TEXT("command"));
+				if (Command.IsEmpty())
+					return FUnrealMcpToolResult::Error(TEXT("Missing required 'command'."));
+				if (!GEngine)
+					return FUnrealMcpToolResult::Error(TEXT("No engine available."));
+
+				UWorld* World = FUnrealMcpObjectRef::GetEditorWorld();
+
+				FStringOutputDevice Output;
+				Output.SetAutoEmitLineTerminator(true);
+				const bool bHandled = GEngine->Exec(World, *Command, Output);
+
+				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
+				S->SetStringField(TEXT("command"), Command);
+				S->SetBoolField(TEXT("handled"), bHandled);
+				S->SetStringField(TEXT("output"), Output);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Ran '%s' (%s)."), *Command, bHandled ? TEXT("handled") : TEXT("not handled")), S);
+			});
+
+		// ============================================================================================
+		// reflection-method-find — UFunction discovery by class (+ optional name filter).
+		// ============================================================================================
+		Registry.Tool(TEXT("reflection-method-find"))
+			.Title(TEXT("Find Reflection Method"))
+			.Description(TEXT("Discover UFunctions on a class (native class path, short name, or Blueprint asset/"
+			                  "generated-class path, §3.2). Returns signatures: params (name/type), return type, "
+			                  "and flags (static/instance, BlueprintCallable, pure, CallInEditor, callable). "
+			                  "Optional 'name' filters by case-insensitive substring. Read-only."))
+			.ParamString(TEXT("class"), TEXT("Class ref to search (native path/name or Blueprint path)."), EUnrealMcpParamRequirement::Required)
+			.ParamString(TEXT("name"), TEXT("Optional case-insensitive substring to match the function name."))
+			.ParamInt(TEXT("limit"), TEXT("Max functions to return; default 100, <=0 = all."))
+			.ReadOnlyHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const FString ClassRef = Call.GetString(TEXT("class"));
+				UClass* Class = FUnrealMcpObjectRef::ResolveClass(ClassRef);
+				if (!Class)
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Class '%s' was not found."), *ClassRef));
+
+				const FString NameFilter = Call.GetString(TEXT("name"));
+				const int32 Limit = (int32)Call.GetInt(TEXT("limit"), 100);
+
+				TArray<TSharedPtr<FJsonValue>> Methods;
+				int32 Matched = 0;
+				TSet<FName> SeenNames;
+				for (TFieldIterator<UFunction> It(Class, EFieldIteratorFlags::IncludeSuper); It; ++It)
+				{
+					UFunction* Function = *It;
+					// IncludeSuper walks most-derived first, so an override appears once per declaring class
+					// in the hierarchy. Keep only the first (most-derived) occurrence of each name.
+					bool bAlreadySeen = false;
+					SeenNames.Add(Function->GetFName(), &bAlreadySeen);
+					if (bAlreadySeen)
+						continue;
+					if (!NameFilter.IsEmpty() && !Function->GetName().Contains(NameFilter, ESearchCase::IgnoreCase))
+						continue;
+					++Matched;
+					if (Limit > 0 && Methods.Num() >= Limit)
+						continue; // keep counting Matched for an honest total, but stop materializing
+					Methods.Add(MakeShared<FJsonValueObject>(ConsoleReflectionDescribeFunction(Function)));
+				}
+
+				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
+				S->SetStringField(TEXT("class"), Class->GetPathName());
+				S->SetNumberField(TEXT("matched"), Matched);
+				S->SetNumberField(TEXT("returned"), Methods.Num());
+				S->SetArrayField(TEXT("methods"), Methods);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Found %d method(s) on '%s' (returned %d)."), Matched, *Class->GetName(), Methods.Num()), S);
+			});
+
+		// ============================================================================================
+		// reflection-method-call — safety-gated ProcessEvent over a constructed param frame.
+		// ============================================================================================
+		Registry.Tool(TEXT("reflection-method-call"))
+			.Title(TEXT("Call Reflection Method"))
+			.Description(TEXT("Invoke a UFunction by name. Provide EITHER 'target' (an object/actor ref, §3.2 — "
+			                  "the function is resolved and called on it) OR 'class' (the function is called on "
+			                  "that class's CDO — use for static functions). 'args' is a JSON object mapping "
+			                  "parameter names to values (§3.2). SAFETY: only BlueprintCallable functions may be "
+			                  "called; anything else is rejected — and the 'class' (CDO) path additionally requires "
+			                  "a static function (instance methods must use 'target'). ACCEPTED RISK: callable "
+			                  "functions can still be destructive (QuitGame, console exec, DestroyActor), consistent "
+			                  "with console-run-command. Returns the function's return value and any out-params."))
+			.ParamString(TEXT("target"), TEXT("Object/actor ref to call the method on (instance methods)."))
+			.ParamString(TEXT("class"), TEXT("Class ref whose CDO to call on (static methods)."))
+			.ParamString(TEXT("method"), TEXT("The UFunction name to invoke."), EUnrealMcpParamRequirement::Required)
+			.Param(TEXT("args"), TEXT("object"), TEXT("Parameter name -> value map (§3.2)."), EUnrealMcpParamRequirement::Optional, ConsoleReflectionMakeArgsBagSchema(TEXT("Parameter name -> value map.")))
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				const FString MethodName = Call.GetString(TEXT("method"));
+				if (MethodName.IsEmpty())
+					return FUnrealMcpToolResult::Error(TEXT("Missing required 'method'."));
+
+				const FString TargetRef = Call.GetString(TEXT("target"));
+				const FString ClassRef = Call.GetString(TEXT("class"));
+				if (TargetRef.IsEmpty() && ClassRef.IsEmpty())
+					return FUnrealMcpToolResult::Error(TEXT("Provide either 'target' (instance) or 'class' (CDO/static)."));
+				// The receiver is EITHER/OR — reject an ambiguous pair instead of silently preferring one.
+				if (!TargetRef.IsEmpty() && !ClassRef.IsEmpty())
+					return FUnrealMcpToolResult::Error(TEXT("Provide EITHER 'target' (instance) OR 'class' (CDO/static), not both."));
+
+				// Resolve the receiving object: an explicit instance ref, else the class CDO.
+				const bool bViaCDO = TargetRef.IsEmpty();
+				UObject* Target = nullptr;
+				if (!TargetRef.IsEmpty())
+				{
+					Target = FUnrealMcpObjectRef::ResolveObject(TargetRef);
+					if (!Target)
+						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Target '%s' was not found."), *TargetRef));
+				}
+				else
+				{
+					UClass* Class = FUnrealMcpObjectRef::ResolveClass(ClassRef);
+					if (!Class)
+						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Class '%s' was not found."), *ClassRef));
+					Target = Class->GetDefaultObject();
+					if (!Target)
+						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Class '%s' has no default object."), *ClassRef));
+				}
+
+				UFunction* Function = Target->FindFunction(FName(*MethodName));
+				if (!Function)
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("Method '%s' was not found on '%s'."), *MethodName, *Target->GetClass()->GetName()));
+
+				// SAFETY GATE (§10, §12.7 runtime variant): reject anything that is not explicitly callable. An
+				// unguarded ProcessEvent surface would let an agent invoke arbitrary native engine functions — a
+				// security finding. RUNTIME: BlueprintCallable only (the CallInEditor allowance is excluded —
+				// see the header note). ACCEPTED RISK: BlueprintCallable still includes destructive functions
+				// (UKismetSystemLibrary::QuitGame, ExecuteConsoleCommand, AActor::K2_DestroyActor). console-run-command
+				// already grants equivalent power, so this is in keeping with the family's purpose rather than a
+				// separate escalation — gated by intent, not by an allow-list of individual functions.
+				if (!ConsoleReflectionIsCallableFunction(Function))
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("Method '%s' is not BlueprintCallable; refusing to call it."), *MethodName));
+
+				// The 'class' path runs on the CDO, which is only safe for static functions at runtime (see
+				// ConsoleReflectionIsCdoCallableFunction). Reject a plain instance method here and steer it to 'target'.
+				if (bViaCDO && !ConsoleReflectionIsCdoCallableFunction(Function))
+					return FUnrealMcpToolResult::Error(FString::Printf(
+						TEXT("Method '%s' is an instance method; call it via 'target' (an instance), not 'class' "
+						     "(whose CDO is only for static functions)."), *MethodName));
+
+				// 'args' is optional; absent -> an empty bag (every param defaults). But a PRESENT-but-non-object
+				// 'args' (e.g. an array or a bare string) is a malformed call — error rather than silently
+				// dropping it to an empty bag, which would zero every parameter without telling the caller.
+				const TSharedPtr<FJsonObject>* ArgsPtr = nullptr;
+				if (Call.Arguments->HasField(TEXT("args")) && !(Call.Arguments->TryGetObjectField(TEXT("args"), ArgsPtr) && ArgsPtr))
+					return FUnrealMcpToolResult::Error(TEXT("'args' must be a JSON object mapping parameter names to values."));
+				TSharedPtr<FJsonObject> Args = ArgsPtr ? *ArgsPtr : MakeShared<FJsonObject>();
+
+				// Build + own a parameter frame for the duration of the call (init -> import -> call -> read -> destroy).
+				TArray<uint8> ParmFrame;
+				ParmFrame.SetNumZeroed(FMath::Max<int32>(Function->ParmsSize, 1));
+				uint8* Frame = ParmFrame.GetData();
+
+				for (TFieldIterator<FProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
+					It->InitializeValue_InContainer(Frame);
+
+				// Import inputs (everything that is not the return value; out-params may also be seeded).
+				FString ImportError;
+				for (TFieldIterator<FProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
+				{
+					FProperty* Prop = *It;
+					if (Prop->HasAnyPropertyFlags(CPF_ReturnParm))
+						continue;
+					const TSharedPtr<FJsonValue> Field = Args->TryGetField(Prop->GetName());
+					if (!Field.IsValid())
+						continue; // absent -> zero/default; UE handles optional/defaulted params
+					void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(Frame);
+					FText Fail;
+					if (!FJsonObjectConverter::JsonValueToUProperty(Field, Prop, ValuePtr, 0, 0, false, &Fail))
+					{
+						ImportError = FString::Printf(TEXT("Failed to convert argument '%s': %s"), *Prop->GetName(), *Fail.ToString());
+						break;
+					}
+				}
+
+				if (ImportError.IsEmpty())
+				{
+#if WITH_EDITOR
+					// AActor::ProcessEvent gates script execution in the EDITOR world: for an actor in the editor
+					// world (not PIE, not a CDO) a plain BlueprintCallable function is SILENTLY SKIPPED unless
+					// GAllowActorScriptExecutionInEditor is set — the tool would otherwise return Success with a
+					// zeroed return/out-params. Scope the call in the same guard the editor's own details-panel /
+					// CallInEditor invocations use (it also resets the runaway-loop counter). The §10 safety gate
+					// above remains the authorization layer; this only lets an already-authorized call actually run.
+					// The guard is editor-only (UnrealEd); at runtime ProcessEvent runs normally without it.
+					FEditorScriptExecutionGuard ScriptGuard;
+#endif
+					Target->ProcessEvent(Function, Frame);
+				}
+
+				// Read the return value + any out-params back into JSON (before destroying the frame).
+				TSharedPtr<FJsonObject> Returned = MakeShared<FJsonObject>();
+				TSharedPtr<FJsonValue> ReturnValue;
+				if (ImportError.IsEmpty())
+				{
+					for (TFieldIterator<FProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
+					{
+						FProperty* Prop = *It;
+						const bool bReturn = Prop->HasAnyPropertyFlags(CPF_ReturnParm);
+						const bool bOut = Prop->HasAnyPropertyFlags(CPF_OutParm);
+						if (!bReturn && !bOut)
+							continue;
+						const void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(Frame);
+						TSharedPtr<FJsonValue> JV = FJsonObjectConverter::UPropertyToJsonValue(Prop, ValuePtr);
+						if (bReturn)
+							ReturnValue = JV;
+						else
+							Returned->SetField(Prop->GetName(), JV);
+					}
+				}
+
+				// Always destroy the frame (init succeeded for every param above).
+				for (TFieldIterator<FProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
+					It->DestroyValue_InContainer(Frame);
+
+				if (!ImportError.IsEmpty())
+					return FUnrealMcpToolResult::Error(ImportError);
+
+				TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
+				S->SetStringField(TEXT("method"), MethodName);
+				S->SetStringField(TEXT("target"), Target->GetPathName());
+				if (ReturnValue.IsValid())
+					S->SetField(TEXT("returnValue"), ReturnValue);
+				S->SetObjectField(TEXT("outParams"), Returned);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Called '%s' on '%s'."), *MethodName, *Target->GetName()), S);
+			});
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Tools/UnrealMcpRuntimeLevelTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Tools/UnrealMcpRuntimeLevelTools.cpp
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpRuntimeCoreTools.h"
+#include "UnrealMcpToolRegistry.h"
+#include "Tools/UnrealMcpObjectRef.h"
+#include "Tools/UnrealMcpPropertyJson.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "EngineUtils.h"            // TActorIterator
+#include "Engine/World.h"
+#include "Engine/Level.h"
+#include "GameFramework/Actor.h"
+#include "Misc/PackageName.h"
+#include "UObject/Package.h"
+
+/**
+ * The runtime level-data tool (docs/ARCHITECTURE.md §10 "level family" read-only runtime subset, §12.7).
+ * A single read-only tool, level-get-data, moved DOWN into the Type=Runtime module so it works over a
+ * runtime connection in PIE and packaged Development builds as well as the editor:
+ *
+ *  - `level-get-data` — an actor-tree snapshot of the world resolved by FUnrealMcpWorldProvider (the
+ *    editor world in the editor, the live game world at runtime). Returns each actor's identity,
+ *    optionally including reflected data scoped to the dotted `paths` filter (§3.2); pass `actor` to
+ *    scope the read to a single actor.
+ *
+ * RUNTIME-SAFE: it touches only Engine UWorld surface (TActorIterator, IsPartitionedWorld, GetLevels,
+ * GetCurrentLevel, PersistentLevel) + FUnrealMcpObjectRef / FUnrealMcpPropertyJson — no GEditor, no
+ * UnrealEd. The actor label is read via GetActorNameOrLabel (the friendly label in the editor, the
+ * object name at runtime; GetActorLabel itself is WITH_EDITOR-only). All level WRITE tools
+ * (level-create/open/save/set-current/unload-sublevel) and the editor read-only level-list-loaded stay
+ * editor-only in the editor module's UnrealMcpLevelTools — they need UnrealEd (UEditorLoadingAndSavingUtils,
+ * UEditorLevelUtils). The handler runs ON the game thread (the §4 dispatcher).
+ */
+namespace
+{
+	// --- Local helpers (family-unique names per the unity-build ODR rule; mirror the editor level family) ---
+
+	/** An `array` of strings — the §3.2 scoped-read `paths` filter. */
+	TSharedPtr<FJsonObject> RuntimeLevelMakeStringArraySchema(const FString& Desc)
+	{
+		TSharedPtr<FJsonObject> Items = MakeShared<FJsonObject>();
+		Items->SetStringField(TEXT("type"), TEXT("string"));
+
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), TEXT("array"));
+		if (!Desc.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Desc);
+		Schema->SetObjectField(TEXT("items"), Items);
+		return Schema;
+	}
+
+	/** Read a string array argument (the scoped-read `paths` filter); a non-string entry fails via OutError. */
+	TArray<FString> RuntimeLevelGetStringArray(const FUnrealMcpToolCall& Call, const FString& Key, FString& OutError)
+	{
+		TArray<FString> Out;
+		const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
+		if (Call.Arguments->TryGetArrayField(Key, Arr) && Arr)
+		{
+			for (const TSharedPtr<FJsonValue>& V : *Arr)
+			{
+				FString S;
+				if (V.IsValid() && V->TryGetString(S))
+				{
+					Out.Add(S);
+				}
+				else
+				{
+					OutError = FString::Printf(TEXT("'%s' must be an array of strings; a non-string entry was provided."), *Key);
+					Out.Reset();
+					return Out;
+				}
+			}
+		}
+		return Out;
+	}
+
+	/** Long package name of a level's outermost package (e.g. /Game/Maps/Arena); empty when null. */
+	FString RuntimeLevelPackageName(const ULevel* Level)
+	{
+		if (!Level)
+			return FString();
+		const UPackage* Package = Level->GetOutermost();
+		return Package ? Package->GetName() : FString();
+	}
+
+	/** Short, content-browser-style name of a level (e.g. "Arena"); empty when null. */
+	FString RuntimeLevelShortName(const ULevel* Level)
+	{
+		const FString PackageName = RuntimeLevelPackageName(Level);
+		return PackageName.IsEmpty() ? FString() : FPackageName::GetShortName(PackageName);
+	}
+
+	/** A `{ name, package, isPersistent, isCurrent }` identity block for a level loaded in @p World. */
+	TSharedPtr<FJsonObject> RuntimeLevelIdentity(const ULevel* Level, const UWorld* World)
+	{
+		TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+		Out->SetStringField(TEXT("name"), RuntimeLevelShortName(Level));
+		Out->SetStringField(TEXT("package"), RuntimeLevelPackageName(Level));
+		const bool bPersistent = World && Level == World->PersistentLevel;
+		Out->SetBoolField(TEXT("isPersistent"), bPersistent);
+		Out->SetBoolField(TEXT("isCurrent"), World && Level == World->GetCurrentLevel());
+		return Out;
+	}
+}
+
+namespace UnrealMcpRuntimeLevelTools
+{
+	UNREALMCPRUNTIME_API void Register(FUnrealMcpToolRegistry& Registry)
+	{
+		// level-get-data — actor-tree snapshot of the resolved world; scoped reads via 'paths' (§3.2).
+		Registry.Tool(TEXT("level-get-data"))
+			.Title(TEXT("Get Level Data"))
+			.Description(TEXT("Read an actor-tree snapshot of the active world (the editor world in the editor, the "
+			                  "live game world over a runtime connection). Returns each actor's identity, optionally "
+			                  "including reflected data scoped to the dotted 'paths' filter (§3.2) to save tokens. "
+			                  "Pass 'actor' to scope the read to a single actor instead of the whole world."))
+			.ParamString(TEXT("actor"), TEXT("Label / name / path of a single actor to read. Omit to snapshot the whole world."))
+			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include per actor (scoped read). Identity only when omitted."), EUnrealMcpParamRequirement::Optional, RuntimeLevelMakeStringArraySchema(TEXT("Dotted property paths to include per actor (scoped read).")))
+			.ParamInt(TEXT("limit"), TEXT("Maximum number of actors to return for a world snapshot. Defaults to 200; pass 0 or a negative value for no limit."))
+			.ReadOnlyHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				UWorld* World = FUnrealMcpObjectRef::GetEditorWorld();
+				if (!World)
+					return FUnrealMcpToolResult::Error(TEXT("No active world available."));
+
+				FString PathsError;
+				const TArray<FString> Paths = RuntimeLevelGetStringArray(Call, TEXT("paths"), PathsError);
+				if (!PathsError.IsEmpty())
+					return FUnrealMcpToolResult::Error(PathsError);
+
+				// Single-actor scope.
+				const FString ActorRef = Call.GetString(TEXT("actor"));
+				if (!ActorRef.IsEmpty())
+				{
+					AActor* Actor = FUnrealMcpObjectRef::ResolveActor(ActorRef, World);
+					if (!Actor)
+						return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No actor matched '%s' (by label/name/path)."), *ActorRef));
+
+					TSharedPtr<FJsonObject> Entry = FUnrealMcpObjectRef::ActorIdentity(Actor);
+					// Attach reflected data only when a scoped 'paths' filter is given — matching the whole-world
+					// branch and the "Identity only when omitted" contract (an empty Paths returns the full dump).
+					if (Paths.Num() > 0)
+						Entry->SetObjectField(TEXT("data"), FUnrealMcpPropertyJson::SerializeObject(Actor, Paths));
+					return FUnrealMcpToolResult::Success(
+						FString::Printf(TEXT("Read actor '%s'."), *Actor->GetActorNameOrLabel()), Entry);
+				}
+
+				// Whole-world snapshot.
+				const int32 Limit = static_cast<int32>(Call.GetInt(TEXT("limit"), 200));
+				TArray<TSharedPtr<FJsonValue>> Actors;
+				int32 Total = 0;
+				for (TActorIterator<AActor> It(World); It; ++It)
+				{
+					AActor* Actor = *It;
+					if (!Actor)
+						continue;
+					++Total;
+					if (Limit > 0 && Actors.Num() >= Limit)
+						continue; // keep counting the total, stop materializing entries
+
+					TSharedPtr<FJsonObject> Entry = FUnrealMcpObjectRef::ActorIdentity(Actor);
+					if (Paths.Num() > 0)
+						Entry->SetObjectField(TEXT("data"), FUnrealMcpPropertyJson::SerializeObject(Actor, Paths));
+					Actors.Add(MakeShared<FJsonValueObject>(Entry));
+				}
+
+				TSharedPtr<FJsonObject> Structured = RuntimeLevelIdentity(World->GetCurrentLevel(), World);
+				Structured->SetStringField(TEXT("world"), World->GetName());
+				Structured->SetBoolField(TEXT("isPartitionedWorld"), World->IsPartitionedWorld());
+				Structured->SetNumberField(TEXT("levelCount"), World->GetLevels().Num());
+				Structured->SetNumberField(TEXT("count"), Actors.Num());
+				Structured->SetNumberField(TEXT("total"), Total);
+				Structured->SetArrayField(TEXT("actors"), Actors);
+				return FUnrealMcpToolResult::Success(
+					FString::Printf(TEXT("Snapshot of world '%s': %d actor(s) (returned %d)."), *World->GetName(), Total, Actors.Num()),
+					Structured);
+			});
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Tools/UnrealMcpRuntimeScreenshotTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Tools/UnrealMcpRuntimeScreenshotTools.cpp
@@ -1,0 +1,382 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpRuntimeCoreTools.h"
+#include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpLog.h"
+#include "Tools/UnrealMcpObjectRef.h"
+
+#include "Dom/JsonObject.h"
+#include "Misc/App.h"
+#include "Misc/Base64.h"
+#include "Misc/ScopeExit.h"
+#include "UObject/GCObjectScopeGuard.h"
+#include "UObject/Package.h"        // UPackage complete type (GetTransientPackage()) — editor PCH supplied it transitively; the Game target needs it explicitly
+
+#include "Engine/Engine.h"
+#include "Engine/GameViewportClient.h"
+#include "UnrealClient.h"
+#include "ImageUtils.h"
+#include "TextureResource.h"
+
+#include "GameFramework/Actor.h"
+#include "Engine/World.h"
+#include "Engine/TextureRenderTarget2D.h"
+#include "Engine/SceneCapture2D.h"
+#include "Components/SceneCaptureComponent2D.h"
+#include "Camera/CameraComponent.h"
+
+/**
+ * The runtime screenshot subset (docs/ARCHITECTURE.md §10 "screenshot family" runtime subset, §12.7).
+ * The two runtime-safe screenshot tools, moved DOWN into the Type=Runtime module so an LLM can inspect
+ * what a running game (PIE or packaged Development) is rendering:
+ *
+ *  - `screenshot-game-view` — the live game viewport via GEngine->GameViewport->Viewport (the
+ *    GameViewportClient exists in PIE and in a packaged game; in the editor coordinator the editor's PIE
+ *    game viewport is the same FViewport). Replaces the editor family's GEditor->GetPIEViewport() so it
+ *    works without GEditor.
+ *  - `screenshot-camera` — render from a §3.2-resolved camera actor through a transient
+ *    USceneCaptureComponent2D into a render target, then read back. SceneCapture2D + UWorld::SpawnActor
+ *    are runtime-available; the world is the FUnrealMcpWorldProvider-resolved world.
+ *
+ * The editor-only screenshot-viewport (GEditor->GetActiveViewport) and screenshot-isolated stay in the
+ * editor module's UnrealMcpScreenshotTools. Every handler runs ON the game thread (the §4 dispatcher).
+ * Captures are dimension-capped (default 1024, hard cap 2048 per side; width/height clamped). Actual
+ * pixel capture needs a GPU — headless `-nullrhi` cannot render, so each capture path validates its
+ * arguments first (those branches are GPU-free and headless-spec-covered) and only then attempts the
+ * GPU read-back, returning a structured "rendering unavailable" error under `-nullrhi`. The capture
+ * paths themselves are LIVE-VERIFIED WINDOWED (issue #17 verification model). Screenshot APIs
+ * (USceneCaptureComponent2D, UGameViewportClient, FViewport::ReadPixels) are stable 5.5→5.7 (§12.10).
+ */
+namespace UnrealMcpRuntimeScreenshotTools
+{
+	// ---- GPU-free dimension logic (exported in UnrealMcpRuntimeCoreTools.h for headless specs) -------
+
+	int32 ResolveCaptureDimension(int64 Requested)
+	{
+		if (Requested <= 0)
+			return DefaultCaptureDimension;
+		return (int32)FMath::Clamp<int64>(Requested, (int64)1, (int64)MaxCaptureDimension);
+	}
+
+	void CapToMaxDimension(int32 InW, int32 InH, int32& OutW, int32& OutH)
+	{
+		OutW = FMath::Max(InW, 1);
+		OutH = FMath::Max(InH, 1);
+		const int32 LongestSide = FMath::Max(OutW, OutH);
+		if (LongestSide > MaxCaptureDimension)
+		{
+			const double Scale = (double)MaxCaptureDimension / (double)LongestSide;
+			OutW = FMath::Max(1, FMath::RoundToInt(OutW * Scale));
+			OutH = FMath::Max(1, FMath::RoundToInt(OutH * Scale));
+		}
+	}
+
+	// ---- Local helpers (family-unique names per the unity-build ODR rule) --------------------------
+
+	namespace
+	{
+		// Keep the encoded payload well under the §1.2 64 MiB IPC line cap (base64 expands ~4/3).
+		static constexpr int64 RuntimeScreenshotMaxEncodedBytes = 40 * 1024 * 1024;
+
+		/** True when the engine can render; false under headless `-nullrhi`. */
+		bool RuntimeScreenshotEnsureRenderingAvailable(FString& OutError)
+		{
+			if (!FApp::CanEverRender())
+			{
+				OutError = TEXT("Rendering is unavailable (headless/-nullrhi). Screenshot capture requires a "
+				                "GPU-backed game/editor; run windowed and retry.");
+				return false;
+			}
+			return true;
+		}
+
+		/** Force every pixel opaque so a viewport/render-target alpha of 0 does not yield a transparent PNG. */
+		void RuntimeScreenshotForceOpaque(TArray<FColor>& Pixels)
+		{
+			for (FColor& Pixel : Pixels)
+				Pixel.A = 255;
+		}
+
+		/** The structured block every screenshot tool returns alongside the image content. */
+		TSharedPtr<FJsonObject> RuntimeScreenshotMakeStructured(const FString& Source, int32 Width, int32 Height, int32 EncodedBytes)
+		{
+			TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+			Structured->SetStringField(TEXT("source"), Source);
+			Structured->SetNumberField(TEXT("width"), Width);
+			Structured->SetNumberField(TEXT("height"), Height);
+			Structured->SetStringField(TEXT("mimeType"), TEXT("image/png"));
+			Structured->SetNumberField(TEXT("byteSize"), EncodedBytes);
+			return Structured;
+		}
+
+		/** Resample a captured buffer to (DstW, DstH) when it differs from the source size. */
+		void RuntimeScreenshotResizeIfNeeded(TArray<FColor>& Pixels, int32 SrcW, int32 SrcH, int32 DstW, int32 DstH)
+		{
+			if ((SrcW == DstW && SrcH == DstH) || DstW <= 0 || DstH <= 0)
+				return;
+			TArray<FColor> Resized;
+			Resized.SetNumUninitialized(DstW * DstH);
+			FImageUtils::ImageResize(SrcW, SrcH, Pixels, DstW, DstH, Resized, /*bResizeSRGBinLinearSpace*/ false);
+			Pixels = MoveTemp(Resized);
+		}
+
+		/** Encode a BGRA8 FColor buffer to a base64 PNG (forcing opaque first). */
+		bool RuntimeScreenshotEncodePngBase64(TArray<FColor>& Pixels, int32 Width, int32 Height,
+			FString& OutBase64, int32& OutEncodedBytes, FString& OutError)
+		{
+			if (Width <= 0 || Height <= 0)
+			{
+				OutError = TEXT("Capture produced a zero-sized image.");
+				return false;
+			}
+			if (Pixels.Num() < Width * Height)
+			{
+				OutError = FString::Printf(TEXT("Capture pixel buffer (%d) is smaller than %dx%d."), Pixels.Num(), Width, Height);
+				return false;
+			}
+			RuntimeScreenshotForceOpaque(Pixels);
+
+			TArray64<uint8> Png;
+			FImageUtils::PNGCompressImageArray(Width, Height,
+				TArrayView64<const FColor>(Pixels.GetData(), (int64)Width * (int64)Height), Png);
+			if (Png.Num() == 0)
+			{
+				OutError = TEXT("PNG encoding produced no bytes.");
+				return false;
+			}
+			if (Png.Num() > RuntimeScreenshotMaxEncodedBytes)
+			{
+				OutError = FString::Printf(
+					TEXT("Encoded PNG (%lld bytes) exceeds the %lld-byte cap; request a smaller width/height."),
+					(int64)Png.Num(), RuntimeScreenshotMaxEncodedBytes);
+				return false;
+			}
+			OutBase64 = FBase64::Encode(Png.GetData(), Png.Num());
+			OutEncodedBytes = (int32)Png.Num();
+			return true;
+		}
+
+		/**
+		 * Effective output size for a viewport-style capture. When BOTH width and height are supplied they
+		 * are each clamped to [1, 2048]; when only ONE is supplied the other is derived from the native
+		 * aspect ratio; when NEITHER is supplied the native size is used. The result is then hard-capped.
+		 */
+		void RuntimeScreenshotEffectiveViewportSize(const FUnrealMcpToolCall& Call, int32 NativeW, int32 NativeH, int32& OutW, int32& OutH)
+		{
+			const int64 ReqW = Call.GetInt(TEXT("width"), 0);
+			const int64 ReqH = Call.GetInt(TEXT("height"), 0);
+			int32 W, H;
+			if (ReqW > 0 && ReqH > 0)
+			{
+				W = ResolveCaptureDimension(ReqW);
+				H = ResolveCaptureDimension(ReqH);
+			}
+			else if (ReqW > 0)
+			{
+				W = ResolveCaptureDimension(ReqW);
+				H = NativeW > 0 ? FMath::Max(1, FMath::RoundToInt(W * (double)NativeH / (double)NativeW)) : NativeH;
+			}
+			else if (ReqH > 0)
+			{
+				H = ResolveCaptureDimension(ReqH);
+				W = NativeH > 0 ? FMath::Max(1, FMath::RoundToInt(H * (double)NativeW / (double)NativeH)) : NativeW;
+			}
+			else
+			{
+				W = NativeW;
+				H = NativeH;
+			}
+			CapToMaxDimension(W, H, OutW, OutH);
+		}
+
+		/** Read + encode an FViewport (the live game viewport). Called only on the GPU-available path. */
+		FUnrealMcpToolResult RuntimeScreenshotCaptureFromViewport(const FUnrealMcpToolCall& Call, FViewport* Viewport, const FString& Source)
+		{
+			const FIntPoint Size = Viewport->GetSizeXY();
+			if (Size.X <= 0 || Size.Y <= 0)
+				return FUnrealMcpToolResult::Error(FString::Printf(TEXT("The %s has a zero-sized render area."), *Source));
+
+			Viewport->Draw(); // ensure a current frame is present before the read-back
+
+			TArray<FColor> Pixels;
+			if (!Viewport->ReadPixels(Pixels, FReadSurfaceDataFlags(), FIntRect(0, 0, Size.X, Size.Y)))
+				return FUnrealMcpToolResult::Error(FString::Printf(TEXT("Failed to read pixels from the %s."), *Source));
+
+			int32 OutW = 0, OutH = 0;
+			RuntimeScreenshotEffectiveViewportSize(Call, Size.X, Size.Y, OutW, OutH);
+			RuntimeScreenshotResizeIfNeeded(Pixels, Size.X, Size.Y, OutW, OutH);
+
+			FString Base64; int32 Bytes = 0; FString Error;
+			if (!RuntimeScreenshotEncodePngBase64(Pixels, OutW, OutH, Base64, Bytes, Error))
+				return FUnrealMcpToolResult::Error(Error);
+
+			const FString Message = FString::Printf(TEXT("Captured %s (%dx%d PNG, %d bytes)."), *Source, OutW, OutH, Bytes);
+			UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] %s"), *Message);
+			return FUnrealMcpToolResult::SuccessWithImage(Message, Base64, RuntimeScreenshotMakeStructured(Source, OutW, OutH, Bytes));
+		}
+
+		/**
+		 * Render through a transient SceneCapture2D into a transient render target, then read back. The
+		 * capture actor is spawned RF_Transient + hidden from the outliner and destroyed on every path, so
+		 * the world is never dirtied. Called only on the GPU-available path. screenshot-camera passes no
+		 * background and keeps the cheaper tonemapped LDR path.
+		 */
+		FUnrealMcpToolResult RuntimeScreenshotCaptureWithSceneCapture(
+			UWorld* World, const FTransform& CaptureXform, float FovDeg, int32 Width, int32 Height, const FString& Source)
+		{
+			// NewObject's single-arg overload takes a UObject* Outer; GetTransientPackage() returns UPackage*.
+			// In the editor target the shared PCH made the conversion implicit, but the Game target compiles this
+			// module standalone, so spell the Outer as a UObject* explicitly (UPackage is a UObject).
+			UTextureRenderTarget2D* RenderTarget = NewObject<UTextureRenderTarget2D>(static_cast<UObject*>(GetTransientPackage()));
+			RenderTarget->RenderTargetFormat = RTF_RGBA8;
+			RenderTarget->ClearColor = FLinearColor::Black;
+			RenderTarget->bAutoGenerateMips = false;
+			RenderTarget->InitAutoFormat(Width, Height);
+			RenderTarget->UpdateResourceImmediate(true);
+			FGCObjectScopeGuard RenderTargetGuard(RenderTarget);
+
+			FActorSpawnParameters SpawnParams;
+			SpawnParams.ObjectFlags |= RF_Transient;
+#if WITH_EDITOR
+			// bHideFromSceneOutliner is an editor-only FActorSpawnParameters member (the outliner does not exist
+			// in a packaged game); guard it so the Game target compiles. RF_Transient above already keeps the
+			// throwaway capture actor out of any save in both configs.
+			SpawnParams.bHideFromSceneOutliner = true;
+#endif
+			SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+
+			ASceneCapture2D* CaptureActor = World->SpawnActor<ASceneCapture2D>(
+				ASceneCapture2D::StaticClass(), CaptureXform, SpawnParams);
+			if (!CaptureActor)
+				return FUnrealMcpToolResult::Error(TEXT("Failed to spawn a transient SceneCapture2D actor."));
+			ON_SCOPE_EXIT { if (IsValid(CaptureActor)) CaptureActor->Destroy(); };
+
+			USceneCaptureComponent2D* Capture = CaptureActor->GetCaptureComponent2D();
+			if (!Capture)
+				return FUnrealMcpToolResult::Error(TEXT("Transient SceneCapture2D had no capture component."));
+
+			Capture->TextureTarget = RenderTarget;
+			Capture->FOVAngle = FovDeg;
+			Capture->CaptureSource = SCS_FinalColorLDR;
+			Capture->bCaptureEveryFrame = false;
+			Capture->bCaptureOnMovement = false;
+			// Pin auto-exposure. A single-shot CaptureScene() never gives eye-adaptation a chance to
+			// converge, so the default auto-exposure leaves one-off captures badly under/over-exposed.
+			// Locking min == max brightness makes exposure a fixed factor (no adaptation transient), so the
+			// capture is deterministic regardless of the scene's prior adaptation state.
+			Capture->PostProcessSettings.bOverride_AutoExposureMinBrightness = true;
+			Capture->PostProcessSettings.AutoExposureMinBrightness = 1.0f;
+			Capture->PostProcessSettings.bOverride_AutoExposureMaxBrightness = true;
+			Capture->PostProcessSettings.AutoExposureMaxBrightness = 1.0f;
+			// The capture component is the spawned actor's root (the actor was spawned at CaptureXform), so
+			// its world transform already equals CaptureXform — no explicit SetWorldLocationAndRotation needed.
+			Capture->CaptureScene();
+
+			FTextureRenderTargetResource* Resource = RenderTarget->GameThread_GetRenderTargetResource();
+			if (!Resource)
+				return FUnrealMcpToolResult::Error(TEXT("Render target resource was not available after capture."));
+
+			TArray<FColor> Pixels;
+			FReadSurfaceDataFlags ReadFlags(RCM_UNorm, CubeFace_MAX);
+			ReadFlags.SetLinearToGamma(false);
+			if (!Resource->ReadPixels(Pixels, ReadFlags))
+				return FUnrealMcpToolResult::Error(TEXT("Failed to read pixels from the capture render target."));
+
+			FString Base64; int32 Bytes = 0; FString Error;
+			if (!RuntimeScreenshotEncodePngBase64(Pixels, Width, Height, Base64, Bytes, Error))
+				return FUnrealMcpToolResult::Error(Error);
+
+			const FString Message = FString::Printf(TEXT("Captured %s (%dx%d PNG, %d bytes)."), *Source, Width, Height, Bytes);
+			UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] %s"), *Message);
+			return FUnrealMcpToolResult::SuccessWithImage(Message, Base64, RuntimeScreenshotMakeStructured(Source, Width, Height, Bytes));
+		}
+
+		/** Shared description tail documenting the size caps (so each tool advertises them, §10). */
+		const TCHAR* RuntimeScreenshotSizeCapNote()
+		{
+			return TEXT(" Returns a base64 PNG as MCP image content. Optional 'width'/'height' are clamped to "
+			            "[1, 2048] per side; the default is 1024. Requires a GPU-backed (windowed) game/editor.");
+		}
+
+		/** The live game viewport (PIE or packaged game), or null when no game viewport client is up. */
+		FViewport* RuntimeScreenshotGameViewport()
+		{
+			if (GEngine && GEngine->GameViewport)
+				return GEngine->GameViewport->Viewport;
+			return nullptr;
+		}
+	}
+
+	// ---- Registration -----------------------------------------------------------------------------
+
+	UNREALMCPRUNTIME_API void Register(FUnrealMcpToolRegistry& Registry)
+	{
+		// screenshot-game-view — the live game viewport (PIE or packaged game).
+		Registry.Tool(TEXT("screenshot-game-view"))
+			.Title(TEXT("Screenshot Game View"))
+			.Description(FString(TEXT("Capture the live game viewport — the Play-In-Editor game view in the editor, "
+				"or the game window over a runtime connection. Errors when no game viewport is active (e.g. no PIE "
+				"session and not a running game).")) + RuntimeScreenshotSizeCapNote())
+			.ParamInt(TEXT("width"), TEXT("Optional output width in pixels (clamped to [1, 2048]); when only 'height' is given the width is derived from the native aspect ratio, and the native game-view width is used when both are omitted."))
+			.ParamInt(TEXT("height"), TEXT("Optional output height in pixels (clamped to [1, 2048]); when only 'width' is given the height is derived from the native aspect ratio, and the native game-view height is used when both are omitted."))
+			.ReadOnlyHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				// Validate the game-viewport precondition FIRST (GPU-free, headless-spec-covered).
+				FViewport* GameViewport = RuntimeScreenshotGameViewport();
+				if (!GameViewport)
+					return FUnrealMcpToolResult::Error(TEXT("No game viewport is active. Start PIE (in the editor) or run the game before calling screenshot-game-view."));
+
+				FString Error;
+				if (!RuntimeScreenshotEnsureRenderingAvailable(Error))
+					return FUnrealMcpToolResult::Error(Error);
+
+				return RuntimeScreenshotCaptureFromViewport(Call, GameViewport, TEXT("game view"));
+			});
+
+		// screenshot-camera — render from a resolved camera actor via SceneCapture2D.
+		Registry.Tool(TEXT("screenshot-camera"))
+			.Title(TEXT("Screenshot Camera"))
+			.Description(FString(TEXT("Render the scene from a chosen camera actor (resolved by label/name/path) and capture it.")) + RuntimeScreenshotSizeCapNote())
+			.ParamString(TEXT("camera"), TEXT("Camera actor reference (label, object name, or path) to render from."), EUnrealMcpParamRequirement::Required)
+			.ParamInt(TEXT("width"), TEXT("Optional output width in pixels (clamped to [1, 2048]); default 1024."))
+			.ParamInt(TEXT("height"), TEXT("Optional output height in pixels (clamped to [1, 2048]); default 1024."))
+			.ParamNumber(TEXT("fov"), TEXT("Optional horizontal field-of-view override in degrees (clamped to [5, 170]); defaults to the camera component's FOV (or 90)."))
+			.ReadOnlyHint(true)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				// Validate arguments + resolve the camera FIRST (GPU-free, headless-spec-covered).
+				if (!Call.Has(TEXT("camera")))
+					return FUnrealMcpToolResult::Error(TEXT("'camera' is required."));
+
+				UWorld* World = FUnrealMcpObjectRef::GetEditorWorld();
+				if (!World)
+					return FUnrealMcpToolResult::Error(TEXT("No active world is available."));
+
+				const FString CameraRef = Call.GetString(TEXT("camera"));
+				AActor* CameraActor = FUnrealMcpObjectRef::ResolveActor(CameraRef, World);
+				if (!CameraActor)
+					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No actor matched camera reference '%s'."), *CameraRef));
+
+				UCameraComponent* CameraComponent = CameraActor->FindComponentByClass<UCameraComponent>();
+				// Clamp once at parse time to a sane perspective range; a degenerate FOV (<= 0 or >= 180)
+				// yields a NaN/garbage projection matrix rather than a usable render.
+				const float Fov = FMath::Clamp(Call.Has(TEXT("fov"))
+					? (float)Call.GetNumber(TEXT("fov"))
+					: (CameraComponent ? CameraComponent->FieldOfView : 90.0f), 5.0f, 170.0f);
+				const FTransform CaptureXform = CameraComponent
+					? CameraComponent->GetComponentTransform()
+					: CameraActor->GetActorTransform();
+
+				FString Error;
+				if (!RuntimeScreenshotEnsureRenderingAvailable(Error))
+					return FUnrealMcpToolResult::Error(Error);
+
+				const int32 Width = ResolveCaptureDimension(Call.GetInt(TEXT("width"), 0));
+				const int32 Height = ResolveCaptureDimension(Call.GetInt(TEXT("height"), 0));
+				const FString Source = FString::Printf(TEXT("camera '%s'"), *CameraActor->GetActorNameOrLabel());
+				return RuntimeScreenshotCaptureWithSceneCapture(World, CaptureXform, Fov, Width, Height, Source);
+			});
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
@@ -54,10 +54,15 @@ void UUnrealMcpRuntimeSubsystem::Initialize(FSubsystemCollectionBase& Collection
 
 	// Build the runtime-owned machinery (mirrors FUnrealMcpEditorCoordinator, §12.3 Model A) — registry +
 	// runtime-safe families + dispatcher + bridge. Editor-only families are NOT registered here (this path
-	// runs in a packaged game where they would not compile/link); R4 adds the remaining runtime-safe families.
+	// runs in a packaged game where they would not compile/link). R4 (§12.7) registers the full runtime-safe
+	// set: ping, actor/component, the console+reflection subset, the screenshot subset, and level-get-data.
 	Impl = MakePimpl<FRuntimeImpl>();
 	Impl->Registry = MakeUnique<FUnrealMcpToolRegistry>();
 	UnrealMcpPingTool::Register(*Impl->Registry);
+	UnrealMcpActorTools::Register(*Impl->Registry); // §10 actor / component family (World->SpawnActor runtime branch)
+	UnrealMcpConsoleReflectionTools::Register(*Impl->Registry); // §10 console + reflection runtime subset
+	UnrealMcpRuntimeScreenshotTools::Register(*Impl->Registry); // §10 screenshot runtime subset (game-view, camera)
+	UnrealMcpRuntimeLevelTools::Register(*Impl->Registry); // §10 read-only level-get-data
 
 	Impl->Dispatcher = MakeUnique<FUnrealMcpGameThreadDispatcher>();
 	Impl->BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(*Impl->Registry, *Impl->Dispatcher);

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeCoreTools.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeCoreTools.h
@@ -10,17 +10,84 @@ class FUnrealMcpToolRegistry;
 /**
  * Registration entry points for the RUNTIME-safe core tool families (docs/ARCHITECTURE.md §10, §12.7).
  *
- * In R1 the only runtime-safe family that has moved into the UnrealMcpRuntime module is `ping`. The
- * editor-only families (actor/component, blueprint, asset, editor/console/reflection, level, screenshot,
- * source) keep their Register declarations in the editor module's UnrealMcpCoreTools.h. The remaining
- * runtime-safe families (actor/component, the runtime console/reflection subset, the runtime screenshot
- * subset, level-get-data) migrate here in R4 (unreal-mcp-runtime-tool-families).
+ * R1 moved `ping` down. R4 (unreal-mcp-runtime-tool-families) moves the remaining runtime-safe families
+ * here: the actor/component family (made runtime-safe with a World->SpawnActor spawn branch + WITH_EDITOR
+ * guards), the runtime console/reflection subset (console-get/clear-logs, console-run-command,
+ * reflection-method-find/-call EXCLUDING CallInEditor), the runtime screenshot subset
+ * (screenshot-game-view + screenshot-camera), and read-only level-get-data. The editor-only families
+ * (blueprint, asset, source, level WRITE, editor-application-*, editor-selection-*, viewport/isolated
+ * screenshots, CallInEditor reflection) keep their Register declarations in the editor module's
+ * UnrealMcpCoreTools.h.
  *
  * Exported with UNREALMCPRUNTIME_API so the editor coordinator wires them on boot (Model A — editor and
  * runtime register on top of the SAME registry) AND the Automation specs can register + exercise them in
- * isolation, and (in R3+) the runtime bootstrap subsystem can register them in a packaged game.
+ * isolation, and the runtime bootstrap subsystem (R3) registers them in a packaged game.
  */
 namespace UnrealMcpPingTool
+{
+	UNREALMCPRUNTIME_API void Register(FUnrealMcpToolRegistry& Registry);
+}
+
+/**
+ * The actor & component tool family (docs/ARCHITECTURE.md §10 "actor family", §12.7). ~13 native C++
+ * tools — actor lifecycle (create/destroy/duplicate), scoped reads + FProperty writes (find/modify),
+ * parent/attachment, component management (add/destroy/get/modify/list-all), and generic UObject access
+ * (object-get-data/object-modify). RUNTIME-SAFE: actor-create spawns through the engine `World->SpawnActor`
+ * path against the world resolved by FUnrealMcpWorldProvider (editor world in the editor, the live game
+ * world at runtime); editor-only conveniences (`FScopedTransaction`, `FActorLabelUtilities::
+ * SetActorLabelUnique`, `EditorDestroyActor`, `GetActorLabel`) are WITH_EDITOR-guarded so the family
+ * compiles + links in the non-editor Game target while preserving today's editor behaviour byte-for-byte.
+ */
+namespace UnrealMcpActorTools
+{
+	UNREALMCPRUNTIME_API void Register(FUnrealMcpToolRegistry& Registry);
+}
+
+/**
+ * The runtime console / reflection tool family (docs/ARCHITECTURE.md §10 "editor/reflection family"
+ * runtime subset, §12.7). Five kebab-case tools, all runtime-safe: console-get-logs / console-clear-logs
+ * (the FUnrealMcpLogCollector GLog ring buffer), console-run-command (GEngine->Exec on the resolved
+ * world), and reflection-method-find / reflection-method-call (UFunction discovery + safety-gated
+ * ProcessEvent, EXCLUDING CallInEditor — only FUNC_BlueprintCallable/FUNC_Static are accepted so the
+ * gate needs no WITH_EDITORONLY_DATA CallInEditor metadata). The editor-only editor-application-* and
+ * editor-selection-* tools stay in the editor module's UnrealMcpEditorTools.
+ */
+namespace UnrealMcpConsoleReflectionTools
+{
+	UNREALMCPRUNTIME_API void Register(FUnrealMcpToolRegistry& Registry);
+}
+
+/**
+ * The runtime screenshot subset (docs/ARCHITECTURE.md §10 "screenshot family" runtime subset, §12.7).
+ * Two kebab-case tools that return a base64 PNG as MCP image content: screenshot-game-view (the live
+ * game viewport via GEngine->GameViewport, version-checked across 5.5→5.7) and screenshot-camera
+ * (render from a resolved camera actor through a transient USceneCaptureComponent2D). Both need a
+ * GPU-backed (windowed) game/editor — headless `-nullrhi` returns a structured "rendering unavailable"
+ * error. The editor-only screenshot-viewport + screenshot-isolated stay in the editor module's
+ * UnrealMcpScreenshotTools.
+ */
+namespace UnrealMcpRuntimeScreenshotTools
+{
+	UNREALMCPRUNTIME_API void Register(FUnrealMcpToolRegistry& Registry);
+
+	/** Hard cap (per side) and default for a single capture dimension (§10 — default 1024, hard cap 2048). */
+	enum : int32 { MaxCaptureDimension = 2048, DefaultCaptureDimension = 1024 };
+
+	/** Clamp a requested dimension to [1, MaxCaptureDimension]; a value <= 0 yields DefaultCaptureDimension. GPU-free (spec-testable). */
+	UNREALMCPRUNTIME_API int32 ResolveCaptureDimension(int64 Requested);
+
+	/** Downscale (InW, InH) proportionally so the longest side is <= MaxCaptureDimension; a no-op when already within the cap. GPU-free. */
+	UNREALMCPRUNTIME_API void CapToMaxDimension(int32 InW, int32 InH, int32& OutW, int32& OutH);
+}
+
+/**
+ * The runtime level-data tool (docs/ARCHITECTURE.md §10 "level family" read-only runtime subset, §12.7).
+ * A single read-only tool, level-get-data: an actor-tree snapshot of the live world resolved by
+ * FUnrealMcpWorldProvider (each actor's identity, optionally scoped reflected data via the dotted
+ * `paths` filter). All level WRITE tools (level-create/open/save/set-current/unload-sublevel) and
+ * level-list-loaded stay editor-only in the editor module's UnrealMcpLevelTools.
+ */
+namespace UnrealMcpRuntimeLevelTools
 {
 	UNREALMCPRUNTIME_API void Register(FUnrealMcpToolRegistry& Registry);
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1147,6 +1147,35 @@ editor-driven tools follow the user into PIE (matches Unity) — deferred until 
 Net runtime built-in set ≈22. PLUS user-authored runtime tools via the extension bus (§12.9) — the PRIMARY
 Unity runtime use case. Parity is "framework + your custom tools," not "all 62 built-ins in-game."
 
+**R4 implementation (landed).** The runtime-safe families now live in the runtime module and are registered
+by BOTH the editor coordinator (Model A, on top of the shared registry) and the runtime bootstrap subsystem
+(`UUnrealMcpRuntimeSubsystem::Initialize`). The realized split — exactly 22 runtime built-ins:
+`ping` (1) + actor/component (13: `actor-create/destroy/duplicate/find/modify/set-parent`,
+`actor-component-add/destroy/get/modify/list-all`, `object-get-data/modify`) +
+console/reflection (5: `console-get-logs/clear-logs/run-command`, `reflection-method-find/-call`) +
+screenshot (2: `screenshot-game-view`, `screenshot-camera`) + `level-get-data` (1). Files:
+`UnrealMcpRuntime/Private/Tools/UnrealMcpActorTools.cpp` (moved DOWN, `git mv`),
+`UnrealMcpConsoleReflectionTools.cpp`, `UnrealMcpRuntimeScreenshotTools.cpp`, `UnrealMcpRuntimeLevelTools.cpp`
+(new). Editor-only families stay editor-registered, unchanged in count.
+- **Undo transaction reconciliation.** §12.2 listed `FScopedTransaction` as a `#if WITH_EDITOR`-guarded
+  coupling, but `FScopedTransaction` lives in the **UnrealEd module**, which the Type=Runtime module
+  deliberately does not link — so even guarded, the editor build of the runtime module fails to LINK it. The
+  actor family therefore drops its own named undo transaction (a no-op RAII seam in both configs); the
+  per-op `Modify()` + `MarkPackageDirty()` calls are retained (Engine, WITH_EDITOR) so the editor's active
+  transaction still records the mutation — only the per-op named undo grouping is lost when the family is
+  driven from the runtime module. Likewise `FActorLabelUtilities::SetActorLabelUnique` (UnrealEd) is replaced
+  by `AActor::SetActorLabel` (Engine, WITH_EDITOR); the friendly label is read via `GetActorNameOrLabel`
+  (runtime-safe) instead of the WITH_EDITOR-only `GetActorLabel`.
+- **`screenshot-game-view`** uses `GEngine->GameViewport->Viewport` (runtime-available) instead of the editor
+  family's `GEditor->GetPIEViewport()`.
+- **Reflection runtime gate** accepts BlueprintCallable (+ Static for the CDO path) ONLY — the editor family's
+  `CallInEditor` allowance is excluded (that metadata is `WITH_EDITORONLY_DATA`).
+- **Lost-transitive-include fixes** the Game-target BuildPlugin surfaced (the editor PCH had masked them):
+  explicit `#include`s for `UObject/TextProperty.h` + `UObject/EnumProperty.h` (reflection property `IsA<>`)
+  and `UObject/Package.h` (`GetTransientPackage()` Outer); `FActorSpawnParameters::bHideFromSceneOutliner` is
+  `#if WITH_EDITOR`-guarded. "editor-only tools absent from the runtime manifest" is a deterministic
+  Automation gate (`UnrealMcp.RuntimeSubsystem` → "runtime manifest separation").
+
 ### 12.8 Security analysis (shipped-game remote-control surface)
 A runtime connection is remote control of a running game (actor-create, object-modify, console-run-command
 arbitrary CVars, reflection-method-call arbitrary UFunctions) — RCE-class if reachable. Mitigations (ALL in design):


### PR DESCRIPTION
## Summary
- Move the runtime-safe tool subset DOWN from `UnrealMcpEditor` into the `Type=Runtime` `UnrealMcpRuntime` module (docs/ARCHITECTURE.md §12.7, Model A) so it works over a runtime connection (PIE / packaged Development) as well as in the editor; editor-only families stay editor-registered and unchanged.
- Runtime-safe set (22 built-ins), registered by BOTH the editor coordinator and the runtime bootstrap subsystem: actor/component (13, `git mv` + `World->SpawnActor` spawn branch + WITH_EDITOR seams), console/reflection (5, new family, BlueprintCallable/Static gate — no CallInEditor), screenshot (2: `screenshot-game-view`/`screenshot-camera`), read-only `level-get-data` (1).
- `FScopedTransaction`/`FActorLabelUtilities` live in UnrealEd (unlinkable from a runtime module) → the actor family's named undo transaction is a no-op seam and `SetActorLabel` replaces `SetActorLabelUnique`; per-op `Modify()`/`MarkPackageDirty()` retained. Lost-transitive-include fixes the Game-target BuildPlugin surfaced (`TextProperty.h`, `EnumProperty.h`, `Package.h`; `bHideFromSceneOutliner` WITH_EDITOR-guarded).
- Automation specs split to match + a new `UnrealMcp.RuntimeSubsystem` "runtime manifest separation" spec proving editor-only tools are absent from the runtime registry and the 22 runtime tools present.

## Test plan
- [x] UBT editor build (`UnrealTestProjectEditor Win64 Development`) exit 0 — from a fully clean state (module-graph change).
- [x] RunUAT **BuildPlugin** (Game+Editor, UnrealGame Shipping+Development, `-WarningsAsErrors`) exit 0 — proves the runtime module compiles in the non-editor target.
- [x] Headless boot smoke: `[Unreal-MCP] plugin loaded`, exit 0.
- [x] `UnrealMcp.*` Automation: **282 tests, 0 failed**.
- [x] Live e2e (gamedev-mcp-server ⇄ bridge ⇄ headless editor): `tools/list` shows the runtime tools; `console-run-command`, `reflection-method-call` (2+3=5), `actor-create` (native AND a `/Game/E2E/BP_E2EProbe.BP_E2EProbe_C` Blueprint class), and `level-get-data` all succeed; clean no-orphan teardown.

Closes #121
