### PR TITLE
feat(plugin): bundle the .NET sidecar into packaged games (#123)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
+++ b/UnrealMCP/Source/UnrealMcpEditor/UnrealMcpEditor.Build.cs
@@ -99,15 +99,14 @@ public class UnrealMcpEditor : ModuleRules
 			PublicDefinitions.Add("WITH_UNREAL_MCP_LIVE_CODING=0");
 		}
 
-		// Bundle the prebuilt self-contained sidecar payloads (docs/ARCHITECTURE.md §6 BUNDLE model).
-		// Staged into the packaged plugin under Binaries/ThirdParty/UnrealMcpBridge/<rid>/ so the editor
-		// can spawn the bridge with zero install (FUnrealMcpSidecarManager::ResolveBridgeBinaryPath). The
-		// binaries are NOT committed to git; the release job stages them before BuildPlugin (task T4). The
-		// recursive "..." wildcard is a no-op on a dev checkout that has not staged them, so local source
-		// builds still compile and resolve the bridge via UNREAL_MCP_BRIDGE_PATH instead. NonUFS = raw
-		// (not cooked) files, correct for native runtime binaries.
-		RuntimeDependencies.Add(
-			Path.Combine(PluginDirectory, "Binaries", "ThirdParty", "UnrealMcpBridge", "...", "*"),
-			StagedFileType.NonUFS);
+		// NOTE (R2, docs/ARCHITECTURE.md §12.5): the RuntimeDependencies.Add(.../UnrealMcpBridge/<rid>/*)
+		// sidecar-staging declaration MOVED out of this editor module and DOWN into UnrealMcpRuntime.Build.cs
+		// (task unreal-mcp-runtime-sidecar-packaging, issue #123). UBT only stages a RuntimeDependency into
+		// builds that include the declaring module's target; declaring it on the EDITOR module bundled the
+		// sidecar into editor packages but NOT into packaged GAMES (the editor module is absent from a Game
+		// target). Declaring it on the runtime module — which is part of both the editor AND the game target —
+		// bundles the bridge into packaged Development/Shipping game builds too, the whole point of R2. The
+		// editor BuildPlugin path still bundles because UnrealMcpRuntime is a transitive dependency of the
+		// editor module, so its RuntimeDependencies are honoured by the editor package as well (no regression).
 	}
 }

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Sidecar/UnrealMcpSidecarManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Sidecar/UnrealMcpSidecarManager.cpp
@@ -186,15 +186,32 @@ bool FUnrealMcpSidecarManager::StartForPort(int32 InIpcPort, const FString& InTo
 	BridgePath = ResolveBridgeBinaryPath();
 	if (BridgePath.IsEmpty())
 	{
-		// §6.3 step 3 graceful-degrade: a packaged plugin missing the <rid> bridge, OR a dev source
-		// checkout with no (or a stale) UNREAL_MCP_BRIDGE_PATH. The bridge server still listens; surface
-		// an actionable error (the bundled binary is the production path, the env var is the dev path).
-		// Report the EFFECTIVE rid (arm64-probed, matching ResolveBridgeBinaryPath) so the reinstall hint
-		// names the slice that was actually looked for — not osx-arm64 on a host that degraded to osx-x64.
+		// §6.3 step 3 graceful-degrade. Two distinct causes; surface the right actionable error for each.
+		const FString EffectiveRid = ResolveEffectiveRid();
+		if (EffectiveRid.IsEmpty())
+		{
+			// docs/ARCHITECTURE.md §12.5 — Desktop-only constraint. ResolveRid returns empty on a non-desktop
+			// host (console/mobile), which cannot spawn an external .NET process; no sidecar is bundled or
+			// spawnable there. This is an unsupported-platform condition, NOT a missing-install one, so do not
+			// emit the reinstall hint (there is nothing to reinstall). The bridge server still listens, but the
+			// runtime MCP feature is unavailable on this platform by design.
+			UE_LOG(LogUnrealMcp, Warning,
+				TEXT("[Unreal-MCP] the .NET sidecar is unavailable on this platform — runtime MCP is Desktop-only ")
+				TEXT("(Win64/Mac/Linux); console/mobile cannot spawn an external .NET process (docs/ARCHITECTURE.md §12.5). ")
+				TEXT("The bridge is listening on %d, but no sidecar will be spawned."),
+				IpcPort);
+			return false;
+		}
+
+		// A packaged plugin missing the <rid> bridge, OR a dev source checkout with no (or a stale)
+		// UNREAL_MCP_BRIDGE_PATH. The bridge server still listens; surface an actionable error (the bundled
+		// binary is the production path, the env var is the dev path). Report the EFFECTIVE rid (arm64-probed,
+		// matching ResolveBridgeBinaryPath) so the reinstall hint names the slice that was actually looked for
+		// — not osx-arm64 on a host that degraded to osx-x64.
 		UE_LOG(LogUnrealMcp, Warning,
 			TEXT("[Unreal-MCP] no sidecar binary resolved for rid '%s' (bundled path absent and UNREAL_MCP_BRIDGE_PATH unset or pointing at a missing file). ")
 			TEXT("The bridge is listening on %d. End users: reinstall the plugin for your platform; developers: set UNREAL_MCP_BRIDGE_PATH or run `unreal-mcp-cli bootstrap-local`."),
-			*ResolveEffectiveRid(), IpcPort);
+			*EffectiveRid, IpcPort);
 		return false;
 	}
 

--- a/UnrealMCP/Source/UnrealMcpRuntime/UnrealMcpRuntime.Build.cs
+++ b/UnrealMCP/Source/UnrealMcpRuntime/UnrealMcpRuntime.Build.cs
@@ -1,10 +1,27 @@
 // Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
 // See the LICENSE file in the repository root for more information.
 
+using System.IO;
 using UnrealBuildTool;
 
 public class UnrealMcpRuntime : ModuleRules
 {
+	// docs/ARCHITECTURE.md §12.5 + §6.2 / Sidecar/UnrealMcpSidecarManager.cpp::ResolveRid — the .NET RID
+	// directory name the C++ resolver looks under (Binaries/ThirdParty/UnrealMcpBridge/<rid>/). Kept in
+	// lockstep with ResolveRid: win-x64 / linux-x64 / osx-* (both mac slices). Returns null for a non-desktop
+	// platform (console/mobile) — those cannot spawn an external .NET process, so runtime MCP is Desktop-only
+	// (Win64/Mac/Linux) and nothing is staged there (matches ResolveRid returning empty on those hosts).
+	private static string[] BridgeRidsForPlatform(UnrealTargetPlatform Platform)
+	{
+		if (Platform == UnrealTargetPlatform.Win64)
+			return new string[] { "win-x64" };
+		if (Platform == UnrealTargetPlatform.Linux)
+			return new string[] { "linux-x64" };
+		if (Platform == UnrealTargetPlatform.Mac)
+			return new string[] { "osx-arm64", "osx-x64" }; // ResolveRid picks one at runtime from the host CPU
+		return null; // non-desktop (console/mobile) — Desktop-only constraint, stage nothing
+	}
+
 	public UnrealMcpRuntime(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
@@ -56,8 +73,45 @@ public class UnrealMcpRuntime : ModuleRules
 		bool bUnrealMcpAllowShipping = false;
 		PublicDefinitions.Add("UNREAL_MCP_ALLOW_SHIPPING=" + (bUnrealMcpAllowShipping ? "1" : "0"));
 
-		// NOTE (R2): RuntimeDependencies.Add(.../UnrealMcpBridge/<rid>/*) deliberately stays in
-		// UnrealMcpEditor.Build.cs for now. Moving it here (so the sidecar bundles into packaged GAMES) is
-		// the explicit scope of task R2 (unreal-mcp-runtime-sidecar-packaging) — out of scope for R1.
+		// R2 (docs/ARCHITECTURE.md §12.5): bundle the prebuilt self-contained sidecar payloads into the
+		// packaged plugin under Binaries/ThirdParty/UnrealMcpBridge/<rid>/ — the exact path the C++ resolver
+		// (FUnrealMcpSidecarManager::ResolveBridgeBinaryPath / ComposeBundledBridgePath) reads at runtime, so
+		// a packaged game spawns the bridge with zero install and zero first-run download (§6 BUNDLE model).
+		//
+		// Why this declaration lives on the RUNTIME module (the whole point of R2): UBT only stages a module's
+		// RuntimeDependencies into a build whose target includes that module. UnrealMcpRuntime (Type: Runtime)
+		// is part of BOTH the editor target AND a packaged Game target, so its RuntimeDependencies bundle into
+		// packaged Development/Shipping GAME builds — not just editor packages. (When it lived on the Editor
+		// module it staged into editor packages only; a Game target omits the editor module entirely, so a
+		// packaged game shipped without the sidecar — the bug R2 fixes.) The editor BuildPlugin path still
+		// bundles because the editor module depends on UnrealMcpRuntime, so UBT honours this module's
+		// RuntimeDependencies in the editor package as well — no regression.
+		//
+		// Conservative gating (adopted defaults, design Open questions 1 & 2):
+		//  - Stage ONLY the targeted-platform RID(s) (BridgeRidsForPlatform), not a recursive "..." wildcard
+		//    over all four RIDs. Each self-contained slice is ~73-80 MB, so a per-platform package carries
+		//    only the slice it can actually run (e.g. a Win64 game stages win-x64 alone).
+		//  - DESKTOP-ONLY: console/mobile cannot spawn an external .NET process, so BridgeRidsForPlatform
+		//    returns null there and nothing is staged (mirrors ResolveRid returning empty on those hosts).
+		//  - SHIPPING is NOT staged by default: a Shipping game omits the sidecar unless the consumer opts in
+		//    via bUnrealMcpAllowShipping (the same flag that gates runtime Connect() in Shipping, §12.8 #3).
+		//    Development/editor builds always stage. This keeps a default Shipping build lean and closes the
+		//    runtime remote-control surface unless deliberately enabled.
+		//
+		// The binaries are NEVER committed to git (Binaries/ is gitignored); the release job stages the signed
+		// per-RID slices into this path before BuildPlugin (docs/RELEASING.md). The "*" wildcard is a no-op on
+		// a dev source checkout that has not staged them, so local source builds still compile and resolve the
+		// bridge via UNREAL_MCP_BRIDGE_PATH instead. NonUFS = raw (uncooked) files, correct for native binaries.
+		bool bStageSidecar = (Target.Configuration != UnrealTargetConfiguration.Shipping) || bUnrealMcpAllowShipping;
+		string[] StageRids = BridgeRidsForPlatform(Target.Platform);
+		if (bStageSidecar && StageRids != null)
+		{
+			foreach (string Rid in StageRids)
+			{
+				RuntimeDependencies.Add(
+					Path.Combine(PluginDirectory, "Binaries", "ThirdParty", "UnrealMcpBridge", Rid, "*"),
+					StagedFileType.NonUFS);
+			}
+		}
 	}
 }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -64,11 +64,62 @@ artifact jobs in `release.yml`:
   notarytool are macOS-only — hence the two-runner split.)
 - **`build-plugin-zip`** (self-hosted UE 5.7) — downloads the four signed RID
   dirs, **stages them into `UnrealMCP/Binaries/ThirdParty/UnrealMcpBridge/<rid>/`**
-  (the exact path the C++ resolver + the `UnrealMcpEditor.Build.cs`
-  `RuntimeDependencies` wildcard expect), runs `BuildPlugin -Rocket` so the
-  staged binaries are packaged, then zips the plugin. A post-BuildPlugin guard
-  copies the binaries into the package output if `RuntimeDependencies` did not
-  stage them (a defensive fallback for the one unverified UBT behavior).
+  (the exact path the C++ resolver + the `UnrealMcpRuntime.Build.cs`
+  `RuntimeDependencies` per-RID staging expect — moved out of the editor module in
+  R2 so the bridge bundles into packaged GAMES, not just editor packages; see
+  [Packaged-game sidecar bundling](#packaged-game-sidecar-bundling-r2) below), runs
+  `BuildPlugin -Rocket` so the staged binaries are packaged, then zips the plugin.
+  A post-BuildPlugin guard copies the binaries into the package output if
+  `RuntimeDependencies` did not stage them (a defensive fallback for the one
+  unverified UBT behavior).
+
+### Packaged-game sidecar bundling (R2)
+
+The `RuntimeDependencies.Add(.../UnrealMcpBridge/<rid>/*)` declaration that stages
+the sidecar lives in **`UnrealMcpRuntime.Build.cs`** (the `Type: Runtime` module),
+NOT the editor module (`docs/ARCHITECTURE.md` §12.5). UBT only stages a module's
+RuntimeDependencies into a build whose target includes that module: the runtime
+module is part of both the editor target and a packaged Game target, so the bridge
+now bundles into packaged **Development/Shipping game** builds — the editor module
+is absent from a Game target, so when the declaration lived there a packaged game
+shipped without the sidecar.
+
+Conservative staging (adopted defaults, design Open questions 1 & 2):
+
+- **Per-RID, not all four** — only the targeted platform's RID(s) are staged
+  (`win-x64`, `linux-x64`, or both macOS slices), since each self-contained slice
+  is ~73-80 MB.
+- **Desktop-only** — nothing is staged for console/mobile targets (they cannot
+  spawn an external .NET process); runtime MCP is Win64/Mac/Linux only.
+- **Shipping is NOT bundled by default** — a Shipping game omits the sidecar unless
+  the consumer opts in via the `bUnrealMcpAllowShipping` Build flag (the same flag
+  that gates runtime `Connect()` in Shipping, §12.8 #3). Development and editor
+  builds always stage.
+
+**Staging a packaged game (testbed / consumer build):** the bridge binaries are
+gitignored, so a fresh checkout has an empty `Binaries/ThirdParty/UnrealMcpBridge/`.
+Before packaging a **game** (`BuildCookRun -build -cook -stage`, e.g. the
+`Unreal-Test-Project` testbed) you must publish the sidecar for the target RID and
+place it at the bundled path first — otherwise the per-RID `RuntimeDependencies`
+wildcard matches nothing and the staged game has no sidecar:
+
+```bash
+# 1. Publish the self-contained sidecar for the target RID (e.g. win-x64):
+bash bridge/publish.sh Release win-x64 --no-zip
+# 2. Place it at the bundled path the resolver reads:
+#    <plugin>/Binaries/ThirdParty/UnrealMcpBridge/<rid>/unreal-mcp-bridge[.exe]
+mkdir -p UnrealMCP/Binaries/ThirdParty/UnrealMcpBridge/win-x64
+cp bridge/publish/win-x64/unreal-mcp-bridge.exe \
+   UnrealMCP/Binaries/ThirdParty/UnrealMcpBridge/win-x64/
+# 3. Package the game (Win64 Development): RunUAT BuildCookRun -build -cook -stage.
+#    The staged game then contains
+#    <Staged>/<Project>/Plugins/UnrealMCP/Binaries/ThirdParty/UnrealMcpBridge/win-x64/
+#    unreal-mcp-bridge.exe — ResolveBridgeBinaryPath resolves it in the packaged process.
+```
+
+In CI this is automatic: `build-plugin-zip` downloads the signed per-RID dirs and
+stages them before BuildPlugin. The manual sequence above is for a local
+packaged-game verification of the bundle (it is not part of a normal release).
 
 **Binaries are never committed to git.** `Binaries/` is gitignored; the signed
 binaries exist only transiently on the runners during a release. A dev source


### PR DESCRIPTION
## Summary
- **Move** the `RuntimeDependencies.Add(.../UnrealMcpBridge/<rid>/*)` sidecar-staging declaration from `UnrealMcpEditor.Build.cs` → `UnrealMcpRuntime.Build.cs` so UBT bundles the `.NET` sidecar into packaged **Development/Shipping game** builds, not just editor packages (docs/ARCHITECTURE.md §12.5). The editor BuildPlugin path still bundles via the editor module's transitive runtime dependency — no regression.
- **Conservative gating** (design Open questions 1 & 2): stage only the targeted-platform RID(s) (not a recursive `...` wildcard over all four ~73-80 MB slices); **Desktop-only** (nothing staged for console/mobile); **Shipping NOT staged by default** unless `bUnrealMcpAllowShipping` is set.
- **Extend** `FUnrealMcpSidecarManager::StartForPort`'s resolution error to distinguish the Desktop-only / unsupported-platform case (no reinstall hint) from the missing-bundled-binary case.
- **docs/RELEASING.md**: new "Packaged-game sidecar bundling" section + a runbook to publish & place the bridge before a local packaged-game build.

## Test plan
- [x] Clean editor build (UBT, exit 0) — module-graph change, built from a fully clean state.
- [x] Headless boot smoke — `[Unreal-MCP] plugin loaded` (exit 0).
- [x] Automation `UnrealMcp.*` — **failed: 0, succeeded: 264 / 282** (run with the committed empty-`Binaries/` state).
- [x] RunUAT BuildPlugin (Game+Editor, UnrealGame Development+Shipping, `-WarningsAsErrors`) — exit 0.
- [x] **R2 acceptance proof — packaged Development game build**: `BuildCookRun -build -cook -stage -pak -archive` (Win64 Development) of `Unreal-Test-Project` stages the bridge at `<Staged>/UnrealTestProject/Plugins/UnrealMCP/Binaries/ThirdParty/UnrealMcpBridge/win-x64/unreal-mcp-bridge.exe` (73,136,065 bytes; confirmed in the NonUFS staging manifest). Since the editor module is absent from a Game target, this staging is solely from the **UnrealMcpRuntime** module.
- [x] Bridge binary is gitignored / NOT committed (`Binaries/` is gitignored).

Closes #123
