### PR TITLE
feat: Prompts/Resources groundwork — IPC v2 + bridge scaffold + kind-aware extension manager

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
@@ -78,9 +78,21 @@ void FUnrealMcpEditorCoordinator::Startup()
 	// Discover 3rd-party extension tool providers (§5) and merge them into the registry BEFORE the bridge
 	// starts accepting, so the first manifest a sidecar reads on handshake already includes them. Late
 	// register/unregister events rebuild the registry and re-push the manifest via the OnChanged callback.
+	// §A.1 kind-aware OnChanged: a rebuild re-pushes ALL THREE manifests (tool + prompt + resource). The
+	// prompt/resource pushes are scaffold no-ops until P1/P2 wire those registries (and are gated on a
+	// v2-negotiated link), but firing all three here makes the extension manager's change contract
+	// kind-uniform so P1/P2 only add a registry — not a new notify path.
 	ExtensionManager = MakeUnique<FUnrealMcpExtensionManager>(
 		*Registry,
-		[this]() { if (BridgeServer.IsValid()) BridgeServer->PushManifest(); });
+		[this]()
+		{
+			if (BridgeServer.IsValid())
+			{
+				BridgeServer->PushManifest();
+				BridgeServer->PushPromptManifest();
+				BridgeServer->PushResourceManifest();
+			}
+		});
 	ExtensionManager->Startup();
 
 	const FString ProjectPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpIpcVersionSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpIpcVersionSpec.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+
+#include "Bridge/UnrealMcpBridgeServer.h"
+
+/**
+ * IPC version negotiation (M16 P0, docs/ARCHITECTURE.md §A.1): the plugin↔sidecar handshake negotiates the
+ * effective wire-protocol version as min(local, remote), so a v2 plugin paired with a v1 sidecar (or vice
+ * versa) negotiates down to v1 and the link stays tools-only — an old peer keeps working, and the v2
+ * prompt/resource families are simply never exchanged. Mirrors the bridge's IpcProtocolV2Tests so both ends
+ * of the contract are pinned. Pure-function coverage of FUnrealMcpBridgeServer::NegotiateIpcVersion +
+ * GetIpcVersion (no live socket).
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpIpcVersionSpec, "UnrealMcp.IpcVersion",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FUnrealMcpIpcVersionSpec)
+
+void FUnrealMcpIpcVersionSpec::Define()
+{
+	Describe("IPC version", [this]()
+	{
+		It("advertises v2 (the M16 P0 bump)", [this]()
+		{
+			TestEqual(TEXT("plugin IpcVersion"), FUnrealMcpBridgeServer::GetIpcVersion(), 2);
+		});
+	});
+
+	Describe("version negotiation (old/new pair compatibility)", [this]()
+	{
+		It("negotiates v2 when both peers are v2 (prompts/resources enabled)", [this]()
+		{
+			TestEqual(TEXT("v2 x v2"), FUnrealMcpBridgeServer::NegotiateIpcVersion(2, 2), 2);
+		});
+
+		It("negotiates DOWN to v1 when the sidecar is an old v1 peer (tools-only; old peer keeps working)", [this]()
+		{
+			TestEqual(TEXT("v2 plugin x v1 sidecar"), FUnrealMcpBridgeServer::NegotiateIpcVersion(2, 1), 1);
+		});
+
+		It("negotiates DOWN to v1 when this plugin is older than the sidecar", [this]()
+		{
+			TestEqual(TEXT("v1 plugin x v2 sidecar"), FUnrealMcpBridgeServer::NegotiateIpcVersion(1, 2), 1);
+		});
+
+		It("negotiates v1 when both peers are v1", [this]()
+		{
+			TestEqual(TEXT("v1 x v1"), FUnrealMcpBridgeServer::NegotiateIpcVersion(1, 1), 1);
+		});
+
+		It("treats an absent/legacy remote version (0) as v1", [this]()
+		{
+			TestEqual(TEXT("v2 plugin x legacy handshake"), FUnrealMcpBridgeServer::NegotiateIpcVersion(2, 0), 1);
+		});
+
+		It("a future-newer sidecar still negotiates down to this plugin's version", [this]()
+		{
+			TestEqual(TEXT("v2 plugin x v3 sidecar"), FUnrealMcpBridgeServer::NegotiateIpcVersion(2, 3), 2);
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.cpp
@@ -29,6 +29,13 @@ namespace
 	const FString TypeToolCall = TEXT("tool-call");
 	const FString TypeToolResponse = TEXT("tool-response");
 	const FString TypeToolCancel = TEXT("tool-cancel");
+	// v2 prompt/resource message families (docs/ARCHITECTURE.md §A.1) — exchanged only on a v2-negotiated link.
+	const FString TypePromptManifest = TEXT("prompt-manifest");
+	const FString TypeResourceManifest = TEXT("resource-manifest");
+	const FString TypePromptGet = TEXT("prompt-get");
+	const FString TypeResourceRead = TEXT("resource-read");
+	const FString TypePromptResponse = TEXT("prompt-response");
+	const FString TypeResourceResponse = TEXT("resource-response");
 	const FString TypeConfig = TEXT("config");
 	const FString TypeStatus = TEXT("status");
 	const FString TypeDeviceAuth = TEXT("device-auth");
@@ -47,7 +54,13 @@ namespace
 	const FString TypePong = TEXT("pong");
 	const FString TypeShutdown = TEXT("shutdown");
 
-	constexpr int32 IpcVersion = 1;
+	// IPC wire-protocol version (§9.2 / §A.1). v2 adds the prompt/resource message families; it is NEGOTIATED on
+	// the handshake (min of this plugin's version and the sidecar's advertised ipcVersion). A v1 sidecar paired
+	// with this v2 plugin negotiates down to 1 and the link stays tools-only — the tool path is identical at every
+	// version, so a version mismatch never breaks tools (an old sidecar keeps working).
+	constexpr int32 IpcVersion = 2;
+	// The lowest negotiated version at which the prompt/resource families are exchanged (§A.1).
+	constexpr int32 PromptsResourcesMinVersion = 2;
 	constexpr int32 HeartbeatIntervalSeconds = 5;
 	constexpr int32 HeartbeatTimeoutSeconds = 15;
 	constexpr int32 DefaultToolTimeoutMs = 30000;
@@ -107,6 +120,21 @@ int32 FUnrealMcpBridgeServer::ComputeDeterministicPort(const FString& InProjectP
 		(static_cast<uint32>(Digest[2]) << 8) |
 		(static_cast<uint32>(Digest[3]));
 	return 30000 + static_cast<int32>(Value % 10000);
+}
+
+int32 FUnrealMcpBridgeServer::NegotiateIpcVersion(int32 LocalVersion, int32 RemoteVersion)
+{
+	// min(local, remote) = the highest version both peers understand (§A.1). A non-positive / absent remote
+	// (a legacy handshake that omitted the field) is treated as v1. Mirrors the sidecar's
+	// IpcProtocol.NegotiateVersion so both ends agree on the negotiated version without re-exchanging it.
+	const int32 Remote = RemoteVersion > 0 ? RemoteVersion : 1;
+	const int32 Local = LocalVersion > 0 ? LocalVersion : 1;
+	return FMath::Min(Local, Remote);
+}
+
+int32 FUnrealMcpBridgeServer::GetIpcVersion()
+{
+	return IpcVersion;
 }
 
 int32 FUnrealMcpBridgeServer::Start(const FString& InToken, const FString& InProjectPath, const FString& InPluginVersion, const FString& InEngineVersion,
@@ -329,6 +357,8 @@ void FUnrealMcpBridgeServer::HandleLine(const FString& Line, int32 Generation)
 	if (Type == TypeHandshake)        HandleHandshake(Message, Generation);
 	else if (Type == TypeToolCall)    HandleToolCall(Message);
 	else if (Type == TypeToolCancel)  HandleToolCancel(Message);
+	else if (Type == TypePromptGet)   HandlePromptGet(Message);     // v2 scaffold stub (§A.1)
+	else if (Type == TypeResourceRead) HandleResourceRead(Message); // v2 scaffold stub (§A.1)
 	else if (Type == TypePing)
 	{
 		TSharedPtr<FJsonObject> Pong = MakeShared<FJsonObject>();
@@ -387,19 +417,36 @@ void FUnrealMcpBridgeServer::HandleHandshake(const TSharedPtr<FJsonObject>& Mess
 				Generation, ConnectionGeneration);
 			return;
 		}
+		// §A.1 version negotiation: the link runs at min(this plugin, sidecar). A v1 sidecar negotiates down to
+		// 1 (tools-only); a v2 sidecar enables the prompt/resource families. Read the sidecar's advertised version
+		// off the handshake (absent/legacy → v1). Stored under ConnectionMutex alongside bHandshakeOk so the
+		// post-handshake manifest push (same reader thread) reads a settled value.
+		int32 SidecarIpcVersion = 0;
+		{
+			double VersionNumber = 0.0;
+			if (Message->TryGetNumberField(TEXT("ipcVersion"), VersionNumber))
+				SidecarIpcVersion = static_cast<int32>(VersionNumber);
+		}
+		NegotiatedIpcVersion = FUnrealMcpBridgeServer::NegotiateIpcVersion(IpcVersion, SidecarIpcVersion);
 		bHandshakeOk = true;
 	}
 
-	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] handshake accepted."));
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] handshake accepted (IPC v%d negotiated; prompts/resources %s)."),
+		NegotiatedIpcVersion,
+		NegotiatedIpcVersion >= PromptsResourcesMinVersion ? TEXT("ENABLED") : TEXT("tools-only"));
 	SendHandshakeAck();
 
-	// §1.5: on Ready immediately push the manifest AND the effective connection config (§1.3 `config`, §8).
+	// §1.5: on Ready immediately push the manifest(s) AND the effective connection config (§1.3 `config`, §8).
 	// The handshake-ack already carries the config for the sidecar's initial SignalR connect; the standalone
 	// `config` message satisfies the §8 "on Ready and on change" contract and is the channel a later UI edit
-	// re-pushes through (SetEffectiveConfig → PushConfig).
+	// re-pushes through (SetEffectiveConfig → PushConfig). The prompt/resource manifests are §A.1 scaffold
+	// no-ops until P1/P2 wire the registries (and are gated on a v2-negotiated link), but pushing them here
+	// keeps the on-Ready ordering identical to what P1/P2 expect.
 	{
 		FScopeLock Lock(&WriteMutex);
 		SendManifestLocked();
+		SendPromptManifestLocked();
+		SendResourceManifestLocked();
 		SendConfigLocked();
 	}
 
@@ -526,6 +573,39 @@ void FUnrealMcpBridgeServer::HandleToolCancel(const TSharedPtr<FJsonObject>& Mes
 		(*Flag).Get() = true;
 }
 
+void FUnrealMcpBridgeServer::HandlePromptGet(const TSharedPtr<FJsonObject>& Message)
+{
+	// SCAFFOLD (M16 P0, §A.1): no prompt registry is wired until P1. Answer with an error-status
+	// `prompt-response` correlated by requestId so the sidecar's pending call resolves (fail fast) rather
+	// than hanging to its timeout — exactly how a tool-call to an unknown tool fails. P1 replaces this body
+	// with a real dispatch through FUnrealMcpGameThreadDispatcher (game-thread, no-modal-UI, §4).
+	FString RequestId;
+	Message->TryGetStringField(TEXT("requestId"), RequestId);
+
+	TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
+	Response->SetStringField(TEXT("type"), TypePromptResponse);
+	Response->SetStringField(TEXT("requestId"), RequestId);
+	Response->SetStringField(TEXT("status"), TEXT("error"));
+	Response->SetStringField(TEXT("error"), TEXT("Prompts are not implemented yet (scaffold)."));
+	SendMessage(Response);
+}
+
+void FUnrealMcpBridgeServer::HandleResourceRead(const TSharedPtr<FJsonObject>& Message)
+{
+	// SCAFFOLD (M16 P0, §A.1): no resource registry is wired until P2 — same error-status fast-fail as the
+	// prompt stub. P2 replaces this with a real read dispatched on the game thread (an asset enumeration must
+	// not block the game thread unboundedly, §A.1 risk 7).
+	FString RequestId;
+	Message->TryGetStringField(TEXT("requestId"), RequestId);
+
+	TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
+	Response->SetStringField(TEXT("type"), TypeResourceResponse);
+	Response->SetStringField(TEXT("requestId"), RequestId);
+	Response->SetStringField(TEXT("status"), TEXT("error"));
+	Response->SetStringField(TEXT("error"), TEXT("Resources are not implemented yet (scaffold)."));
+	SendMessage(Response);
+}
+
 bool FUnrealMcpBridgeServer::SendMessage(const TSharedPtr<FJsonObject>& Message)
 {
 	const FString Json = SerializeCondensed(Message);
@@ -644,6 +724,40 @@ void FUnrealMcpBridgeServer::PushManifest()
 		return;
 	FScopeLock Lock(&WriteMutex);
 	SendManifestLocked();
+}
+
+void FUnrealMcpBridgeServer::PushPromptManifest()
+{
+	if (!bClientConnected || !bHandshakeOk)
+		return;
+	FScopeLock Lock(&WriteMutex);
+	SendPromptManifestLocked();
+}
+
+void FUnrealMcpBridgeServer::PushResourceManifest()
+{
+	if (!bClientConnected || !bHandshakeOk)
+		return;
+	FScopeLock Lock(&WriteMutex);
+	SendResourceManifestLocked();
+}
+
+void FUnrealMcpBridgeServer::SendPromptManifestLocked()
+{
+	// SCAFFOLD (M16 P0, §A.1): no prompt registry exists until P1, so there is nothing to send. Also gated on a
+	// v2-negotiated link — a tools-only (v1) sidecar never receives a prompt-manifest. The real body (mirroring
+	// SendManifestLocked over the prompt registry's BuildManifestJson) lands with the P1 registry.
+	if (NegotiatedIpcVersion < PromptsResourcesMinVersion)
+		return;
+	// (no-op: P1 fills this in)
+}
+
+void FUnrealMcpBridgeServer::SendResourceManifestLocked()
+{
+	// SCAFFOLD (M16 P0, §A.1): no resource registry exists until P2. Same v2 gate + no-op as the prompt manifest.
+	if (NegotiatedIpcVersion < PromptsResourcesMinVersion)
+		return;
+	// (no-op: P2 fills this in)
 }
 
 void FUnrealMcpBridgeServer::SendConfigLocked()

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.h
@@ -52,8 +52,18 @@ public:
 	int32 GetBoundPort() const { return BoundPort; }
 	bool IsClientConnected() const { return bClientConnected; }
 
-	/** Re-push the manifest (call after the registry changes, §2.2 hot reload). No-op when disconnected. */
+	/** Re-push the tool manifest (call after the registry changes, §2.2 hot reload). No-op when disconnected. */
 	void PushManifest();
+
+	/**
+	 * Re-push the prompt / resource manifests (IPC v2, docs/ARCHITECTURE.md §A.1). SCAFFOLD STUBS (M16 P0):
+	 * a prompt/resource registry is not wired until P1/P2, so today these no-op (nothing to send) — they
+	 * exist so the kind-aware extension manager's OnChanged can fire all three Push*Manifest() uniformly.
+	 * Both are additionally GATED on a v2-negotiated link: on a tools-only (v1) connection they never send,
+	 * so an old sidecar keeps working. No-op when disconnected. The real bodies arrive with the P1/P2 registries.
+	 */
+	void PushPromptManifest();
+	void PushResourceManifest();
 
 	/**
 	 * Replace the effective connection config and, if a sidecar is connected, push the §1.3 `config` message
@@ -114,6 +124,19 @@ public:
 	/** Deterministic IPC port for a project path (§1.1): 30000 + sha(path) % 10000. */
 	static int32 ComputeDeterministicPort(const FString& ProjectPath);
 
+	/**
+	 * Negotiate the effective IPC version for a link from the two peers' advertised versions (§A.1): the
+	 * MINIMUM of @p LocalVersion and @p RemoteVersion (the highest both understand). A non-positive / absent
+	 * remote version (a legacy handshake that omitted the field) is treated as v1, so a v2 plugin paired with
+	 * a v1 sidecar negotiates to 1 and stays tools-only. Pure + static + UNREALMCPRUNTIME_API-exported so the
+	 * negotiation matrix is unit-testable from the Tests module without standing up a live socket — and so the
+	 * .NET sidecar's IpcProtocol.NegotiateVersion and this share one documented contract.
+	 */
+	static int32 NegotiateIpcVersion(int32 LocalVersion, int32 RemoteVersion);
+
+	/** This plugin's advertised IPC wire-protocol version (§9.2 / §A.1). Exported for the negotiation spec. */
+	static int32 GetIpcVersion();
+
 	// FRunnable (the reader loop) ------------------------------------------------------------------
 	virtual bool Init() override;
 	virtual uint32 Run() override;
@@ -127,9 +150,21 @@ private:
 	void HandleToolCall(const TSharedPtr<FJsonObject>& Message);
 	void HandleToolCancel(const TSharedPtr<FJsonObject>& Message);
 
+	/**
+	 * Handle a v2 `prompt-get` / `resource-read` request (§A.1). SCAFFOLD STUBS (M16 P0): no prompt/resource
+	 * registry is wired until P1/P2, so each answers with an `error`-status response carrying a "not
+	 * implemented" reason (correlated by requestId), exactly as a tool-call to an unknown tool would fail —
+	 * never silently dropped, so the sidecar's pending call resolves instead of hanging. The real bodies
+	 * (marshalling through FUnrealMcpGameThreadDispatcher) land with the P1/P2 registries.
+	 */
+	void HandlePromptGet(const TSharedPtr<FJsonObject>& Message);
+	void HandleResourceRead(const TSharedPtr<FJsonObject>& Message);
+
 	bool SendMessage(const TSharedPtr<FJsonObject>& Message);
 	void SendHandshakeAck();
 	void SendManifestLocked();
+	void SendPromptManifestLocked();   // v2 scaffold: no-op until a prompt registry is wired (P1)
+	void SendResourceManifestLocked(); // v2 scaffold: no-op until a resource registry is wired (P2)
 	void SendConfigLocked(); // WriteMutex held: frame + send the §1.3 `config` message (no-op when no config)
 	bool TrySendFramedLocked(const TArray<uint8>& Framed); // WriteMutex+ConnectionMutex held, ClientSocket valid
 	void CloseActiveConnection();
@@ -180,6 +215,13 @@ private:
 	FThreadSafeBool bStopRequested = false;
 	FThreadSafeBool bClientConnected = false;
 	FThreadSafeBool bHandshakeOk = false;
+
+	// The IPC version negotiated on the current connection's handshake (§A.1): min(this plugin's IpcVersion,
+	// the sidecar's advertised ipcVersion). 0 until a handshake completes. When below the v2 floor the link is
+	// tools-only and the prompt/resource families are never pushed (an old sidecar keeps working). Written on
+	// the reader thread in HandleHandshake (under ConnectionMutex with bHandshakeOk), read on the reader thread
+	// in the Push*ManifestLocked gate — same thread, so a plain int suffices.
+	int32 NegotiatedIpcVersion = 0;
 	FThreadSafeCounter LastActivitySeconds; // wall-clock seconds of last inbound activity
 
 	mutable FCriticalSection WriteMutex;     // serializes all socket sends (§1.2)

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Extensions/UnrealMcpExtensionManager.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Extensions/UnrealMcpExtensionManager.h
@@ -34,7 +34,7 @@ struct FUnrealMcpExtensionRecord
  * Discovers IUnrealMcpToolProvider modular features, merges their tools into the plugin's single
  * FUnrealMcpToolRegistry in deterministic order (sorted by ExtensionId), isolates invalid/duplicate
  * entries (§5), and persists per-extension enable state. On every change it rebuilds the registry and
- * fires OnChanged so the bridge re-pushes the manifest (§2.2 hot-reload).
+ * fires OnChanged so the bridge re-pushes the manifest(s) (§2.2 / §A.1 hot-reload).
  *
  * Threading: all rebuilds run on the game thread. Initial discovery happens during plugin StartupModule;
  * late register/unregister events arrive on the game thread (module load/unload), as do UI toggles (§7).
@@ -42,6 +42,17 @@ struct FUnrealMcpExtensionRecord
  * Persistence: disabledExtensions[] is stored in a minimal standalone JSON file under the project's
  * Saved dir. TODO(connection-config §8): fold this into FUnrealMcpConfig once that store lands, so the
  * extension enable state shares one config surface with connection settings.
+ *
+ * KIND-AWARENESS (M16, docs/ARCHITECTURE.md §A.2). This manager is the single hot-reload coordinator for
+ * ALL extension kinds — tools today, prompts (P1) and resources (P2) next. The shared, load-bearing
+ * machinery is the re-entrancy guard / deferred-rebuild, the disabled-set persistence, and the ExtensionId
+ * sort; it is written ONCE here and reused per kind so the §5 isolation guarantees hold identically for
+ * prompts and resources. The OnChanged callback is already kind-uniform: a single rebuild fires the owner's
+ * notify, which re-pushes the tool AND prompt AND resource manifests (the coordinator/subsystem wires all
+ * three Push*Manifest() — the prompt/resource pushes are scaffold no-ops until P1/P2). When P1/P2 land they
+ * add, alongside the tool Registry below: a prompt/resource registry reference, an IUnrealMcp{Prompt,Resource}Provider
+ * modular-feature subscription (mirroring RegisteredHandle/UnregisteredHandle), and a RegisterExtension pass in
+ * RebuildFromProviders gated by the SAME DisabledExtensions set — no new notify path, no duplicated guard.
  */
 class UNREALMCPRUNTIME_API FUnrealMcpExtensionManager
 {

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
@@ -71,9 +71,20 @@ void UUnrealMcpRuntimeSubsystem::Initialize(FSubsystemCollectionBase& Collection
 
 	// Discover §5 extension providers and merge them BEFORE the bridge arms, so the first manifest a sidecar
 	// reads on a later Connect already includes them; a late register/unregister re-pushes the manifest.
+	// §A.1 kind-aware OnChanged: a rebuild re-pushes ALL THREE manifests (tool + prompt + resource). The
+	// prompt/resource pushes are scaffold no-ops until P1/P2 wire those registries (and are gated on a
+	// v2-negotiated link); firing all three keeps the change contract kind-uniform with the editor coordinator.
 	Impl->ExtensionManager = MakeUnique<FUnrealMcpExtensionManager>(
 		*Impl->Registry,
-		[this]() { if (Impl && Impl->BridgeServer.IsValid()) Impl->BridgeServer->PushManifest(); });
+		[this]()
+		{
+			if (Impl && Impl->BridgeServer.IsValid())
+			{
+				Impl->BridgeServer->PushManifest();
+				Impl->BridgeServer->PushPromptManifest();
+				Impl->BridgeServer->PushResourceManifest();
+			}
+		});
 	Impl->ExtensionManager->Startup();
 
 	const FString ProjectPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());

--- a/bridge/src/Ipc/IpcClient.cs
+++ b/bridge/src/Ipc/IpcClient.cs
@@ -38,6 +38,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         private readonly ILogger? _logger;
 
         private readonly PendingCallRegistry _pending = new();
+        // v2 (§A.1) prompt-get / resource-read pending registries — reuse the same correlation machinery as
+        // tool-calls (generic over the response type). Failed/drained alongside _pending on every disconnect.
+        private readonly PendingCallRegistry<PromptResponseMessage> _pendingPrompts = new();
+        private readonly PendingCallRegistry<ResourceResponseMessage> _pendingResources = new();
         private readonly ReconnectBackoff _backoff = new();
         private readonly SemaphoreSlim _writeLock = new(1, 1);
 
@@ -51,6 +55,31 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
 
         /// <summary>Routes applied tool manifests; set by the host before <see cref="RunAsync"/>.</summary>
         public ManifestRegistrar? Registrar { get; set; }
+
+        /// <summary>
+        /// Routes applied prompt manifests (IPC v2, §A.1); set by the host (P1) before <see cref="RunAsync"/>.
+        /// Null in the P0 scaffold — a <c>prompt-manifest</c> that arrives with no registrar wired is logged
+        /// and dropped (forward-compatible: the plugin never pushes one until both peers negotiate v2 and a
+        /// prompt registry exists).
+        /// </summary>
+        public IManifestSink<PromptManifestMessage>? PromptRegistrar { get; set; }
+
+        /// <summary>
+        /// Routes applied resource manifests (IPC v2, §A.1); set by the host (P2) before <see cref="RunAsync"/>.
+        /// Null in the P0 scaffold — see <see cref="PromptRegistrar"/>.
+        /// </summary>
+        public IManifestSink<ResourceManifestMessage>? ResourceRegistrar { get; set; }
+
+        /// <summary>
+        /// The IPC version negotiated on the most recent accepted handshake (<see cref="IpcProtocol.NegotiateVersion"/>):
+        /// the minimum of this sidecar's <see cref="IpcProtocol.IpcVersion"/> and the version the plugin advertised in
+        /// the handshake-ack. <c>0</c> until the first ack. When below <see cref="IpcProtocol.PromptsResourcesMinVersion"/>
+        /// the link is tools-only and the prompt/resource families are never exchanged (an old peer keeps working).
+        /// </summary>
+        public int NegotiatedIpcVersion { get; private set; }
+
+        /// <summary>True once a handshake negotiated an IPC version that exchanges the v2 prompt/resource families.</summary>
+        public bool SupportsPromptsResources => IpcProtocol.SupportsPromptsResources(NegotiatedIpcVersion);
 
         /// <summary>Raised when a <c>handshake-ack</c> is received (the link is established, §1.5).</summary>
         public event Action<HandshakeAckMessage>? HandshakeAccepted;
@@ -166,6 +195,13 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
                 if (first == ackTcs.Task && ackTcs.Task.IsCompletedSuccessfully)
                 {
                     _backoff.Reset();
+                    // §A.1 version negotiation: the link runs at min(local, plugin) — the highest both understand.
+                    // A v1 plugin negotiates down to 1 (tools-only); a v2 plugin enables the prompt/resource families.
+                    // The tool path is identical at every version, so a mismatch never breaks tools (an old peer works).
+                    NegotiatedIpcVersion = IpcProtocol.NegotiateVersion(IpcProtocol.IpcVersion, ackTcs.Task.Result.IpcVersion);
+                    _logger?.LogInformation("IPC version negotiated: {Negotiated} (local {Local}, plugin {Remote}); prompts/resources {State}.",
+                        NegotiatedIpcVersion, IpcProtocol.IpcVersion, ackTcs.Task.Result.IpcVersion,
+                        SupportsPromptsResources ? "ENABLED" : "tools-only");
                     _ackAccepted = true; // open the gate: tool-calls may now hit the wire (§1.4)
                     HandshakeAccepted?.Invoke(ackTcs.Task.Result);
                     using var heartbeat = StartHeartbeat(connCts);
@@ -196,7 +232,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
             {
                 CloseConnection(tcp);
                 _pending.FailAll(); // every in-flight proxy call fails fast (§2.2 step 4)
+                _pendingPrompts.FailAll();   // v2: in-flight prompt-get/resource-read fail fast too (§A.1)
+                _pendingResources.FailAll();
                 Registrar?.ResetForReconnect(); // §1.5: next handshake-ack re-applies the manifest
+                PromptRegistrar?.ResetForReconnect();
+                ResourceRegistrar?.ResetForReconnect();
             }
         }
 
@@ -253,6 +293,40 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
                     var response = node!.Deserialize<ToolResponseMessage>(IpcProtocol.JsonOptions);
                     if (response != null && !_pending.TryComplete(response.RequestId, response))
                         _logger?.LogDebug("Dropped tool-response for unknown/completed requestId {Id}.", response.RequestId);
+                    break;
+                }
+                case IpcProtocol.Type.PromptManifest:
+                {
+                    // v2 (§A.1): apply the prompt-set snapshot. Dropped (logged) when no registrar is wired — the
+                    // P0 scaffold has none, and a v1-negotiated link never receives this anyway.
+                    var manifest = node!.Deserialize<PromptManifestMessage>(IpcProtocol.JsonOptions);
+                    if (manifest != null && PromptRegistrar != null)
+                        PromptRegistrar.ApplyManifest(manifest);
+                    else if (manifest != null)
+                        _logger?.LogDebug("Received prompt-manifest but no PromptRegistrar is wired (scaffold); dropping.");
+                    break;
+                }
+                case IpcProtocol.Type.ResourceManifest:
+                {
+                    var manifest = node!.Deserialize<ResourceManifestMessage>(IpcProtocol.JsonOptions);
+                    if (manifest != null && ResourceRegistrar != null)
+                        ResourceRegistrar.ApplyManifest(manifest);
+                    else if (manifest != null)
+                        _logger?.LogDebug("Received resource-manifest but no ResourceRegistrar is wired (scaffold); dropping.");
+                    break;
+                }
+                case IpcProtocol.Type.PromptResponse:
+                {
+                    var response = node!.Deserialize<PromptResponseMessage>(IpcProtocol.JsonOptions);
+                    if (response != null && !_pendingPrompts.TryComplete(response.RequestId, response))
+                        _logger?.LogDebug("Dropped prompt-response for unknown/completed requestId {Id}.", response.RequestId);
+                    break;
+                }
+                case IpcProtocol.Type.ResourceResponse:
+                {
+                    var response = node!.Deserialize<ResourceResponseMessage>(IpcProtocol.JsonOptions);
+                    if (response != null && !_pendingResources.TryComplete(response.RequestId, response))
+                        _logger?.LogDebug("Dropped resource-response for unknown/completed requestId {Id}.", response.RequestId);
                     break;
                 }
                 case IpcProtocol.Type.Ping:
@@ -410,6 +484,86 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
             return await task.ConfigureAwait(false);
         }
 
+        // --- Prompt/Resource outbound channels (IPC v2, §A.1) ----------------------------------------
+
+        /// <summary>
+        /// Send a <c>prompt-get</c> and await its terminal <c>prompt-response</c> (IPC v2, §A.1). Mirrors
+        /// <see cref="CallToolAsync"/> exactly — gates on a completed handshake, correlates by requestId via
+        /// the prompt pending registry, forwards cancellation as the generic <c>tool-cancel</c>, and arms the
+        /// same local timeout backstop. Throws <see cref="IpcDisconnectedException"/> when the link is down so
+        /// the proxy (P1) fails fast. The plugin only serves these on a v2-negotiated link.
+        /// </summary>
+        public Task<PromptResponseMessage> GetPromptAsync(string prompt, JsonObject? arguments, int timeoutMs, CancellationToken cancellationToken)
+            => RoundTripAsync(_pendingPrompts,
+                requestId => new PromptGetMessage { RequestId = requestId, Prompt = prompt, Arguments = arguments, TimeoutMs = timeoutMs },
+                $"Prompt '{prompt}'", timeoutMs, cancellationToken);
+
+        /// <summary>
+        /// Send a <c>resource-read</c> and await its terminal <c>resource-response</c> (IPC v2, §A.1). The
+        /// resource analog of <see cref="GetPromptAsync"/>; same handshake gate, requestId correlation,
+        /// <c>tool-cancel</c> forwarding, and timeout backstop.
+        /// </summary>
+        public Task<ResourceResponseMessage> ReadResourceAsync(string uri, int timeoutMs, CancellationToken cancellationToken)
+            => RoundTripAsync(_pendingResources,
+                requestId => new ResourceReadMessage { RequestId = requestId, Uri = uri, TimeoutMs = timeoutMs },
+                $"Resource '{uri}'", timeoutMs, cancellationToken);
+
+        /// <summary>
+        /// The shared request→response round-trip for the v2 prompt-get / resource-read channels: identical to
+        /// <see cref="CallToolAsync"/>'s body but parameterized over the pending registry + request factory, so
+        /// the handshake gate, requestId correlation, cancellation-as-tool-cancel, and local timeout backstop
+        /// are written once. <typeparamref name="TResponse"/> is the matching terminal response type.
+        /// </summary>
+        private async Task<TResponse> RoundTripAsync<TResponse>(
+            PendingCallRegistry<TResponse> registry,
+            Func<string, object> buildRequest,
+            string what,
+            int timeoutMs,
+            CancellationToken cancellationToken)
+        {
+            // Gate on a COMPLETED handshake, not merely an open socket — same race as CallToolAsync (§1.4).
+            var stream = _stream;
+            if (stream == null || !_ackAccepted || _tcp is not { Connected: true })
+                throw new IpcDisconnectedException();
+
+            var requestId = Guid.NewGuid().ToString("N");
+            var task = registry.Register(requestId);
+
+            // Cancellation: forward the caller's token as the GENERIC tool-cancel (by requestId, reused for all
+            // kinds, §A.1) and fail the pending call.
+            using var registration = cancellationToken.Register(() =>
+            {
+                _ = SafeAwait(SendAsync(new ToolCancelMessage { RequestId = requestId }, CancellationToken.None));
+                registry.TryFail(requestId, new OperationCanceledException(cancellationToken));
+            });
+
+            try
+            {
+                await SendAsync(buildRequest(requestId), cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                registry.TryFail(requestId, new IpcDisconnectedException());
+                throw new IpcDisconnectedException();
+            }
+
+            if (timeoutMs > 0)
+            {
+                using var backstopCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                var completed = await Task.WhenAny(task, Task.Delay(timeoutMs + IpcProtocol.CallTimeoutGraceMs, backstopCts.Token)).ConfigureAwait(false);
+                backstopCts.Cancel();
+                if (completed != task && !cancellationToken.IsCancellationRequested)
+                {
+                    var timeout = new TimeoutException($"{what} call timed out after {timeoutMs + IpcProtocol.CallTimeoutGraceMs} ms with no IPC response.");
+                    _ = SafeAwait(SendAsync(new ToolCancelMessage { RequestId = requestId }, CancellationToken.None));
+                    registry.TryFail(requestId, timeout);
+                    throw timeout;
+                }
+            }
+
+            return await task.ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Send a sidecar→plugin message (the §7 <c>device-auth</c> / <c>status</c> feed) over the live IPC
         /// link. No-op (returns false) when no connection is up — the plugin re-reads state on the next
@@ -479,6 +633,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
             try { _tcp?.Close(); } catch { /* ignore */ }
             _writeLock.Dispose();
             _pending.FailAll();
+            _pendingPrompts.FailAll();
+            _pendingResources.FailAll();
             return ValueTask.CompletedTask;
         }
     }

--- a/bridge/src/Ipc/IpcMessages.cs
+++ b/bridge/src/Ipc/IpcMessages.cs
@@ -87,6 +87,124 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         [JsonPropertyName("structured")] public JsonNode? Structured { get; set; }
     }
 
+    // ── Prompts/Resources (IPC v2, docs/ARCHITECTURE.md §A.1) ────────────────────────────────────────
+    // These message families are exchanged ONLY on a link whose negotiated IPC version is
+    // >= IpcProtocol.PromptsResourcesMinVersion (a tools-only/v1 link never sees them). They mirror the
+    // tool families 1:1 — a revision-guarded full-snapshot manifest the sidecar diffs, plus a per-request
+    // get/read round-trip correlated by requestId (reusing PendingCallRegistry + the generic tool-cancel).
+
+    /// <summary>
+    /// One entry in <see cref="PromptManifestMessage.Prompts"/> — shaped to fill <c>IRunPrompt</c> 1:1
+    /// (§A.1). <c>inputSchema</c> is a JSON Schema the manager flattens to the prompt's arguments[];
+    /// <c>role</c> is the message author role (<c>"user"</c> | <c>"assistant"</c>).
+    /// </summary>
+    public sealed class PromptDescriptor
+    {
+        [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+        [JsonPropertyName("title")] public string? Title { get; set; }
+        [JsonPropertyName("description")] public string? Description { get; set; }
+        /// <summary>The prompt message author role — <c>"user"</c> or <c>"assistant"</c> (§A.1).</summary>
+        [JsonPropertyName("role")] public string? Role { get; set; }
+        [JsonPropertyName("inputSchema")] public JsonNode? InputSchema { get; set; }
+        [JsonPropertyName("enabled")] public bool Enabled { get; set; } = true;
+        [JsonPropertyName("extensionId")] public string? ExtensionId { get; set; }
+        [JsonPropertyName("schemaHash")] public string? SchemaHash { get; set; }
+    }
+
+    /// <summary>plugin → sidecar: full prompt-set snapshot (v2, §A.1). The sidecar diffs it against the last applied.</summary>
+    public sealed class PromptManifestMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.PromptManifest;
+        [JsonPropertyName("revision")] public int Revision { get; set; }
+        [JsonPropertyName("prompts")] public List<PromptDescriptor> Prompts { get; set; } = new();
+    }
+
+    /// <summary>
+    /// One entry in <see cref="ResourceManifestMessage.Resources"/> — shaped to fill <c>IRunResource</c>
+    /// 1:1 (§A.1). <c>uri</c> is the resource's MCP URI (the manager's route); MVP resources are
+    /// static fixed-URI (templated URIs are deferred — see §A.1).
+    /// </summary>
+    public sealed class ResourceDescriptor
+    {
+        [JsonPropertyName("uri")] public string Uri { get; set; } = string.Empty;
+        [JsonPropertyName("name")] public string? Name { get; set; }
+        [JsonPropertyName("description")] public string? Description { get; set; }
+        [JsonPropertyName("mimeType")] public string? MimeType { get; set; }
+        [JsonPropertyName("enabled")] public bool Enabled { get; set; } = true;
+        [JsonPropertyName("extensionId")] public string? ExtensionId { get; set; }
+        [JsonPropertyName("schemaHash")] public string? SchemaHash { get; set; }
+    }
+
+    /// <summary>plugin → sidecar: full resource-set snapshot (v2, §A.1). The sidecar diffs it against the last applied.</summary>
+    public sealed class ResourceManifestMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.ResourceManifest;
+        [JsonPropertyName("revision")] public int Revision { get; set; }
+        [JsonPropertyName("resources")] public List<ResourceDescriptor> Resources { get; set; } = new();
+    }
+
+    /// <summary>sidecar → plugin: fetch one prompt's rendered messages (v2, §A.1). Round-trips like a tool-call.</summary>
+    public sealed class PromptGetMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.PromptGet;
+        [JsonPropertyName("requestId")] public string RequestId { get; set; } = string.Empty;
+        [JsonPropertyName("prompt")] public string Prompt { get; set; } = string.Empty;
+        [JsonPropertyName("arguments")] public JsonObject? Arguments { get; set; }
+        [JsonPropertyName("timeoutMs")] public int TimeoutMs { get; set; } = IpcProtocol.DefaultToolTimeoutMs;
+    }
+
+    /// <summary>One rendered prompt message (≈ <c>ResponseGetPrompt.Messages[]</c>, §A.1): a role + content text.</summary>
+    public sealed class PromptResponseEntry
+    {
+        [JsonPropertyName("role")] public string? Role { get; set; }
+        [JsonPropertyName("text")] public string? Text { get; set; }
+    }
+
+    /// <summary>plugin → sidecar: terminal prompt-get result (v2, §A.1), correlated by requestId (≈ ResponseGetPrompt).</summary>
+    public sealed class PromptResponseMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.PromptResponse;
+        [JsonPropertyName("requestId")] public string RequestId { get; set; } = string.Empty;
+        [JsonPropertyName("status")] public string Status { get; set; } = IpcProtocol.Status.Success;
+        [JsonPropertyName("description")] public string? Description { get; set; }
+        [JsonPropertyName("messages")] public List<PromptResponseEntry>? Messages { get; set; }
+        /// <summary>A short human-readable reason on an <c>error</c> status (never a secret).</summary>
+        [JsonPropertyName("error")] public string? Error { get; set; }
+    }
+
+    /// <summary>sidecar → plugin: read one resource's content by uri (v2, §A.1). Round-trips like a tool-call.</summary>
+    public sealed class ResourceReadMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.ResourceRead;
+        [JsonPropertyName("requestId")] public string RequestId { get; set; } = string.Empty;
+        [JsonPropertyName("uri")] public string Uri { get; set; } = string.Empty;
+        [JsonPropertyName("timeoutMs")] public int TimeoutMs { get; set; } = IpcProtocol.DefaultToolTimeoutMs;
+    }
+
+    /// <summary>
+    /// One resource content block (≈ <c>ResponseResourceContent</c>, §A.1): <c>text</c> XOR
+    /// <c>blob</c> (base64) + <c>mimeType</c> — binary rides as base64 like screenshot images.
+    /// </summary>
+    public sealed class ResourceContentEntry
+    {
+        [JsonPropertyName("uri")] public string? Uri { get; set; }
+        [JsonPropertyName("mimeType")] public string? MimeType { get; set; }
+        [JsonPropertyName("text")] public string? Text { get; set; }
+        /// <summary>Base64-encoded binary content (XOR with <see cref="Text"/>).</summary>
+        [JsonPropertyName("blob")] public string? Blob { get; set; }
+    }
+
+    /// <summary>plugin → sidecar: terminal resource-read result (v2, §A.1), correlated by requestId.</summary>
+    public sealed class ResourceResponseMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.ResourceResponse;
+        [JsonPropertyName("requestId")] public string RequestId { get; set; } = string.Empty;
+        [JsonPropertyName("status")] public string Status { get; set; } = IpcProtocol.Status.Success;
+        [JsonPropertyName("contents")] public List<ResourceContentEntry>? Contents { get; set; }
+        /// <summary>A short human-readable reason on an <c>error</c> status (never a secret).</summary>
+        [JsonPropertyName("error")] public string? Error { get; set; }
+    }
+
     /// <summary>sidecar → plugin: cooperative cancellation of an in-flight call (§4).</summary>
     public sealed class ToolCancelMessage
     {

--- a/bridge/src/Ipc/IpcProtocol.cs
+++ b/bridge/src/Ipc/IpcProtocol.cs
@@ -22,8 +22,46 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         /// <summary>
         /// IPC wire-protocol version (§9.2). Bumped only on a breaking framing/schema change; the
         /// handshake (§1.3) carries it so a future version can negotiate without breaking old pairs.
+        ///
+        /// <para>
+        /// <b>v2</b> (M16 P0) adds the prompt/resource message families — the
+        /// <c>prompt-manifest</c>/<c>resource-manifest</c>, <c>prompt-get</c>/<c>resource-read</c>, and
+        /// <c>prompt-response</c>/<c>resource-response</c> discriminators. The version is NEGOTIATED on
+        /// the handshake (<see cref="NegotiateVersion"/>): two v2 peers exchange prompts/resources; a v1
+        /// peer paired with a v2 peer negotiates down to v1 and the link stays TOOLS-ONLY (the v2 peer
+        /// simply never pushes/serves the prompt/resource families). The tool path is byte-identical
+        /// across both versions, so a version mismatch never breaks tools.
+        /// </para>
         /// </summary>
-        public const int IpcVersion = 1;
+        public const int IpcVersion = 2;
+
+        /// <summary>
+        /// The lowest IPC version at which the prompt/resource message families (v2) are exchanged. When
+        /// the negotiated version (<see cref="NegotiateVersion"/>) is below this, the link stays tools-only.
+        /// </summary>
+        public const int PromptsResourcesMinVersion = 2;
+
+        /// <summary>
+        /// Negotiate the effective IPC version for a link from the two peers' advertised versions: the
+        /// MINIMUM of the local and remote versions (the highest both understand). A peer must not use a
+        /// message family the negotiated version does not cover, so a v2↔v1 pair negotiates to 1 and stays
+        /// tools-only, while a v2↔v2 pair negotiates to 2 and may exchange prompts/resources. Pure +
+        /// static so the negotiation matrix is unit-testable without a live socket. A non-positive or
+        /// absent remote version (a malformed/legacy handshake that omitted the field) is treated as 1.
+        /// </summary>
+        public static int NegotiateVersion(int localVersion, int remoteVersion)
+        {
+            var remote = remoteVersion > 0 ? remoteVersion : 1;
+            var local = localVersion > 0 ? localVersion : 1;
+            return local < remote ? local : remote;
+        }
+
+        /// <summary>
+        /// Whether a link whose negotiated IPC version is <paramref name="negotiatedVersion"/> exchanges
+        /// the v2 prompt/resource message families. False on a tools-only (v1-negotiated) link.
+        /// </summary>
+        public static bool SupportsPromptsResources(int negotiatedVersion) =>
+            negotiatedVersion >= PromptsResourcesMinVersion;
 
         /// <summary>Max NDJSON line length (§1.2). A peer aborts the connection on violation.</summary>
         public const int MaxLineBytes = 64 * 1024 * 1024;
@@ -58,10 +96,24 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
             // Correlated to the originating request by requestId; carries the engine-agnostic DTO.
             public const string AgentConfigResult = "agent-config-result";
 
+            // sidecar → plugin: fetch one prompt's rendered messages / read one resource's content (v2, §A.1).
+            // Both round-trip through PendingCallRegistry by requestId, exactly like a tool-call, and reuse the
+            // generic `tool-cancel` (by requestId) for cooperative cancellation — no new cancel verbs.
+            public const string PromptGet = "prompt-get";
+            public const string ResourceRead = "resource-read";
+
             // plugin → sidecar
             public const string HandshakeAck = "handshake-ack";
             public const string ToolManifest = "tool-manifest";
             public const string ToolResponse = "tool-response";
+            // plugin → sidecar: full prompt/resource-set snapshots (v2, §A.1) — diffed against the last applied
+            // by the prompt/resource manifest registrars, mirroring `tool-manifest`. Only exchanged when the
+            // negotiated IPC version is >= PromptsResourcesMinVersion (a tools-only link never sees these).
+            public const string PromptManifest = "prompt-manifest";
+            public const string ResourceManifest = "resource-manifest";
+            // plugin → sidecar: terminal prompt-get / resource-read results (v2, §A.1), correlated by requestId.
+            public const string PromptResponse = "prompt-response";
+            public const string ResourceResponse = "resource-response";
             public const string Config = "config";
             public const string AuthStart = "auth-start";
             public const string AuthCancel = "auth-cancel";

--- a/bridge/src/Ipc/PendingCallRegistry.cs
+++ b/bridge/src/Ipc/PendingCallRegistry.cs
@@ -16,17 +16,23 @@ using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
 namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
 {
     /// <summary>
-    /// Correlates in-flight <c>tool-call</c>s with their <c>tool-response</c>s by <c>requestId</c>
+    /// Correlates in-flight requests with their terminal responses by <c>requestId</c>
     /// (docs/ARCHITECTURE.md §1.3, §2.2). Thread-safe. On IPC disconnect, <see cref="FailAll"/> completes
     /// every pending call with <see cref="IpcDisconnectedException"/> immediately rather than letting it
-    /// hang to its timeout (§1.5, §2.2 step 4). A <c>tool-response</c> for an unknown / already-completed
-    /// id is silently dropped (<see cref="TryComplete"/> returns false) — covering late responses that
-    /// straddle a reconnect (§1.5).
+    /// hang to its timeout (§1.5, §2.2 step 4). A response for an unknown / already-completed id is silently
+    /// dropped (<see cref="TryComplete"/> returns false) — covering late responses that straddle a reconnect
+    /// (§1.5).
+    ///
+    /// <para>
+    /// Generic over the response type so the SAME correlation machinery serves tool-calls
+    /// (<typeparamref name="TResponse"/> = <c>ToolResponseMessage</c>, via <see cref="PendingCallRegistry"/>),
+    /// prompt-get, and resource-read (IPC v2, §A.1) — "reuse the PendingCallRegistry" per the design.
+    /// </para>
     /// </summary>
-    public sealed class PendingCallRegistry
+    public class PendingCallRegistry<TResponse>
     {
         private readonly object _gate = new();
-        private readonly Dictionary<string, TaskCompletionSource<ToolResponseMessage>> _pending = new();
+        private readonly Dictionary<string, TaskCompletionSource<TResponse>> _pending = new();
 
         public int Count
         {
@@ -38,9 +44,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         /// asynchronously so completing it from the reader loop never inlines proxy/handler code onto
         /// the reader thread.
         /// </summary>
-        public Task<ToolResponseMessage> Register(string requestId)
+        public Task<TResponse> Register(string requestId)
         {
-            var tcs = new TaskCompletionSource<ToolResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource<TResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
             lock (_gate)
             {
                 // A duplicate id (should never happen — ids are unique per call) fails the prior waiter.
@@ -55,9 +61,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         /// Complete a pending call with its response. Returns false (and drops the response) when no call
         /// with that id is pending — a late or duplicate response straddling a reconnect (§1.5).
         /// </summary>
-        public bool TryComplete(string requestId, ToolResponseMessage response)
+        public bool TryComplete(string requestId, TResponse response)
         {
-            TaskCompletionSource<ToolResponseMessage>? tcs;
+            TaskCompletionSource<TResponse>? tcs;
             lock (_gate)
             {
                 if (!_pending.TryGetValue(requestId, out tcs))
@@ -70,7 +76,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         /// <summary>Cancel/forget a single pending call (e.g. the caller's CancellationToken fired).</summary>
         public bool TryFail(string requestId, Exception exception)
         {
-            TaskCompletionSource<ToolResponseMessage>? tcs;
+            TaskCompletionSource<TResponse>? tcs;
             lock (_gate)
             {
                 if (!_pending.TryGetValue(requestId, out tcs))
@@ -86,15 +92,24 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         /// </summary>
         public void FailAll(Exception? exception = null)
         {
-            List<TaskCompletionSource<ToolResponseMessage>> waiters;
+            List<TaskCompletionSource<TResponse>> waiters;
             lock (_gate)
             {
-                waiters = new List<TaskCompletionSource<ToolResponseMessage>>(_pending.Values);
+                waiters = new List<TaskCompletionSource<TResponse>>(_pending.Values);
                 _pending.Clear();
             }
             var ex = exception ?? new IpcDisconnectedException();
             foreach (var tcs in waiters)
                 tcs.TrySetException(ex);
         }
+    }
+
+    /// <summary>
+    /// The tool-call pending registry (<c>tool-call</c> ⇄ <c>tool-response</c> by requestId). A thin alias
+    /// of <see cref="PendingCallRegistry{TResponse}"/> at <c>ToolResponseMessage</c> so the original
+    /// non-generic call sites and xUnit tests are unchanged.
+    /// </summary>
+    public sealed class PendingCallRegistry : PendingCallRegistry<ToolResponseMessage>
+    {
     }
 }

--- a/bridge/src/Tools/ManifestRegistrar.cs
+++ b/bridge/src/Tools/ManifestRegistrar.cs
@@ -44,29 +44,33 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
     /// Applies tool manifests (docs/ARCHITECTURE.md §2.2) to an <see cref="IProxyToolSink"/>: diff against
     /// the previously applied set, then remove / add (as <see cref="ProxyTool"/>s) / re-add changed /
     /// toggle enabled. Honours the out-of-order revision guard (§2.2 step 3) — but
-    /// <see cref="ResetForReconnect"/> (called on every <c>handshake-ack</c>, §1.5) resets the
-    /// last-applied revision to −1 so a post-reconnect re-push with an unchanged revision is always
-    /// applied. NOT thread-safe by itself: ProxyTool's docs require the host to serialize tool-set
-    /// mutations; the IPC client invokes this from its single reader loop.
+    /// <see cref="ManifestRegistrarBase{TDescriptor}.ResetForReconnect"/> (called on every
+    /// <c>handshake-ack</c>, §1.5) resets the last-applied revision to −1 so a post-reconnect re-push with
+    /// an unchanged revision is always applied. NOT thread-safe by itself: ProxyTool's docs require the host
+    /// to serialize tool-set mutations; the IPC client invokes this from its single reader loop.
+    ///
+    /// <para>
+    /// The revision-guard / reconnect-reset / diff-application machinery lives in the shared, kind-agnostic
+    /// <see cref="ManifestRegistrarBase{TDescriptor}"/> so the prompt (P1) and resource (P2) registrars
+    /// reuse it. This tool registrar is the original behaviour expressed through that base (gated by the
+    /// bridge xUnit suite); the tool-specific bits are the <see cref="ProxyTool"/> sink + the
+    /// <see cref="ManifestDiffer"/> name/schema-hash diff.
+    /// </para>
     /// </summary>
-    public sealed class ManifestRegistrar
+    public sealed class ManifestRegistrar : ManifestRegistrarBase<ToolDescriptor>
     {
         private readonly IProxyToolSink _sink;
         private readonly IToolCallChannel _channel;
-        private readonly ILogger? _logger;
-
-        private readonly Dictionary<string, ToolDescriptor> _applied = new();
-        private int _lastAppliedRevision = -1;
 
         public ManifestRegistrar(IProxyToolSink sink, IToolCallChannel channel, ILogger? logger = null)
+            : base(logger)
         {
             _sink = sink;
             _channel = channel;
-            _logger = logger;
         }
 
         /// <summary>Names of the tools currently registered by this registrar (test/inspection aid).</summary>
-        public IReadOnlyCollection<string> AppliedToolNames => _applied.Keys;
+        public IReadOnlyCollection<string> AppliedToolNames => Applied.Keys;
 
         /// <summary>
         /// A snapshot of the currently-applied tool descriptors (§7 skill-file generation reads this). The
@@ -74,68 +78,54 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
         /// Description / hints / input+output schema) — exactly the source the SKILL.md generator needs, so the
         /// sidecar can author the docs without any extra C++→sidecar payload. A copied list (caller mutation-safe).
         /// </summary>
-        public IReadOnlyList<ToolDescriptor> AppliedDescriptors => new List<ToolDescriptor>(_applied.Values);
+        public IReadOnlyList<ToolDescriptor> AppliedDescriptors => new List<ToolDescriptor>(Applied.Values);
 
-        public int LastAppliedRevision => _lastAppliedRevision;
-
-        /// <summary>
-        /// Reset the revision guard after a (re)connection handshake (§1.5). The applied snapshot is
-        /// retained — the long-lived McpPlugin still has the proxies registered, so a re-pushed manifest
-        /// that is byte-identical diffs to a no-op (correct), while a genuine change while the link was
-        /// down is still caught by the diff.
-        /// </summary>
-        public void ResetForReconnect() => _lastAppliedRevision = -1;
-
-        /// <summary>Apply a manifest. Returns the diff that was applied (empty when ignored/no-op).</summary>
+        /// <summary>Apply a tool manifest. Returns the diff that was applied (empty when ignored/no-op).</summary>
         public ManifestDiff Apply(ToolManifestMessage manifest)
         {
-            if (manifest.Revision <= _lastAppliedRevision)
-            {
-                _logger?.LogDebug(
-                    "Ignoring tool-manifest revision {Revision} (<= last applied {LastApplied}).",
-                    manifest.Revision, _lastAppliedRevision);
-                return new ManifestDiff();
-            }
+            // ApplyEntries drives the shared remove/changed/add/enabled orchestration through the hooks below
+            // and returns the kind-agnostic diff; re-shape it into the concrete ManifestDiff the §7 callers and
+            // the existing xUnit suite consume (the lists are the same references — no copy of the descriptors).
+            var generic = ApplyEntries(manifest.Revision, manifest.Tools);
 
-            var diff = ManifestDiffer.Compute(_applied, manifest.Tools);
-
-            foreach (var name in diff.Removed)
-            {
-                _sink.RemoveTool(name);
-                _applied.Remove(name);
-            }
-
-            foreach (var desc in diff.Changed)
-            {
-                _sink.RemoveTool(desc.Name);
-                _sink.AddTool(desc.Name, ProxyToolFactory.Create(desc, _channel));
-                _applied[desc.Name] = desc;
-            }
-
-            foreach (var desc in diff.Added)
-            {
-                _sink.AddTool(desc.Name, ProxyToolFactory.Create(desc, _channel));
-                _applied[desc.Name] = desc;
-            }
-
-            foreach (var (name, enabled) in diff.EnabledChanged)
-            {
-                _sink.SetToolEnabled(name, enabled);
-                if (_applied.TryGetValue(name, out var existing))
-                    existing.Enabled = enabled;
-            }
-
-            _lastAppliedRevision = manifest.Revision;
-
-            if (!diff.IsEmpty)
-            {
-                _logger?.LogInformation(
-                    "Applied tool-manifest revision {Revision}: +{Added} ~{Changed} -{Removed} ⏼{Enabled} (total {Total}).",
-                    manifest.Revision, diff.Added.Count, diff.Changed.Count, diff.Removed.Count,
-                    diff.EnabledChanged.Count, _applied.Count);
-            }
-
+            var diff = new ManifestDiff();
+            diff.Added.AddRange(generic.Added);
+            diff.Changed.AddRange(generic.Changed);
+            diff.Removed.AddRange(generic.Removed);
+            diff.EnabledChanged.AddRange(generic.EnabledChanged);
             return diff;
+        }
+
+        protected override string KindLabel => "tool";
+
+        protected override string KeyOf(ToolDescriptor descriptor) => descriptor.Name;
+
+        protected override ManifestDiff<ToolDescriptor> ComputeDiff(IReadOnlyList<ToolDescriptor> next)
+        {
+            // Reuse the existing tool-specific differ (name + schemaHash, with the structural fallback), then
+            // re-shape its result into the kind-agnostic diff the base applies.
+            var toolDiff = ManifestDiffer.Compute(Applied, next);
+            var generic = new ManifestDiff<ToolDescriptor>();
+            generic.Added.AddRange(toolDiff.Added);
+            generic.Changed.AddRange(toolDiff.Changed);
+            generic.Removed.AddRange(toolDiff.Removed);
+            generic.EnabledChanged.AddRange(toolDiff.EnabledChanged);
+            return generic;
+        }
+
+        protected override void SinkRemove(string key) => _sink.RemoveTool(key);
+
+        protected override void SinkAdd(ToolDescriptor descriptor) =>
+            _sink.AddTool(descriptor.Name, ProxyToolFactory.Create(descriptor, _channel));
+
+        protected override void SinkSetEnabled(string key, bool enabled) => _sink.SetToolEnabled(key, enabled);
+
+        protected override ToolDescriptor WithEnabled(ToolDescriptor descriptor, bool enabled)
+        {
+            // Mutate in place + return the same instance — preserves the pre-generalization behaviour exactly
+            // (the retained snapshot's Enabled flag is updated on the existing descriptor object).
+            descriptor.Enabled = enabled;
+            return descriptor;
         }
     }
 }

--- a/bridge/src/Tools/ManifestRegistrarBase.cs
+++ b/bridge/src/Tools/ManifestRegistrarBase.cs
@@ -1,0 +1,172 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// The minimal contract the IPC client needs to route an inbound manifest message of a given kind to its
+    /// registrar without knowing the descriptor type: apply a manifest snapshot, and reset the revision guard
+    /// on (re)connect (§1.5). Implemented by the prompt (P1) / resource (P2) registrars over their manifest
+    /// message type; the IPC client holds them as <c>IManifestSink&lt;PromptManifestMessage&gt;</c> etc. so the
+    /// v2 routing compiles in the P0 scaffold before the concrete registrars exist.
+    /// </summary>
+    public interface IManifestSink<in TManifest>
+    {
+        /// <summary>Apply a manifest snapshot (diff against the retained set, honouring the revision guard).</summary>
+        void ApplyManifest(TManifest manifest);
+
+        /// <summary>Reset the revision guard after a (re)connection handshake (§1.5).</summary>
+        void ResetForReconnect();
+    }
+
+    /// <summary>
+    /// The kind-agnostic result of diffing a freshly-received manifest against the previously applied set
+    /// (docs/ARCHITECTURE.md §2.2 step 1 / §A.1). <typeparamref name="TDescriptor"/> is the per-entry
+    /// descriptor (tool / prompt / resource). Pure data; computed by a kind-specific differ and consumed by
+    /// <see cref="ManifestRegistrarBase{TDescriptor}"/>.
+    /// </summary>
+    public sealed class ManifestDiff<TDescriptor>
+    {
+        /// <summary>Entries present in the new manifest but not the previous set → add.</summary>
+        public List<TDescriptor> Added { get; } = new();
+
+        /// <summary>Entries whose schema hash changed → remove then add.</summary>
+        public List<TDescriptor> Changed { get; } = new();
+
+        /// <summary>Keys removed from the new manifest → remove.</summary>
+        public List<string> Removed { get; } = new();
+
+        /// <summary>Entries whose ONLY change is the enabled flag → set-enabled.</summary>
+        public List<(string Key, bool Enabled)> EnabledChanged { get; } = new();
+
+        public bool IsEmpty =>
+            Added.Count == 0 && Changed.Count == 0 && Removed.Count == 0 && EnabledChanged.Count == 0;
+    }
+
+    /// <summary>
+    /// The kind-agnostic manifest-application machinery shared by the tool, prompt (P1), and resource (P2)
+    /// registrars (docs/ARCHITECTURE.md §2.2 / §A.1): the out-of-order revision guard, the §1.5 reconnect
+    /// reset, the retained applied-snapshot, and the remove → changed → add → toggle-enabled orchestration.
+    /// A subclass supplies the kind-specific behaviour through the abstract hooks — the diff, the sink
+    /// mutation (add/remove/set-enabled), the descriptor key, and the enabled-flag mutation on a retained
+    /// descriptor. NOT thread-safe by itself: the host serializes manifest application (the IPC client
+    /// invokes Apply from its single reader loop), exactly as the tool registrar always has.
+    ///
+    /// <para>
+    /// Generalizing the (formerly tool-only) <c>ManifestRegistrar</c> into this base lets P1/P2 instantiate
+    /// prompt/resource registrars cheaply WITHOUT re-deriving the revision guard / reconnect reset / diff
+    /// loop. The tool registrar (<see cref="ManifestRegistrar"/>) derives from this base and is behaviourally
+    /// identical to its pre-generalization form (gated by the existing bridge xUnit suite).
+    /// </para>
+    /// </summary>
+    public abstract class ManifestRegistrarBase<TDescriptor>
+    {
+        protected readonly ILogger? Logger;
+
+        /// <summary>The currently-applied descriptors, keyed by their kind-specific key (name / uri).</summary>
+        protected readonly Dictionary<string, TDescriptor> Applied = new();
+
+        private int _lastAppliedRevision = -1;
+
+        protected ManifestRegistrarBase(ILogger? logger) => Logger = logger;
+
+        public int LastAppliedRevision => _lastAppliedRevision;
+
+        /// <summary>
+        /// Reset the revision guard after a (re)connection handshake (§1.5). The applied snapshot is
+        /// retained — the long-lived McpPlugin still has the proxies registered, so a re-pushed manifest
+        /// that is byte-identical diffs to a no-op (correct), while a genuine change while the link was
+        /// down is still caught by the diff.
+        /// </summary>
+        public void ResetForReconnect() => _lastAppliedRevision = -1;
+
+        /// <summary>The kind label used in log lines ("tool" / "prompt" / "resource").</summary>
+        protected abstract string KindLabel { get; }
+
+        /// <summary>Extract the kind-specific dedup/registration key from a descriptor (tool name / resource uri).</summary>
+        protected abstract string KeyOf(TDescriptor descriptor);
+
+        /// <summary>Compute the diff of <paramref name="next"/> against the retained <see cref="Applied"/> set.</summary>
+        protected abstract ManifestDiff<TDescriptor> ComputeDiff(IReadOnlyList<TDescriptor> next);
+
+        /// <summary>Remove the registered proxy for <paramref name="key"/> from the underlying manager.</summary>
+        protected abstract void SinkRemove(string key);
+
+        /// <summary>Create + register a fresh proxy for <paramref name="descriptor"/> on the underlying manager.</summary>
+        protected abstract void SinkAdd(TDescriptor descriptor);
+
+        /// <summary>Toggle the enabled flag for <paramref name="key"/> on the underlying manager.</summary>
+        protected abstract void SinkSetEnabled(string key, bool enabled);
+
+        /// <summary>Return a copy of <paramref name="descriptor"/> with its enabled flag set to <paramref name="enabled"/>
+        /// (the retained snapshot is updated so a later diff sees the new flag).</summary>
+        protected abstract TDescriptor WithEnabled(TDescriptor descriptor, bool enabled);
+
+        /// <summary>
+        /// Apply a manifest revision carrying <paramref name="entries"/>. Honours the out-of-order revision
+        /// guard (§2.2 step 3 — a revision &lt;= the last applied is ignored, unless <see cref="ResetForReconnect"/>
+        /// reset it to −1). Returns the diff that was applied (empty when ignored / no-op).
+        /// </summary>
+        protected ManifestDiff<TDescriptor> ApplyEntries(int revision, IReadOnlyList<TDescriptor> entries)
+        {
+            if (revision <= _lastAppliedRevision)
+            {
+                Logger?.LogDebug(
+                    "Ignoring {Kind}-manifest revision {Revision} (<= last applied {LastApplied}).",
+                    KindLabel, revision, _lastAppliedRevision);
+                return new ManifestDiff<TDescriptor>();
+            }
+
+            var diff = ComputeDiff(entries);
+
+            foreach (var key in diff.Removed)
+            {
+                SinkRemove(key);
+                Applied.Remove(key);
+            }
+
+            foreach (var desc in diff.Changed)
+            {
+                var key = KeyOf(desc);
+                SinkRemove(key);
+                SinkAdd(desc);
+                Applied[key] = desc;
+            }
+
+            foreach (var desc in diff.Added)
+            {
+                SinkAdd(desc);
+                Applied[KeyOf(desc)] = desc;
+            }
+
+            foreach (var (key, enabled) in diff.EnabledChanged)
+            {
+                SinkSetEnabled(key, enabled);
+                if (Applied.TryGetValue(key, out var existing))
+                    Applied[key] = WithEnabled(existing, enabled);
+            }
+
+            _lastAppliedRevision = revision;
+
+            if (!diff.IsEmpty)
+            {
+                Logger?.LogInformation(
+                    "Applied {Kind}-manifest revision {Revision}: +{Added} ~{Changed} -{Removed} ⏼{Enabled} (total {Total}).",
+                    KindLabel, revision, diff.Added.Count, diff.Changed.Count, diff.Removed.Count,
+                    diff.EnabledChanged.Count, Applied.Count);
+            }
+
+            return diff;
+        }
+    }
+}

--- a/bridge/tests/IpcProtocolV2Tests.cs
+++ b/bridge/tests/IpcProtocolV2Tests.cs
@@ -1,0 +1,186 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>
+    /// IPC v2 (M16 P0, docs/ARCHITECTURE.md §A.1): version negotiation (old/new pair compatibility) and the
+    /// new prompt/resource message DTO round-trips over the shared camelCase NDJSON serializer.
+    /// </summary>
+    public class IpcProtocolV2Tests
+    {
+        [Fact]
+        public void IpcVersion_IsTwo()
+        {
+            // The bump 1→2 is the headline of P0; pin it so a later accidental revert is caught.
+            Assert.Equal(2, IpcProtocol.IpcVersion);
+        }
+
+        [Theory]
+        // local, remote → negotiated. min(local, remote); a missing/<=0 remote is treated as legacy v1.
+        [InlineData(2, 2, 2)] // both new → v2: prompts/resources exchanged
+        [InlineData(2, 1, 1)] // new sidecar, OLD plugin → v1: tools-only (old peer keeps working)
+        [InlineData(1, 2, 1)] // old sidecar, new plugin → v1: tools-only
+        [InlineData(1, 1, 1)] // both old → v1
+        [InlineData(2, 0, 1)] // plugin omitted the field (legacy handshake) → treated as v1
+        [InlineData(3, 2, 2)] // a future-newer sidecar still negotiates down to the plugin's v2
+        public void NegotiateVersion_PicksTheHighestBothUnderstand(int local, int remote, int expected)
+        {
+            Assert.Equal(expected, IpcProtocol.NegotiateVersion(local, remote));
+        }
+
+        [Theory]
+        [InlineData(2, true)]
+        [InlineData(1, false)]
+        [InlineData(0, false)]
+        public void SupportsPromptsResources_GatesOnV2(int negotiated, bool expected)
+        {
+            Assert.Equal(expected, IpcProtocol.SupportsPromptsResources(negotiated));
+        }
+
+        [Fact]
+        public void PromptManifest_RoundTripsThroughTheSharedSerializer()
+        {
+            var manifest = new PromptManifestMessage
+            {
+                Revision = 4,
+                Prompts =
+                {
+                    new PromptDescriptor
+                    {
+                        Name = "level-design-brief",
+                        Title = "Level design brief",
+                        Description = "Drafts a brief",
+                        Role = "user",
+                        InputSchema = JsonNode.Parse("""{"type":"object","properties":{"theme":{"type":"string"}}}"""),
+                        Enabled = true,
+                        ExtensionId = "core",
+                        SchemaHash = "abc123",
+                    },
+                },
+            };
+
+            var json = JsonSerializer.Serialize(manifest, IpcProtocol.JsonOptions);
+            // camelCase discriminator + fields (the §A.1 NDJSON contract the C++ plugin must match).
+            Assert.Contains("\"type\":\"prompt-manifest\"", json);
+            Assert.Contains("\"role\":\"user\"", json);
+            Assert.Contains("\"inputSchema\"", json);
+
+            var back = JsonSerializer.Deserialize<PromptManifestMessage>(json, IpcProtocol.JsonOptions)!;
+            Assert.Equal(4, back.Revision);
+            var p = Assert.Single(back.Prompts);
+            Assert.Equal("level-design-brief", p.Name);
+            Assert.Equal("user", p.Role);
+            Assert.Equal("core", p.ExtensionId);
+            Assert.True(p.Enabled);
+        }
+
+        [Fact]
+        public void ResourceManifest_RoundTripsThroughTheSharedSerializer()
+        {
+            var manifest = new ResourceManifestMessage
+            {
+                Revision = 7,
+                Resources =
+                {
+                    new ResourceDescriptor
+                    {
+                        Uri = "unreal://project/levels",
+                        Name = "Project levels",
+                        Description = "All maps in the project",
+                        MimeType = "application/json",
+                        Enabled = true,
+                        ExtensionId = "core",
+                        SchemaHash = "def456",
+                    },
+                },
+            };
+
+            var json = JsonSerializer.Serialize(manifest, IpcProtocol.JsonOptions);
+            Assert.Contains("\"type\":\"resource-manifest\"", json);
+            Assert.Contains("\"uri\":\"unreal://project/levels\"", json);
+            Assert.Contains("\"mimeType\":\"application/json\"", json);
+
+            var back = JsonSerializer.Deserialize<ResourceManifestMessage>(json, IpcProtocol.JsonOptions)!;
+            Assert.Equal(7, back.Revision);
+            var r = Assert.Single(back.Resources);
+            Assert.Equal("unreal://project/levels", r.Uri);
+            Assert.Equal("application/json", r.MimeType);
+        }
+
+        [Fact]
+        public void PromptGetAndResponse_RoundTrip()
+        {
+            var get = new PromptGetMessage
+            {
+                RequestId = "r1",
+                Prompt = "level-design-brief",
+                Arguments = new JsonObject { ["theme"] = "forest" },
+                TimeoutMs = 12345,
+            };
+            var getJson = JsonSerializer.Serialize(get, IpcProtocol.JsonOptions);
+            Assert.Contains("\"type\":\"prompt-get\"", getJson);
+            var getBack = JsonSerializer.Deserialize<PromptGetMessage>(getJson, IpcProtocol.JsonOptions)!;
+            Assert.Equal("level-design-brief", getBack.Prompt);
+            Assert.Equal(12345, getBack.TimeoutMs);
+            Assert.Equal("forest", getBack.Arguments!["theme"]!.GetValue<string>());
+
+            var response = new PromptResponseMessage
+            {
+                RequestId = "r1",
+                Status = IpcProtocol.Status.Success,
+                Description = "ok",
+                Messages = new() { new PromptResponseEntry { Role = "user", Text = "Design a forest level." } },
+            };
+            var respJson = JsonSerializer.Serialize(response, IpcProtocol.JsonOptions);
+            Assert.Contains("\"type\":\"prompt-response\"", respJson);
+            var respBack = JsonSerializer.Deserialize<PromptResponseMessage>(respJson, IpcProtocol.JsonOptions)!;
+            Assert.Equal("r1", respBack.RequestId);
+            var entry = Assert.Single(respBack.Messages!);
+            Assert.Equal("user", entry.Role);
+            Assert.Equal("Design a forest level.", entry.Text);
+        }
+
+        [Fact]
+        public void ResourceReadAndResponse_RoundTrip_WithTextAndBlob()
+        {
+            var read = new ResourceReadMessage { RequestId = "r2", Uri = "unreal://project/levels", TimeoutMs = 5000 };
+            var readJson = JsonSerializer.Serialize(read, IpcProtocol.JsonOptions);
+            Assert.Contains("\"type\":\"resource-read\"", readJson);
+            var readBack = JsonSerializer.Deserialize<ResourceReadMessage>(readJson, IpcProtocol.JsonOptions)!;
+            Assert.Equal("unreal://project/levels", readBack.Uri);
+
+            var response = new ResourceResponseMessage
+            {
+                RequestId = "r2",
+                Status = IpcProtocol.Status.Success,
+                Contents = new()
+                {
+                    new ResourceContentEntry { Uri = "unreal://project/levels", MimeType = "application/json", Text = "[]" },
+                    new ResourceContentEntry { Uri = "unreal://thumb.png", MimeType = "image/png", Blob = "aGVsbG8=" },
+                },
+            };
+            var respJson = JsonSerializer.Serialize(response, IpcProtocol.JsonOptions);
+            Assert.Contains("\"type\":\"resource-response\"", respJson);
+
+            var respBack = JsonSerializer.Deserialize<ResourceResponseMessage>(respJson, IpcProtocol.JsonOptions)!;
+            Assert.Equal(2, respBack.Contents!.Count);
+            Assert.Equal("[]", respBack.Contents![0].Text);
+            Assert.Null(respBack.Contents![0].Blob);
+            Assert.Equal("aGVsbG8=", respBack.Contents![1].Blob);   // base64 binary rides intact
+            Assert.Null(respBack.Contents![1].Text);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **IPC v2** (`bridge/src/Ipc/` + C++): bump `IpcVersion` 1→2 with handshake **negotiation** (a v2↔v1 pair negotiates down to tools-only, so an old peer keeps working); add the `prompt-manifest`/`resource-manifest`, `prompt-get`/`resource-read`, `prompt-response`/`resource-response` discriminators + descriptor DTOs (§A.1). The generic `tool-cancel` is reused for both.
- **Generalized the bridge `ManifestRegistrar`** into a shared, kind-aware `ManifestRegistrarBase<TDescriptor>` (revision guard / reconnect reset / add-remove-changed-enabled diff) so P1/P2 instantiate prompt/resource registrars cheaply; the tool registrar derives from it with identical behaviour. `IpcClient` gains inbound manifest/response routing + outbound `GetPromptAsync`/`ReadResourceAsync` channels reusing a now-generic `PendingCallRegistry<TResponse>`.
- **Kind-aware extension-manager OnChanged**: the editor coordinator + runtime subsystem now fire all three `Push*Manifest()` on a rebuild, so P1/P2 add a registry + subscription with no new notify path. Shared re-entrancy guard / disabled-set / ExtensionId sort untouched (§A.2).
- **C++ scaffold** on `FUnrealMcpBridgeServer`: empty/gated `PushPromptManifest`/`PushResourceManifest` + error-fast-fail `HandlePromptGet`/`HandleResourceRead` stubs; IPC version negotiation. New types live in `UnrealMcpRuntime` (Model-A).

**Zero tool behaviour change** — this is the shared P0 groundwork; prompt/resource providers/builders/families are P1/P2, README is P3.

## Test plan
- [x] Bridge xUnit: **179/0** (165 baseline + 14 new — IPC v2 negotiation matrix + DTO round-trips incl. base64 blob)
- [x] Clean editor build (UBT, exit 0) — full testbed+plugin artifact wipe first (runtime-module change)
- [x] RunUAT BuildPlugin (Game+Editor, UnrealGame Shipping, `-WarningsAsErrors`): **BUILD SUCCESSFUL**, exit 0
- [x] Headless boot smoke: exit 0 + `[Unreal-MCP] plugin loaded`
- [x] `UnrealMcp.*` Automation: **failed:0, succeeded:277** (baseline 270 + 7 new `UnrealMcp.IpcVersion` specs; the existing extension specs still pass)
- [x] IPC version negotiation unit-tested both ends (.NET + C++ old/new pair compatibility)
- [x] Tool-path-unchanged: the full tool Automation suite (which drives the registry/dispatcher/bridge/sidecar wire path headlessly) + all existing bridge `ManifestRegistrar` xUnit tests pass unchanged against the generalized base. (Pure-infra refactor — not a tool-family task — so Suite 7 live-e2e is not gated per the profile.)

Closes #131