### PR TITLE
feat: runtime extension bus + runtime gameplay-tool sample (#125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ IModularFeatures::Get().RegisterModularFeature(
 **Learn more:**
 
 - **Full author guide:** [`docs/EXTENSIONS.md`](docs/EXTENSIONS.md) — the contract, the tool builder, lifecycle, ordering, isolation semantics, and versioning.
-- **Working sample:** [`samples/UnrealAITemplate/`](samples/UnrealAITemplate) — a complete, buildable plugin with a `hello-extension` tool and a compile-time switch (`UNREAL_AI_TEMPLATE_INVALID_SCHEMA=1`) that demonstrates the isolation behaviour first-hand.
+- **Working samples:** [`samples/UnrealAITemplate/`](samples/UnrealAITemplate) — a complete, buildable **editor** extension plugin with a `hello-extension` tool and a compile-time switch (`UNREAL_AI_TEMPLATE_INVALID_SCHEMA=1`) that demonstrates the isolation behaviour first-hand; [`samples/UnrealAIRuntimeSample/`](samples/UnrealAIRuntimeSample) — the **runtime (in-game)** counterpart, a `Type=Runtime` plugin whose `game-time-dilation` tool reads/sets the live world's time dilation, callable in a running game over a runtime MCP connection ([`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) §12.9; see EXTENSIONS.md "Runtime usage").
 
 ![AI Game Developer — Unreal MCP](https://github.com/IvanMurzak/Unreal-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
 
@@ -467,7 +467,8 @@ An `MCP Tool` is a function the LLM can call to interact with Unreal. These tool
 | [`UnrealMCP/`](UnrealMCP/) | The UE editor plugin (C++, module `UnrealMcpEditor`, UE 5.5+ floor, developed against 5.7) |
 | [`bridge/`](bridge/) | The .NET 9 sidecar (`unreal-mcp-bridge`) — McpPlugin host, IPC ⇄ SignalR relay |
 | [`cli/`](cli/) | `unreal-mcp-cli` npm package (TypeScript) — 16 commands |
-| [`samples/UnrealAITemplate/`](samples/UnrealAITemplate/) | Extension template plugin (`hello-extension`) |
+| [`samples/UnrealAITemplate/`](samples/UnrealAITemplate/) | Editor extension template plugin (`hello-extension`) |
+| [`samples/UnrealAIRuntimeSample/`](samples/UnrealAIRuntimeSample/) | Runtime (in-game) extension sample (`game-time-dilation`, `Type=Runtime`) |
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | The authoritative architecture design |
 | [`docs/EXTENSIONS.md`](docs/EXTENSIONS.md) | Extension author guide |
 | [`docs/RELEASING.md`](docs/RELEASING.md) | CI/CD + operator release runbook |

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpRuntimeExtensionProviderSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpRuntimeExtensionProviderSpec.cpp
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/Paths.h"
+#include "Misc/Guid.h"
+#include "HAL/FileManager.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Features/IModularFeatures.h"
+#include "Engine/GameInstance.h" // a transient UGameInstance as the subsystem's Outer (ClassWithin=UGameInstance)
+
+#include "IUnrealMcpToolProvider.h"
+#include "UnrealMcpToolRegistry.h"
+#include "Extensions/UnrealMcpExtensionManager.h"
+#include "UnrealMcpRuntimeSubsystem.h"
+
+/**
+ * Specs for the R5 runtime extension bus (docs/ARCHITECTURE.md §12.9) — the PRIMARY Unity-parity runtime
+ * use case: a game registers a CUSTOM tool provider at runtime and Unreal-MCP rebuilds the registry +
+ * re-pushes the manifest so a connected sidecar's tools/list gains/loses the tool.
+ *
+ * The R5 deliverable adds the ergonomic UUnrealMcpRuntimeSubsystem::RegisterToolProvider /
+ * UnregisterToolProvider wrappers (so a game need not touch IModularFeatures directly). These wrappers are
+ * thin pass-throughs to IModularFeatures::Register/UnregisterModularFeature; they do NOT touch the
+ * subsystem's PImpl, so a bare (un-Initialized) NewObject subsystem is enough to exercise them — exactly
+ * as UnrealMcpRuntimeSubsystemSpec exercises the pre-Initialize security gates. The §5 extension manager
+ * (wired to its own registry here) is the observer that proves the register/unregister actually rebuilt
+ * the registry and fired the manifest re-push callback.
+ *
+ * The live sidecar connect → server → tools/list wire path is the live-e2e / PIE runbook (test.md Suite 7);
+ * here we assert the registry+manifest contract headlessly, which is what makes "a runtime-registered
+ * provider's tool appears/disappears in the manifest" a deterministic CI gate.
+ */
+namespace
+{
+	/** A test-only runtime tool provider whose RegisterTools registers one gameplay-style tool. */
+	class FRuntimeExtSpecProvider : public IUnrealMcpToolProvider
+	{
+	public:
+		explicit FRuntimeExtSpecProvider(const FString& InId, const FString& InToolName)
+			: Id(InId), ToolName(InToolName), Display(FText::FromString(InId)) {}
+
+		virtual FString GetExtensionId() const override { return Id; }
+		virtual FText GetDisplayName() const override { return Display; }
+		virtual FString GetExtensionVersion() const override { return TEXT("1.0.0"); }
+		virtual void RegisterTools(FUnrealMcpToolRegistry& Registry) override
+		{
+			const FString Name = ToolName;
+			Registry.Tool(Name)
+				.Title(TEXT("Runtime sample tool"))
+				.Description(TEXT("A runtime-registered gameplay tool (R5 §12.9 spec fixture)."))
+				.ParamNumber(TEXT("value"), TEXT("an optional value"))
+				.Handle([](const FUnrealMcpToolCall&) { return FUnrealMcpToolResult::Success(TEXT("ok")); });
+		}
+
+		FString Id;
+		FString ToolName;
+		FText Display;
+	};
+
+	/** Whether the manifest's tools[] array contains a tool with the given name (mirrors the §5 spec helper). */
+	bool RuntimeExtManifestHasTool(const FUnrealMcpToolRegistry& Registry, const FString& Name)
+	{
+		const TSharedPtr<FJsonObject> Manifest = Registry.BuildManifestJson();
+		const TArray<TSharedPtr<FJsonValue>>* Tools = nullptr;
+		if (!Manifest->TryGetArrayField(TEXT("tools"), Tools))
+			return false;
+		for (const TSharedPtr<FJsonValue>& Value : *Tools)
+		{
+			const TSharedPtr<FJsonObject> Obj = Value->AsObject();
+			if (Obj.IsValid() && Obj->GetStringField(TEXT("name")) == Name)
+				return true;
+		}
+		return false;
+	}
+
+	FString RuntimeExtMakeTempConfigPath()
+	{
+		return FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("UnrealMcpTests"),
+			FString::Printf(TEXT("runtime-ext-%s.json"), *FGuid::NewGuid().ToString(EGuidFormats::Digits)));
+	}
+
+	/** A bare (un-Initialize'd) runtime subsystem — enough for the IModularFeatures pass-through wrappers,
+	 *  which do not touch the subsystem's PImpl. ClassWithin=UGameInstance requires a UGameInstance Outer. */
+	UUnrealMcpRuntimeSubsystem* RuntimeExtMakeSubsystem()
+	{
+		UGameInstance* OuterGI = NewObject<UGameInstance>(GetTransientPackage());
+		return NewObject<UUnrealMcpRuntimeSubsystem>(OuterGI);
+	}
+}
+
+BEGIN_DEFINE_SPEC(FUnrealMcpRuntimeExtensionProviderSpec, "UnrealMcp.RuntimeExtensionProvider",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FUnrealMcpRuntimeExtensionProviderSpec)
+
+void FUnrealMcpRuntimeExtensionProviderSpec::Define()
+{
+	Describe("RegisterToolProvider / UnregisterToolProvider (§12.9 ergonomic API)", [this]()
+	{
+		It("re-pushes the manifest when a provider is registered then unregistered via the subsystem helper", [this]()
+		{
+			// A throwaway config path so Startup() does not read the developer's real Extensions.json.
+			const FString ConfigPath = RuntimeExtMakeTempConfigPath();
+
+			FUnrealMcpToolRegistry Registry;
+			int32 OnChangedCount = 0;
+			FUnrealMcpExtensionManager Manager(Registry, [&OnChangedCount]() { ++OnChangedCount; }, ConfigPath);
+
+			// Default provider source = live IModularFeatures discovery; subscribe to register/unregister events.
+			Manager.Startup();
+
+			UUnrealMcpRuntimeSubsystem* Subsystem = RuntimeExtMakeSubsystem();
+
+			// A uniquely-named provider/tool so the assertions are robust against any ambient providers.
+			FRuntimeExtSpecProvider Provider(TEXT("test.runtime.ext"), TEXT("runtime-ext-probe-tool"));
+
+			TestFalse(TEXT("probe tool absent before register"), Registry.HasTool(TEXT("runtime-ext-probe-tool")));
+			const int32 RevBefore = Registry.GetRevision();
+			const int32 OnBefore = OnChangedCount;
+
+			// --- The R5 ergonomic register path (NOT a direct IModularFeatures call). ---
+			Subsystem->RegisterToolProvider(&Provider);
+
+			TestTrue(TEXT("probe tool present after RegisterToolProvider"), Registry.HasTool(TEXT("runtime-ext-probe-tool")));
+			TestTrue(TEXT("probe tool in the manifest after register"), RuntimeExtManifestHasTool(Registry, TEXT("runtime-ext-probe-tool")));
+			TestTrue(TEXT("revision bumped on register"), Registry.GetRevision() > RevBefore);
+			TestTrue(TEXT("manifest re-push (OnChanged) fired on register"), OnChangedCount > OnBefore);
+
+			const int32 RevAfterReg = Registry.GetRevision();
+			const int32 OnAfterReg = OnChangedCount;
+
+			// --- The R5 ergonomic unregister path. ---
+			Subsystem->UnregisterToolProvider(&Provider);
+
+			TestFalse(TEXT("probe tool absent after UnregisterToolProvider"), Registry.HasTool(TEXT("runtime-ext-probe-tool")));
+			TestFalse(TEXT("probe tool gone from the manifest after unregister"), RuntimeExtManifestHasTool(Registry, TEXT("runtime-ext-probe-tool")));
+			TestTrue(TEXT("revision bumped on unregister"), Registry.GetRevision() > RevAfterReg);
+			TestTrue(TEXT("manifest re-push (OnChanged) fired on unregister"), OnChangedCount > OnAfterReg);
+
+			Manager.Shutdown();
+			IFileManager::Get().Delete(*ConfigPath, /*RequireExists*/ false, /*EvenReadOnly*/ true);
+		});
+
+		It("treats a null provider as a harmless no-op (no rebuild, no manifest churn)", [this]()
+		{
+			const FString ConfigPath = RuntimeExtMakeTempConfigPath();
+
+			FUnrealMcpToolRegistry Registry;
+			int32 OnChangedCount = 0;
+			FUnrealMcpExtensionManager Manager(Registry, [&OnChangedCount]() { ++OnChangedCount; }, ConfigPath);
+			Manager.Startup();
+
+			UUnrealMcpRuntimeSubsystem* Subsystem = RuntimeExtMakeSubsystem();
+
+			const int32 RevBefore = Registry.GetRevision();
+			const int32 OnBefore = OnChangedCount;
+
+			// RegisterToolProvider logs a Warning on null; whitelist it so the framework does not fail the spec
+			// and so this test also asserts the loud signal actually fired.
+			AddExpectedError(TEXT("null provider ignored"), EAutomationExpectedErrorFlags::Contains);
+			Subsystem->RegisterToolProvider(nullptr);
+			Subsystem->UnregisterToolProvider(nullptr); // silent no-op
+
+			TestEqual(TEXT("revision unchanged on null register/unregister"), Registry.GetRevision(), RevBefore);
+			TestEqual(TEXT("no manifest re-push on null register/unregister"), OnChangedCount, OnBefore);
+
+			Manager.Shutdown();
+			IFileManager::Get().Delete(*ConfigPath, /*RequireExists*/ false, /*EvenReadOnly*/ true);
+		});
+	});
+
+	Describe("re-push parity: subsystem helper vs direct IModularFeatures", [this]()
+	{
+		It("a provider registered via the helper is observed identically to a direct modular-feature registration", [this]()
+		{
+			const FString ConfigPath = RuntimeExtMakeTempConfigPath();
+
+			FUnrealMcpToolRegistry Registry;
+			int32 OnChangedCount = 0;
+			FUnrealMcpExtensionManager Manager(Registry, [&OnChangedCount]() { ++OnChangedCount; }, ConfigPath);
+			Manager.Startup();
+
+			UUnrealMcpRuntimeSubsystem* Subsystem = RuntimeExtMakeSubsystem();
+
+			FRuntimeExtSpecProvider ViaHelper(TEXT("test.runtime.helper"), TEXT("runtime-helper-tool"));
+			FRuntimeExtSpecProvider ViaDirect(TEXT("test.runtime.direct"), TEXT("runtime-direct-tool"));
+
+			// Register one through the ergonomic helper, the other straight through IModularFeatures.
+			Subsystem->RegisterToolProvider(&ViaHelper);
+			IModularFeatures::Get().RegisterModularFeature(IUnrealMcpToolProvider::GetModularFeatureName(), &ViaDirect);
+
+			TestTrue(TEXT("helper-registered tool present"), Registry.HasTool(TEXT("runtime-helper-tool")));
+			TestTrue(TEXT("direct-registered tool present"), Registry.HasTool(TEXT("runtime-direct-tool")));
+			TestTrue(TEXT("both records discovered"),
+				Manager.FindExtension(TEXT("test.runtime.helper")) != nullptr
+				&& Manager.FindExtension(TEXT("test.runtime.direct")) != nullptr);
+
+			// Clean up both registrations regardless of which path created them.
+			Subsystem->UnregisterToolProvider(&ViaHelper);
+			IModularFeatures::Get().UnregisterModularFeature(IUnrealMcpToolProvider::GetModularFeatureName(), &ViaDirect);
+
+			TestFalse(TEXT("helper tool removed"), Registry.HasTool(TEXT("runtime-helper-tool")));
+			TestFalse(TEXT("direct tool removed"), Registry.HasTool(TEXT("runtime-direct-tool")));
+
+			Manager.Shutdown();
+			IFileManager::Get().Delete(*ConfigPath, /*RequireExists*/ false, /*EvenReadOnly*/ true);
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
@@ -12,7 +12,9 @@
 #include "Sidecar/UnrealMcpSidecarManager.h"
 #include "Extensions/UnrealMcpExtensionManager.h"
 #include "Tools/UnrealMcpWorldProvider.h"
+#include "IUnrealMcpToolProvider.h"
 
+#include "Features/IModularFeatures.h"
 #include "Engine/GameInstance.h"
 #include "Engine/World.h"
 #include "Misc/Paths.h"
@@ -291,6 +293,34 @@ UUnrealMcpRuntimeSubsystem* UUnrealMcpRuntimeSubsystem::Get(const UObject* World
 		return nullptr;
 	UGameInstance* GI = World->GetGameInstance();
 	return GI ? GI->GetSubsystem<UUnrealMcpRuntimeSubsystem>() : nullptr;
+}
+
+void UUnrealMcpRuntimeSubsystem::RegisterToolProvider(IUnrealMcpToolProvider* Provider)
+{
+	if (!Provider)
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] RegisterToolProvider: null provider ignored."));
+		return;
+	}
+
+	// Thin wrapper over IModularFeatures (§12.9): the extension manager subscribed to the register event in
+	// Initialize(), so this registration triggers the same registry rebuild + manifest re-push that a
+	// plugin-load-time registration does. The subsystem does NOT take ownership — the caller keeps the
+	// provider alive and is responsible for UnregisterToolProvider before destroying it.
+	IModularFeatures::Get().RegisterModularFeature(IUnrealMcpToolProvider::GetModularFeatureName(), Provider);
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] runtime tool provider '%s' registered."), *Provider->GetExtensionId());
+}
+
+void UUnrealMcpRuntimeSubsystem::UnregisterToolProvider(IUnrealMcpToolProvider* Provider)
+{
+	if (!Provider)
+		return; // null is a harmless no-op (mirrors a Disconnect() that was never connected)
+
+	// The manager observes the unregister event, rebuilds, and re-pushes the manifest so a connected
+	// sidecar drops the provider's tools. IModularFeatures tolerates unregistering a feature that was never
+	// registered, so a double-unregister or an unknown provider is harmless.
+	IModularFeatures::Get().UnregisterModularFeature(IUnrealMcpToolProvider::GetModularFeatureName(), Provider);
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] runtime tool provider '%s' unregistered."), *Provider->GetExtensionId());
 }
 
 bool UUnrealMcpRuntimeSubsystem::IsLoopbackHost(const FString& Host)

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeSubsystem.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeSubsystem.h
@@ -8,6 +8,10 @@
 #include "Templates/PimplPtr.h"
 #include "UnrealMcpRuntimeSubsystem.generated.h"
 
+// Forward-declared: RegisterToolProvider/UnregisterToolProvider take it by pointer only (§12.9), so the
+// PUBLIC header needs no extension-contract include — callers include IUnrealMcpToolProvider.h themselves.
+class IUnrealMcpToolProvider;
+
 // The runtime-owned machinery (registry/dispatcher/bridge/sidecar/extensions) is held behind a PImpl
 // (FRuntimeImpl, defined in the .cpp) so this PUBLIC header forward-declares nothing module-private and the
 // TUniquePtr<incomplete-type> members never reach UHT's generated vtable-helper ctor in the .gen.cpp (which,
@@ -106,6 +110,36 @@ public:
 	 */
 	UFUNCTION(BlueprintPure, Category = "Unreal MCP", meta = (WorldContext = "WorldContext"))
 	static UUnrealMcpRuntimeSubsystem* Get(const UObject* WorldContext);
+
+	/**
+	 * Register a custom gameplay tool provider at runtime (docs/ARCHITECTURE.md §12.9) — the ergonomic
+	 * UE analog of Unity's `WithToolsFromAssembly` / `[AiTool]` scan (README Chess example). A game module
+	 * registers an IUnrealMcpToolProvider it owns and its tools merge into the live registry; the §5
+	 * extension manager rebuilds the registry and re-pushes the manifest so a CONNECTED sidecar's
+	 * `tools/list` gains the provider's tools without the developer touching IModularFeatures directly.
+	 *
+	 * This is a thin, discoverable wrapper over
+	 * `IModularFeatures::Get().RegisterModularFeature(IUnrealMcpToolProvider::GetModularFeatureName(), Provider)`:
+	 * the manager subscribed to the modular-feature register/unregister events in Initialize(), so the
+	 * registration is observed and the manifest re-pushed exactly as a plugin-load-time registration is
+	 * (docs/EXTENSIONS.md "Runtime usage"). The same provider may be registered via either path.
+	 *
+	 * OWNERSHIP: @p Provider is NOT owned by the subsystem — the caller keeps it alive for as long as it is
+	 * registered (typically a member of the game module/subsystem) and MUST call UnregisterToolProvider
+	 * (or unregister the modular feature) before destroying it. A null @p Provider is a no-op.
+	 *
+	 * Callable from C++ and Blueprint is NOT offered (a raw interface pointer is not a Blueprint type);
+	 * Blueprint authors expose tools by registering their provider in C++ module startup as today.
+	 */
+	void RegisterToolProvider(IUnrealMcpToolProvider* Provider);
+
+	/**
+	 * Unregister a gameplay tool provider previously registered via RegisterToolProvider (or directly via
+	 * IModularFeatures). The §5 manager observes the unregister event, rebuilds the registry, and re-pushes
+	 * the manifest so a connected sidecar's `tools/list` drops the provider's tools. A null @p Provider, or
+	 * one that was never registered, is a harmless no-op (IModularFeatures tolerates an unknown unregister).
+	 */
+	void UnregisterToolProvider(IUnrealMcpToolProvider* Provider);
 
 	/** Whether the loopback listener armed (a port is bound). False means Initialize failed to bind. */
 	bool IsListenerArmed() const { return BoundPort > 0; }

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -186,9 +186,51 @@ version, and your `GetExtensionVersion()` is your own.
 
 ---
 
-## Reference example
+## Runtime usage (in-game extensions)
 
-[`samples/UnrealAITemplate/`](../samples/UnrealAITemplate) is a complete, buildable plugin implementing
-everything above with a `hello-extension` tool. It also carries a compile-time switch
-(`UNREAL_AI_TEMPLATE_INVALID_SCHEMA=1`) that emits an intentionally invalid tool so you can observe the
-isolation behaviour first-hand.
+Everything above also works **in a running game** (PIE, Standalone, packaged Development) — this is the
+primary Unity-parity use case (`docs/ARCHITECTURE.md` §12.9): a game ships its own gameplay tools and an
+AI assistant drives them live, the UE analog of Unity's `[AiTool]` Chess-bot example.
+
+The contract is identical — the extension headers (`IUnrealMcpToolProvider.h`, `UnrealMcpToolRegistry.h`)
+live in the Unreal-MCP plugin's **runtime module** `UnrealMcpRuntime`, and `IModularFeatures` is
+runtime-available — with two differences for a game extension:
+
+- **Make your module `Type=Runtime`** (not `Editor`) in its `.uplugin`, and depend on **`UnrealMcpRuntime`**
+  (not `UnrealMcpEditor`) in your `*.Build.cs`, so it compiles into a packaged Game target where the editor
+  module is absent.
+- **The runtime MCP surface is opt-in and OFF by default** (`docs/ARCHITECTURE.md` §12.8). Your tools only
+  become reachable after the game enables the kill switch (Project Settings → Plugins → Unreal MCP (Runtime)
+  → `bRuntimeMcpEnabled`) and explicitly connects:
+  `UUnrealMcpRuntimeSubsystem::Get(this)->Connect("http://localhost:8080", "my-token")` (or the QA console
+  command `UnrealMcp.Connect <host> [token]`).
+
+### Ergonomic registration via the runtime subsystem
+
+Module-startup registration (Step 3) works in a game too, but the runtime subsystem also offers a
+discoverable wrapper so you never have to touch `IModularFeatures` directly:
+
+```cpp
+#include "UnrealMcpRuntimeSubsystem.h"
+#include "IUnrealMcpToolProvider.h"
+
+if (UUnrealMcpRuntimeSubsystem* Mcp = UUnrealMcpRuntimeSubsystem::Get(this))
+    Mcp->RegisterToolProvider(MyProviderInstance);     // tools merge into the live registry; manifest re-pushed
+// ... later, before destroying the provider:
+    Mcp->UnregisterToolProvider(MyProviderInstance);   // tools drop out; manifest re-pushed
+```
+
+Both paths feed the same extension manager: registering or unregistering at any time rebuilds the registry
+and **re-pushes the manifest**, so a connected sidecar's `tools/list` gains/loses your tools automatically.
+The subsystem does **not** take ownership of the provider — keep it alive while it is registered (typically
+a member of your game module or a `UGameInstanceSubsystem`) and unregister before destroying it.
+
+## Reference examples
+
+- [`samples/UnrealAITemplate/`](../samples/UnrealAITemplate) — the **editor** extension sample: a complete,
+  buildable `Type=Editor` plugin with a `hello-extension` tool. It also carries a compile-time switch
+  (`UNREAL_AI_TEMPLATE_INVALID_SCHEMA=1`) that emits an intentionally invalid tool so you can observe the
+  isolation behaviour first-hand.
+- [`samples/UnrealAIRuntimeSample/`](../samples/UnrealAIRuntimeSample) — the **runtime (in-game)** extension
+  sample: a `Type=Runtime` plugin whose `game-time-dilation` tool reads/sets the live `UWorld`'s
+  `AWorldSettings::TimeDilation`, callable in a running game over a runtime MCP connection (§12.9).

--- a/samples/UnrealAIRuntimeSample/README.md
+++ b/samples/UnrealAIRuntimeSample/README.md
@@ -1,0 +1,71 @@
+# UnrealAIRuntimeSample
+
+A minimal, standalone Unreal Engine plugin demonstrating the **Unreal-MCP RUNTIME (in-game) extension
+contract** ([`IUnrealMcpToolProvider`](../../UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpToolProvider.h)),
+registered through `IModularFeatures` under the feature name `UnrealMcpToolProvider`. It contributes a
+single `game-time-dilation` gameplay tool **callable in a running game** (PIE / Standalone / packaged
+Development), proving the §12.9 runtime extension bus end-to-end. It is the runtime counterpart of the
+editor-side [`samples/UnrealAITemplate`](../UnrealAITemplate) and the UE analog of Unity's `[AiTool]`
+Chess-bot in-game example.
+
+## What it shows
+
+- A **`Type=Runtime`** game module (not editor) implementing `IUnrealMcpToolProvider` — so it compiles
+  into a **packaged game** (the editor module is absent in a Game target).
+- A tool that drives **real gameplay state on the live `UWorld`**: it reads and optionally sets
+  `AWorldSettings::TimeDilation` (slow-motion / fast-forward).
+- Registering / unregistering the provider as a modular feature in `StartupModule` / `ShutdownModule`,
+  which makes Unreal-MCP rebuild the registry and **re-push the manifest** so a connected sidecar's
+  `tools/list` gains/loses the tool at runtime.
+
+## The `game-time-dilation` tool
+
+| Param | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `value` | number | no | New global time dilation (> 0). Omit to **read** the current value without changing it. |
+
+The result's structured payload is `{ "timeDilation": <effective value>, "wasSet": <bool>, "world": <name> }`.
+When `value` is supplied, `AWorldSettings::SetTimeDilation` clamps it to
+`[MinGlobalTimeDilation, MaxGlobalTimeDilation]`, so the **effective** (post-clamp) value is returned —
+not the raw request.
+
+## Layout
+
+```
+UnrealAIRuntimeSample.uplugin                                       # plugin descriptor (depends on UnrealMCP); module Type=Runtime
+Source/UnrealAIRuntimeSample/UnrealAIRuntimeSample.Build.cs         # module rules (depends on UnrealMcpRuntime)
+Source/UnrealAIRuntimeSample/Private/UnrealAIRuntimeSampleModule.cpp # provider + module
+```
+
+## Using it (in-game)
+
+1. Copy or symlink this folder into a UE project's `Plugins/` directory **alongside the `UnrealMCP`
+   plugin** (this sample's module depends on `UnrealMcpRuntime`).
+2. Enable both plugins and build the **Game** target (or a packaged Development build).
+3. In-game, opt the runtime MCP surface in (it is OFF by default — `docs/ARCHITECTURE.md` §12.8):
+   - Enable the kill switch: **Project Settings → Plugins → Unreal MCP (Runtime) →
+     `bRuntimeMcpEnabled`**.
+   - Connect from `BeginPlay` (or the console): `UUnrealMcpRuntimeSubsystem::Get(this)->Connect("http://localhost:8080", "my-token")`,
+     or the QA console command `UnrealMcp.Connect http://localhost:8080 my-token`.
+4. With an MCP client connected through the sidecar, `game-time-dilation` appears in `tools/list` and,
+   when executed, reads/sets the live world's time dilation.
+
+## Registering a provider at runtime (ergonomic API)
+
+Beyond module-startup registration (what this sample does), a game can register a provider explicitly
+once the runtime subsystem is up — no direct `IModularFeatures` call needed:
+
+```cpp
+#include "UnrealMcpRuntimeSubsystem.h"
+#include "IUnrealMcpToolProvider.h"
+
+if (UUnrealMcpRuntimeSubsystem* Mcp = UUnrealMcpRuntimeSubsystem::Get(this))
+    Mcp->RegisterToolProvider(MyProviderInstance);   // ... ->UnregisterToolProvider(MyProviderInstance) to remove
+
+```
+
+Both paths feed the same §5 extension manager, which rebuilds the registry and re-pushes the manifest.
+Keep the provider instance alive for as long as it is registered.
+
+See [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) §12.9 and
+[`docs/EXTENSIONS.md`](../../docs/EXTENSIONS.md).

--- a/samples/UnrealAIRuntimeSample/Source/UnrealAIRuntimeSample/Private/UnrealAIRuntimeSampleModule.cpp
+++ b/samples/UnrealAIRuntimeSample/Source/UnrealAIRuntimeSample/Private/UnrealAIRuntimeSampleModule.cpp
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "Modules/ModuleManager.h"
+#include "Features/IModularFeatures.h"
+
+#include "IUnrealMcpToolProvider.h"
+#include "UnrealMcpToolRegistry.h"
+
+#include "Engine/Engine.h"          // GEngine->GetWorldContexts() — resolve the live game/PIE world
+#include "Engine/World.h"
+#include "GameFramework/WorldSettings.h" // AWorldSettings::TimeDilation — the live gameplay state this tool drives
+
+DEFINE_LOG_CATEGORY_STATIC(LogUnrealAIRuntimeSample, Log, All);
+
+namespace
+{
+	/**
+	 * Resolve the live game/PIE world this in-game tool operates on. An extension author does NOT have
+	 * access to Unreal-MCP's private FUnrealMcpWorldProvider, so a real game extension resolves the world
+	 * from the engine's world contexts (Engine-module only, runtime-safe), preferring a Game world and
+	 * falling back to a PIE world so the sample also works when exercised inside the editor's PIE session.
+	 * A sample-unique helper name per the unity-build ODR rule (docs/CLAUDE.md conventions).
+	 */
+	UWorld* RuntimeSampleResolveGameWorld()
+	{
+		if (!GEngine)
+			return nullptr;
+
+		UWorld* PieFallback = nullptr;
+		for (const FWorldContext& Context : GEngine->GetWorldContexts())
+		{
+			UWorld* World = Context.World();
+			if (!World)
+				continue;
+			if (Context.WorldType == EWorldType::Game)
+				return World; // a real packaged/standalone game world — the primary in-game target
+			if (Context.WorldType == EWorldType::PIE && PieFallback == nullptr)
+				PieFallback = World; // editor Play-In-Editor session — used when no standalone Game world exists
+		}
+		return PieFallback;
+	}
+}
+
+/**
+ * The sample's RUNTIME tool provider — the in-game analog of samples/UnrealAITemplate's editor provider
+ * (docs/ARCHITECTURE.md §12.9, docs/EXTENSIONS.md "Runtime usage"). It contributes ONE gameplay tool,
+ * `game-time-dilation`, that reads and (optionally) sets the live world's AWorldSettings::TimeDilation —
+ * genuine gameplay state mutated on the live UWorld, proving a custom tool registered at runtime is
+ * callable in a running game over a runtime MCP connection.
+ */
+class FUnrealAIRuntimeSampleProvider : public IUnrealMcpToolProvider
+{
+public:
+	virtual FString GetExtensionId() const override { return TEXT("com.ivanmurzak.unreal-ai-runtime-sample"); }
+	virtual FText GetDisplayName() const override { return NSLOCTEXT("UnrealAIRuntimeSample", "DisplayName", "Unreal AI Runtime Sample"); }
+	virtual FString GetExtensionVersion() const override { return TEXT("1.0.0"); }
+
+	virtual void RegisterTools(FUnrealMcpToolRegistry& Registry) override
+	{
+		Registry.Tool(TEXT("game-time-dilation"))
+			.Title(TEXT("Get / Set Game Time Dilation"))
+			.Description(TEXT("Reads the live game world's global time dilation (AWorldSettings::TimeDilation). "
+			                  "Pass the optional 'value' to SET it first (slow-motion < 1, fast-forward > 1), then "
+			                  "the current value is returned. A runtime gameplay-tool sample: it drives real "
+			                  "gameplay state on the live UWorld, callable in a running game over a runtime MCP "
+			                  "connection (docs/ARCHITECTURE.md §12.9)."))
+			.ParamNumber(TEXT("value"), TEXT("Optional new global time dilation (> 0). Omit to read the current value without changing it."))
+			.IdempotentHint(true) // setting to the same value twice yields the same state
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
+			{
+				// Runs ON the game thread (the dispatcher guarantees it, §4), so touching the live world is safe.
+				UWorld* World = RuntimeSampleResolveGameWorld();
+				if (!World)
+				{
+					return FUnrealMcpToolResult::Error(TEXT(
+						"No live game world is available. Call this tool while a game is running (PIE, Standalone, "
+						"or a packaged Development build) — the runtime MCP connection must be made from in-game."));
+				}
+
+				AWorldSettings* Settings = World->GetWorldSettings();
+				if (!Settings)
+					return FUnrealMcpToolResult::Error(TEXT("The live world has no AWorldSettings; cannot read or set time dilation."));
+
+				bool bWasSet = false;
+				if (Call.Has(TEXT("value")))
+				{
+					const double Requested = Call.GetNumber(TEXT("value"));
+					if (Requested <= 0.0)
+						return FUnrealMcpToolResult::Error(TEXT("'value' must be greater than 0 (time dilation cannot be zero or negative)."));
+
+					// AWorldSettings clamps the assigned value to [MinGlobalTimeDilation, MaxGlobalTimeDilation],
+					// so read the EFFECTIVE value back rather than echoing the request.
+					Settings->SetTimeDilation(static_cast<float>(Requested));
+					bWasSet = true;
+				}
+
+				const double Current = Settings->TimeDilation;
+
+				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
+				Structured->SetNumberField(TEXT("timeDilation"), Current);
+				Structured->SetBoolField(TEXT("wasSet"), bWasSet);
+				Structured->SetStringField(TEXT("world"), World->GetName());
+
+				const FString Message = bWasSet
+					? FString::Printf(TEXT("Set global time dilation to %.4f (effective, after clamping) on world '%s'."), Current, *World->GetName())
+					: FString::Printf(TEXT("Global time dilation is %.4f on world '%s'."), Current, *World->GetName());
+				return FUnrealMcpToolResult::Success(Message, Structured);
+			});
+	}
+};
+
+/**
+ * Runtime (game) module that owns the provider and registers it as a modular feature. Mirrors
+ * samples/UnrealAITemplate but Type=Runtime, so it loads in a packaged game (where the editor module is
+ * absent). Registering on StartupModule lets Unreal-MCP discover the tool on boot OR live via the
+ * OnModularFeatureRegistered event; unregistering on shutdown triggers a registry rebuild + manifest
+ * re-push on the Unreal-MCP side (docs/ARCHITECTURE.md §12.9).
+ *
+ * Equivalent ergonomic alternative (docs/EXTENSIONS.md "Runtime usage"): once the runtime subsystem is up,
+ * a game can call `UUnrealMcpRuntimeSubsystem::Get(this)->RegisterToolProvider(Provider)` instead of
+ * touching IModularFeatures directly — both paths feed the same extension manager.
+ */
+class FUnrealAIRuntimeSampleModule : public IModuleInterface
+{
+public:
+	virtual void StartupModule() override
+	{
+		Provider = MakeUnique<FUnrealAIRuntimeSampleProvider>();
+		IModularFeatures::Get().RegisterModularFeature(IUnrealMcpToolProvider::GetModularFeatureName(), Provider.Get());
+		UE_LOG(LogUnrealAIRuntimeSample, Log, TEXT("[UnrealAIRuntimeSample] registered runtime MCP tool provider '%s'."), *Provider->GetExtensionId());
+	}
+
+	virtual void ShutdownModule() override
+	{
+		if (Provider.IsValid())
+		{
+			IModularFeatures::Get().UnregisterModularFeature(IUnrealMcpToolProvider::GetModularFeatureName(), Provider.Get());
+			Provider.Reset();
+			UE_LOG(LogUnrealAIRuntimeSample, Log, TEXT("[UnrealAIRuntimeSample] unregistered runtime MCP tool provider."));
+		}
+	}
+
+private:
+	TUniquePtr<FUnrealAIRuntimeSampleProvider> Provider;
+};
+
+IMPLEMENT_MODULE(FUnrealAIRuntimeSampleModule, UnrealAIRuntimeSample)

--- a/samples/UnrealAIRuntimeSample/Source/UnrealAIRuntimeSample/UnrealAIRuntimeSample.Build.cs
+++ b/samples/UnrealAIRuntimeSample/Source/UnrealAIRuntimeSample/UnrealAIRuntimeSample.Build.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+using UnrealBuildTool;
+
+public class UnrealAIRuntimeSample : ModuleRules
+{
+	public UnrealAIRuntimeSample(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+
+		PublicDependencyModuleNames.AddRange(new string[]
+		{
+			"Core",
+		});
+
+		PrivateDependencyModuleNames.AddRange(new string[]
+		{
+			"CoreUObject",
+			"Engine",
+			"Projects",
+			// "Json" is needed because the public registry header (UnrealMcpToolRegistry.h) includes
+			// Dom/JsonObject.h, and the sample's handler builds a structured result with FJsonObject.
+			"Json",
+			// The extension contract (IUnrealMcpToolProvider.h) + tool registry (UnrealMcpToolRegistry.h)
+			// live in the Unreal-MCP plugin's RUNTIME module (docs/ARCHITECTURE.md §12.1). This sample is
+			// itself a Type=Runtime module, so it depends on the runtime module — exactly what a packaged
+			// GAME extension does (the editor module is absent in a Game target).
+			"UnrealMcpRuntime",
+		});
+	}
+}

--- a/samples/UnrealAIRuntimeSample/UnrealAIRuntimeSample.uplugin
+++ b/samples/UnrealAIRuntimeSample/UnrealAIRuntimeSample.uplugin
@@ -1,0 +1,29 @@
+{
+  "FileVersion": 3,
+  "Version": 1,
+  "VersionName": "1.0.0",
+  "FriendlyName": "Unreal AI Runtime Sample (in-game MCP extension)",
+  "Description": "Minimal standalone sample demonstrating the Unreal-MCP RUNTIME extension contract (docs/ARCHITECTURE.md §12.9): a Type=Runtime game module that registers a custom gameplay tool callable IN A LIVE GAME (PIE / Standalone / packaged Development). The 'game-time-dilation' tool reads and sets the live UWorld's AWorldSettings::TimeDilation, proving an extension author can drive real gameplay state over a runtime MCP connection — the UE analog of Unity's [AiTool] Chess-bot example. Mirrors samples/UnrealAITemplate (the EDITOR-side extension sample) but Type=Runtime so it compiles into a packaged game.",
+  "Category": "AI",
+  "CreatedBy": "Ivan Murzak",
+  "CreatedByURL": "https://github.com/IvanMurzak",
+  "DocsURL": "https://github.com/IvanMurzak/Unreal-MCP/blob/main/docs/EXTENSIONS.md",
+  "SupportURL": "https://github.com/IvanMurzak/Unreal-MCP/issues",
+  "CanContainContent": false,
+  "IsBetaVersion": true,
+  "IsExperimentalVersion": false,
+  "Installed": false,
+  "Modules": [
+    {
+      "Name": "UnrealAIRuntimeSample",
+      "Type": "Runtime",
+      "LoadingPhase": "Default"
+    }
+  ],
+  "Plugins": [
+    {
+      "Name": "UnrealMCP",
+      "Enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `UUnrealMcpRuntimeSubsystem::RegisterToolProvider` / `UnregisterToolProvider` (docs/ARCHITECTURE.md §12.9) — ergonomic runtime registration of custom `IUnrealMcpToolProvider` gameplay tools without touching `IModularFeatures`; the §5 extension manager rebuilds the registry and re-pushes the manifest on register/unregister (proven by a new Automation spec).
- Add `samples/UnrealAIRuntimeSample/` — a `Type=Runtime` plugin whose `game-time-dilation` tool reads/sets the live `UWorld`'s `AWorldSettings::TimeDilation`, the in-game counterpart of `samples/UnrealAITemplate` (Unity `[AiTool]` Chess-bot parity).
- Document runtime extension authoring (EXTENSIONS.md "Runtime usage") + both samples (README).

## Test plan
- [x] Suite 1 — clean UBT editor build (exit 0).
- [x] Suite 1b — clean RunUAT BuildPlugin (Game+Editor, UnrealGame Shipping, -WarningsAsErrors) BUILD SUCCESSFUL — the new exported methods compile/link in the non-editor target.
- [x] Suite 2 — headless boot smoke: `[Unreal-MCP] plugin loaded`.
- [x] Suite 3 — `UnrealMcp.*` Automation: failed 0 (267 succeeded), incl. 3 new `UnrealMcp.RuntimeExtensionProvider` specs (register/unregister manifest re-push, null no-op, helper-vs-direct parity).
- [x] Sample compiles to `UnrealEditor-UnrealAIRuntimeSample.dll` and registers its provider on boot (extension manager discovered 1 extension) — verified by transiently junctioning it into the testbed; reverted after.
- Runtime-connection `tools/list` execution is the §12.9 in-game (packaged Development) scenario — covered by the Automation manifest-re-push spec + the sample README runbook; a full live-e2e is not headlessly feasible.

Closes #125