### PR TITLE
feat: custom MCP prompt registration (editor + runtime) + bridge ProxyPrompt + sample

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
@@ -5,7 +5,9 @@
 #include "UnrealMcpLog.h"
 #include "UnrealMcpCoreTools.h"
 #include "UnrealMcpRuntimeCoreTools.h"
+#include "UnrealMcpRuntimeCorePrompts.h"
 #include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpPromptRegistry.h"
 #include "Config/UnrealMcpConfig.h"
 #include "Dispatch/UnrealMcpGameThreadDispatcher.h"
 #include "Bridge/UnrealMcpBridgeServer.h"
@@ -72,8 +74,15 @@ void FUnrealMcpEditorCoordinator::Startup()
 	UnrealMcpScreenshotTools::Register(*Registry); // §10 editor screenshot subset (screenshot-viewport, screenshot-isolated)
 	UnrealMcpSourceTools::Register(*Registry); // §10 C++ source / script family (issue #18)
 
+	// §A.1 prompt registry (P1): the prompt sibling of the tool registry, built on the SAME Model A path. The
+	// core prompt family registers before the bridge starts accepting so the first prompt-manifest a v2 sidecar
+	// reads on handshake already includes it. The §8 config has EnabledTools/DisabledTools for tools but NO
+	// EnabledPrompts/DisabledPrompts field today, so no prompt filter is applied at boot (all-enabled default).
+	PromptRegistry = MakeUnique<FUnrealMcpPromptRegistry>();
+	UnrealMcpCorePrompts::Register(*PromptRegistry);
+
 	Dispatcher = MakeUnique<FUnrealMcpGameThreadDispatcher>();
-	BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(*Registry, *Dispatcher);
+	BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(*Registry, *Dispatcher, PromptRegistry.Get());
 
 	// Discover 3rd-party extension tool providers (§5) and merge them into the registry BEFORE the bridge
 	// starts accepting, so the first manifest a sidecar reads on handshake already includes them. Late
@@ -92,7 +101,9 @@ void FUnrealMcpEditorCoordinator::Startup()
 				BridgeServer->PushPromptManifest();
 				BridgeServer->PushResourceManifest();
 			}
-		});
+		},
+		/*InConfigPath*/ FString(),
+		PromptRegistry.Get()); // §A.2 kind-aware: also merge prompt-provider extensions into the prompt registry
 	ExtensionManager->Startup();
 
 	const FString ProjectPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
@@ -491,6 +502,7 @@ void FUnrealMcpEditorCoordinator::Shutdown()
 	}
 
 	Dispatcher.Reset();
+	PromptRegistry.Reset(); // after ExtensionManager (which holds a raw pointer to it) is torn down above
 	Registry.Reset();
 
 	// §12.6: drop the editor world resolver so no stale GEditor-capturing lambda survives teardown. The

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.h
@@ -6,6 +6,7 @@
 #include "CoreMinimal.h"
 
 class FUnrealMcpToolRegistry;
+class FUnrealMcpPromptRegistry;
 class FUnrealMcpGameThreadDispatcher;
 class FUnrealMcpBridgeServer;
 class FUnrealMcpSidecarManager;
@@ -46,6 +47,8 @@ public:
 
 private:
 	TUniquePtr<FUnrealMcpToolRegistry> Registry;
+	// §A.1 prompt registry (P1): built alongside the tool registry on the SAME Model A path.
+	TUniquePtr<FUnrealMcpPromptRegistry> PromptRegistry;
 	TUniquePtr<FUnrealMcpGameThreadDispatcher> Dispatcher;
 	TUniquePtr<FUnrealMcpBridgeServer> BridgeServer;
 	TUniquePtr<FUnrealMcpSidecarManager> SidecarManager;

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpPromptRegistrySpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpPromptRegistrySpec.cpp
@@ -1,0 +1,218 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "UnrealMcpRuntimeCorePrompts.h"
+#include "UnrealMcpPromptRegistry.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+
+/** Prompt registry + core-prompt specs (docs/ARCHITECTURE.md §A.1 / §A.2). */
+BEGIN_DEFINE_SPEC(FUnrealMcpPromptRegistrySpec, "UnrealMcp.Prompts.Registry",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FUnrealMcpPromptRegistrySpec)
+
+namespace
+{
+	// Spec-UNIQUE helper names (unity-build ODR). Find the prompt descriptor with the given name in a manifest.
+	TSharedPtr<FJsonObject> PromptSpecFindDescriptor(const TSharedPtr<FJsonObject>& Manifest, const FString& Name)
+	{
+		const TArray<TSharedPtr<FJsonValue>>* Prompts = nullptr;
+		if (!Manifest->TryGetArrayField(TEXT("prompts"), Prompts))
+			return nullptr;
+		for (const TSharedPtr<FJsonValue>& Value : *Prompts)
+		{
+			const TSharedPtr<FJsonObject> Obj = Value->AsObject();
+			if (Obj.IsValid() && Obj->GetStringField(TEXT("name")) == Name)
+				return Obj;
+		}
+		return nullptr;
+	}
+
+	/** A test-only prompt provider that registers one prompt under a given id/name. */
+	class FPromptSpecProvider
+	{
+	public:
+		static void RegisterInto(FUnrealMcpPromptRegistry& Registry, const FString& Name)
+		{
+			Registry.Prompt(Name)
+				.Title(TEXT("Spec prompt"))
+				.Description(TEXT("A spec fixture prompt."))
+				.Role(EUnrealMcpPromptRole::User)
+				.ParamString(TEXT("theme"), TEXT("a theme"), EUnrealMcpParamRequirement::Required)
+				.Handle([](const FUnrealMcpToolCall&) { return FUnrealMcpPromptResult::Success(TEXT("ok"), EUnrealMcpPromptRole::User); });
+		}
+	};
+}
+
+void FUnrealMcpPromptRegistrySpec::Define()
+{
+	Describe("core prompt registration", [this]()
+	{
+		It("registers level-design-brief and bumps the revision", [this]()
+		{
+			FUnrealMcpPromptRegistry Registry;
+			const int32 Before = Registry.GetRevision();
+			UnrealMcpCorePrompts::Register(Registry);
+			TestTrue(TEXT("has level-design-brief"), Registry.HasPrompt(TEXT("level-design-brief")));
+			TestEqual(TEXT("one prompt"), Registry.Num(), 1);
+			TestTrue(TEXT("revision bumped"), Registry.GetRevision() > Before);
+		});
+
+		It("executes with a theme arg -> templated User message (success)", [this]()
+		{
+			FUnrealMcpPromptRegistry Registry;
+			UnrealMcpCorePrompts::Register(Registry);
+
+			TSharedPtr<FJsonObject> Args = MakeShared<FJsonObject>();
+			Args->SetStringField(TEXT("theme"), TEXT("haunted forest"));
+			FUnrealMcpToolCall Call(Args);
+
+			const FUnrealMcpPromptResult Result = Registry.Execute(TEXT("level-design-brief"), Call);
+			TestTrue(TEXT("success"), Result.bSuccess);
+			TestEqual(TEXT("one message"), Result.Messages.Num(), 1);
+			if (Result.Messages.Num() == 1)
+			{
+				TestTrue(TEXT("role is User"), Result.Messages[0].Role == EUnrealMcpPromptRole::User);
+				TestTrue(TEXT("templated theme present"), Result.Messages[0].Text.Contains(TEXT("haunted forest")));
+			}
+		});
+
+		It("returns an error when theme is missing", [this]()
+		{
+			FUnrealMcpPromptRegistry Registry;
+			UnrealMcpCorePrompts::Register(Registry);
+			const FUnrealMcpPromptResult Result = Registry.Execute(TEXT("level-design-brief"), FUnrealMcpToolCall());
+			TestFalse(TEXT("not success"), Result.bSuccess);
+		});
+
+		It("returns an error for an unknown prompt", [this]()
+		{
+			FUnrealMcpPromptRegistry Registry;
+			const FUnrealMcpPromptResult Result = Registry.Execute(TEXT("does-not-exist"), FUnrealMcpToolCall());
+			TestFalse(TEXT("not success"), Result.bSuccess);
+		});
+	});
+
+	Describe("manifest JSON", [this]()
+	{
+		It("has type prompt-manifest, a revision, and the level-design-brief descriptor with role=user + required theme + a schema hash", [this]()
+		{
+			FUnrealMcpPromptRegistry Registry;
+			UnrealMcpCorePrompts::Register(Registry);
+
+			TSharedPtr<FJsonObject> Manifest = Registry.BuildManifestJson();
+			TestEqual(TEXT("type"), Manifest->GetStringField(TEXT("type")), FString(TEXT("prompt-manifest")));
+			TestEqual(TEXT("revision"), (int32)Manifest->GetNumberField(TEXT("revision")), Registry.GetRevision());
+
+			TSharedPtr<FJsonObject> Desc = PromptSpecFindDescriptor(Manifest, TEXT("level-design-brief"));
+			if (TestTrue(TEXT("descriptor present"), Desc.IsValid()))
+			{
+				TestEqual(TEXT("role"), Desc->GetStringField(TEXT("role")), FString(TEXT("user")));
+				TestFalse(TEXT("schema hash non-empty"), Desc->GetStringField(TEXT("schemaHash")).IsEmpty());
+
+				const TSharedPtr<FJsonObject>* InputSchema = nullptr;
+				if (TestTrue(TEXT("has inputSchema"), Desc->TryGetObjectField(TEXT("inputSchema"), InputSchema)))
+				{
+					const TArray<TSharedPtr<FJsonValue>>* Required = nullptr;
+					if (TestTrue(TEXT("inputSchema has required[]"), (*InputSchema)->TryGetArrayField(TEXT("required"), Required)))
+					{
+						bool bThemeRequired = false;
+						for (const TSharedPtr<FJsonValue>& V : *Required)
+						{
+							FString Field;
+							if (V->TryGetString(Field) && Field == TEXT("theme"))
+								bThemeRequired = true;
+						}
+						TestTrue(TEXT("theme is required"), bThemeRequired);
+					}
+				}
+			}
+		});
+
+		It("produces a stable schema hash for an unchanged prompt", [this]()
+		{
+			FUnrealMcpPromptRegistry A, B;
+			UnrealMcpCorePrompts::Register(A);
+			UnrealMcpCorePrompts::Register(B);
+			TestEqual(TEXT("same hash"),
+				A.Find(TEXT("level-design-brief"))->SchemaHash, B.Find(TEXT("level-design-brief"))->SchemaHash);
+		});
+	});
+
+	Describe("enable filter", [this]()
+	{
+		It("excludes a disabled prompt from the manifest and errors on Execute", [this]()
+		{
+			FUnrealMcpPromptRegistry Registry;
+			UnrealMcpCorePrompts::Register(Registry);
+
+			const int32 RevBefore = Registry.GetRevision();
+			TestTrue(TEXT("toggle changed"), Registry.SetPromptEnabled(TEXT("level-design-brief"), false));
+			TestTrue(TEXT("revision bumped on toggle"), Registry.GetRevision() > RevBefore);
+
+			TSharedPtr<FJsonObject> Manifest = Registry.BuildManifestJson();
+			TestFalse(TEXT("disabled prompt excluded from manifest"),
+				PromptSpecFindDescriptor(Manifest, TEXT("level-design-brief")).IsValid());
+
+			TSharedPtr<FJsonObject> Args = MakeShared<FJsonObject>();
+			Args->SetStringField(TEXT("theme"), TEXT("x"));
+			const FUnrealMcpPromptResult Result = Registry.Execute(TEXT("level-design-brief"), FUnrealMcpToolCall(Args));
+			TestFalse(TEXT("disabled prompt errors on Execute"), Result.bSuccess);
+		});
+	});
+
+	Describe("extension registration (§5 isolation, pure registry)", [this]()
+	{
+		It("registers a valid extension prompt under its id and bumps the revision", [this]()
+		{
+			FUnrealMcpPromptRegistry Registry;
+			const int32 RevBefore = Registry.GetRevision();
+			const FUnrealMcpExtensionRegistrationResult Result = Registry.RegisterExtension(
+				TEXT("com.spec.ext"), [](FUnrealMcpPromptRegistry& Reg)
+				{
+					FPromptSpecProvider::RegisterInto(Reg, TEXT("ext-prompt"));
+				});
+			TestEqual(TEXT("one entry registered"), Result.ToolsRegistered, 1);
+			TestEqual(TEXT("no errors"), Result.Errors.Num(), 0);
+			TestTrue(TEXT("ext prompt present"), Registry.HasPrompt(TEXT("ext-prompt")));
+			TestTrue(TEXT("revision bumped"), Registry.GetRevision() > RevBefore);
+			if (const FUnrealMcpRegisteredPrompt* P = Registry.Find(TEXT("ext-prompt")))
+				TestEqual(TEXT("stamped extension id"), P->ExtensionId, FString(TEXT("com.spec.ext")));
+		});
+
+		It("rejects a duplicate prompt name within an extension", [this]()
+		{
+			FUnrealMcpPromptRegistry Registry;
+			const FUnrealMcpExtensionRegistrationResult Result = Registry.RegisterExtension(
+				TEXT("com.spec.dup"), [](FUnrealMcpPromptRegistry& Reg)
+				{
+					FPromptSpecProvider::RegisterInto(Reg, TEXT("dup-prompt"));
+					FPromptSpecProvider::RegisterInto(Reg, TEXT("dup-prompt")); // duplicate -> rejected
+				});
+			TestEqual(TEXT("only one entry registered"), Result.ToolsRegistered, 1);
+			TestTrue(TEXT("a rejection was recorded"), Result.Errors.Num() >= 1);
+			TestEqual(TEXT("one prompt total"), Registry.Num(), 1);
+		});
+
+		It("drops an invalid prompt name", [this]()
+		{
+			FUnrealMcpPromptRegistry Registry;
+			const FUnrealMcpExtensionRegistrationResult Result = Registry.RegisterExtension(
+				TEXT("com.spec.bad"), [](FUnrealMcpPromptRegistry& Reg)
+				{
+					Reg.Prompt(TEXT("Bad Name")) // spaces + uppercase -> invalid kebab
+						.Title(TEXT("Bad"))
+						.Handle([](const FUnrealMcpToolCall&) { return FUnrealMcpPromptResult::Success(TEXT("ok"), EUnrealMcpPromptRole::User); });
+				});
+			TestEqual(TEXT("nothing registered"), Result.ToolsRegistered, 0);
+			TestTrue(TEXT("a drop was recorded"), Result.Errors.Num() >= 1);
+			TestEqual(TEXT("no prompts"), Registry.Num(), 0);
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.cpp
@@ -4,6 +4,7 @@
 #include "UnrealMcpBridgeServer.h"
 #include "UnrealMcpNdjson.h"
 #include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpPromptRegistry.h"
 #include "Dispatch/UnrealMcpGameThreadDispatcher.h"
 #include "UnrealMcpLog.h"
 
@@ -91,8 +92,10 @@ namespace
 	}
 }
 
-FUnrealMcpBridgeServer::FUnrealMcpBridgeServer(FUnrealMcpToolRegistry& InRegistry, FUnrealMcpGameThreadDispatcher& InDispatcher)
+FUnrealMcpBridgeServer::FUnrealMcpBridgeServer(FUnrealMcpToolRegistry& InRegistry, FUnrealMcpGameThreadDispatcher& InDispatcher,
+	FUnrealMcpPromptRegistry* InPromptRegistry)
 	: Registry(InRegistry)
+	, PromptRegistry(InPromptRegistry)
 	, Dispatcher(InDispatcher)
 {
 }
@@ -575,19 +578,136 @@ void FUnrealMcpBridgeServer::HandleToolCancel(const TSharedPtr<FJsonObject>& Mes
 
 void FUnrealMcpBridgeServer::HandlePromptGet(const TSharedPtr<FJsonObject>& Message)
 {
-	// SCAFFOLD (M16 P0, §A.1): no prompt registry is wired until P1. Answer with an error-status
-	// `prompt-response` correlated by requestId so the sidecar's pending call resolves (fail fast) rather
-	// than hanging to its timeout — exactly how a tool-call to an unknown tool fails. P1 replaces this body
-	// with a real dispatch through FUnrealMcpGameThreadDispatcher (game-thread, no-modal-UI, §4).
-	FString RequestId;
-	Message->TryGetStringField(TEXT("requestId"), RequestId);
+	// Do not start new work once teardown has begun (same contract as HandleToolCall): the continuation
+	// captures `this` and the body the prompt registry, both freed right after Shutdown().
+	if (bStopRequested)
+		return;
 
-	TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
-	Response->SetStringField(TEXT("type"), TypePromptResponse);
-	Response->SetStringField(TEXT("requestId"), RequestId);
-	Response->SetStringField(TEXT("status"), TEXT("error"));
-	Response->SetStringField(TEXT("error"), TEXT("Prompts are not implemented yet (scaffold)."));
-	SendMessage(Response);
+	FString RequestId, PromptName;
+	Message->TryGetStringField(TEXT("requestId"), RequestId);
+	Message->TryGetStringField(TEXT("prompt"), PromptName);
+
+	// Defensive: a prompt-get must never arrive on a tools-only build (the v2 gate blocks the manifest), but
+	// answer with a correlated error rather than dropping the pending call if PromptRegistry is null.
+	if (PromptRegistry == nullptr)
+	{
+		TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
+		Response->SetStringField(TEXT("type"), TypePromptResponse);
+		Response->SetStringField(TEXT("requestId"), RequestId);
+		Response->SetStringField(TEXT("status"), TEXT("error"));
+		Response->SetStringField(TEXT("error"), TEXT("Prompts are not implemented."));
+		SendMessage(Response);
+		return;
+	}
+
+	int32 TimeoutMs = DefaultToolTimeoutMs;
+	double TimeoutValue;
+	if (Message->TryGetNumberField(TEXT("timeoutMs"), TimeoutValue) && TimeoutValue > 0)
+		TimeoutMs = static_cast<int32>(TimeoutValue);
+
+	TSharedPtr<FJsonObject> Arguments = MakeShared<FJsonObject>();
+	const TSharedPtr<FJsonObject>* ArgsPtr;
+	if (Message->TryGetObjectField(TEXT("arguments"), ArgsPtr) && ArgsPtr->IsValid())
+		Arguments = *ArgsPtr;
+
+	// Per-call cancel flag (§4) — reuse the SAME CancelFlags map as tool-calls (the generic tool-cancel by
+	// requestId covers all kinds, §A.1). Shared ownership keeps it alive past the map-entry removal.
+	TSharedRef<FThreadSafeBool, ESPMode::ThreadSafe> CancelFlag = MakeShared<FThreadSafeBool, ESPMode::ThreadSafe>(false);
+
+	bool bTrackCancel = false;
+	if (!RequestId.IsEmpty())
+	{
+		FScopeLock Lock(&CancelMutex);
+		if (CancelFlags.Contains(RequestId))
+		{
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] duplicate prompt-get requestId '%s'; not tracking cancellation for it."), *RequestId);
+		}
+		else
+		{
+			CancelFlags.Add(RequestId, CancelFlag);
+			bTrackCancel = true;
+		}
+	}
+
+	FUnrealMcpToolCall Call(Arguments);
+	Call.CancelRequested = CancelFlag;
+
+	const FString CapturedPrompt = PromptName;
+	const FString CapturedRequestId = RequestId;
+	const bool bRemoveOnDone = bTrackCancel;
+	FUnrealMcpPromptRegistry* CapturedRegistry = PromptRegistry;
+
+	InFlightCalls.Increment();
+
+	// The dispatcher's Dispatch is hard-typed to FUnrealMcpToolResult, so marshal the prompt Execute onto the
+	// game thread through it and PACK the FUnrealMcpPromptResult into a FUnrealMcpToolResult transport: the
+	// Structured JSON carries { description, messages:[{role,text}] } and the bSuccess flag rides on
+	// FUnrealMcpToolResult::bSuccess / Message (the error reason). The .Next unpacks it into a prompt-response.
+	// This keeps the game-thread + per-call timeout + cancel semantics identical to the tool path with the
+	// least new surface (no second Dispatch overload / no parallel registry plumbing in the dispatcher).
+	Dispatcher.Dispatch(
+		Call,
+		[CapturedRegistry, CapturedPrompt](const FUnrealMcpToolCall& C) -> FUnrealMcpToolResult
+		{
+			const FUnrealMcpPromptResult PromptResult = CapturedRegistry->Execute(CapturedPrompt, C);
+
+			TSharedPtr<FJsonObject> Packed = MakeShared<FJsonObject>();
+			Packed->SetStringField(TEXT("description"), PromptResult.Description);
+			TArray<TSharedPtr<FJsonValue>> Messages;
+			for (const FUnrealMcpPromptMessage& Msg : PromptResult.Messages)
+			{
+				TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+				Entry->SetStringField(TEXT("role"), Msg.Role == EUnrealMcpPromptRole::Assistant ? TEXT("assistant") : TEXT("user"));
+				Entry->SetStringField(TEXT("text"), Msg.Text);
+				Messages.Add(MakeShared<FJsonValueObject>(Entry));
+			}
+			Packed->SetArrayField(TEXT("messages"), Messages);
+
+			// On success Message is unused; on error it carries the reason so the .Next surfaces it as `error`.
+			FUnrealMcpToolResult Transport = PromptResult.bSuccess
+				? FUnrealMcpToolResult::Success(FString(), Packed)
+				: FUnrealMcpToolResult::Error(PromptResult.Description);
+			Transport.Structured = Packed; // Error() drops Structured — re-attach so the .Next can read messages
+			return Transport;
+		},
+		FTimespan::FromMilliseconds(TimeoutMs))
+		.Next([this, CapturedRequestId, bRemoveOnDone](FUnrealMcpToolResult Result)
+		{
+			TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
+			Response->SetStringField(TEXT("type"), TypePromptResponse);
+			Response->SetStringField(TEXT("requestId"), CapturedRequestId);
+			Response->SetStringField(TEXT("status"), Result.bSuccess ? TEXT("success") : TEXT("error"));
+
+			if (Result.bSuccess)
+			{
+				// Unpack the transport: description + messages[] (the timeout path leaves Structured null —
+				// then this is an empty success, which the sidecar maps to a no-message prompt response).
+				if (Result.Structured.IsValid())
+				{
+					FString Description;
+					if (Result.Structured->TryGetStringField(TEXT("description"), Description))
+						Response->SetStringField(TEXT("description"), Description);
+
+					const TArray<TSharedPtr<FJsonValue>>* Messages = nullptr;
+					if (Result.Structured->TryGetArrayField(TEXT("messages"), Messages))
+						Response->SetArrayField(TEXT("messages"), *Messages);
+				}
+			}
+			else
+			{
+				// Result.Message carries the error reason (registry error, or the dispatcher's timeout error).
+				Response->SetStringField(TEXT("error"), Result.Message);
+			}
+
+			SendMessage(Response);
+
+			if (bRemoveOnDone)
+			{
+				FScopeLock Lock(&CancelMutex);
+				CancelFlags.Remove(CapturedRequestId);
+			}
+			InFlightCalls.Decrement();
+		});
 }
 
 void FUnrealMcpBridgeServer::HandleResourceRead(const TSharedPtr<FJsonObject>& Message)
@@ -744,12 +864,33 @@ void FUnrealMcpBridgeServer::PushResourceManifest()
 
 void FUnrealMcpBridgeServer::SendPromptManifestLocked()
 {
-	// SCAFFOLD (M16 P0, §A.1): no prompt registry exists until P1, so there is nothing to send. Also gated on a
-	// v2-negotiated link — a tools-only (v1) sidecar never receives a prompt-manifest. The real body (mirroring
-	// SendManifestLocked over the prompt registry's BuildManifestJson) lands with the P1 registry.
+	// Caller holds WriteMutex. Gated on a v2-negotiated link — a tools-only (v1) sidecar never receives a
+	// prompt-manifest (an old sidecar keeps working). Mirrors SendManifestLocked exactly over the prompt
+	// registry's BuildManifestJson. The same startup-stability argument applies (the prompt registry is built
+	// before the bridge accepts; dynamic re-registration marshals through the dispatcher).
 	if (NegotiatedIpcVersion < PromptsResourcesMinVersion)
 		return;
-	// (no-op: P1 fills this in)
+	if (PromptRegistry == nullptr)
+		return;
+
+	const TSharedPtr<FJsonObject> Manifest = PromptRegistry->BuildManifestJson();
+	const FString Json = SerializeCondensed(Manifest);
+	const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(Json);
+
+	FScopeLock ConnLock(&ConnectionMutex);
+	if (ClientSocket == nullptr)
+		return;
+
+	if (!TrySendFramedLocked(Framed))
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] prompt-manifest send failed mid-frame; dropping connection."));
+		SocketsPendingDestroy.Add(ClientSocket);
+		ClientSocket = nullptr;
+		bClientConnected = false;
+		bHandshakeOk = false;
+		bHeartbeatStop = true;
+		return;
+	}
 }
 
 void FUnrealMcpBridgeServer::SendResourceManifestLocked()

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.h
@@ -13,6 +13,7 @@
 #include <atomic>
 
 class FUnrealMcpToolRegistry;
+class FUnrealMcpPromptRegistry;
 class FUnrealMcpGameThreadDispatcher;
 class FTcpListener;
 class FSocket;
@@ -32,7 +33,10 @@ struct FIPv4Endpoint;
 class UNREALMCPRUNTIME_API FUnrealMcpBridgeServer : public FRunnable
 {
 public:
-	FUnrealMcpBridgeServer(FUnrealMcpToolRegistry& InRegistry, FUnrealMcpGameThreadDispatcher& InDispatcher);
+	// @p InPromptRegistry is nullable — a tools-only caller may omit it and the prompt path stays inert
+	// (SendPromptManifestLocked / HandlePromptGet guard on it). Both coordinators pass it (P1).
+	FUnrealMcpBridgeServer(FUnrealMcpToolRegistry& InRegistry, FUnrealMcpGameThreadDispatcher& InDispatcher,
+		FUnrealMcpPromptRegistry* InPromptRegistry = nullptr);
 	virtual ~FUnrealMcpBridgeServer() override;
 
 	/**
@@ -175,6 +179,9 @@ private:
 	void DrainInFlightCalls(FTimespan Grace);      // wait (bounded) for in-flight continuations to finish
 
 	FUnrealMcpToolRegistry& Registry;
+	// Nullable: the prompt registry (P1). When null the prompt path is inert (SendPromptManifestLocked /
+	// HandlePromptGet guard on it) so a tools-only build / test still compiles + links.
+	FUnrealMcpPromptRegistry* PromptRegistry = nullptr;
 	FUnrealMcpGameThreadDispatcher& Dispatcher;
 
 	FTcpListener* Listener = nullptr;

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Extensions/UnrealMcpExtensionManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Extensions/UnrealMcpExtensionManager.cpp
@@ -4,7 +4,9 @@
 #include "Extensions/UnrealMcpExtensionManager.h"
 
 #include "IUnrealMcpToolProvider.h"
+#include "IUnrealMcpPromptProvider.h"
 #include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpPromptRegistry.h"
 #include "UnrealMcpLog.h"
 
 #include "Features/IModularFeatures.h"
@@ -68,16 +70,19 @@ namespace
 }
 
 FUnrealMcpExtensionManager::FUnrealMcpExtensionManager(
-	FUnrealMcpToolRegistry& InRegistry, TFunction<void()> InOnChanged, const FString& InConfigPath)
+	FUnrealMcpToolRegistry& InRegistry, TFunction<void()> InOnChanged, const FString& InConfigPath,
+	FUnrealMcpPromptRegistry* InPromptRegistry)
 	: Registry(InRegistry)
+	, PromptRegistry(InPromptRegistry)
 	, OnChanged(MoveTemp(InOnChanged))
 {
 	ConfigPath = InConfigPath.IsEmpty()
 		? FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("Config"), TEXT("UnrealMCP"), TEXT("Extensions.json"))
 		: InConfigPath;
 
-	// Default provider source: the live modular-feature registry. Overridable for deterministic tests.
+	// Default provider sources: the live modular-feature registry. Overridable for deterministic tests.
 	ProviderSource = [this]() { return GatherProviders(); };
+	PromptProviderSource = [this]() { return GatherPromptProviders(); };
 }
 
 FUnrealMcpExtensionManager::~FUnrealMcpExtensionManager()
@@ -143,6 +148,12 @@ TArray<IUnrealMcpToolProvider*> FUnrealMcpExtensionManager::GatherProviders() co
 {
 	return IModularFeatures::Get().GetModularFeatureImplementations<IUnrealMcpToolProvider>(
 		IUnrealMcpToolProvider::GetModularFeatureName());
+}
+
+TArray<IUnrealMcpPromptProvider*> FUnrealMcpExtensionManager::GatherPromptProviders() const
+{
+	return IModularFeatures::Get().GetModularFeatureImplementations<IUnrealMcpPromptProvider>(
+		IUnrealMcpPromptProvider::GetModularFeatureName());
 }
 
 void FUnrealMcpExtensionManager::Rebuild(bool bNotify)
@@ -243,7 +254,14 @@ void FUnrealMcpExtensionManager::RebuildFromProviders(const TArray<IUnrealMcpToo
 		Records.Add(MoveTemp(Record));
 	}
 
-	// 4. Notify the owner to re-push the manifest (§2.2).
+	// 3.5 (§A.2) PROMPT pass: merge prompt-provider extensions into the prompt registry, gated by the SAME
+	//     DisabledExtensions set / IsValidExtensionId / ExtensionId sort. Runs inside the same re-entrancy guard
+	//     so the single OnChanged below covers BOTH passes (no duplicated notify, no second guard). No-op when
+	//     PromptRegistry == nullptr. The tool Records[] above stay tool-centric (the §7 UI is P4) — this is purely
+	//     additive: it does not touch Records / RegisteredExtensionIds, only the prompt registry + its own id list.
+	RebuildPromptProviders();
+
+	// 4. Notify the owner to re-push the manifest(s) (§2.2 / §A.1 — tool + prompt + resource).
 	if (bNotify && OnChanged)
 		OnChanged();
 
@@ -259,11 +277,81 @@ void FUnrealMcpExtensionManager::RebuildFromProviders(const TArray<IUnrealMcpToo
 	}
 }
 
+void FUnrealMcpExtensionManager::RebuildPromptProviders()
+{
+	// §A.2 prompt pass — the prompt analog of the tool pass in RebuildFromProviders, sharing the same
+	// DisabledExtensions set, IsValidExtensionId discipline, and ExtensionId sort. Called from inside the
+	// re-entrancy guard, so it never opens a nested registry scope across the two passes (the prompt registry's
+	// own RegisterExtension scope is independent of the tool registry's and is opened+closed here per provider).
+	if (PromptRegistry == nullptr)
+		return;
+
+	// 1. Clear the previous prompt-extension contribution (core prompts are untouched: only ids we registered).
+	for (const FString& Id : RegisteredPromptExtensionIds)
+		PromptRegistry->RemovePromptsForExtension(Id);
+	RegisteredPromptExtensionIds.Reset();
+
+	const TArray<IUnrealMcpPromptProvider*> Providers = PromptProviderSource ? PromptProviderSource() : GatherPromptProviders();
+
+	// 2. Deterministic ordering by ExtensionId (StableSort keeps registration order as the tie-break).
+	TArray<IUnrealMcpPromptProvider*> Sorted;
+	Sorted.Reserve(Providers.Num());
+	for (IUnrealMcpPromptProvider* P : Providers)
+	{
+		if (P != nullptr)
+			Sorted.Add(P);
+	}
+	Sorted.StableSort([](const IUnrealMcpPromptProvider& A, const IUnrealMcpPromptProvider& B)
+	{
+		return A.GetExtensionId() < B.GetExtensionId();
+	});
+
+	// 3. Register each ENABLED + valid + non-duplicate provider's prompts.
+	TSet<FString> SeenIds;
+	for (IUnrealMcpPromptProvider* Provider : Sorted)
+	{
+		const FString Id = Provider->GetExtensionId();
+
+		// 3a. Validate the id (reuse the SAME helper as the tool pass — never register under "core"/garbage).
+		FString IdError;
+		if (!IsValidExtensionId(Id, IdError))
+		{
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] prompt extension rejected: %s — its prompts were skipped."), *IdError);
+			continue;
+		}
+
+		// 3b. Duplicate id (first-sorted wins). The tool pass already records the public Record for this id; the
+		//     prompt pass only needs to avoid double-registration / a clobbered removal key.
+		if (SeenIds.Contains(Id))
+		{
+			UE_LOG(LogUnrealMcp, Warning,
+				TEXT("[Unreal-MCP] duplicate prompt extension id '%s' — another provider already registered it; this provider's prompts were skipped."),
+				*Id);
+			continue;
+		}
+		SeenIds.Add(Id);
+
+		// 3c. Gated by the SAME DisabledExtensions set as tools (one toggle disables an extension's tools AND prompts).
+		if (DisabledExtensions.Contains(Id))
+			continue;
+
+		PromptRegistry->RegisterExtension(Id, [Provider](FUnrealMcpPromptRegistry& Reg) { Provider->RegisterPrompts(Reg); });
+		RegisteredPromptExtensionIds.AddUnique(Id);
+	}
+}
+
 void FUnrealMcpExtensionManager::OnFeatureRegistered(const FName& Type, IModularFeature* /*Feature*/)
 {
+	// The single OnModularFeatureRegistered subscription receives EVERY feature type; rebuild when the type is
+	// the tool OR (§A.2) the prompt provider feature. A rebuild runs both passes + the single OnChanged.
 	if (Type == IUnrealMcpToolProvider::GetModularFeatureName())
 	{
 		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] tool provider registered; rebuilding extensions."));
+		Rebuild(/*bNotify*/ true);
+	}
+	else if (PromptRegistry != nullptr && Type == IUnrealMcpPromptProvider::GetModularFeatureName())
+	{
+		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] prompt provider registered; rebuilding extensions."));
 		Rebuild(/*bNotify*/ true);
 	}
 }
@@ -273,6 +361,11 @@ void FUnrealMcpExtensionManager::OnFeatureUnregistered(const FName& Type, IModul
 	if (Type == IUnrealMcpToolProvider::GetModularFeatureName())
 	{
 		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] tool provider unregistered; rebuilding extensions."));
+		Rebuild(/*bNotify*/ true);
+	}
+	else if (PromptRegistry != nullptr && Type == IUnrealMcpPromptProvider::GetModularFeatureName())
+	{
+		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] prompt provider unregistered; rebuilding extensions."));
 		Rebuild(/*bNotify*/ true);
 	}
 }

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Extensions/UnrealMcpExtensionManager.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Extensions/UnrealMcpExtensionManager.h
@@ -9,7 +9,9 @@
 #include "UObject/NameTypes.h"
 
 class FUnrealMcpToolRegistry;
+class FUnrealMcpPromptRegistry;
 class IUnrealMcpToolProvider;
+class IUnrealMcpPromptProvider;
 class IModularFeature;
 
 /**
@@ -58,11 +60,15 @@ class UNREALMCPRUNTIME_API FUnrealMcpExtensionManager
 {
 public:
 	/**
-	 * @param InRegistry   the plugin-owned registry to merge extension tools into (core tools must already be registered).
-	 * @param InOnChanged  fired after every rebuild so the owner can re-push the manifest (no-op when disconnected).
-	 * @param InConfigPath absolute path of the disabledExtensions[] JSON file; empty => default under the project Saved dir.
+	 * @param InRegistry        the plugin-owned tool registry to merge extension tools into (core tools must already be registered).
+	 * @param InOnChanged       fired after every rebuild so the owner can re-push the manifest(s) (no-op when disconnected).
+	 * @param InConfigPath      absolute path of the disabledExtensions[] JSON file; empty => default under the project Saved dir.
+	 * @param InPromptRegistry  OPTIONAL (§A.2) prompt registry to ALSO merge prompt-provider extensions into. Nullable —
+	 *                          when null the manager is tool-only (existing call sites keep compiling). Gated by the SAME
+	 *                          DisabledExtensions set / re-entrancy guard / ExtensionId sort as the tool pass.
 	 */
-	FUnrealMcpExtensionManager(FUnrealMcpToolRegistry& InRegistry, TFunction<void()> InOnChanged, const FString& InConfigPath = FString());
+	FUnrealMcpExtensionManager(FUnrealMcpToolRegistry& InRegistry, TFunction<void()> InOnChanged, const FString& InConfigPath = FString(),
+		FUnrealMcpPromptRegistry* InPromptRegistry = nullptr);
 	~FUnrealMcpExtensionManager();
 
 	/** Load persisted disabled set, subscribe to modular-feature events, and run the initial rebuild. */
@@ -86,14 +92,23 @@ public:
 	/** Rebuild from an explicit provider list — deterministic, no global IModularFeatures (test seam). */
 	void RebuildFromProviders(const TArray<IUnrealMcpToolProvider*>& Providers, bool bNotify = true);
 
-	/** Override the provider source used by Startup/SetExtensionEnabled rebuilds (test seam; default = live discovery). */
+	/** Override the TOOL provider source used by Startup/SetExtensionEnabled rebuilds (test seam; default = live discovery). */
 	void SetProviderSourceForTesting(TFunction<TArray<IUnrealMcpToolProvider*>()> InSource) { ProviderSource = MoveTemp(InSource); }
+
+	/** Override the PROMPT provider source used by rebuilds (§A.2 test seam; default = live discovery). */
+	void SetPromptProviderSourceForTesting(TFunction<TArray<IUnrealMcpPromptProvider*>()> InSource) { PromptProviderSource = MoveTemp(InSource); }
 
 private:
 	/** Rebuild from the current ProviderSource (live IModularFeatures discovery by default). */
 	void Rebuild(bool bNotify);
 
 	TArray<IUnrealMcpToolProvider*> GatherProviders() const;
+	TArray<IUnrealMcpPromptProvider*> GatherPromptProviders() const;
+
+	/** §A.2 prompt pass of a rebuild: clear previous prompt-extension contributions, then merge enabled+valid+
+	 *  non-duplicate prompt providers into PromptRegistry (same DisabledExtensions / IsValidExtensionId / sort).
+	 *  No-op when PromptRegistry == nullptr. Driven from RebuildFromProviders so the single OnChanged covers both. */
+	void RebuildPromptProviders();
 
 	void OnFeatureRegistered(const FName& Type, IModularFeature* Feature);
 	void OnFeatureUnregistered(const FName& Type, IModularFeature* Feature);
@@ -102,14 +117,19 @@ private:
 	void SaveConfig() const;
 
 	FUnrealMcpToolRegistry& Registry;
+	// §A.2: nullable prompt registry. When set, RebuildFromProviders also runs a prompt pass.
+	FUnrealMcpPromptRegistry* PromptRegistry = nullptr;
 	TFunction<void()> OnChanged;
 	FString ConfigPath;
 	TFunction<TArray<IUnrealMcpToolProvider*>()> ProviderSource;
+	TFunction<TArray<IUnrealMcpPromptProvider*>()> PromptProviderSource;
 
 	TArray<FUnrealMcpExtensionRecord> Records;
 	TSet<FString> DisabledExtensions;
 	/** Extension ids that currently contributed tools, so a rebuild can remove exactly those before re-registering. */
 	TArray<FString> RegisteredExtensionIds;
+	/** §A.2: extension ids that currently contributed prompts (the prompt-pass analog of RegisteredExtensionIds). */
+	TArray<FString> RegisteredPromptExtensionIds;
 
 	FDelegateHandle RegisteredHandle;
 	FDelegateHandle UnregisteredHandle;

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Prompts/UnrealMcpCorePrompts.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Prompts/UnrealMcpCorePrompts.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpRuntimeCorePrompts.h"
+#include "UnrealMcpPromptRegistry.h"
+
+/**
+ * The core `level-design-brief` prompt (docs/ARCHITECTURE.md §A.1). A self-contained, engine-call-free
+ * prompt that templates a level-design brief from a required `theme` argument — the prompt analog of the
+ * `ping` core tool (the end-to-end smoke target for the v2 prompt path:
+ * MCP server -> SignalR -> sidecar -> IPC -> UE plugin (game thread) -> back).
+ */
+namespace UnrealMcpCorePrompts
+{
+	UNREALMCPRUNTIME_API void Register(FUnrealMcpPromptRegistry& Registry)
+	{
+		Registry.Prompt(TEXT("level-design-brief"))
+			.Title(TEXT("Level Design Brief"))
+			.Description(TEXT("Generate a level design brief for a themed level — layout, pacing, key "
+			                  "encounters, and mood — from a single 'theme' argument."))
+			.Role(EUnrealMcpPromptRole::User)
+			.ParamString(TEXT("theme"), TEXT("The level theme (e.g. 'abandoned space station', 'haunted forest')."), EUnrealMcpParamRequirement::Required)
+			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpPromptResult
+			{
+				// Runs ON the game thread (the dispatcher guarantees it, §4). No engine calls — pure templating.
+				const FString Theme = Call.GetString(TEXT("theme"));
+				if (Theme.IsEmpty())
+					return FUnrealMcpPromptResult::Error(TEXT("theme is required."));
+
+				const FString Text = FString::Printf(
+					TEXT("Draft a level design brief for a \"%s\"-themed level. Cover layout, pacing, key encounters, and mood."),
+					*Theme);
+
+				const FString Description = FString::Printf(TEXT("Level design brief for a \"%s\"-themed level."), *Theme);
+				return FUnrealMcpPromptResult::Success(Text, EUnrealMcpPromptRole::User, Description);
+			});
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Prompts/UnrealMcpPromptRegistry.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Prompts/UnrealMcpPromptRegistry.cpp
@@ -1,0 +1,453 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpPromptRegistry.h"
+#include "UnrealMcpLog.h"
+#include "Misc/SecureHash.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
+
+// --- Schema building ------------------------------------------------------------------------------
+// The §3.2 schema generation is VERBATIM identical to the tool registry's. The tool file's anonymous-namespace
+// helpers (MakeTypedSchema / MakeVectorSchema / SerializeStable) cannot be reused across translation units in a
+// unity build without an ODR collision, so the prompt registry gets family-UNIQUE copies (Prompt*-prefixed).
+
+namespace
+{
+	TSharedPtr<FJsonObject> PromptMakeTypedSchema(const FString& JsonType, const FString& Description)
+	{
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), JsonType);
+		if (!Description.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Description);
+		return Schema;
+	}
+
+	/** A {x,y,z: number} object schema (the §3.2 FVector mapping). */
+	TSharedPtr<FJsonObject> PromptMakeVectorSchema(const FString& Description)
+	{
+		TSharedPtr<FJsonObject> Props = MakeShared<FJsonObject>();
+		Props->SetObjectField(TEXT("x"), PromptMakeTypedSchema(TEXT("number"), FString()));
+		Props->SetObjectField(TEXT("y"), PromptMakeTypedSchema(TEXT("number"), FString()));
+		Props->SetObjectField(TEXT("z"), PromptMakeTypedSchema(TEXT("number"), FString()));
+
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), TEXT("object"));
+		if (!Description.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Description);
+		Schema->SetObjectField(TEXT("properties"), Props);
+		return Schema;
+	}
+
+	FString PromptSerializeStable(const TSharedPtr<FJsonObject>& Object)
+	{
+		FString Out;
+		TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =
+			TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&Out);
+		FJsonSerializer::Serialize(Object.ToSharedRef(), Writer);
+		return Out;
+	}
+
+	/** The wire string for an EUnrealMcpPromptRole ("user" | "assistant"). */
+	const TCHAR* PromptRoleToString(EUnrealMcpPromptRole Role)
+	{
+		return Role == EUnrealMcpPromptRole::Assistant ? TEXT("assistant") : TEXT("user");
+	}
+}
+
+TSharedPtr<FJsonObject> FUnrealMcpRegisteredPrompt::BuildInputSchema() const
+{
+	// Identical to FUnrealMcpRegisteredTool::BuildInputSchema (§3.2): object / properties / required.
+	TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+	Schema->SetStringField(TEXT("type"), TEXT("object"));
+
+	TSharedPtr<FJsonObject> Properties = MakeShared<FJsonObject>();
+	TArray<TSharedPtr<FJsonValue>> Required;
+
+	for (const FUnrealMcpParamSpec& Param : Params)
+	{
+		TSharedPtr<FJsonObject> ParamSchema = Param.ObjectSchema.IsValid()
+			? Param.ObjectSchema
+			: PromptMakeTypedSchema(Param.JsonType, Param.Description);
+
+		Properties->SetObjectField(Param.Name, ParamSchema);
+		if (Param.Requirement == EUnrealMcpParamRequirement::Required)
+			Required.Add(MakeShared<FJsonValueString>(Param.Name));
+	}
+
+	Schema->SetObjectField(TEXT("properties"), Properties);
+	if (Required.Num() > 0)
+		Schema->SetArrayField(TEXT("required"), Required);
+	return Schema;
+}
+
+TSharedPtr<FJsonObject> FUnrealMcpRegisteredPrompt::ToDescriptorJson() const
+{
+	// Mirrors the tool descriptor minus the tool-only hint/skill fields, PLUS the `role` string field (§A.1).
+	TSharedPtr<FJsonObject> Desc = MakeShared<FJsonObject>();
+	Desc->SetStringField(TEXT("name"), Name);
+	Desc->SetStringField(TEXT("title"), Title);
+	Desc->SetStringField(TEXT("description"), Description);
+	Desc->SetStringField(TEXT("role"), PromptRoleToString(Role));
+	Desc->SetObjectField(TEXT("inputSchema"), BuildInputSchema());
+	Desc->SetBoolField(TEXT("enabled"), bEnabled);
+	Desc->SetStringField(TEXT("extensionId"), ExtensionId);
+	Desc->SetStringField(TEXT("schemaHash"), SchemaHash);
+	return Desc;
+}
+
+// --- FUnrealMcpPromptBuilder ----------------------------------------------------------------------
+
+FUnrealMcpPromptBuilder::FUnrealMcpPromptBuilder(FUnrealMcpPromptRegistry& InRegistry, const FString& InName)
+	: Registry(InRegistry)
+{
+	Prompt.Name = InName;
+}
+
+FUnrealMcpPromptBuilder& FUnrealMcpPromptBuilder::Title(const FString& InTitle) { Prompt.Title = InTitle; return *this; }
+FUnrealMcpPromptBuilder& FUnrealMcpPromptBuilder::Description(const FString& InDescription) { Prompt.Description = InDescription; return *this; }
+FUnrealMcpPromptBuilder& FUnrealMcpPromptBuilder::Role(EUnrealMcpPromptRole InRole) { Prompt.Role = InRole; return *this; }
+
+FUnrealMcpPromptBuilder& FUnrealMcpPromptBuilder::ParamString(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req)
+{
+	Prompt.Params.Add(FUnrealMcpParamSpec{ Name, TEXT("string"), Desc, Req, nullptr });
+	return *this;
+}
+FUnrealMcpPromptBuilder& FUnrealMcpPromptBuilder::ParamInt(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req)
+{
+	Prompt.Params.Add(FUnrealMcpParamSpec{ Name, TEXT("integer"), Desc, Req, nullptr });
+	return *this;
+}
+FUnrealMcpPromptBuilder& FUnrealMcpPromptBuilder::ParamNumber(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req)
+{
+	Prompt.Params.Add(FUnrealMcpParamSpec{ Name, TEXT("number"), Desc, Req, nullptr });
+	return *this;
+}
+FUnrealMcpPromptBuilder& FUnrealMcpPromptBuilder::ParamBool(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req)
+{
+	Prompt.Params.Add(FUnrealMcpParamSpec{ Name, TEXT("boolean"), Desc, Req, nullptr });
+	return *this;
+}
+FUnrealMcpPromptBuilder& FUnrealMcpPromptBuilder::ParamVector(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req)
+{
+	FUnrealMcpParamSpec Spec{ Name, TEXT("object"), Desc, Req, PromptMakeVectorSchema(Desc) };
+	Prompt.Params.Add(Spec);
+	return *this;
+}
+FUnrealMcpPromptBuilder& FUnrealMcpPromptBuilder::Param(const FString& Name, const FString& JsonType, const FString& Desc, EUnrealMcpParamRequirement Req, TSharedPtr<FJsonObject> CustomSchema)
+{
+	Prompt.Params.Add(FUnrealMcpParamSpec{ Name, JsonType, Desc, Req, CustomSchema });
+	return *this;
+}
+FUnrealMcpPromptBuilder& FUnrealMcpPromptBuilder::ExtensionId(const FString& InExtensionId) { Prompt.ExtensionId = InExtensionId; return *this; }
+
+void FUnrealMcpPromptBuilder::Handle(FUnrealMcpPromptHandler InHandler)
+{
+	Prompt.Handler = MoveTemp(InHandler);
+	Registry.Commit(MoveTemp(Prompt));
+}
+
+// --- FUnrealMcpPromptRegistry ---------------------------------------------------------------------
+
+FUnrealMcpPromptBuilder FUnrealMcpPromptRegistry::Prompt(const FString& Name)
+{
+	return FUnrealMcpPromptBuilder(*this, Name);
+}
+
+FString FUnrealMcpPromptRegistry::ComputeSchemaHash(const FUnrealMcpRegisteredPrompt& InPrompt)
+{
+	// Hash the canonicalized descriptor MINUS the enabled flag (mirror the tool registry). Reuse
+	// ToDescriptorJson and drop "enabled" + "schemaHash" so the hash is stable regardless of those fields.
+	FUnrealMcpRegisteredPrompt Copy = InPrompt;
+	Copy.SchemaHash.Empty();
+	TSharedPtr<FJsonObject> Desc = Copy.ToDescriptorJson();
+	Desc->RemoveField(TEXT("enabled"));
+	Desc->RemoveField(TEXT("schemaHash"));
+
+	const FString Canonical = PromptSerializeStable(Desc);
+	FSHA1 Sha;
+	const FTCHARToUTF8 Utf8(*Canonical);
+	Sha.Update(reinterpret_cast<const uint8*>(Utf8.Get()), Utf8.Length());
+	Sha.Final();
+	uint8 Digest[20];
+	Sha.GetHash(Digest);
+	return FString(TEXT("sha1:")) + BytesToHex(Digest, 20).ToLower();
+}
+
+bool FUnrealMcpPromptRegistry::IsValidPromptName(const FString& Name)
+{
+	// Same kebab rule as the tool registry (no leading/trailing/doubled hyphen; lowercase letters/digits).
+	if (Name.IsEmpty())
+		return false;
+
+	bool bPrevHyphen = false;
+	const int32 Len = Name.Len();
+	for (int32 i = 0; i < Len; ++i)
+	{
+		const TCHAR C = Name[i];
+		const bool bLower = (C >= TEXT('a') && C <= TEXT('z'));
+		const bool bDigit = (C >= TEXT('0') && C <= TEXT('9'));
+		const bool bHyphen = (C == TEXT('-'));
+		if (!bLower && !bDigit && !bHyphen)
+			return false;
+		if (bHyphen && (i == 0 || i == Len - 1 || bPrevHyphen))
+			return false;
+		bPrevHyphen = bHyphen;
+	}
+	return true;
+}
+
+bool FUnrealMcpPromptRegistry::ValidatePrompt(const FUnrealMcpRegisteredPrompt& InPrompt, FString& OutError)
+{
+	if (!IsValidPromptName(InPrompt.Name))
+	{
+		OutError = FString::Printf(
+			TEXT("invalid prompt name '%s' (must be non-empty kebab-case: lowercase letters, digits, single internal hyphens)"),
+			*InPrompt.Name);
+		return false;
+	}
+
+	if (!InPrompt.Handler)
+	{
+		OutError = FString::Printf(TEXT("prompt '%s' has no bound handler"), *InPrompt.Name);
+		return false;
+	}
+
+	static const TCHAR* const KnownTypes[] = { TEXT("string"), TEXT("integer"), TEXT("number"), TEXT("boolean"), TEXT("object"), TEXT("array") };
+	TSet<FString> SeenParams;
+	for (const FUnrealMcpParamSpec& Param : InPrompt.Params)
+	{
+		if (Param.Name.IsEmpty())
+		{
+			OutError = FString::Printf(TEXT("prompt '%s' has a parameter with an empty name (malformed schema)"), *InPrompt.Name);
+			return false;
+		}
+
+		bool bKnown = false;
+		for (const TCHAR* const Known : KnownTypes)
+		{
+			if (Param.JsonType == Known) { bKnown = true; break; }
+		}
+		if (!bKnown)
+		{
+			OutError = FString::Printf(TEXT("prompt '%s' parameter '%s' has unknown JSON type '%s' (malformed schema)"),
+				*InPrompt.Name, *Param.Name, *Param.JsonType);
+			return false;
+		}
+
+		if ((Param.JsonType == TEXT("object") || Param.JsonType == TEXT("array")) && !Param.ObjectSchema.IsValid())
+		{
+			OutError = FString::Printf(TEXT("prompt '%s' %s parameter '%s' has no schema (malformed schema)"),
+				*InPrompt.Name, *Param.JsonType, *Param.Name);
+			return false;
+		}
+
+		bool bAlreadyPresent = false;
+		SeenParams.Add(Param.Name, &bAlreadyPresent);
+		if (bAlreadyPresent)
+		{
+			OutError = FString::Printf(TEXT("prompt '%s' declares duplicate parameter '%s' (malformed schema)"),
+				*InPrompt.Name, *Param.Name);
+			return false;
+		}
+	}
+	return true;
+}
+
+void FUnrealMcpPromptRegistry::Commit(FUnrealMcpRegisteredPrompt&& InPrompt)
+{
+	if (bExtensionScope)
+	{
+		// Extensions are untrusted: stamp the owning id, validate, and dedup (§5).
+		InPrompt.ExtensionId = ScopeExtensionId;
+
+		FString Error;
+		if (!ValidatePrompt(InPrompt, Error))
+		{
+			ScopeErrors.Add(Error);
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] extension '%s': %s — entry dropped."), *ScopeExtensionId, *Error);
+			return;
+		}
+
+		if (const FUnrealMcpRegisteredPrompt* Existing = Prompts.Find(InPrompt.Name))
+		{
+			FString Rejection;
+			if (Existing->ExtensionId == TEXT("core"))
+			{
+				Rejection = FString::Printf(
+					TEXT("prompt '%s' rejected: name collides with a built-in core prompt (extensions may not shadow core)"),
+					*InPrompt.Name);
+			}
+			else if (Existing->ExtensionId == ScopeExtensionId)
+			{
+				Rejection = FString::Printf(
+					TEXT("prompt '%s' rejected: this extension already declared a prompt with that name (duplicate within the extension)"),
+					*InPrompt.Name);
+			}
+			else
+			{
+				Rejection = FString::Printf(
+					TEXT("prompt '%s' rejected: name already registered by extension '%s' (first-wins by ExtensionId sort)"),
+					*InPrompt.Name, *Existing->ExtensionId);
+			}
+			ScopeErrors.Add(Rejection);
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] extension '%s': %s"), *ScopeExtensionId, *Rejection);
+			return;
+		}
+
+		++ScopePromptsRegistered;
+	}
+
+	InPrompt.SchemaHash = ComputeSchemaHash(InPrompt);
+	const FString Name = InPrompt.Name;
+	// §7/§8 retention: a (re-)registered prompt inherits the retained whitelist/blocklist immediately.
+	InPrompt.bEnabled = ShouldPromptBeEnabled(Name);
+	Prompts.Add(Name, MoveTemp(InPrompt));
+	++Revision;
+	UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] registered prompt '%s' (revision %d)."), *Name, Revision);
+}
+
+FUnrealMcpExtensionRegistrationResult FUnrealMcpPromptRegistry::RegisterExtension(
+	const FString& ExtensionId, TFunctionRef<void(FUnrealMcpPromptRegistry&)> RegisterFn)
+{
+	checkf(!bExtensionScope, TEXT("FUnrealMcpPromptRegistry::RegisterExtension does not support nested scopes."));
+
+	bExtensionScope = true;
+	ScopeExtensionId = ExtensionId;
+	ScopePromptsRegistered = 0;
+	ScopeErrors.Reset();
+
+	RegisterFn(*this);
+
+	FUnrealMcpExtensionRegistrationResult Result;
+	Result.ToolsRegistered = ScopePromptsRegistered; // reused struct: count means "entries registered"
+	Result.Errors = MoveTemp(ScopeErrors);
+
+	bExtensionScope = false;
+	ScopeExtensionId.Empty();
+	ScopePromptsRegistered = 0;
+	ScopeErrors.Reset();
+	return Result;
+}
+
+int32 FUnrealMcpPromptRegistry::RemovePromptsForExtension(const FString& ExtensionId)
+{
+	TArray<FString> ToRemove;
+	for (const TPair<FString, FUnrealMcpRegisteredPrompt>& Pair : Prompts)
+	{
+		if (Pair.Value.ExtensionId == ExtensionId)
+			ToRemove.Add(Pair.Key);
+	}
+	for (const FString& Name : ToRemove)
+		Prompts.Remove(Name);
+	if (ToRemove.Num() > 0)
+		++Revision;
+	return ToRemove.Num();
+}
+
+TSharedPtr<FJsonObject> FUnrealMcpPromptRegistry::BuildManifestJson() const
+{
+	TSharedPtr<FJsonObject> Manifest = MakeShared<FJsonObject>();
+	Manifest->SetStringField(TEXT("type"), TEXT("prompt-manifest"));
+	Manifest->SetNumberField(TEXT("revision"), Revision);
+
+	TArray<TSharedPtr<FJsonValue>> PromptArray;
+	TArray<FString> Names;
+	Prompts.GetKeys(Names);
+	Names.Sort();
+	for (const FString& Name : Names)
+	{
+		// A disabled prompt is EXCLUDED from the served manifest entirely (mirror the tool registry).
+		const FUnrealMcpRegisteredPrompt& P = Prompts[Name];
+		if (!P.bEnabled)
+			continue;
+		PromptArray.Add(MakeShared<FJsonValueObject>(P.ToDescriptorJson()));
+	}
+
+	Manifest->SetArrayField(TEXT("prompts"), PromptArray);
+	return Manifest;
+}
+
+TArray<FString> FUnrealMcpPromptRegistry::GetPromptNamesSorted() const
+{
+	TArray<FString> Names;
+	Prompts.GetKeys(Names);
+	Names.Sort();
+	return Names;
+}
+
+int32 FUnrealMcpPromptRegistry::NumEnabled() const
+{
+	int32 Count = 0;
+	for (const TPair<FString, FUnrealMcpRegisteredPrompt>& Pair : Prompts)
+	{
+		if (Pair.Value.bEnabled)
+			++Count;
+	}
+	return Count;
+}
+
+bool FUnrealMcpPromptRegistry::SetPromptEnabled(const FString& Name, bool bEnabled)
+{
+	FUnrealMcpRegisteredPrompt* Found = Prompts.Find(Name);
+	if (Found == nullptr || Found->bEnabled == bEnabled)
+		return false;
+	Found->bEnabled = bEnabled;
+	++Revision;
+	UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] prompt '%s' %s (revision %d)."),
+		*Name, bEnabled ? TEXT("enabled") : TEXT("disabled"), Revision);
+	return true;
+}
+
+bool FUnrealMcpPromptRegistry::ShouldPromptBeEnabled(const FString& Name) const
+{
+	return PassesEnabledPromptsWhitelist(Name) && !DisabledPromptNames.Contains(Name);
+}
+
+bool FUnrealMcpPromptRegistry::PassesEnabledPromptsWhitelist(const FString& Name) const
+{
+	return EnabledPromptsWhitelist.IsEmpty() || EnabledPromptsWhitelist.Contains(Name);
+}
+
+void FUnrealMcpPromptRegistry::RecomputeEnablement()
+{
+	bool bAnyChanged = false;
+	for (TPair<FString, FUnrealMcpRegisteredPrompt>& Pair : Prompts)
+	{
+		const bool bShouldEnable = ShouldPromptBeEnabled(Pair.Key);
+		if (Pair.Value.bEnabled != bShouldEnable)
+		{
+			Pair.Value.bEnabled = bShouldEnable;
+			bAnyChanged = true;
+		}
+	}
+	if (bAnyChanged)
+		++Revision;
+}
+
+void FUnrealMcpPromptRegistry::SetEnabledPromptsFilter(const TArray<FString>& EnabledPrompts)
+{
+	EnabledPromptsWhitelist = TSet<FString>(EnabledPrompts);
+	RecomputeEnablement();
+}
+
+void FUnrealMcpPromptRegistry::ApplyDisabledPrompts(const TArray<FString>& DisabledNames)
+{
+	DisabledPromptNames = TSet<FString>(DisabledNames);
+	RecomputeEnablement();
+}
+
+FUnrealMcpPromptResult FUnrealMcpPromptRegistry::Execute(const FString& Name, const FUnrealMcpToolCall& Call) const
+{
+	const FUnrealMcpRegisteredPrompt* Found = Prompts.Find(Name);
+	if (Found == nullptr || !Found->Handler)
+		return FUnrealMcpPromptResult::Error(FString::Printf(TEXT("Unknown prompt '%s'."), *Name));
+
+	// Gate disabled prompts at the execution boundary (mirror the tool registry): a disabled prompt is
+	// dropped from BuildManifestJson, but a stale prompts/list could still dispatch it by name.
+	if (!Found->bEnabled)
+		return FUnrealMcpPromptResult::Error(FString::Printf(TEXT("Prompt '%s' is disabled."), *Name));
+
+	return Found->Handler(Call);
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
@@ -5,7 +5,9 @@
 #include "UnrealMcpRuntimeSettings.h"
 #include "UnrealMcpLog.h"
 #include "UnrealMcpRuntimeCoreTools.h"
+#include "UnrealMcpRuntimeCorePrompts.h"
 #include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpPromptRegistry.h"
 #include "Config/UnrealMcpConfig.h"
 #include "Dispatch/UnrealMcpGameThreadDispatcher.h"
 #include "Bridge/UnrealMcpBridgeServer.h"
@@ -13,6 +15,7 @@
 #include "Extensions/UnrealMcpExtensionManager.h"
 #include "Tools/UnrealMcpWorldProvider.h"
 #include "IUnrealMcpToolProvider.h"
+#include "IUnrealMcpPromptProvider.h"
 
 #include "Features/IModularFeatures.h"
 #include "Engine/GameInstance.h"
@@ -35,6 +38,7 @@
 struct UUnrealMcpRuntimeSubsystem::FRuntimeImpl
 {
 	TUniquePtr<FUnrealMcpToolRegistry> Registry;
+	TUniquePtr<FUnrealMcpPromptRegistry> PromptRegistry;
 	TUniquePtr<FUnrealMcpGameThreadDispatcher> Dispatcher;
 	TUniquePtr<FUnrealMcpBridgeServer> BridgeServer;
 	TUniquePtr<FUnrealMcpSidecarManager> SidecarManager;
@@ -66,8 +70,14 @@ void UUnrealMcpRuntimeSubsystem::Initialize(FSubsystemCollectionBase& Collection
 	UnrealMcpRuntimeScreenshotTools::Register(*Impl->Registry); // §10 screenshot runtime subset (game-view, camera)
 	UnrealMcpRuntimeLevelTools::Register(*Impl->Registry); // §10 read-only level-get-data
 
+	// §A.1 prompt registry (P1): the prompt sibling of the tool registry, built on the SAME Model A path. The
+	// core prompt family registers before the bridge arms so the first prompt-manifest a v2 sidecar reads on
+	// handshake already includes it. No §7/§8 prompt filters here (the runtime path applies none for tools either).
+	Impl->PromptRegistry = MakeUnique<FUnrealMcpPromptRegistry>();
+	UnrealMcpCorePrompts::Register(*Impl->PromptRegistry);
+
 	Impl->Dispatcher = MakeUnique<FUnrealMcpGameThreadDispatcher>();
-	Impl->BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(*Impl->Registry, *Impl->Dispatcher);
+	Impl->BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(*Impl->Registry, *Impl->Dispatcher, Impl->PromptRegistry.Get());
 
 	// Discover §5 extension providers and merge them BEFORE the bridge arms, so the first manifest a sidecar
 	// reads on a later Connect already includes them; a late register/unregister re-pushes the manifest.
@@ -84,7 +94,9 @@ void UUnrealMcpRuntimeSubsystem::Initialize(FSubsystemCollectionBase& Collection
 				Impl->BridgeServer->PushPromptManifest();
 				Impl->BridgeServer->PushResourceManifest();
 			}
-		});
+		},
+		/*InConfigPath*/ FString(),
+		Impl->PromptRegistry.Get()); // §A.2 kind-aware: also merge prompt-provider extensions into the prompt registry
 	Impl->ExtensionManager->Startup();
 
 	const FString ProjectPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
@@ -149,6 +161,7 @@ void UUnrealMcpRuntimeSubsystem::Deinitialize()
 		}
 
 		Impl->Dispatcher.Reset();
+		Impl->PromptRegistry.Reset();
 		Impl->Registry.Reset();
 		Impl.Reset();
 	}
@@ -332,6 +345,30 @@ void UUnrealMcpRuntimeSubsystem::UnregisterToolProvider(IUnrealMcpToolProvider* 
 	// registered, so a double-unregister or an unknown provider is harmless.
 	IModularFeatures::Get().UnregisterModularFeature(IUnrealMcpToolProvider::GetModularFeatureName(), Provider);
 	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] runtime tool provider '%s' unregistered."), *Provider->GetExtensionId());
+}
+
+void UUnrealMcpRuntimeSubsystem::RegisterPromptProvider(IUnrealMcpPromptProvider* Provider)
+{
+	if (!Provider)
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] RegisterPromptProvider: null provider ignored."));
+		return;
+	}
+
+	// Thin wrapper over IModularFeatures (§A.2): the extension manager subscribed to the prompt register event
+	// in Initialize(), so this triggers the same prompt-registry rebuild + manifest re-push a plugin-load-time
+	// registration does. Not owned — the caller keeps the provider alive and must UnregisterPromptProvider.
+	IModularFeatures::Get().RegisterModularFeature(IUnrealMcpPromptProvider::GetModularFeatureName(), Provider);
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] runtime prompt provider '%s' registered."), *Provider->GetExtensionId());
+}
+
+void UUnrealMcpRuntimeSubsystem::UnregisterPromptProvider(IUnrealMcpPromptProvider* Provider)
+{
+	if (!Provider)
+		return; // null is a harmless no-op
+
+	IModularFeatures::Get().UnregisterModularFeature(IUnrealMcpPromptProvider::GetModularFeatureName(), Provider);
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] runtime prompt provider '%s' unregistered."), *Provider->GetExtensionId());
 }
 
 bool UUnrealMcpRuntimeSubsystem::IsLoopbackHost(const FString& Host)

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpPromptProvider.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpPromptProvider.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Features/IModularFeature.h"
+
+class FUnrealMcpPromptRegistry;
+
+/**
+ * The Unreal-MCP PROMPT extension contract (docs/ARCHITECTURE.md §5 / §A.2) — the prompt sibling of
+ * IUnrealMcpToolProvider. To declare prompts you also include UnrealMcpPromptRegistry.h, and to register
+ * the provider as a modular feature you include Features/IModularFeatures.h (mirrors the tool path).
+ *
+ * An extension is any UE plugin that implements this interface and registers an instance as a modular
+ * feature under GetModularFeatureName():
+ *
+ *     IModularFeatures::Get().RegisterModularFeature(
+ *         IUnrealMcpPromptProvider::GetModularFeatureName(), MyProviderInstance);
+ *
+ * Unreal-MCP discovers every registered provider on boot (and subscribes to register/unregister events
+ * for late-loaded / hot-unloaded plugins), merges their prompts into the single prompt registry in
+ * deterministic order (sorted by ExtensionId), and surfaces the merged manifest to the sidecar (§A.1).
+ *
+ * Isolation (§5): identical to the tool contract — descriptor-level, not body-level (UE builds without
+ * C++ exceptions). Each prompt a provider declares is validated (name pattern, schema well-formedness,
+ * handler bound). Invalid entries are dropped and a duplicate prompt name across providers rejects the
+ * later registration (first-wins by the ExtensionId sort). Other extensions are never affected.
+ */
+class IUnrealMcpPromptProvider : public IModularFeature
+{
+public:
+	virtual ~IUnrealMcpPromptProvider() = default;
+
+	/** The modular-feature name every prompt provider registers under. Stable across the plugin's lifetime. */
+	static FName GetModularFeatureName()
+	{
+		return FName(TEXT("UnrealMcpPromptProvider"));
+	}
+
+	/**
+	 * Stable, unique extension identifier — reverse-DNS recommended (e.g. "com.foo.niagara-ai"). Used as
+	 * the deterministic sort key and as the manifest's per-prompt extensionId. Two providers with the same
+	 * id is an authoring error (the second's duplicate prompts are rejected).
+	 */
+	virtual FString GetExtensionId() const = 0;
+
+	/** Human-readable name shown in the extensions UI row (§7). */
+	virtual FText GetDisplayName() const = 0;
+
+	/** Free-form version string of the extension (independent of the Unreal-MCP plugin version). */
+	virtual FString GetExtensionVersion() const = 0;
+
+	/**
+	 * Declare the extension's prompts into @p Registry using the fluent FUnrealMcpPromptBuilder
+	 * (Registry.Prompt("my-prompt").Title(...).Param*(...).Handle(...)). Called on the game thread.
+	 * Prompts are automatically stamped with this provider's ExtensionId — do not call .ExtensionId().
+	 * Invalid or duplicate entries are dropped/rejected and recorded; valid entries register normally.
+	 */
+	virtual void RegisterPrompts(FUnrealMcpPromptRegistry& Registry) = 0;
+};

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpPromptRegistry.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpPromptRegistry.h
@@ -1,0 +1,232 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+#include "Templates/Function.h"
+// Prompt args reuse FUnrealMcpParamSpec / EUnrealMcpParamRequirement / FUnrealMcpToolCall verbatim, and the
+// §3.2 schema generation is identical to the tool path — include the tool registry header rather than
+// re-declaring those types (mirror, don't fork).
+#include "UnrealMcpToolRegistry.h"
+
+/**
+ * Core prompt-registration types for the Unreal-MCP plugin (docs/ARCHITECTURE.md §A.1 / §A.2). The exact
+ * prompt sibling of UnrealMcpToolRegistry.h: the registry is the plugin-owned source of truth for the
+ * prompt set; each family declares its prompts through the fluent FUnrealMcpPromptBuilder; the registry
+ * compiles each declaration into a JSON descriptor (the prompt-manifest shape) and dispatches incoming
+ * prompt-get requests to the declared handler. The sidecar mirrors the manifest into MCP ProxyPrompts.
+ *
+ * Prompt arguments reuse FUnrealMcpParamSpec + EUnrealMcpParamRequirement and the §3.2 schema generation
+ * VERBATIM (the same MakeTypedSchema / MakeVectorSchema / object/properties/required shape), and a prompt
+ * handler receives the same FUnrealMcpToolCall args+cancel surface as a tool handler — the prompt args are
+ * the same JSON-object shape. Only the prompt-specific result (role-tagged messages) differs.
+ */
+
+/** The message author role of a rendered prompt message (mirrors the .NET Role enum: User | Assistant). */
+enum class EUnrealMcpPromptRole : uint8
+{
+	User,
+	Assistant
+};
+
+/** One rendered prompt message: an author role + the message text. */
+struct UNREALMCPRUNTIME_API FUnrealMcpPromptMessage
+{
+	EUnrealMcpPromptRole Role = EUnrealMcpPromptRole::User;
+	FString Text;
+};
+
+/** Terminal result of a prompt-get, mirroring the IPC prompt-response shape (§A.1). */
+struct UNREALMCPRUNTIME_API FUnrealMcpPromptResult
+{
+	bool bSuccess = true;
+	FString Description;                          // optional human-readable prompt description
+	TArray<FUnrealMcpPromptMessage> Messages;     // the rendered messages (role + text)
+
+	static FUnrealMcpPromptResult Success(const TArray<FUnrealMcpPromptMessage>& InMessages, const FString& InDescription = FString())
+	{
+		FUnrealMcpPromptResult Result;
+		Result.bSuccess = true;
+		Result.Description = InDescription;
+		Result.Messages = InMessages;
+		return Result;
+	}
+
+	/** Convenience: a single-message success (the common one-shot prompt). */
+	static FUnrealMcpPromptResult Success(const FString& Text, EUnrealMcpPromptRole Role, const FString& Description = FString())
+	{
+		FUnrealMcpPromptResult Result;
+		Result.bSuccess = true;
+		Result.Description = Description;
+		Result.Messages.Add(FUnrealMcpPromptMessage{ Role, Text });
+		return Result;
+	}
+
+	static FUnrealMcpPromptResult Error(const FString& InDescription)
+	{
+		FUnrealMcpPromptResult Result;
+		Result.bSuccess = false;
+		Result.Description = InDescription;
+		return Result;
+	}
+};
+
+/**
+ * Signature of a prompt handler: runs on the game thread (the dispatcher guarantees it, §4), returns a
+ * terminal result synchronously. Reuses FUnrealMcpToolCall as the args+cancel surface — the prompt args
+ * are the same JSON-object shape as a tool call's.
+ */
+using FUnrealMcpPromptHandler = TFunction<FUnrealMcpPromptResult(const FUnrealMcpToolCall&)>;
+
+/** A fully compiled prompt: descriptor (manifest shape) + handler. */
+struct UNREALMCPRUNTIME_API FUnrealMcpRegisteredPrompt
+{
+	FString Name;
+	FString Title;
+	FString Description;
+	EUnrealMcpPromptRole Role = EUnrealMcpPromptRole::User;
+	TArray<FUnrealMcpParamSpec> Params;
+	bool bEnabled = true;
+	FString ExtensionId = TEXT("core");
+	FString SchemaHash;
+	FUnrealMcpPromptHandler Handler;
+
+	/** Build the JSON Schema for this prompt's inputs from its declared params (§3.2 subset — identical to a tool's). */
+	TSharedPtr<FJsonObject> BuildInputSchema() const;
+
+	/** The prompt-manifest descriptor object (one entry in prompt-manifest.prompts[]). */
+	TSharedPtr<FJsonObject> ToDescriptorJson() const;
+};
+
+class FUnrealMcpPromptRegistry;
+
+/** Fluent declaration builder (§3.3 prompt analog). One per prompt; commits on Handle(). */
+class UNREALMCPRUNTIME_API FUnrealMcpPromptBuilder
+{
+public:
+	FUnrealMcpPromptBuilder(FUnrealMcpPromptRegistry& InRegistry, const FString& InName);
+
+	FUnrealMcpPromptBuilder& Title(const FString& InTitle);
+	FUnrealMcpPromptBuilder& Description(const FString& InDescription);
+	FUnrealMcpPromptBuilder& Role(EUnrealMcpPromptRole InRole);
+	FUnrealMcpPromptBuilder& ParamString(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req = EUnrealMcpParamRequirement::Optional);
+	FUnrealMcpPromptBuilder& ParamInt(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req = EUnrealMcpParamRequirement::Optional);
+	FUnrealMcpPromptBuilder& ParamNumber(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req = EUnrealMcpParamRequirement::Optional);
+	FUnrealMcpPromptBuilder& ParamBool(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req = EUnrealMcpParamRequirement::Optional);
+	FUnrealMcpPromptBuilder& ParamVector(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req = EUnrealMcpParamRequirement::Optional);
+	/** Generic escape hatch for params whose JSON Schema the typed helpers do not cover (mirror the tool builder). */
+	FUnrealMcpPromptBuilder& Param(const FString& Name, const FString& JsonType, const FString& Desc, EUnrealMcpParamRequirement Req, TSharedPtr<FJsonObject> CustomSchema = nullptr);
+	FUnrealMcpPromptBuilder& ExtensionId(const FString& InExtensionId);
+
+	/** Bind the handler and commit the prompt into the registry. */
+	void Handle(FUnrealMcpPromptHandler InHandler);
+
+private:
+	FUnrealMcpPromptRegistry& Registry;
+	FUnrealMcpRegisteredPrompt Prompt;
+};
+
+/**
+ * The plugin-owned prompt registry (docs/ARCHITECTURE.md §A.1) — the exact prompt sibling of
+ * FUnrealMcpToolRegistry. Holds the compiled prompt set, produces the JSON manifest snapshot for the
+ * bridge, and dispatches prompt-get requests by name. A monotonic Revision bumps on every change so the
+ * sidecar's manifest diff can reason about ordering. Not thread-safe (same contract as the tool registry):
+ * all mutation happens at startup before the bridge accepts; any DYNAMIC re-registration MUST marshal both
+ * the mutation and the manifest read through the game-thread dispatcher (§4).
+ *
+ * Prompt args reuse FUnrealMcpParamSpec + the §3.2 schema generation verbatim (see BuildInputSchema).
+ */
+class UNREALMCPRUNTIME_API FUnrealMcpPromptRegistry
+{
+public:
+	/** Begin declaring a prompt (the §3.3 fluent API, prompt analog). */
+	FUnrealMcpPromptBuilder Prompt(const FString& Name);
+
+	/**
+	 * Commit a fully-built prompt (called by the builder's Handle()).
+	 * - Core path (default): replaces any same-named prompt — core families are trusted.
+	 * - Extension scope (inside RegisterExtension): the prompt is stamped with the scope's ExtensionId,
+	 *   validated (§5), and deduped. An invalid entry is DROPPED and a duplicate is REJECTED (first-wins).
+	 */
+	void Commit(FUnrealMcpRegisteredPrompt&& InPrompt);
+
+	/**
+	 * Register an extension provider's prompts (§5). Opens an "extension scope": every Commit during
+	 * @p RegisterFn is stamped with @p ExtensionId, validated, and deduped. Reuses the tool registry's
+	 * FUnrealMcpExtensionRegistrationResult (its `ToolsRegistered` count here means "entries registered").
+	 * Scopes never nest.
+	 */
+	FUnrealMcpExtensionRegistrationResult RegisterExtension(const FString& ExtensionId, TFunctionRef<void(FUnrealMcpPromptRegistry&)> RegisterFn);
+
+	/** Remove every prompt stamped with @p ExtensionId (hot-unload / rebuild, §5). Bumps revision if any removed. Returns count removed. */
+	int32 RemovePromptsForExtension(const FString& ExtensionId);
+
+	/** True iff @p Name is a valid kebab-case prompt id (same rule as the tool registry). */
+	static bool IsValidPromptName(const FString& Name);
+
+	/** Validate a prompt descriptor for the §5 isolation contract. Returns false + a reason on the first problem. */
+	static bool ValidatePrompt(const FUnrealMcpRegisteredPrompt& InPrompt, FString& OutError);
+
+	bool HasPrompt(const FString& Name) const { return Prompts.Contains(Name); }
+	int32 Num() const { return Prompts.Num(); }
+	const FUnrealMcpRegisteredPrompt* Find(const FString& Name) const { return Prompts.Find(Name); }
+
+	/** Every registered prompt name, sorted. */
+	TArray<FString> GetPromptNamesSorted() const;
+
+	/** Count of prompts whose bEnabled flag is set. */
+	int32 NumEnabled() const;
+
+	/** True iff @p Name passes the §8 EnabledPrompts whitelist gate (empty whitelist, or the name is listed). */
+	bool PassesEnabledPromptsWhitelist(const FString& Name) const;
+
+	/**
+	 * Set one prompt's enabled flag directly — a GRANULAR helper, NOT a production §7 toggle. Does NOT
+	 * update the retained whitelist/blocklist. Disabled prompts are EXCLUDED from BuildManifestJson.
+	 * Bumps the revision on a real change. Unknown name / no-op change: returns false, no bump. Game-thread only.
+	 */
+	bool SetPromptEnabled(const FString& Name, bool bEnabled);
+
+	/** Set the §8 env whitelist. Mirrors the tool registry's SetEnabledToolsFilter exactly. Game-thread only. */
+	void SetEnabledPromptsFilter(const TArray<FString>& EnabledPrompts);
+
+	/** Apply the persisted §7 per-prompt enable-map (blocklist). Mirrors the tool registry's ApplyDisabledTools. Game-thread only. */
+	void ApplyDisabledPrompts(const TArray<FString>& DisabledNames);
+
+	/** Current manifest revision (bumps on every registry mutation). */
+	int32 GetRevision() const { return Revision; }
+
+	/** Build the full prompt-manifest message body (revision + prompts[]) for the bridge (§A.1). Disabled prompts excluded, sorted by name. */
+	TSharedPtr<FJsonObject> BuildManifestJson() const;
+
+	/**
+	 * Execute a prompt by name on the CURRENT thread (the dispatcher has already marshalled to the game
+	 * thread). Returns an error result for an unknown / disabled prompt. The handler owns argument interpretation.
+	 */
+	FUnrealMcpPromptResult Execute(const FString& Name, const FUnrealMcpToolCall& Call) const;
+
+	/** Compute the stable schema hash for a prompt descriptor (excludes the enabled flag). */
+	static FString ComputeSchemaHash(const FUnrealMcpRegisteredPrompt& InPrompt);
+
+private:
+	TMap<FString, FUnrealMcpRegisteredPrompt> Prompts;
+	int32 Revision = 0;
+
+	// --- Retained §7/§8 enablement filters (mirror the tool registry exactly). ---
+	TSet<FString> EnabledPromptsWhitelist; // §8 whitelist; empty = no filter
+	TSet<FString> DisabledPromptNames;     // §7 persisted blocklist
+
+	/** The combined §8 effective-served predicate: enabled iff (whitelist empty OR member) AND NOT blocklisted. */
+	bool ShouldPromptBeEnabled(const FString& Name) const;
+
+	/** Re-evaluate every registered prompt's bEnabled against ShouldPromptBeEnabled; bumps the revision once if any changed. */
+	void RecomputeEnablement();
+
+	// --- Extension-scope state (active only inside RegisterExtension; scopes never nest) ----------
+	bool bExtensionScope = false;
+	FString ScopeExtensionId;
+	int32 ScopePromptsRegistered = 0;
+	TArray<FString> ScopeErrors;
+};

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeCorePrompts.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeCorePrompts.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FUnrealMcpPromptRegistry;
+
+/**
+ * Registration entry point for the core PROMPT family (docs/ARCHITECTURE.md §A.1 / §A.2) — the prompt
+ * sibling of UnrealMcpRuntimeCoreTools.h. Exported with UNREALMCPRUNTIME_API so the editor coordinator and
+ * the runtime bootstrap subsystem wire it on boot (Model A — editor + runtime register on the SAME prompt
+ * registry) AND the Automation specs can register + exercise it in isolation.
+ *
+ * The MVP registers a single self-contained prompt (`level-design-brief`) with no engine calls, so the
+ * family compiles + links in both the editor and the non-editor Game target.
+ */
+namespace UnrealMcpCorePrompts
+{
+	UNREALMCPRUNTIME_API void Register(FUnrealMcpPromptRegistry& Registry);
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeSubsystem.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeSubsystem.h
@@ -11,6 +11,8 @@
 // Forward-declared: RegisterToolProvider/UnregisterToolProvider take it by pointer only (§12.9), so the
 // PUBLIC header needs no extension-contract include — callers include IUnrealMcpToolProvider.h themselves.
 class IUnrealMcpToolProvider;
+// Forward-declared for the same reason: RegisterPromptProvider/UnregisterPromptProvider take it by pointer.
+class IUnrealMcpPromptProvider;
 
 // The runtime-owned machinery (registry/dispatcher/bridge/sidecar/extensions) is held behind a PImpl
 // (FRuntimeImpl, defined in the .cpp) so this PUBLIC header forward-declares nothing module-private and the
@@ -140,6 +142,19 @@ public:
 	 * one that was never registered, is a harmless no-op (IModularFeatures tolerates an unknown unregister).
 	 */
 	void UnregisterToolProvider(IUnrealMcpToolProvider* Provider);
+
+	/**
+	 * Register a custom gameplay PROMPT provider at runtime (§A.2) — the prompt sibling of
+	 * RegisterToolProvider. A thin wrapper over
+	 * `IModularFeatures::Get().RegisterModularFeature(IUnrealMcpPromptProvider::GetModularFeatureName(), Provider)`:
+	 * the extension manager subscribed to the prompt modular-feature events in Initialize(), so the
+	 * registration rebuilds the prompt registry and re-pushes the manifest. OWNERSHIP: not owned — the caller
+	 * keeps @p Provider alive and must UnregisterPromptProvider before destroying it. Null is a no-op.
+	 */
+	void RegisterPromptProvider(IUnrealMcpPromptProvider* Provider);
+
+	/** Unregister a prompt provider previously registered via RegisterPromptProvider (or directly via IModularFeatures). Null / unknown is a harmless no-op. */
+	void UnregisterPromptProvider(IUnrealMcpPromptProvider* Provider);
 
 	/** Whether the loopback listener armed (a port is bound). False means Initialize failed to bind. */
 	bool IsListenerArmed() const { return BoundPort > 0; }

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -72,6 +72,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
         private IMcpPlugin? _plugin;
         private ManifestRegistrar? _registrar;
+        // §A.1 (P1) prompt manifest registrar. Null when the built McpPlugin has no PromptManager (defensive —
+        // the empty-then-manifest model means the manager is normally present, like ToolManager).
+        private PromptManifestRegistrar? _promptRegistrar;
         private Reflector? _reflector;
         private int _signalRConnectStarted;
 
@@ -241,6 +244,25 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
             // Wire the registrar BEFORE the IPC loop can deliver a manifest.
             _ipc.Registrar = _registrar;
+
+            // §A.1 (P1) prompts: wire the prompt manifest registrar to the live PromptManager, mirroring the
+            // tool wiring. The manager is NULLABLE on IMcpManager; the empty-then-manifest model (no
+            // WithPrompts* at build, the plugin's prompt-manifest populates it) means it is normally present.
+            // PromptManifestRegistrar implements IManifestSink<PromptManifestMessage>, so this satisfies
+            // IpcClient.PromptRegistrar directly. A v1-negotiated link never delivers a prompt-manifest.
+            var promptManager = _plugin.McpManager.PromptManager;
+            if (promptManager != null)
+            {
+                _promptRegistrar = new PromptManifestRegistrar(
+                    new PromptManagerSink(promptManager),
+                    _ipc,
+                    _loggerProvider?.CreateLogger(nameof(PromptManifestRegistrar)));
+                _ipc.PromptRegistrar = _promptRegistrar;
+            }
+            else
+            {
+                _logger?.LogWarning("Built McpPlugin has no PromptManager; prompts disabled this session.");
+            }
 
             // §7 (issue #109): subscribe to the connected-AI-agent roster so the plugin's "AI agents" status row
             // refreshes live. OnClientsChanged fires with the full active-client list on every agent join/leave;

--- a/bridge/src/Ipc/IpcClient.cs
+++ b/bridge/src/Ipc/IpcClient.cs
@@ -29,7 +29,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
     /// reader thread (RunContinuationsAsynchronously). One mutex-guarded writer serializes every send so
     /// messages never interleave (§1.2).
     /// </summary>
-    public sealed class IpcClient : IToolCallChannel, IAsyncDisposable
+    public sealed class IpcClient : IToolCallChannel, IPromptCallChannel, IAsyncDisposable
     {
         private readonly string _host;
         private readonly int _port;

--- a/bridge/src/Tools/PromptCallChannel.cs
+++ b/bridge/src/Tools/PromptCallChannel.cs
@@ -1,0 +1,40 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// The channel a <see cref="ProxyPrompt"/> uses to round-trip a prompt-get over IPC: serialize a
+    /// <c>prompt-get</c>, await the matching <c>prompt-response</c>, and forward cancellation as the generic
+    /// <c>tool-cancel</c> (docs/ARCHITECTURE.md §A.1). The prompt sibling of <see cref="IToolCallChannel"/>;
+    /// implemented by the IPC client (which already exposes <c>GetPromptAsync</c> with this exact signature),
+    /// kept as an interface so the proxy/registration path is unit-testable with a fake channel.
+    /// </summary>
+    public interface IPromptCallChannel
+    {
+        /// <summary>
+        /// Send a <c>prompt-get</c> and await its terminal <c>prompt-response</c>.
+        /// </summary>
+        /// <exception cref="IpcDisconnectedException">
+        /// The IPC link is down — the proxy must fail fast with the structured "bridge disconnected"
+        /// error (§A.1 / §2.2 step 4), never hang to <paramref name="timeoutMs"/>.
+        /// </exception>
+        Task<PromptResponseMessage> GetPromptAsync(
+            string prompt,
+            JsonObject? arguments,
+            int timeoutMs,
+            CancellationToken ct);
+    }
+}

--- a/bridge/src/Tools/PromptManifestRegistrar.cs
+++ b/bridge/src/Tools/PromptManifestRegistrar.cs
@@ -1,0 +1,161 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Collections.Generic;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// The minimal prompt-set mutation surface the registrar needs (the prompt sibling of
+    /// <see cref="IProxyToolSink"/>). Abstracts <see cref="IPromptManager"/> (adapted by
+    /// <see cref="PromptManagerSink"/>) so the manifest-application logic is unit-tested with a fake sink.
+    /// </summary>
+    public interface IProxyPromptSink
+    {
+        bool HasPrompt(string name);
+        bool AddPrompt(string name, ProxyPrompt prompt);
+        bool RemovePrompt(string name);
+        bool SetPromptEnabled(string name, bool enabled);
+    }
+
+    /// <summary>Adapts the reused <see cref="IPromptManager"/> to <see cref="IProxyPromptSink"/>.</summary>
+    public sealed class PromptManagerSink : IProxyPromptSink
+    {
+        private readonly IPromptManager _promptManager;
+        public PromptManagerSink(IPromptManager promptManager) => _promptManager = promptManager;
+
+        public bool HasPrompt(string name) => _promptManager.HasPrompt(name);
+
+        // IPromptManager.AddPrompt takes ONLY the runner (its name == prompt.Name); the name param is kept on
+        // the sink interface for symmetry/testability with IProxyToolSink and is identical to prompt.Name.
+        public bool AddPrompt(string name, ProxyPrompt prompt) => _promptManager.AddPrompt(prompt);
+
+        public bool RemovePrompt(string name) => _promptManager.RemovePrompt(name);
+        public bool SetPromptEnabled(string name, bool enabled) => _promptManager.SetPromptEnabled(name, enabled);
+    }
+
+    /// <summary>
+    /// The prompt-specific differ (docs/ARCHITECTURE.md §A.1) — the prompt sibling of
+    /// <see cref="ManifestDiffer"/>: compare by <c>name</c> + <c>schemaHash</c> (the hash excludes the enabled
+    /// flag), with a structural-signature fallback when a hash is absent on either side.
+    /// </summary>
+    internal static class PromptManifestDiffer
+    {
+        public static ManifestDiff<PromptDescriptor> Compute(
+            IReadOnlyDictionary<string, PromptDescriptor> previous,
+            IReadOnlyList<PromptDescriptor> next)
+        {
+            var diff = new ManifestDiff<PromptDescriptor>();
+            var nextByName = new Dictionary<string, PromptDescriptor>();
+
+            foreach (var desc in next)
+            {
+                if (string.IsNullOrEmpty(desc.Name))
+                    continue;
+                nextByName[desc.Name] = desc;
+
+                if (!previous.TryGetValue(desc.Name, out var prev))
+                {
+                    diff.Added.Add(desc);
+                    continue;
+                }
+
+                if (!SchemaEquals(prev, desc))
+                    diff.Changed.Add(desc);
+                else if (prev.Enabled != desc.Enabled)
+                    diff.EnabledChanged.Add((desc.Name, desc.Enabled));
+                // else: identical → no-op.
+            }
+
+            foreach (var name in previous.Keys)
+            {
+                if (!nextByName.ContainsKey(name))
+                    diff.Removed.Add(name);
+            }
+
+            return diff;
+        }
+
+        private static bool SchemaEquals(PromptDescriptor a, PromptDescriptor b)
+        {
+            if (!string.IsNullOrEmpty(a.SchemaHash) || !string.IsNullOrEmpty(b.SchemaHash))
+                return a.SchemaHash == b.SchemaHash;
+
+            return Signature(a) == Signature(b);
+        }
+
+        private static string Signature(PromptDescriptor d)
+        {
+            // Structural fallback: everything that defines the prompt's surface EXCEPT the enabled flag.
+            var input = d.InputSchema?.ToJsonString() ?? "null";
+            return string.Join("", d.Name, d.Title, d.Description, d.Role, input, d.ExtensionId);
+        }
+    }
+
+    /// <summary>
+    /// Applies prompt manifests (docs/ARCHITECTURE.md §A.1) to an <see cref="IProxyPromptSink"/> — the prompt
+    /// sibling of <see cref="ManifestRegistrar"/>. Derives from the shared, kind-agnostic
+    /// <see cref="ManifestRegistrarBase{TDescriptor}"/> (the revision guard / reconnect reset / diff-application
+    /// loop) and supplies the prompt-specific bits: the <see cref="ProxyPrompt"/> sink + the
+    /// <see cref="PromptManifestDiffer"/>. Implements <see cref="IManifestSink{PromptManifestMessage}"/> so the
+    /// IPC client routes a <c>prompt-manifest</c> to it without knowing the descriptor type. NOT thread-safe by
+    /// itself: the IPC client invokes Apply from its single reader loop (same contract as the tool registrar).
+    /// </summary>
+    public sealed class PromptManifestRegistrar : ManifestRegistrarBase<PromptDescriptor>, IManifestSink<PromptManifestMessage>
+    {
+        private readonly IProxyPromptSink _sink;
+        private readonly IPromptCallChannel _channel;
+
+        public PromptManifestRegistrar(IProxyPromptSink sink, IPromptCallChannel channel, ILogger? logger = null)
+            : base(logger)
+        {
+            _sink = sink;
+            _channel = channel;
+        }
+
+        /// <summary>Names of the prompts currently registered by this registrar (test/inspection aid).</summary>
+        public IReadOnlyCollection<string> AppliedPromptNames => Applied.Keys;
+
+        /// <summary>A snapshot of the currently-applied prompt descriptors (copied list; caller mutation-safe).</summary>
+        public IReadOnlyList<PromptDescriptor> AppliedDescriptors => new List<PromptDescriptor>(Applied.Values);
+
+        /// <summary>Apply a prompt manifest. Returns the diff that was applied (empty when ignored/no-op).</summary>
+        public ManifestDiff<PromptDescriptor> Apply(PromptManifestMessage manifest)
+            => ApplyEntries(manifest.Revision, manifest.Prompts);
+
+        // --- IManifestSink<PromptManifestMessage> (the type-erased route the IPC client holds) ----------
+        public void ApplyManifest(PromptManifestMessage manifest) => ApplyEntries(manifest.Revision, manifest.Prompts);
+        // ResetForReconnect is provided by the base (public).
+
+        protected override string KindLabel => "prompt";
+
+        protected override string KeyOf(PromptDescriptor descriptor) => descriptor.Name;
+
+        protected override ManifestDiff<PromptDescriptor> ComputeDiff(IReadOnlyList<PromptDescriptor> next)
+            => PromptManifestDiffer.Compute(Applied, next);
+
+        protected override void SinkRemove(string key) => _sink.RemovePrompt(key);
+
+        protected override void SinkAdd(PromptDescriptor descriptor) =>
+            _sink.AddPrompt(descriptor.Name, ProxyPromptFactory.Create(descriptor, _channel));
+
+        protected override void SinkSetEnabled(string key, bool enabled) => _sink.SetPromptEnabled(key, enabled);
+
+        protected override PromptDescriptor WithEnabled(PromptDescriptor descriptor, bool enabled)
+        {
+            // Mutate in place + return the same instance (preserves the tool-registrar behaviour exactly).
+            descriptor.Enabled = enabled;
+            return descriptor;
+        }
+    }
+}

--- a/bridge/src/Tools/ProxyPrompt.cs
+++ b/bridge/src/Tools/ProxyPrompt.cs
@@ -1,0 +1,66 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.Common.Model;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// An <see cref="IRunPrompt"/> whose schema is supplied externally at runtime (the plugin's prompt
+    /// manifest, §A.1) and whose body is an async delegate that round-trips a <c>prompt-get</c> over IPC and
+    /// awaits the matching <c>prompt-response</c>. The prompt sibling of <see cref="ProxyTool"/> — the
+    /// building block for the sidecar's dynamic, manifest-driven prompt set.
+    /// </summary>
+    public sealed class ProxyPrompt : IRunPrompt
+    {
+        private readonly Func<string, IReadOnlyDictionary<string, JsonElement>?, CancellationToken, Task<ResponseGetPrompt>> _handler;
+
+        public string Name { get; }
+        public string? Title { get; }
+        public string? Description { get; }
+        public Role Role { get; }
+        public JsonNode? InputSchema { get; }
+
+        /// <summary>
+        /// Whether this prompt is exposed to MCP clients. Settable so the manifest registrar can toggle a
+        /// runtime prompt on/off (mirrors <see cref="ProxyTool.Enabled"/>; <see cref="IRunPrompt"/> itself
+        /// carries no enabled flag, so the toggle rides on the proxy + <c>IPromptManager.SetPromptEnabled</c>).
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+
+        public ProxyPrompt(
+            string name,
+            string? title,
+            string? description,
+            Role role,
+            JsonNode? inputSchema,
+            Func<string, IReadOnlyDictionary<string, JsonElement>?, CancellationToken, Task<ResponseGetPrompt>> handler)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Title = title;
+            Description = description;
+            Role = role;
+            // Detach the externally supplied schema via a round-trip clone so the proxy owns an immutable,
+            // self-consistent copy (a JsonNode may only have one parent; mirrors ProxyTool).
+            InputSchema = inputSchema is null ? null : JsonNode.Parse(inputSchema.ToJsonString());
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        }
+
+        public Task<ResponseGetPrompt> Run(string requestId, IReadOnlyDictionary<string, JsonElement>? namedParameters, CancellationToken cancellationToken = default)
+            => _handler(requestId, namedParameters, cancellationToken);
+    }
+}

--- a/bridge/src/Tools/ProxyPromptFactory.cs
+++ b/bridge/src/Tools/ProxyPromptFactory.cs
@@ -1,0 +1,88 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// Builds a <see cref="ProxyPrompt"/> from a manifest <see cref="PromptDescriptor"/> (docs/ARCHITECTURE.md
+    /// §A.1) — the prompt sibling of <see cref="ProxyToolFactory"/>. The proxy's body serializes the get onto
+    /// the supplied <see cref="IPromptCallChannel"/>, awaits the terminal <c>prompt-response</c>, and maps it
+    /// to a <see cref="ResponseGetPrompt"/>. On an IPC disconnect the call fails fast with the structured
+    /// "bridge disconnected" error (§2.2 step 4).
+    /// </summary>
+    public static class ProxyPromptFactory
+    {
+        public static ProxyPrompt Create(PromptDescriptor descriptor, IPromptCallChannel channel)
+        {
+            var promptName = descriptor.Name;
+            var timeoutMs = IpcProtocol.DefaultToolTimeoutMs;
+            var role = ParseRole(descriptor.Role) ?? Role.User;
+
+            return new ProxyPrompt(
+                name: promptName,
+                title: descriptor.Title,
+                description: descriptor.Description,
+                role: role,
+                inputSchema: descriptor.InputSchema,
+                handler: async (requestId, namedParameters, cancellationToken) =>
+                {
+                    // Reuse ProxyToolFactory.ToArguments (public static) — the prompt args are the same JSON shape.
+                    var args = ProxyToolFactory.ToArguments(namedParameters);
+                    try
+                    {
+                        var response = await channel
+                            .GetPromptAsync(promptName, args, timeoutMs, cancellationToken)
+                            .ConfigureAwait(false);
+                        return MapResponse(response, requestId, role);
+                    }
+                    catch (IpcDisconnectedException ex)
+                    {
+                        // Fail fast — never hang to timeoutMs (§2.2 step 4).
+                        return ResponseGetPrompt.Error(ex.Message).SetRequestID(requestId);
+                    }
+                }) { Enabled = descriptor.Enabled };
+        }
+
+        /// <summary>
+        /// Map an IPC <c>prompt-response</c> onto a <see cref="ResponseGetPrompt"/>: an <c>error</c> status
+        /// becomes <see cref="ResponseGetPrompt.Error(string)"/>; otherwise each entry becomes a
+        /// <see cref="ResponsePromptMessage"/> (its role parsed, falling back to the descriptor's default role).
+        /// </summary>
+        private static ResponseGetPrompt MapResponse(PromptResponseMessage response, string requestId, Role defaultRole)
+        {
+            if (string.Equals(response.Status, IpcProtocol.Status.Error, StringComparison.OrdinalIgnoreCase))
+                return ResponseGetPrompt.Error(response.Error ?? "Prompt failed.").SetRequestID(requestId);
+
+            var messages = response.Messages?
+                .Select(m => new ResponsePromptMessage(m.Text ?? string.Empty, ParseRole(m.Role) ?? defaultRole))
+                .ToList() ?? new List<ResponsePromptMessage>();
+
+            return ResponseGetPrompt.Success(messages, response.Description).SetRequestID(requestId);
+        }
+
+        /// <summary>Parse a wire role string ("user"/"assistant", case-insensitive) → <see cref="Role"/>; null when absent/unknown.</summary>
+        private static Role? ParseRole(string? role)
+        {
+            if (string.IsNullOrWhiteSpace(role))
+                return null;
+            if (string.Equals(role, "assistant", StringComparison.OrdinalIgnoreCase))
+                return Role.Assistant;
+            if (string.Equals(role, "user", StringComparison.OrdinalIgnoreCase))
+                return Role.User;
+            return null;
+        }
+    }
+}

--- a/bridge/tests/Fakes.cs
+++ b/bridge/tests/Fakes.cs
@@ -167,6 +167,68 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         }
     }
 
+    /// <summary>A scripted <see cref="IPromptCallChannel"/> for testing the prompt proxy/registration path.</summary>
+    public sealed class FakePromptCallChannel : IPromptCallChannel
+    {
+        private readonly Func<string, JsonObject?, PromptResponseMessage>? _responder;
+        public bool Connected { get; set; } = true;
+
+        public string? LastPrompt { get; private set; }
+        public JsonObject? LastArguments { get; private set; }
+        public int Calls { get; private set; }
+
+        public FakePromptCallChannel(Func<string, JsonObject?, PromptResponseMessage>? responder = null)
+            => _responder = responder;
+
+        public Task<PromptResponseMessage> GetPromptAsync(string prompt, JsonObject? arguments, int timeoutMs, CancellationToken ct)
+        {
+            Calls++;
+            LastPrompt = prompt;
+            LastArguments = arguments;
+            if (!Connected)
+                throw new IpcDisconnectedException();
+
+            var response = _responder?.Invoke(prompt, arguments) ?? new PromptResponseMessage
+            {
+                RequestId = "fake",
+                Status = IpcProtocol.Status.Success,
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    /// <summary>An in-memory <see cref="IProxyPromptSink"/> recording the prompt registrar's mutations.</summary>
+    public sealed class FakePromptSink : IProxyPromptSink
+    {
+        public readonly Dictionary<string, ProxyPrompt> Prompts = new();
+        public readonly Dictionary<string, bool> Enabled = new();
+
+        public bool HasPrompt(string name) => Prompts.ContainsKey(name);
+
+        public bool AddPrompt(string name, ProxyPrompt prompt)
+        {
+            if (Prompts.ContainsKey(name))
+                return false;
+            Prompts[name] = prompt;
+            Enabled[name] = prompt.Enabled;
+            return true;
+        }
+
+        public bool RemovePrompt(string name)
+        {
+            Enabled.Remove(name);
+            return Prompts.Remove(name);
+        }
+
+        public bool SetPromptEnabled(string name, bool enabled)
+        {
+            if (!Prompts.ContainsKey(name))
+                return false;
+            Enabled[name] = enabled;
+            return true;
+        }
+    }
+
     /// <summary>
     /// A controllable <see cref="IMcpManager"/> for driving the connected-AI-agent roster path (issue #109): the
     /// test pushes new rosters through <see cref="PushClients"/> (an R3 <see cref="Subject{T}"/> backing

--- a/bridge/tests/PromptManifestRegistrarTests.cs
+++ b/bridge/tests/PromptManifestRegistrarTests.cs
@@ -1,0 +1,118 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak)              │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Linq;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>Prompt manifest application + the §A.1 revision guard + the §1.5 reconnect reset (prompt sibling).</summary>
+    public class PromptManifestRegistrarTests
+    {
+        private static PromptDescriptor Prompt(string name, string hash, bool enabled = true) =>
+            new() { Name = name, SchemaHash = hash, Role = "user", Enabled = enabled };
+
+        private static PromptManifestMessage Manifest(int revision, params PromptDescriptor[] prompts) =>
+            new() { Revision = revision, Prompts = prompts.ToList() };
+
+        private static (PromptManifestRegistrar reg, FakePromptSink sink) New()
+        {
+            var sink = new FakePromptSink();
+            var reg = new PromptManifestRegistrar(sink, new FakePromptCallChannel());
+            return (reg, sink);
+        }
+
+        [Fact]
+        public void Apply_RegistersAddedPromptsAsProxies()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(1, Prompt("level-design-brief", "h1"), Prompt("enemy-brief", "h2")));
+            Assert.True(sink.HasPrompt("level-design-brief"));
+            Assert.True(sink.HasPrompt("enemy-brief"));
+            Assert.Equal(2, sink.Prompts.Count);
+        }
+
+        [Fact]
+        public void Apply_RemovesDroppedPrompts()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(1, Prompt("level-design-brief", "h1"), Prompt("doomed", "h2")));
+            reg.Apply(Manifest(2, Prompt("level-design-brief", "h1")));
+            Assert.True(sink.HasPrompt("level-design-brief"));
+            Assert.False(sink.HasPrompt("doomed"));
+        }
+
+        [Fact]
+        public void Apply_ReregistersChangedPrompt()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(1, Prompt("level-design-brief", "h1")));
+            var first = sink.Prompts["level-design-brief"];
+            reg.Apply(Manifest(2, Prompt("level-design-brief", "h2")));
+            Assert.NotSame(first, sink.Prompts["level-design-brief"]); // remove+add produced a fresh proxy
+        }
+
+        [Fact]
+        public void Apply_TogglesEnabledOnly()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(1, Prompt("level-design-brief", "h1", enabled: true)));
+            reg.Apply(Manifest(2, Prompt("level-design-brief", "h1", enabled: false)));
+            Assert.True(sink.HasPrompt("level-design-brief"));
+            Assert.False(sink.Enabled["level-design-brief"]);
+        }
+
+        [Fact]
+        public void Apply_IgnoresStaleOrEqualRevision()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(5, Prompt("level-design-brief", "h1")));
+            var diff = reg.Apply(Manifest(5, Prompt("level-design-brief", "h1"), Prompt("late", "h2")));
+            Assert.True(diff.IsEmpty);          // revision 5 <= last applied 5 → ignored
+            Assert.False(sink.HasPrompt("late"));
+        }
+
+        [Fact]
+        public void ResetForReconnect_AllowsUnchangedRevisionReapply()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(3, Prompt("level-design-brief", "h1")));
+            Assert.Equal(3, reg.LastAppliedRevision);
+
+            reg.ResetForReconnect();
+            Assert.Equal(-1, reg.LastAppliedRevision);
+
+            var diff = reg.Apply(Manifest(3, Prompt("level-design-brief", "h1"), Prompt("added-offline", "h2")));
+            Assert.False(diff.IsEmpty);
+            Assert.True(sink.HasPrompt("added-offline"));
+            Assert.Equal(3, reg.LastAppliedRevision);
+        }
+
+        [Fact]
+        public void AppliedPromptNames_TracksRegistrations()
+        {
+            var (reg, _) = New();
+            reg.Apply(Manifest(1, Prompt("a", "h1"), Prompt("b", "h2")));
+            Assert.Equal(new[] { "a", "b" }, reg.AppliedPromptNames.OrderBy(n => n));
+        }
+
+        [Fact]
+        public void ApplyManifest_TypeErasedRoute_RegistersPrompts()
+        {
+            // The IpcClient holds the registrar as IManifestSink<PromptManifestMessage>; exercise that route.
+            var (reg, sink) = New();
+            IManifestSink<PromptManifestMessage> sinkRoute = reg;
+            sinkRoute.ApplyManifest(Manifest(1, Prompt("level-design-brief", "h1")));
+            Assert.True(sink.HasPrompt("level-design-brief"));
+        }
+    }
+}

--- a/bridge/tests/ProxyPromptTests.cs
+++ b/bridge/tests/ProxyPromptTests.cs
@@ -1,0 +1,144 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak)              │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    public class ProxyPromptFactoryTests
+    {
+        private static Dictionary<string, JsonElement> Args(string json)
+        {
+            using var doc = JsonDocument.Parse(json);
+            var dict = new Dictionary<string, JsonElement>();
+            foreach (var prop in doc.RootElement.EnumerateObject())
+                dict[prop.Name] = prop.Value.Clone();
+            return dict;
+        }
+
+        [Fact]
+        public async Task Create_RoundTripsGetThroughChannel_MapsMessagesRoleAndDescription()
+        {
+            var channel = new FakePromptCallChannel((prompt, args) => new PromptResponseMessage
+            {
+                RequestId = "x",
+                Status = IpcProtocol.Status.Success,
+                Description = "brief for " + args!["theme"]!.GetValue<string>(),
+                Messages = new List<PromptResponseEntry>
+                {
+                    new() { Role = "user", Text = "Draft a brief for " + args!["theme"]!.GetValue<string>() },
+                    new() { Role = "assistant", Text = "Sure." },
+                },
+            });
+
+            var proxy = ProxyPromptFactory.Create(
+                new PromptDescriptor { Name = "level-design-brief", Role = "user" }, channel);
+            var result = await proxy.Run("req-1", Args("{\"theme\":\"haunted\"}"));
+
+            Assert.Equal("level-design-brief", channel.LastPrompt);
+            Assert.Equal("haunted", channel.LastArguments!["theme"]!.GetValue<string>());
+            Assert.Equal(ResponseStatus.Success, result.Status);
+            Assert.Equal("req-1", result.RequestID);
+            Assert.Equal("brief for haunted", result.Description);
+            Assert.Equal(2, result.Messages.Count);
+            Assert.Equal(Role.User, result.Messages[0].Role);
+            Assert.Equal("Draft a brief for haunted", result.Messages[0].Content?.Text);
+            Assert.Equal(Role.Assistant, result.Messages[1].Role);
+        }
+
+        [Fact]
+        public async Task Create_ErrorStatus_MapsToError()
+        {
+            var channel = new FakePromptCallChannel((prompt, args) => new PromptResponseMessage
+            {
+                RequestId = "x",
+                Status = IpcProtocol.Status.Error,
+                Error = "theme is required.",
+            });
+
+            var proxy = ProxyPromptFactory.Create(new PromptDescriptor { Name = "level-design-brief" }, channel);
+            var result = await proxy.Run("req-2", null);
+
+            Assert.Equal(ResponseStatus.Error, result.Status);
+            Assert.Equal("req-2", result.RequestID);
+            Assert.Contains("theme is required", result.GetMessage());
+        }
+
+        [Fact]
+        public async Task Create_DisconnectedChannel_FailsFastWithStructuredError()
+        {
+            var channel = new FakePromptCallChannel { Connected = false };
+            var proxy = ProxyPromptFactory.Create(new PromptDescriptor { Name = "level-design-brief" }, channel);
+
+            var result = await proxy.Run("req-3", null);
+
+            Assert.Equal(ResponseStatus.Error, result.Status);
+            Assert.Equal("req-3", result.RequestID);
+            Assert.Contains("disconnected", result.GetMessage());
+        }
+
+        [Theory]
+        [InlineData("assistant", Role.Assistant)]
+        [InlineData("USER", Role.User)]
+        [InlineData(null, Role.Assistant)]   // missing → falls back to the descriptor's role
+        public async Task Create_ParsesRole_FallingBackToDescriptorRole(string? entryRole, Role expected)
+        {
+            var channel = new FakePromptCallChannel((prompt, args) => new PromptResponseMessage
+            {
+                Status = IpcProtocol.Status.Success,
+                Messages = new List<PromptResponseEntry> { new() { Role = entryRole, Text = "hi" } },
+            });
+
+            // Descriptor role = assistant so the null-entry case falls back to assistant.
+            var proxy = ProxyPromptFactory.Create(new PromptDescriptor { Name = "p", Role = "assistant" }, channel);
+            var result = await proxy.Run("r", null);
+            Assert.Equal(expected, result.Messages.Single().Role);
+        }
+
+        [Fact]
+        public void Create_MapsDescriptorRoleAndPropagatesEnabledFlag()
+        {
+            var channel = new FakePromptCallChannel();
+            var proxy = ProxyPromptFactory.Create(
+                new PromptDescriptor { Name = "p", Role = "assistant", Enabled = false }, channel);
+            Assert.Equal(Role.Assistant, proxy.Role);
+            Assert.False(proxy.Enabled);
+        }
+
+        [Fact]
+        public void Create_DefaultsRoleToUser_WhenDescriptorRoleAbsent()
+        {
+            var channel = new FakePromptCallChannel();
+            var proxy = ProxyPromptFactory.Create(new PromptDescriptor { Name = "p" }, channel);
+            Assert.Equal(Role.User, proxy.Role);
+        }
+
+        [Fact]
+        public void Create_DetachesInputSchema()
+        {
+            var schema = JsonNode.Parse("{\"type\":\"object\",\"properties\":{\"theme\":{\"type\":\"string\"}}}");
+            var channel = new FakePromptCallChannel();
+            var proxy = ProxyPromptFactory.Create(
+                new PromptDescriptor { Name = "p", InputSchema = schema }, channel);
+            // A detached clone: not the same reference the descriptor handed in.
+            Assert.NotNull(proxy.InputSchema);
+            Assert.NotSame(schema, proxy.InputSchema);
+            Assert.Equal(schema!.ToJsonString(), proxy.InputSchema!.ToJsonString());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- C++ prompt path mirroring the tool registry: `IUnrealMcpPromptProvider`, `FUnrealMcpPromptRegistry`/`FUnrealMcpPromptBuilder` (reusing `FUnrealMcpParamSpec` + the §3.2 schema gen verbatim), `UUnrealMcpRuntimeSubsystem::Register/UnregisterPromptProvider`, a kind-aware `FUnrealMcpExtensionManager` prompt pass, and real `FUnrealMcpBridgeServer` `PushPromptManifest`/`HandlePromptGet` (game-thread dispatch, per-call timeout/cancel, `prompt-response`).
- Bridge `ProxyPrompt : IRunPrompt` + factory + `PromptManifestRegistrar` (`ManifestRegistrarBase<PromptDescriptor>`) + `PromptManagerSink` (over the nullable `IPromptManager.AddPrompt`); `SidecarHost.Build` wiring; `IpcClient` implements `IPromptCallChannel`.
- Core sample prompt `level-design-brief` (User role, templated from a required `theme` arg) proving the path end-to-end.

## Test plan
- [x] Bridge xUnit green (ProxyPrompt round-trip + prompt manifest registrar diff/reconnect).
- [x] Clean editor build + RunUAT BuildPlugin (Game+Editor, -WarningsAsErrors) green; headless boot smoke `[Unreal-MCP] plugin loaded`.
- [x] Full `UnrealMcp.*` Automation `failed: 0` (new `UnrealMcp.Prompts.Registry` specs + existing tool/extension specs).

Closes #133