### PR TITLE
feat: Custom MCP resource registration (editor + runtime, static URIs) + bridge ProxyResource + sample

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
@@ -6,8 +6,10 @@
 #include "UnrealMcpCoreTools.h"
 #include "UnrealMcpRuntimeCoreTools.h"
 #include "UnrealMcpRuntimeCorePrompts.h"
+#include "UnrealMcpRuntimeCoreResources.h"
 #include "UnrealMcpToolRegistry.h"
 #include "UnrealMcpPromptRegistry.h"
+#include "UnrealMcpResourceRegistry.h"
 #include "Config/UnrealMcpConfig.h"
 #include "Dispatch/UnrealMcpGameThreadDispatcher.h"
 #include "Bridge/UnrealMcpBridgeServer.h"
@@ -81,8 +83,15 @@ void FUnrealMcpEditorCoordinator::Startup()
 	PromptRegistry = MakeUnique<FUnrealMcpPromptRegistry>();
 	UnrealMcpCorePrompts::Register(*PromptRegistry);
 
+	// §A.1 resource registry (P2): the resource sibling of the tool/prompt registries, built on the SAME Model A
+	// path. The core resource family registers before the bridge starts accepting so the first resource-manifest a
+	// v2 sidecar reads on handshake already includes it. The §8 config has no EnabledResources/DisabledResources
+	// field today, so no resource filter is applied at boot (all-enabled default).
+	ResourceRegistry = MakeUnique<FUnrealMcpResourceRegistry>();
+	UnrealMcpCoreResources::Register(*ResourceRegistry);
+
 	Dispatcher = MakeUnique<FUnrealMcpGameThreadDispatcher>();
-	BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(*Registry, *Dispatcher, PromptRegistry.Get());
+	BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(*Registry, *Dispatcher, PromptRegistry.Get(), ResourceRegistry.Get());
 
 	// Discover 3rd-party extension tool providers (§5) and merge them into the registry BEFORE the bridge
 	// starts accepting, so the first manifest a sidecar reads on handshake already includes them. Late
@@ -103,7 +112,8 @@ void FUnrealMcpEditorCoordinator::Startup()
 			}
 		},
 		/*InConfigPath*/ FString(),
-		PromptRegistry.Get()); // §A.2 kind-aware: also merge prompt-provider extensions into the prompt registry
+		PromptRegistry.Get(), // §A.2 kind-aware: also merge prompt-provider extensions into the prompt registry
+		ResourceRegistry.Get()); // §A.2 kind-aware: also merge resource-provider extensions into the resource registry
 	ExtensionManager->Startup();
 
 	const FString ProjectPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
@@ -502,6 +512,7 @@ void FUnrealMcpEditorCoordinator::Shutdown()
 	}
 
 	Dispatcher.Reset();
+	ResourceRegistry.Reset(); // after ExtensionManager (which holds a raw pointer to it) is torn down above
 	PromptRegistry.Reset(); // after ExtensionManager (which holds a raw pointer to it) is torn down above
 	Registry.Reset();
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.h
@@ -7,6 +7,7 @@
 
 class FUnrealMcpToolRegistry;
 class FUnrealMcpPromptRegistry;
+class FUnrealMcpResourceRegistry;
 class FUnrealMcpGameThreadDispatcher;
 class FUnrealMcpBridgeServer;
 class FUnrealMcpSidecarManager;
@@ -49,6 +50,8 @@ private:
 	TUniquePtr<FUnrealMcpToolRegistry> Registry;
 	// §A.1 prompt registry (P1): built alongside the tool registry on the SAME Model A path.
 	TUniquePtr<FUnrealMcpPromptRegistry> PromptRegistry;
+	// §A.1 resource registry (P2): built alongside the tool/prompt registries on the SAME Model A path.
+	TUniquePtr<FUnrealMcpResourceRegistry> ResourceRegistry;
 	TUniquePtr<FUnrealMcpGameThreadDispatcher> Dispatcher;
 	TUniquePtr<FUnrealMcpBridgeServer> BridgeServer;
 	TUniquePtr<FUnrealMcpSidecarManager> SidecarManager;

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpResourceExtensionPassSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpResourceExtensionPassSpec.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/Paths.h"
+#include "Misc/Guid.h"
+#include "HAL/FileManager.h"
+
+#include "IUnrealMcpResourceProvider.h"
+#include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpResourceRegistry.h"
+#include "Extensions/UnrealMcpExtensionManager.h"
+
+/**
+ * The §A.2 kind-aware RESOURCE pass of the extension manager: a resource provider's resources merge into the
+ * resource registry through the SAME manager that drives tools/prompts, gated by the SAME DisabledExtensions
+ * set, and a single OnChanged covers the rebuild. Mirrors the tool/prompt pass contract.
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpResourceExtensionPassSpec, "UnrealMcp.Resources.ExtensionPass",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FUnrealMcpResourceExtensionPassSpec)
+
+namespace
+{
+	/** A test-only resource provider whose RegisterResources delegates to a supplied lambda (spec-unique name). */
+	class FResourcePassMockProvider : public IUnrealMcpResourceProvider
+	{
+	public:
+		FResourcePassMockProvider(const FString& InId, TFunction<void(FUnrealMcpResourceRegistry&)> InRegisterFn)
+			: Id(InId), Display(FText::FromString(InId)), Version(TEXT("1.0.0")), RegisterFn(MoveTemp(InRegisterFn)) {}
+
+		virtual FString GetExtensionId() const override { return Id; }
+		virtual FText GetDisplayName() const override { return Display; }
+		virtual FString GetExtensionVersion() const override { return Version; }
+		virtual void RegisterResources(FUnrealMcpResourceRegistry& Registry) override { if (RegisterFn) RegisterFn(Registry); }
+
+		FString Id;
+		FText Display;
+		FString Version;
+		TFunction<void(FUnrealMcpResourceRegistry&)> RegisterFn;
+	};
+
+	void ResourcePassAddSimple(FUnrealMcpResourceRegistry& Registry, const FString& Uri)
+	{
+		Registry.Resource(Uri)
+			.Name(TEXT("pass resource"))
+			.MimeType(TEXT("text/plain"))
+			.Read([](const FString& U) { return FUnrealMcpResourceResult::Text(U, TEXT("ok"), TEXT("text/plain")); });
+	}
+}
+
+void FUnrealMcpResourceExtensionPassSpec::Define()
+{
+	It("merges an enabled resource provider into the resource registry and fires OnChanged", [this]()
+	{
+		FUnrealMcpToolRegistry ToolRegistry;
+		FUnrealMcpResourceRegistry ResourceRegistry;
+		int32 NotifyCount = 0;
+
+		// Empty config path is fine — no disabled set on disk for this in-memory spec.
+		FUnrealMcpExtensionManager Manager(
+			ToolRegistry, [&NotifyCount]() { ++NotifyCount; }, FString(),
+			/*PromptRegistry*/ nullptr, &ResourceRegistry);
+
+		FResourcePassMockProvider Provider(TEXT("com.spec.res"),
+			[](FUnrealMcpResourceRegistry& Reg) { ResourcePassAddSimple(Reg, TEXT("unreal://pass/one")); });
+		Manager.SetResourceProviderSourceForTesting([&Provider]() { return TArray<IUnrealMcpResourceProvider*>{ &Provider }; });
+
+		// RebuildFromProviders runs the tool pass (empty here) AND the resource pass under one guard/notify.
+		Manager.RebuildFromProviders(TArray<IUnrealMcpToolProvider*>(), /*bNotify*/ true);
+
+		TestTrue(TEXT("resource merged into registry"), ResourceRegistry.HasResource(TEXT("unreal://pass/one")));
+		TestEqual(TEXT("OnChanged fired once"), NotifyCount, 1);
+		if (const FUnrealMcpRegisteredResource* R = ResourceRegistry.Find(TEXT("unreal://pass/one")))
+			TestEqual(TEXT("stamped extension id"), R->ExtensionId, FString(TEXT("com.spec.res")));
+	});
+
+	It("a re-run cleanly clears the previous resource contribution (no duplicate / stale entries)", [this]()
+	{
+		FUnrealMcpToolRegistry ToolRegistry;
+		FUnrealMcpResourceRegistry ResourceRegistry;
+		FUnrealMcpExtensionManager Manager(ToolRegistry, []() {}, FString(), nullptr, &ResourceRegistry);
+
+		FResourcePassMockProvider Provider(TEXT("com.spec.res"),
+			[](FUnrealMcpResourceRegistry& Reg) { ResourcePassAddSimple(Reg, TEXT("unreal://pass/one")); });
+		Manager.SetResourceProviderSourceForTesting([&Provider]() { return TArray<IUnrealMcpResourceProvider*>{ &Provider }; });
+
+		Manager.RebuildFromProviders(TArray<IUnrealMcpToolProvider*>(), false);
+		Manager.RebuildFromProviders(TArray<IUnrealMcpToolProvider*>(), false);
+
+		TestTrue(TEXT("resource still present after re-run"), ResourceRegistry.HasResource(TEXT("unreal://pass/one")));
+		TestEqual(TEXT("exactly one resource (no duplicate)"), ResourceRegistry.Num(), 1);
+	});
+
+	It("a disabled extension contributes no resources (gated by the shared DisabledExtensions set)", [this]()
+	{
+		FUnrealMcpToolRegistry ToolRegistry;
+		FUnrealMcpResourceRegistry ResourceRegistry;
+
+		// Use a temp config path so SetExtensionEnabled can persist without touching the project Saved dir.
+		const FString TempConfig = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("Config"), TEXT("UnrealMCP"),
+			FString::Printf(TEXT("ResPassSpec-%s.json"), *FGuid::NewGuid().ToString()));
+		FUnrealMcpExtensionManager Manager(ToolRegistry, []() {}, TempConfig, nullptr, &ResourceRegistry);
+
+		FResourcePassMockProvider Provider(TEXT("com.spec.res"),
+			[](FUnrealMcpResourceRegistry& Reg) { ResourcePassAddSimple(Reg, TEXT("unreal://pass/one")); });
+		Manager.SetResourceProviderSourceForTesting([&Provider]() { return TArray<IUnrealMcpResourceProvider*>{ &Provider }; });
+
+		Manager.RebuildFromProviders(TArray<IUnrealMcpToolProvider*>(), false);
+		TestTrue(TEXT("present while enabled"), ResourceRegistry.HasResource(TEXT("unreal://pass/one")));
+
+		Manager.SetExtensionEnabled(TEXT("com.spec.res"), false); // disable -> rebuild
+		TestFalse(TEXT("absent once the extension is disabled"), ResourceRegistry.HasResource(TEXT("unreal://pass/one")));
+
+		IFileManager::Get().Delete(*TempConfig, /*RequireExists*/ false, /*EvenReadOnly*/ true);
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpResourceRegistrySpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpResourceRegistrySpec.cpp
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/Base64.h"
+#include "UnrealMcpRuntimeCoreResources.h"
+#include "UnrealMcpResourceRegistry.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+/** Resource registry + core-resource specs (docs/ARCHITECTURE.md §A.1 / §A.2). */
+BEGIN_DEFINE_SPEC(FUnrealMcpResourceRegistrySpec, "UnrealMcp.Resources.Registry",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FUnrealMcpResourceRegistrySpec)
+
+namespace
+{
+	// Spec-UNIQUE helper names (unity-build ODR). Find the resource descriptor with the given uri in a manifest.
+	TSharedPtr<FJsonObject> ResourceSpecFindDescriptor(const TSharedPtr<FJsonObject>& Manifest, const FString& Uri)
+	{
+		const TArray<TSharedPtr<FJsonValue>>* Resources = nullptr;
+		if (!Manifest->TryGetArrayField(TEXT("resources"), Resources))
+			return nullptr;
+		for (const TSharedPtr<FJsonValue>& Value : *Resources)
+		{
+			const TSharedPtr<FJsonObject> Obj = Value->AsObject();
+			if (Obj.IsValid() && Obj->GetStringField(TEXT("uri")) == Uri)
+				return Obj;
+		}
+		return nullptr;
+	}
+
+	/** A test-only resource provider that registers one text resource under a given id/uri. */
+	class FResourceSpecProvider
+	{
+	public:
+		static void RegisterInto(FUnrealMcpResourceRegistry& Registry, const FString& Uri)
+		{
+			Registry.Resource(Uri)
+				.Name(TEXT("Spec resource"))
+				.Description(TEXT("A spec fixture resource."))
+				.MimeType(TEXT("text/plain"))
+				.Read([](const FString& U) { return FUnrealMcpResourceResult::Text(U, TEXT("ok"), TEXT("text/plain")); });
+		}
+	};
+}
+
+void FUnrealMcpResourceRegistrySpec::Define()
+{
+	Describe("core resource registration", [this]()
+	{
+		It("registers the core resources and bumps the revision", [this]()
+		{
+			FUnrealMcpResourceRegistry Registry;
+			const int32 Before = Registry.GetRevision();
+			UnrealMcpCoreResources::Register(Registry);
+			TestTrue(TEXT("has unreal://project/levels"), Registry.HasResource(TEXT("unreal://project/levels")));
+			TestTrue(TEXT("has unreal://project/icon"), Registry.HasResource(TEXT("unreal://project/icon")));
+			TestEqual(TEXT("two resources"), Registry.Num(), 2);
+			TestTrue(TEXT("revision bumped"), Registry.GetRevision() > Before);
+		});
+
+		It("reads unreal://project/levels as a JSON text block (application/json)", [this]()
+		{
+			FUnrealMcpResourceRegistry Registry;
+			UnrealMcpCoreResources::Register(Registry);
+
+			const FUnrealMcpResourceResult Result = Registry.Read(TEXT("unreal://project/levels"));
+			TestTrue(TEXT("success"), Result.bSuccess);
+			TestEqual(TEXT("one content block"), Result.Contents.Num(), 1);
+			if (Result.Contents.Num() == 1)
+			{
+				const FUnrealMcpResourceContent& C = Result.Contents[0];
+				TestFalse(TEXT("not a blob"), C.bIsBlob);
+				TestEqual(TEXT("mime is application/json"), C.MimeType, FString(TEXT("application/json")));
+				TestFalse(TEXT("text non-empty"), C.Text.IsEmpty());
+
+				// The text must be valid JSON carrying the "hasWorld" key (null-world safe in headless).
+				TSharedPtr<FJsonObject> Parsed;
+				const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(C.Text);
+				TestTrue(TEXT("text parses as JSON"), FJsonSerializer::Deserialize(Reader, Parsed) && Parsed.IsValid());
+				if (Parsed.IsValid())
+					TestTrue(TEXT("has hasWorld field"), Parsed->HasField(TEXT("hasWorld")));
+			}
+		});
+
+		It("reads unreal://project/icon as a base64 PNG blob (image/png) that decodes to PNG-magic bytes", [this]()
+		{
+			FUnrealMcpResourceRegistry Registry;
+			UnrealMcpCoreResources::Register(Registry);
+
+			const FUnrealMcpResourceResult Result = Registry.Read(TEXT("unreal://project/icon"));
+			TestTrue(TEXT("success"), Result.bSuccess);
+			TestEqual(TEXT("one content block"), Result.Contents.Num(), 1);
+			if (Result.Contents.Num() == 1)
+			{
+				const FUnrealMcpResourceContent& C = Result.Contents[0];
+				TestTrue(TEXT("is a blob"), C.bIsBlob);
+				TestEqual(TEXT("mime is image/png"), C.MimeType, FString(TEXT("image/png")));
+				TestTrue(TEXT("text empty (blob XOR text)"), C.Text.IsEmpty());
+				TestFalse(TEXT("blob non-empty"), C.Blob.IsEmpty());
+
+				// The base64 blob must decode back to bytes whose 8-byte PNG signature is intact (round-trip).
+				TArray<uint8> Decoded;
+				if (TestTrue(TEXT("blob decodes from base64"), FBase64::Decode(C.Blob, Decoded)))
+				{
+					if (TestTrue(TEXT("decoded has >= 8 bytes"), Decoded.Num() >= 8))
+					{
+						static const uint8 PngMagic[8] = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+						bool bMagicOk = true;
+						for (int32 i = 0; i < 8; ++i)
+							bMagicOk = bMagicOk && (Decoded[i] == PngMagic[i]);
+						TestTrue(TEXT("decoded bytes begin with the PNG signature"), bMagicOk);
+					}
+				}
+			}
+		});
+
+		It("returns an error for an unknown resource", [this]()
+		{
+			FUnrealMcpResourceRegistry Registry;
+			const FUnrealMcpResourceResult Result = Registry.Read(TEXT("unreal://does-not-exist"));
+			TestFalse(TEXT("not success"), Result.bSuccess);
+		});
+	});
+
+	Describe("manifest JSON", [this]()
+	{
+		It("has type resource-manifest, a revision, and the levels descriptor with uri + mimeType + a schema hash", [this]()
+		{
+			FUnrealMcpResourceRegistry Registry;
+			UnrealMcpCoreResources::Register(Registry);
+
+			TSharedPtr<FJsonObject> Manifest = Registry.BuildManifestJson();
+			TestEqual(TEXT("type"), Manifest->GetStringField(TEXT("type")), FString(TEXT("resource-manifest")));
+			TestEqual(TEXT("revision"), (int32)Manifest->GetNumberField(TEXT("revision")), Registry.GetRevision());
+
+			TSharedPtr<FJsonObject> Desc = ResourceSpecFindDescriptor(Manifest, TEXT("unreal://project/levels"));
+			if (TestTrue(TEXT("descriptor present"), Desc.IsValid()))
+			{
+				TestEqual(TEXT("uri"), Desc->GetStringField(TEXT("uri")), FString(TEXT("unreal://project/levels")));
+				TestEqual(TEXT("mimeType"), Desc->GetStringField(TEXT("mimeType")), FString(TEXT("application/json")));
+				TestFalse(TEXT("schema hash non-empty"), Desc->GetStringField(TEXT("schemaHash")).IsEmpty());
+			}
+		});
+
+		It("produces a stable schema hash for an unchanged resource", [this]()
+		{
+			FUnrealMcpResourceRegistry A, B;
+			UnrealMcpCoreResources::Register(A);
+			UnrealMcpCoreResources::Register(B);
+			TestEqual(TEXT("same hash"),
+				A.Find(TEXT("unreal://project/levels"))->SchemaHash, B.Find(TEXT("unreal://project/levels"))->SchemaHash);
+		});
+	});
+
+	Describe("enable filter", [this]()
+	{
+		It("excludes a disabled resource from the manifest and errors on Read", [this]()
+		{
+			FUnrealMcpResourceRegistry Registry;
+			UnrealMcpCoreResources::Register(Registry);
+
+			const int32 RevBefore = Registry.GetRevision();
+			TestTrue(TEXT("toggle changed"), Registry.SetResourceEnabled(TEXT("unreal://project/levels"), false));
+			TestTrue(TEXT("revision bumped on toggle"), Registry.GetRevision() > RevBefore);
+
+			TSharedPtr<FJsonObject> Manifest = Registry.BuildManifestJson();
+			TestFalse(TEXT("disabled resource excluded from manifest"),
+				ResourceSpecFindDescriptor(Manifest, TEXT("unreal://project/levels")).IsValid());
+
+			const FUnrealMcpResourceResult Result = Registry.Read(TEXT("unreal://project/levels"));
+			TestFalse(TEXT("disabled resource errors on Read"), Result.bSuccess);
+		});
+	});
+
+	Describe("extension registration (§5 isolation, pure registry)", [this]()
+	{
+		It("registers a valid extension resource under its id and bumps the revision", [this]()
+		{
+			FUnrealMcpResourceRegistry Registry;
+			const int32 RevBefore = Registry.GetRevision();
+			const FUnrealMcpExtensionRegistrationResult Result = Registry.RegisterExtension(
+				TEXT("com.spec.ext"), [](FUnrealMcpResourceRegistry& Reg)
+				{
+					FResourceSpecProvider::RegisterInto(Reg, TEXT("unreal://ext/resource"));
+				});
+			TestEqual(TEXT("one entry registered"), Result.ToolsRegistered, 1);
+			TestEqual(TEXT("no errors"), Result.Errors.Num(), 0);
+			TestTrue(TEXT("ext resource present"), Registry.HasResource(TEXT("unreal://ext/resource")));
+			TestTrue(TEXT("revision bumped"), Registry.GetRevision() > RevBefore);
+			if (const FUnrealMcpRegisteredResource* R = Registry.Find(TEXT("unreal://ext/resource")))
+				TestEqual(TEXT("stamped extension id"), R->ExtensionId, FString(TEXT("com.spec.ext")));
+		});
+
+		It("rejects a duplicate resource uri within an extension", [this]()
+		{
+			FUnrealMcpResourceRegistry Registry;
+			const FUnrealMcpExtensionRegistrationResult Result = Registry.RegisterExtension(
+				TEXT("com.spec.dup"), [](FUnrealMcpResourceRegistry& Reg)
+				{
+					FResourceSpecProvider::RegisterInto(Reg, TEXT("unreal://dup/resource"));
+					FResourceSpecProvider::RegisterInto(Reg, TEXT("unreal://dup/resource")); // duplicate -> rejected
+				});
+			TestEqual(TEXT("only one entry registered"), Result.ToolsRegistered, 1);
+			TestTrue(TEXT("a rejection was recorded"), Result.Errors.Num() >= 1);
+			TestEqual(TEXT("one resource total"), Registry.Num(), 1);
+		});
+
+		It("drops an invalid resource uri", [this]()
+		{
+			FUnrealMcpResourceRegistry Registry;
+			const FUnrealMcpExtensionRegistrationResult Result = Registry.RegisterExtension(
+				TEXT("com.spec.bad"), [](FUnrealMcpResourceRegistry& Reg)
+				{
+					Reg.Resource(TEXT("has space")) // whitespace -> invalid uri
+						.Name(TEXT("Bad"))
+						.Read([](const FString& U) { return FUnrealMcpResourceResult::Text(U, TEXT("ok")); });
+				});
+			TestEqual(TEXT("nothing registered"), Result.ToolsRegistered, 0);
+			TestTrue(TEXT("a drop was recorded"), Result.Errors.Num() >= 1);
+			TestEqual(TEXT("no resources"), Registry.Num(), 0);
+		});
+
+		It("removes an extension's resources by id (hot-unload), leaving core untouched", [this]()
+		{
+			FUnrealMcpResourceRegistry Registry;
+			UnrealMcpCoreResources::Register(Registry);
+			Registry.RegisterExtension(TEXT("com.spec.ext"), [](FUnrealMcpResourceRegistry& Reg)
+			{
+				FResourceSpecProvider::RegisterInto(Reg, TEXT("unreal://ext/resource"));
+			});
+			TestEqual(TEXT("three resources total"), Registry.Num(), 3);
+
+			const int32 Removed = Registry.RemoveResourcesForExtension(TEXT("com.spec.ext"));
+			TestEqual(TEXT("removed exactly the ext resource"), Removed, 1);
+			TestFalse(TEXT("ext resource gone"), Registry.HasResource(TEXT("unreal://ext/resource")));
+			TestTrue(TEXT("core levels still present"), Registry.HasResource(TEXT("unreal://project/levels")));
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.cpp
@@ -5,6 +5,7 @@
 #include "UnrealMcpNdjson.h"
 #include "UnrealMcpToolRegistry.h"
 #include "UnrealMcpPromptRegistry.h"
+#include "UnrealMcpResourceRegistry.h"
 #include "Dispatch/UnrealMcpGameThreadDispatcher.h"
 #include "UnrealMcpLog.h"
 
@@ -93,9 +94,10 @@ namespace
 }
 
 FUnrealMcpBridgeServer::FUnrealMcpBridgeServer(FUnrealMcpToolRegistry& InRegistry, FUnrealMcpGameThreadDispatcher& InDispatcher,
-	FUnrealMcpPromptRegistry* InPromptRegistry)
+	FUnrealMcpPromptRegistry* InPromptRegistry, FUnrealMcpResourceRegistry* InResourceRegistry)
 	: Registry(InRegistry)
 	, PromptRegistry(InPromptRegistry)
+	, ResourceRegistry(InResourceRegistry)
 	, Dispatcher(InDispatcher)
 {
 }
@@ -712,18 +714,131 @@ void FUnrealMcpBridgeServer::HandlePromptGet(const TSharedPtr<FJsonObject>& Mess
 
 void FUnrealMcpBridgeServer::HandleResourceRead(const TSharedPtr<FJsonObject>& Message)
 {
-	// SCAFFOLD (M16 P0, §A.1): no resource registry is wired until P2 — same error-status fast-fail as the
-	// prompt stub. P2 replaces this with a real read dispatched on the game thread (an asset enumeration must
-	// not block the game thread unboundedly, §A.1 risk 7).
-	FString RequestId;
-	Message->TryGetStringField(TEXT("requestId"), RequestId);
+	// Do not start new work once teardown has begun (same contract as HandleToolCall / HandlePromptGet): the
+	// continuation captures `this` and the resource registry, both freed right after Shutdown().
+	if (bStopRequested)
+		return;
 
-	TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
-	Response->SetStringField(TEXT("type"), TypeResourceResponse);
-	Response->SetStringField(TEXT("requestId"), RequestId);
-	Response->SetStringField(TEXT("status"), TEXT("error"));
-	Response->SetStringField(TEXT("error"), TEXT("Resources are not implemented yet (scaffold)."));
-	SendMessage(Response);
+	FString RequestId, Uri;
+	Message->TryGetStringField(TEXT("requestId"), RequestId);
+	Message->TryGetStringField(TEXT("uri"), Uri);
+
+	// Defensive: a resource-read must never arrive on a tools-only build (the v2 gate blocks the manifest), but
+	// answer with a correlated error rather than dropping the pending call if ResourceRegistry is null.
+	if (ResourceRegistry == nullptr)
+	{
+		TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
+		Response->SetStringField(TEXT("type"), TypeResourceResponse);
+		Response->SetStringField(TEXT("requestId"), RequestId);
+		Response->SetStringField(TEXT("status"), TEXT("error"));
+		Response->SetStringField(TEXT("error"), TEXT("Resources are not implemented."));
+		SendMessage(Response);
+		return;
+	}
+
+	int32 TimeoutMs = DefaultToolTimeoutMs;
+	double TimeoutValue;
+	if (Message->TryGetNumberField(TEXT("timeoutMs"), TimeoutValue) && TimeoutValue > 0)
+		TimeoutMs = static_cast<int32>(TimeoutValue);
+
+	// Per-call cancel flag (§4) — reuse the SAME CancelFlags map as tool-calls (the generic tool-cancel by
+	// requestId covers all kinds, §A.1). Shared ownership keeps it alive past the map-entry removal.
+	TSharedRef<FThreadSafeBool, ESPMode::ThreadSafe> CancelFlag = MakeShared<FThreadSafeBool, ESPMode::ThreadSafe>(false);
+
+	bool bTrackCancel = false;
+	if (!RequestId.IsEmpty())
+	{
+		FScopeLock Lock(&CancelMutex);
+		if (CancelFlags.Contains(RequestId))
+		{
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] duplicate resource-read requestId '%s'; not tracking cancellation for it."), *RequestId);
+		}
+		else
+		{
+			CancelFlags.Add(RequestId, CancelFlag);
+			bTrackCancel = true;
+		}
+	}
+
+	// A resource read takes no arguments (static MVP URIs); pass an empty args object + the cancel flag so the
+	// dispatcher contract (game thread + per-call timeout + cancel) is identical to the tool/prompt path.
+	FUnrealMcpToolCall Call(MakeShared<FJsonObject>());
+	Call.CancelRequested = CancelFlag;
+
+	const FString CapturedUri = Uri;
+	const FString CapturedRequestId = RequestId;
+	const bool bRemoveOnDone = bTrackCancel;
+	FUnrealMcpResourceRegistry* CapturedRegistry = ResourceRegistry;
+
+	InFlightCalls.Increment();
+
+	// PACK the FUnrealMcpResourceResult into the FUnrealMcpToolResult transport (same trick as HandlePromptGet):
+	// the Structured JSON carries { contents:[{uri,mimeType,text|blob}] }, bSuccess rides on the tool result's
+	// flag, and the error reason rides on Message. The .Next unpacks it into a resource-response. This keeps the
+	// game-thread + per-call timeout + cancel semantics identical to the tool path with the least new surface.
+	Dispatcher.Dispatch(
+		Call,
+		[CapturedRegistry, CapturedUri](const FUnrealMcpToolCall& /*C*/) -> FUnrealMcpToolResult
+		{
+			const FUnrealMcpResourceResult ResourceResult = CapturedRegistry->Read(CapturedUri);
+
+			TSharedPtr<FJsonObject> Packed = MakeShared<FJsonObject>();
+			TArray<TSharedPtr<FJsonValue>> Contents;
+			for (const FUnrealMcpResourceContent& Content : ResourceResult.Contents)
+			{
+				TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+				Entry->SetStringField(TEXT("uri"), Content.Uri);
+				if (!Content.MimeType.IsEmpty())
+					Entry->SetStringField(TEXT("mimeType"), Content.MimeType);
+				if (Content.bIsBlob)
+					Entry->SetStringField(TEXT("blob"), Content.Blob);
+				else
+					Entry->SetStringField(TEXT("text"), Content.Text);
+				Contents.Add(MakeShared<FJsonValueObject>(Entry));
+			}
+			Packed->SetArrayField(TEXT("contents"), Contents);
+
+			// On success Message is unused; on error it carries the reason so the .Next surfaces it as `error`.
+			FUnrealMcpToolResult Transport = ResourceResult.bSuccess
+				? FUnrealMcpToolResult::Success(FString(), Packed)
+				: FUnrealMcpToolResult::Error(ResourceResult.Error);
+			Transport.Structured = Packed; // Error() drops Structured — re-attach so the .Next can read contents
+			return Transport;
+		},
+		FTimespan::FromMilliseconds(TimeoutMs))
+		.Next([this, CapturedRequestId, bRemoveOnDone](FUnrealMcpToolResult Result)
+		{
+			TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
+			Response->SetStringField(TEXT("type"), TypeResourceResponse);
+			Response->SetStringField(TEXT("requestId"), CapturedRequestId);
+			Response->SetStringField(TEXT("status"), Result.bSuccess ? TEXT("success") : TEXT("error"));
+
+			if (Result.bSuccess)
+			{
+				// Unpack the transport: contents[] (the timeout path leaves Structured null — then this is an
+				// empty success, which the sidecar maps to a no-content resource response).
+				if (Result.Structured.IsValid())
+				{
+					const TArray<TSharedPtr<FJsonValue>>* Contents = nullptr;
+					if (Result.Structured->TryGetArrayField(TEXT("contents"), Contents))
+						Response->SetArrayField(TEXT("contents"), *Contents);
+				}
+			}
+			else
+			{
+				// Result.Message carries the error reason (registry error, or the dispatcher's timeout error).
+				Response->SetStringField(TEXT("error"), Result.Message);
+			}
+
+			SendMessage(Response);
+
+			if (bRemoveOnDone)
+			{
+				FScopeLock Lock(&CancelMutex);
+				CancelFlags.Remove(CapturedRequestId);
+			}
+			InFlightCalls.Decrement();
+		});
 }
 
 bool FUnrealMcpBridgeServer::SendMessage(const TSharedPtr<FJsonObject>& Message)
@@ -895,10 +1010,33 @@ void FUnrealMcpBridgeServer::SendPromptManifestLocked()
 
 void FUnrealMcpBridgeServer::SendResourceManifestLocked()
 {
-	// SCAFFOLD (M16 P0, §A.1): no resource registry exists until P2. Same v2 gate + no-op as the prompt manifest.
+	// Caller holds WriteMutex. Gated on a v2-negotiated link — a tools-only (v1) sidecar never receives a
+	// resource-manifest (an old sidecar keeps working). Mirrors SendPromptManifestLocked exactly over the
+	// resource registry's BuildManifestJson. The same startup-stability argument applies (the resource registry
+	// is built before the bridge accepts; dynamic re-registration marshals through the dispatcher).
 	if (NegotiatedIpcVersion < PromptsResourcesMinVersion)
 		return;
-	// (no-op: P2 fills this in)
+	if (ResourceRegistry == nullptr)
+		return;
+
+	const TSharedPtr<FJsonObject> Manifest = ResourceRegistry->BuildManifestJson();
+	const FString Json = SerializeCondensed(Manifest);
+	const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(Json);
+
+	FScopeLock ConnLock(&ConnectionMutex);
+	if (ClientSocket == nullptr)
+		return;
+
+	if (!TrySendFramedLocked(Framed))
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] resource-manifest send failed mid-frame; dropping connection."));
+		SocketsPendingDestroy.Add(ClientSocket);
+		ClientSocket = nullptr;
+		bClientConnected = false;
+		bHandshakeOk = false;
+		bHeartbeatStop = true;
+		return;
+	}
 }
 
 void FUnrealMcpBridgeServer::SendConfigLocked()

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.h
@@ -14,6 +14,7 @@
 
 class FUnrealMcpToolRegistry;
 class FUnrealMcpPromptRegistry;
+class FUnrealMcpResourceRegistry;
 class FUnrealMcpGameThreadDispatcher;
 class FTcpListener;
 class FSocket;
@@ -33,10 +34,11 @@ struct FIPv4Endpoint;
 class UNREALMCPRUNTIME_API FUnrealMcpBridgeServer : public FRunnable
 {
 public:
-	// @p InPromptRegistry is nullable — a tools-only caller may omit it and the prompt path stays inert
-	// (SendPromptManifestLocked / HandlePromptGet guard on it). Both coordinators pass it (P1).
+	// @p InPromptRegistry / @p InResourceRegistry are nullable — a tools-only caller may omit them and the
+	// prompt/resource paths stay inert (Send*ManifestLocked / Handle* guard on them). Both coordinators pass
+	// the prompt registry (P1) and the resource registry (P2).
 	FUnrealMcpBridgeServer(FUnrealMcpToolRegistry& InRegistry, FUnrealMcpGameThreadDispatcher& InDispatcher,
-		FUnrealMcpPromptRegistry* InPromptRegistry = nullptr);
+		FUnrealMcpPromptRegistry* InPromptRegistry = nullptr, FUnrealMcpResourceRegistry* InResourceRegistry = nullptr);
 	virtual ~FUnrealMcpBridgeServer() override;
 
 	/**
@@ -60,11 +62,11 @@ public:
 	void PushManifest();
 
 	/**
-	 * Re-push the prompt / resource manifests (IPC v2, docs/ARCHITECTURE.md §A.1). SCAFFOLD STUBS (M16 P0):
-	 * a prompt/resource registry is not wired until P1/P2, so today these no-op (nothing to send) — they
-	 * exist so the kind-aware extension manager's OnChanged can fire all three Push*Manifest() uniformly.
-	 * Both are additionally GATED on a v2-negotiated link: on a tools-only (v1) connection they never send,
-	 * so an old sidecar keeps working. No-op when disconnected. The real bodies arrive with the P1/P2 registries.
+	 * Re-push the prompt / resource manifests (IPC v2, docs/ARCHITECTURE.md §A.1). Both mirror PushManifest
+	 * over their respective registry's BuildManifestJson (the prompt registry wired in P1, the resource
+	 * registry in P2). Both are GATED on a v2-negotiated link: on a tools-only (v1) connection they never
+	 * send, so an old sidecar keeps working; they also no-op when the corresponding registry is null (a
+	 * tools-only caller) or when disconnected.
 	 */
 	void PushPromptManifest();
 	void PushResourceManifest();
@@ -155,11 +157,10 @@ private:
 	void HandleToolCancel(const TSharedPtr<FJsonObject>& Message);
 
 	/**
-	 * Handle a v2 `prompt-get` / `resource-read` request (§A.1). SCAFFOLD STUBS (M16 P0): no prompt/resource
-	 * registry is wired until P1/P2, so each answers with an `error`-status response carrying a "not
-	 * implemented" reason (correlated by requestId), exactly as a tool-call to an unknown tool would fail —
-	 * never silently dropped, so the sidecar's pending call resolves instead of hanging. The real bodies
-	 * (marshalling through FUnrealMcpGameThreadDispatcher) land with the P1/P2 registries.
+	 * Handle a v2 `prompt-get` / `resource-read` request (§A.1). Each marshals the registry read onto the game
+	 * thread through FUnrealMcpGameThreadDispatcher (§4) and answers with the correlated `prompt-response` /
+	 * `resource-response`. A null registry (tools-only caller) answers with a correlated `error` status rather
+	 * than dropping the pending call. Prompts wired in P1; resources in P2.
 	 */
 	void HandlePromptGet(const TSharedPtr<FJsonObject>& Message);
 	void HandleResourceRead(const TSharedPtr<FJsonObject>& Message);
@@ -167,8 +168,8 @@ private:
 	bool SendMessage(const TSharedPtr<FJsonObject>& Message);
 	void SendHandshakeAck();
 	void SendManifestLocked();
-	void SendPromptManifestLocked();   // v2 scaffold: no-op until a prompt registry is wired (P1)
-	void SendResourceManifestLocked(); // v2 scaffold: no-op until a resource registry is wired (P2)
+	void SendPromptManifestLocked();   // v2: prompt registry wired (P1); v2-gated + null-guarded
+	void SendResourceManifestLocked(); // v2: resource registry wired (P2); v2-gated + null-guarded
 	void SendConfigLocked(); // WriteMutex held: frame + send the §1.3 `config` message (no-op when no config)
 	bool TrySendFramedLocked(const TArray<uint8>& Framed); // WriteMutex+ConnectionMutex held, ClientSocket valid
 	void CloseActiveConnection();
@@ -182,6 +183,9 @@ private:
 	// Nullable: the prompt registry (P1). When null the prompt path is inert (SendPromptManifestLocked /
 	// HandlePromptGet guard on it) so a tools-only build / test still compiles + links.
 	FUnrealMcpPromptRegistry* PromptRegistry = nullptr;
+	// Nullable: the resource registry (P2). When null the resource path is inert (SendResourceManifestLocked /
+	// HandleResourceRead guard on it) so a tools-only build / test still compiles + links.
+	FUnrealMcpResourceRegistry* ResourceRegistry = nullptr;
 	FUnrealMcpGameThreadDispatcher& Dispatcher;
 
 	FTcpListener* Listener = nullptr;

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Extensions/UnrealMcpExtensionManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Extensions/UnrealMcpExtensionManager.cpp
@@ -5,8 +5,10 @@
 
 #include "IUnrealMcpToolProvider.h"
 #include "IUnrealMcpPromptProvider.h"
+#include "IUnrealMcpResourceProvider.h"
 #include "UnrealMcpToolRegistry.h"
 #include "UnrealMcpPromptRegistry.h"
+#include "UnrealMcpResourceRegistry.h"
 #include "UnrealMcpLog.h"
 
 #include "Features/IModularFeatures.h"
@@ -71,9 +73,10 @@ namespace
 
 FUnrealMcpExtensionManager::FUnrealMcpExtensionManager(
 	FUnrealMcpToolRegistry& InRegistry, TFunction<void()> InOnChanged, const FString& InConfigPath,
-	FUnrealMcpPromptRegistry* InPromptRegistry)
+	FUnrealMcpPromptRegistry* InPromptRegistry, FUnrealMcpResourceRegistry* InResourceRegistry)
 	: Registry(InRegistry)
 	, PromptRegistry(InPromptRegistry)
+	, ResourceRegistry(InResourceRegistry)
 	, OnChanged(MoveTemp(InOnChanged))
 {
 	ConfigPath = InConfigPath.IsEmpty()
@@ -83,6 +86,7 @@ FUnrealMcpExtensionManager::FUnrealMcpExtensionManager(
 	// Default provider sources: the live modular-feature registry. Overridable for deterministic tests.
 	ProviderSource = [this]() { return GatherProviders(); };
 	PromptProviderSource = [this]() { return GatherPromptProviders(); };
+	ResourceProviderSource = [this]() { return GatherResourceProviders(); };
 }
 
 FUnrealMcpExtensionManager::~FUnrealMcpExtensionManager()
@@ -154,6 +158,12 @@ TArray<IUnrealMcpPromptProvider*> FUnrealMcpExtensionManager::GatherPromptProvid
 {
 	return IModularFeatures::Get().GetModularFeatureImplementations<IUnrealMcpPromptProvider>(
 		IUnrealMcpPromptProvider::GetModularFeatureName());
+}
+
+TArray<IUnrealMcpResourceProvider*> FUnrealMcpExtensionManager::GatherResourceProviders() const
+{
+	return IModularFeatures::Get().GetModularFeatureImplementations<IUnrealMcpResourceProvider>(
+		IUnrealMcpResourceProvider::GetModularFeatureName());
 }
 
 void FUnrealMcpExtensionManager::Rebuild(bool bNotify)
@@ -261,6 +271,11 @@ void FUnrealMcpExtensionManager::RebuildFromProviders(const TArray<IUnrealMcpToo
 	//     additive: it does not touch Records / RegisteredExtensionIds, only the prompt registry + its own id list.
 	RebuildPromptProviders();
 
+	// 3.6 (§A.2) RESOURCE pass: the resource analog of the prompt pass — same DisabledExtensions set /
+	//     IsValidExtensionId / ExtensionId sort, also inside the single re-entrancy guard so the one OnChanged
+	//     below covers all three kinds. No-op when ResourceRegistry == nullptr.
+	RebuildResourceProviders();
+
 	// 4. Notify the owner to re-push the manifest(s) (§2.2 / §A.1 — tool + prompt + resource).
 	if (bNotify && OnChanged)
 		OnChanged();
@@ -340,6 +355,69 @@ void FUnrealMcpExtensionManager::RebuildPromptProviders()
 	}
 }
 
+void FUnrealMcpExtensionManager::RebuildResourceProviders()
+{
+	// §A.2 resource pass — the resource analog of RebuildPromptProviders, sharing the same DisabledExtensions
+	// set, IsValidExtensionId discipline, and ExtensionId sort. Called from inside the re-entrancy guard, so it
+	// never opens a nested registry scope across passes (the resource registry's own RegisterExtension scope is
+	// independent of the tool/prompt registries' and is opened+closed here per provider).
+	if (ResourceRegistry == nullptr)
+		return;
+
+	// 1. Clear the previous resource-extension contribution (core resources are untouched: only ids we registered).
+	for (const FString& Id : RegisteredResourceExtensionIds)
+		ResourceRegistry->RemoveResourcesForExtension(Id);
+	RegisteredResourceExtensionIds.Reset();
+
+	const TArray<IUnrealMcpResourceProvider*> Providers = ResourceProviderSource ? ResourceProviderSource() : GatherResourceProviders();
+
+	// 2. Deterministic ordering by ExtensionId (StableSort keeps registration order as the tie-break).
+	TArray<IUnrealMcpResourceProvider*> Sorted;
+	Sorted.Reserve(Providers.Num());
+	for (IUnrealMcpResourceProvider* P : Providers)
+	{
+		if (P != nullptr)
+			Sorted.Add(P);
+	}
+	Sorted.StableSort([](const IUnrealMcpResourceProvider& A, const IUnrealMcpResourceProvider& B)
+	{
+		return A.GetExtensionId() < B.GetExtensionId();
+	});
+
+	// 3. Register each ENABLED + valid + non-duplicate provider's resources.
+	TSet<FString> SeenIds;
+	for (IUnrealMcpResourceProvider* Provider : Sorted)
+	{
+		const FString Id = Provider->GetExtensionId();
+
+		// 3a. Validate the id (reuse the SAME helper as the tool/prompt passes — never register under "core"/garbage).
+		FString IdError;
+		if (!IsValidExtensionId(Id, IdError))
+		{
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] resource extension rejected: %s — its resources were skipped."), *IdError);
+			continue;
+		}
+
+		// 3b. Duplicate id (first-sorted wins). The tool pass already records the public Record for this id; the
+		//     resource pass only needs to avoid double-registration / a clobbered removal key.
+		if (SeenIds.Contains(Id))
+		{
+			UE_LOG(LogUnrealMcp, Warning,
+				TEXT("[Unreal-MCP] duplicate resource extension id '%s' — another provider already registered it; this provider's resources were skipped."),
+				*Id);
+			continue;
+		}
+		SeenIds.Add(Id);
+
+		// 3c. Gated by the SAME DisabledExtensions set as tools/prompts (one toggle disables an extension's tools AND prompts AND resources).
+		if (DisabledExtensions.Contains(Id))
+			continue;
+
+		ResourceRegistry->RegisterExtension(Id, [Provider](FUnrealMcpResourceRegistry& Reg) { Provider->RegisterResources(Reg); });
+		RegisteredResourceExtensionIds.AddUnique(Id);
+	}
+}
+
 void FUnrealMcpExtensionManager::OnFeatureRegistered(const FName& Type, IModularFeature* /*Feature*/)
 {
 	// The single OnModularFeatureRegistered subscription receives EVERY feature type; rebuild when the type is
@@ -354,6 +432,11 @@ void FUnrealMcpExtensionManager::OnFeatureRegistered(const FName& Type, IModular
 		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] prompt provider registered; rebuilding extensions."));
 		Rebuild(/*bNotify*/ true);
 	}
+	else if (ResourceRegistry != nullptr && Type == IUnrealMcpResourceProvider::GetModularFeatureName())
+	{
+		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] resource provider registered; rebuilding extensions."));
+		Rebuild(/*bNotify*/ true);
+	}
 }
 
 void FUnrealMcpExtensionManager::OnFeatureUnregistered(const FName& Type, IModularFeature* /*Feature*/)
@@ -366,6 +449,11 @@ void FUnrealMcpExtensionManager::OnFeatureUnregistered(const FName& Type, IModul
 	else if (PromptRegistry != nullptr && Type == IUnrealMcpPromptProvider::GetModularFeatureName())
 	{
 		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] prompt provider unregistered; rebuilding extensions."));
+		Rebuild(/*bNotify*/ true);
+	}
+	else if (ResourceRegistry != nullptr && Type == IUnrealMcpResourceProvider::GetModularFeatureName())
+	{
+		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] resource provider unregistered; rebuilding extensions."));
 		Rebuild(/*bNotify*/ true);
 	}
 }

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Extensions/UnrealMcpExtensionManager.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Extensions/UnrealMcpExtensionManager.h
@@ -10,8 +10,10 @@
 
 class FUnrealMcpToolRegistry;
 class FUnrealMcpPromptRegistry;
+class FUnrealMcpResourceRegistry;
 class IUnrealMcpToolProvider;
 class IUnrealMcpPromptProvider;
+class IUnrealMcpResourceProvider;
 class IModularFeature;
 
 /**
@@ -66,9 +68,11 @@ public:
 	 * @param InPromptRegistry  OPTIONAL (§A.2) prompt registry to ALSO merge prompt-provider extensions into. Nullable —
 	 *                          when null the manager is tool-only (existing call sites keep compiling). Gated by the SAME
 	 *                          DisabledExtensions set / re-entrancy guard / ExtensionId sort as the tool pass.
+	 * @param InResourceRegistry OPTIONAL (§A.2) resource registry to ALSO merge resource-provider extensions into. Nullable —
+	 *                          same gating + null-safe contract as @p InPromptRegistry (the resource analog).
 	 */
 	FUnrealMcpExtensionManager(FUnrealMcpToolRegistry& InRegistry, TFunction<void()> InOnChanged, const FString& InConfigPath = FString(),
-		FUnrealMcpPromptRegistry* InPromptRegistry = nullptr);
+		FUnrealMcpPromptRegistry* InPromptRegistry = nullptr, FUnrealMcpResourceRegistry* InResourceRegistry = nullptr);
 	~FUnrealMcpExtensionManager();
 
 	/** Load persisted disabled set, subscribe to modular-feature events, and run the initial rebuild. */
@@ -98,17 +102,25 @@ public:
 	/** Override the PROMPT provider source used by rebuilds (§A.2 test seam; default = live discovery). */
 	void SetPromptProviderSourceForTesting(TFunction<TArray<IUnrealMcpPromptProvider*>()> InSource) { PromptProviderSource = MoveTemp(InSource); }
 
+	/** Override the RESOURCE provider source used by rebuilds (§A.2 test seam; default = live discovery). */
+	void SetResourceProviderSourceForTesting(TFunction<TArray<IUnrealMcpResourceProvider*>()> InSource) { ResourceProviderSource = MoveTemp(InSource); }
+
 private:
 	/** Rebuild from the current ProviderSource (live IModularFeatures discovery by default). */
 	void Rebuild(bool bNotify);
 
 	TArray<IUnrealMcpToolProvider*> GatherProviders() const;
 	TArray<IUnrealMcpPromptProvider*> GatherPromptProviders() const;
+	TArray<IUnrealMcpResourceProvider*> GatherResourceProviders() const;
 
 	/** §A.2 prompt pass of a rebuild: clear previous prompt-extension contributions, then merge enabled+valid+
 	 *  non-duplicate prompt providers into PromptRegistry (same DisabledExtensions / IsValidExtensionId / sort).
 	 *  No-op when PromptRegistry == nullptr. Driven from RebuildFromProviders so the single OnChanged covers both. */
 	void RebuildPromptProviders();
+
+	/** §A.2 resource pass of a rebuild — the resource analog of RebuildPromptProviders (same gating + sort).
+	 *  No-op when ResourceRegistry == nullptr. Also driven from RebuildFromProviders under the single guard/notify. */
+	void RebuildResourceProviders();
 
 	void OnFeatureRegistered(const FName& Type, IModularFeature* Feature);
 	void OnFeatureUnregistered(const FName& Type, IModularFeature* Feature);
@@ -119,10 +131,13 @@ private:
 	FUnrealMcpToolRegistry& Registry;
 	// §A.2: nullable prompt registry. When set, RebuildFromProviders also runs a prompt pass.
 	FUnrealMcpPromptRegistry* PromptRegistry = nullptr;
+	// §A.2: nullable resource registry. When set, RebuildFromProviders also runs a resource pass.
+	FUnrealMcpResourceRegistry* ResourceRegistry = nullptr;
 	TFunction<void()> OnChanged;
 	FString ConfigPath;
 	TFunction<TArray<IUnrealMcpToolProvider*>()> ProviderSource;
 	TFunction<TArray<IUnrealMcpPromptProvider*>()> PromptProviderSource;
+	TFunction<TArray<IUnrealMcpResourceProvider*>()> ResourceProviderSource;
 
 	TArray<FUnrealMcpExtensionRecord> Records;
 	TSet<FString> DisabledExtensions;
@@ -130,6 +145,8 @@ private:
 	TArray<FString> RegisteredExtensionIds;
 	/** §A.2: extension ids that currently contributed prompts (the prompt-pass analog of RegisteredExtensionIds). */
 	TArray<FString> RegisteredPromptExtensionIds;
+	/** §A.2: extension ids that currently contributed resources (the resource-pass analog of RegisteredExtensionIds). */
+	TArray<FString> RegisteredResourceExtensionIds;
 
 	FDelegateHandle RegisteredHandle;
 	FDelegateHandle UnregisteredHandle;

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Resources/UnrealMcpCoreResources.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Resources/UnrealMcpCoreResources.cpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpRuntimeCoreResources.h"
+#include "UnrealMcpResourceRegistry.h"
+#include "Tools/UnrealMcpWorldProvider.h"
+
+#include "Engine/World.h"
+#include "Engine/Level.h"
+#include "Engine/LevelStreaming.h"
+#include "Misc/Base64.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+/**
+ * The core resources (docs/ARCHITECTURE.md §A.1). Self-contained, Engine-only handlers — no UnrealEd symbols
+ * (Model-A runtime safety, §A.5 risk 5) — so the family compiles + links in both the editor and the
+ * non-editor Game target. Both run ON the game thread (the dispatcher guarantees it, §4).
+ *
+ * Unity-build ODR note: this file shares a TU with the tool/prompt core families. The helpers here are given
+ * family-unique names (Resource*-prefixed) to dodge a same-name/same-signature collision (conventions.md).
+ */
+namespace
+{
+	/** Serialize a JSON object to a compact string (family-unique name to avoid a unity-build ODR clash). */
+	FString ResourceCoreSerializeJson(const TSharedPtr<FJsonObject>& Object)
+	{
+		FString Out;
+		TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Object.ToSharedRef(), Writer);
+		return Out;
+	}
+
+	/** Build the unreal://project/levels JSON body from the active world (Engine-only; null-world safe). */
+	FString ResourceBuildLevelsJson()
+	{
+		TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+
+		UWorld* World = FUnrealMcpWorldProvider::GetActiveWorld();
+		if (World == nullptr)
+		{
+			// No world resolved (un-wired runtime module, or no active world yet) — return an honest empty
+			// snapshot rather than failing, so the resource read still round-trips deterministically.
+			Root->SetBoolField(TEXT("hasWorld"), false);
+			Root->SetArrayField(TEXT("levels"), TArray<TSharedPtr<FJsonValue>>());
+			return ResourceCoreSerializeJson(Root);
+		}
+
+		Root->SetBoolField(TEXT("hasWorld"), true);
+		Root->SetStringField(TEXT("worldName"), World->GetName());
+
+		TArray<TSharedPtr<FJsonValue>> Levels;
+
+		// The persistent level first.
+		if (ULevel* Persistent = World->PersistentLevel)
+		{
+			TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+			Entry->SetStringField(TEXT("name"), Persistent->GetOutermost()->GetName());
+			Entry->SetBoolField(TEXT("persistent"), true);
+			Entry->SetBoolField(TEXT("loaded"), true);
+			Levels.Add(MakeShared<FJsonValueObject>(Entry));
+		}
+
+		// Then every streaming level (Engine-module API — UWorld::GetStreamingLevels / ULevelStreaming).
+		for (const ULevelStreaming* Streaming : World->GetStreamingLevels())
+		{
+			if (Streaming == nullptr)
+				continue;
+			TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+			Entry->SetStringField(TEXT("name"), Streaming->GetWorldAssetPackageName());
+			Entry->SetBoolField(TEXT("persistent"), false);
+			Entry->SetBoolField(TEXT("loaded"), Streaming->IsLevelLoaded());
+			Levels.Add(MakeShared<FJsonValueObject>(Entry));
+		}
+
+		Root->SetNumberField(TEXT("count"), Levels.Num());
+		Root->SetArrayField(TEXT("levels"), Levels);
+		return ResourceCoreSerializeJson(Root);
+	}
+}
+
+namespace UnrealMcpCoreResources
+{
+	UNREALMCPRUNTIME_API void Register(FUnrealMcpResourceRegistry& Registry)
+	{
+		// 1. unreal://project/levels — a JSON snapshot of the active world + its levels (application/json).
+		Registry.Resource(TEXT("unreal://project/levels"))
+			.Name(TEXT("Project Levels"))
+			.Description(TEXT("A JSON snapshot of the active world and its loaded/streaming levels."))
+			.MimeType(TEXT("application/json"))
+			.Read([](const FString& Uri) -> FUnrealMcpResourceResult
+			{
+				// Runs ON the game thread (the dispatcher guarantees it, §4) — engine-only, no UnrealEd symbols.
+				return FUnrealMcpResourceResult::Text(Uri, ResourceBuildLevelsJson(), TEXT("application/json"));
+			});
+
+		// 2. unreal://project/icon — a tiny base64 PNG, covering the Blob (binary) round-trip end to end.
+		//    A 1x1 transparent PNG: the smallest valid PNG, base64-encoded. We re-encode from raw bytes at
+		//    read time so the path exercises FBase64::Encode exactly like a real screenshot/asset blob would.
+		Registry.Resource(TEXT("unreal://project/icon"))
+			.Name(TEXT("Project Icon"))
+			.Description(TEXT("A 1x1 transparent PNG, returned as a base64 blob (binary round-trip sample)."))
+			.MimeType(TEXT("image/png"))
+			.Read([](const FString& Uri) -> FUnrealMcpResourceResult
+			{
+				// A minimal valid 1x1 transparent PNG (67 bytes). Held as raw bytes so the handler exercises the
+				// real FBase64::Encode path (not a hard-coded base64 literal) — the same path a screenshot blob uses.
+				static const uint8 PngBytes[] = {
+					0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+					0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+					0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+					0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+					0x42, 0x60, 0x82
+				};
+
+				const FString Base64 = FBase64::Encode(PngBytes, sizeof(PngBytes));
+				return FUnrealMcpResourceResult::Blob(Uri, Base64, TEXT("image/png"));
+			});
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Resources/UnrealMcpCoreResources.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Resources/UnrealMcpCoreResources.cpp
@@ -9,8 +9,11 @@
 #include "Engine/Level.h"
 #include "Engine/LevelStreaming.h"
 #include "Misc/Base64.h"
+#include "Dom/JsonObject.h"          // FJsonObject::SetStringField overloads — NOT transitively present in the Game build
+#include "Dom/JsonValue.h"           // FJsonValueObject for the levels[] array
 #include "Serialization/JsonSerializer.h"
 #include "Serialization/JsonWriter.h"
+#include "UObject/Package.h"         // UObject::GetOutermost()->GetName() (UPackage) — Game-build standalone include
 
 /**
  * The core resources (docs/ARCHITECTURE.md §A.1). Self-contained, Engine-only handlers — no UnrealEd symbols

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Resources/UnrealMcpResourceRegistry.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Resources/UnrealMcpResourceRegistry.cpp
@@ -1,0 +1,318 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpResourceRegistry.h"
+#include "UnrealMcpLog.h"
+#include "Misc/SecureHash.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
+
+// --- Stable serialization helper (family-UNIQUE name) ---------------------------------------------
+// The tool/prompt registries each have their own SerializeStable in an anonymous namespace; a unity build
+// concatenates every .cpp into one TU, so an anonymous-namespace helper is NOT file-private. Give the
+// resource copy a family-unique name (Resource*-prefixed) to dodge the §ODR collision (conventions.md).
+
+namespace
+{
+	FString ResourceSerializeStable(const TSharedPtr<FJsonObject>& Object)
+	{
+		FString Out;
+		TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =
+			TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&Out);
+		FJsonSerializer::Serialize(Object.ToSharedRef(), Writer);
+		return Out;
+	}
+}
+
+TSharedPtr<FJsonObject> FUnrealMcpRegisteredResource::ToDescriptorJson() const
+{
+	// Mirrors the ResourceDescriptor IPC shape (§A.1): uri (the route + identity), name, description, mimeType.
+	TSharedPtr<FJsonObject> Desc = MakeShared<FJsonObject>();
+	Desc->SetStringField(TEXT("uri"), Uri);
+	Desc->SetStringField(TEXT("name"), Name);
+	Desc->SetStringField(TEXT("description"), Description);
+	Desc->SetStringField(TEXT("mimeType"), MimeType);
+	Desc->SetBoolField(TEXT("enabled"), bEnabled);
+	Desc->SetStringField(TEXT("extensionId"), ExtensionId);
+	Desc->SetStringField(TEXT("schemaHash"), SchemaHash);
+	return Desc;
+}
+
+// --- FUnrealMcpResourceBuilder --------------------------------------------------------------------
+
+FUnrealMcpResourceBuilder::FUnrealMcpResourceBuilder(FUnrealMcpResourceRegistry& InRegistry, const FString& InUri)
+	: Registry(InRegistry)
+{
+	Resource.Uri = InUri;
+}
+
+FUnrealMcpResourceBuilder& FUnrealMcpResourceBuilder::Name(const FString& InName) { Resource.Name = InName; return *this; }
+FUnrealMcpResourceBuilder& FUnrealMcpResourceBuilder::Description(const FString& InDescription) { Resource.Description = InDescription; return *this; }
+FUnrealMcpResourceBuilder& FUnrealMcpResourceBuilder::MimeType(const FString& InMimeType) { Resource.MimeType = InMimeType; return *this; }
+FUnrealMcpResourceBuilder& FUnrealMcpResourceBuilder::ExtensionId(const FString& InExtensionId) { Resource.ExtensionId = InExtensionId; return *this; }
+
+void FUnrealMcpResourceBuilder::Read(FUnrealMcpResourceHandler InHandler)
+{
+	Resource.Handler = MoveTemp(InHandler);
+	Registry.Commit(MoveTemp(Resource));
+}
+
+// --- FUnrealMcpResourceRegistry -------------------------------------------------------------------
+
+FUnrealMcpResourceBuilder FUnrealMcpResourceRegistry::Resource(const FString& Uri)
+{
+	return FUnrealMcpResourceBuilder(*this, Uri);
+}
+
+FString FUnrealMcpResourceRegistry::ComputeSchemaHash(const FUnrealMcpRegisteredResource& InResource)
+{
+	// Hash the canonicalized descriptor MINUS the enabled flag (mirror the tool/prompt registries). Reuse
+	// ToDescriptorJson and drop "enabled" + "schemaHash" so the hash is stable regardless of those fields.
+	FUnrealMcpRegisteredResource Copy = InResource;
+	Copy.SchemaHash.Empty();
+	TSharedPtr<FJsonObject> Desc = Copy.ToDescriptorJson();
+	Desc->RemoveField(TEXT("enabled"));
+	Desc->RemoveField(TEXT("schemaHash"));
+
+	const FString Canonical = ResourceSerializeStable(Desc);
+	FSHA1 Sha;
+	const FTCHARToUTF8 Utf8(*Canonical);
+	Sha.Update(reinterpret_cast<const uint8*>(Utf8.Get()), Utf8.Length());
+	Sha.Final();
+	uint8 Digest[20];
+	Sha.GetHash(Digest);
+	return FString(TEXT("sha1:")) + BytesToHex(Digest, 20).ToLower();
+}
+
+bool FUnrealMcpResourceRegistry::IsValidResourceUri(const FString& Uri)
+{
+	// Static MVP: a resource URI must be non-empty and free of control characters / whitespace (a malformed
+	// uri would leak into the manifest as the manager's route). We deliberately do NOT enforce a scheme so a
+	// game can use any opaque "scheme://path" form (e.g. "unreal://project/levels"); templated URIs are
+	// deferred (§A.1) so a brace/placeholder is not special here.
+	if (Uri.IsEmpty())
+		return false;
+
+	for (const TCHAR C : Uri)
+	{
+		if (C <= 0x20 || C == 0x7F) // control chars + space
+			return false;
+	}
+	return true;
+}
+
+bool FUnrealMcpResourceRegistry::ValidateResource(const FUnrealMcpRegisteredResource& InResource, FString& OutError)
+{
+	if (!IsValidResourceUri(InResource.Uri))
+	{
+		OutError = FString::Printf(
+			TEXT("invalid resource uri '%s' (must be non-empty and contain no whitespace/control characters)"),
+			*InResource.Uri);
+		return false;
+	}
+
+	if (!InResource.Handler)
+	{
+		OutError = FString::Printf(TEXT("resource '%s' has no bound read handler"), *InResource.Uri);
+		return false;
+	}
+	return true;
+}
+
+void FUnrealMcpResourceRegistry::Commit(FUnrealMcpRegisteredResource&& InResource)
+{
+	if (bExtensionScope)
+	{
+		// Extensions are untrusted: stamp the owning id, validate, and dedup (§5).
+		InResource.ExtensionId = ScopeExtensionId;
+
+		FString Error;
+		if (!ValidateResource(InResource, Error))
+		{
+			ScopeErrors.Add(Error);
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] extension '%s': %s — entry dropped."), *ScopeExtensionId, *Error);
+			return;
+		}
+
+		if (const FUnrealMcpRegisteredResource* Existing = Resources.Find(InResource.Uri))
+		{
+			FString Rejection;
+			if (Existing->ExtensionId == TEXT("core"))
+			{
+				Rejection = FString::Printf(
+					TEXT("resource '%s' rejected: uri collides with a built-in core resource (extensions may not shadow core)"),
+					*InResource.Uri);
+			}
+			else if (Existing->ExtensionId == ScopeExtensionId)
+			{
+				Rejection = FString::Printf(
+					TEXT("resource '%s' rejected: this extension already declared a resource with that uri (duplicate within the extension)"),
+					*InResource.Uri);
+			}
+			else
+			{
+				Rejection = FString::Printf(
+					TEXT("resource '%s' rejected: uri already registered by extension '%s' (first-wins by ExtensionId sort)"),
+					*InResource.Uri, *Existing->ExtensionId);
+			}
+			ScopeErrors.Add(Rejection);
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] extension '%s': %s"), *ScopeExtensionId, *Rejection);
+			return;
+		}
+
+		++ScopeResourcesRegistered;
+	}
+
+	InResource.SchemaHash = ComputeSchemaHash(InResource);
+	const FString Uri = InResource.Uri;
+	// §7/§8 retention: a (re-)registered resource inherits the retained whitelist/blocklist immediately.
+	InResource.bEnabled = ShouldResourceBeEnabled(Uri);
+	Resources.Add(Uri, MoveTemp(InResource));
+	++Revision;
+	UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] registered resource '%s' (revision %d)."), *Uri, Revision);
+}
+
+FUnrealMcpExtensionRegistrationResult FUnrealMcpResourceRegistry::RegisterExtension(
+	const FString& ExtensionId, TFunctionRef<void(FUnrealMcpResourceRegistry&)> RegisterFn)
+{
+	checkf(!bExtensionScope, TEXT("FUnrealMcpResourceRegistry::RegisterExtension does not support nested scopes."));
+
+	bExtensionScope = true;
+	ScopeExtensionId = ExtensionId;
+	ScopeResourcesRegistered = 0;
+	ScopeErrors.Reset();
+
+	RegisterFn(*this);
+
+	FUnrealMcpExtensionRegistrationResult Result;
+	Result.ToolsRegistered = ScopeResourcesRegistered; // reused struct: count means "entries registered"
+	Result.Errors = MoveTemp(ScopeErrors);
+
+	bExtensionScope = false;
+	ScopeExtensionId.Empty();
+	ScopeResourcesRegistered = 0;
+	ScopeErrors.Reset();
+	return Result;
+}
+
+int32 FUnrealMcpResourceRegistry::RemoveResourcesForExtension(const FString& ExtensionId)
+{
+	TArray<FString> ToRemove;
+	for (const TPair<FString, FUnrealMcpRegisteredResource>& Pair : Resources)
+	{
+		if (Pair.Value.ExtensionId == ExtensionId)
+			ToRemove.Add(Pair.Key);
+	}
+	for (const FString& Uri : ToRemove)
+		Resources.Remove(Uri);
+	if (ToRemove.Num() > 0)
+		++Revision;
+	return ToRemove.Num();
+}
+
+TSharedPtr<FJsonObject> FUnrealMcpResourceRegistry::BuildManifestJson() const
+{
+	TSharedPtr<FJsonObject> Manifest = MakeShared<FJsonObject>();
+	Manifest->SetStringField(TEXT("type"), TEXT("resource-manifest"));
+	Manifest->SetNumberField(TEXT("revision"), Revision);
+
+	TArray<TSharedPtr<FJsonValue>> ResourceArray;
+	TArray<FString> Uris;
+	Resources.GetKeys(Uris);
+	Uris.Sort();
+	for (const FString& Uri : Uris)
+	{
+		// A disabled resource is EXCLUDED from the served manifest entirely (mirror the tool/prompt registries).
+		const FUnrealMcpRegisteredResource& R = Resources[Uri];
+		if (!R.bEnabled)
+			continue;
+		ResourceArray.Add(MakeShared<FJsonValueObject>(R.ToDescriptorJson()));
+	}
+
+	Manifest->SetArrayField(TEXT("resources"), ResourceArray);
+	return Manifest;
+}
+
+TArray<FString> FUnrealMcpResourceRegistry::GetResourceUrisSorted() const
+{
+	TArray<FString> Uris;
+	Resources.GetKeys(Uris);
+	Uris.Sort();
+	return Uris;
+}
+
+int32 FUnrealMcpResourceRegistry::NumEnabled() const
+{
+	int32 Count = 0;
+	for (const TPair<FString, FUnrealMcpRegisteredResource>& Pair : Resources)
+	{
+		if (Pair.Value.bEnabled)
+			++Count;
+	}
+	return Count;
+}
+
+bool FUnrealMcpResourceRegistry::SetResourceEnabled(const FString& Uri, bool bEnabled)
+{
+	FUnrealMcpRegisteredResource* Found = Resources.Find(Uri);
+	if (Found == nullptr || Found->bEnabled == bEnabled)
+		return false;
+	Found->bEnabled = bEnabled;
+	++Revision;
+	UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] resource '%s' %s (revision %d)."),
+		*Uri, bEnabled ? TEXT("enabled") : TEXT("disabled"), Revision);
+	return true;
+}
+
+bool FUnrealMcpResourceRegistry::ShouldResourceBeEnabled(const FString& Uri) const
+{
+	return PassesEnabledResourcesWhitelist(Uri) && !DisabledResourceUris.Contains(Uri);
+}
+
+bool FUnrealMcpResourceRegistry::PassesEnabledResourcesWhitelist(const FString& Uri) const
+{
+	return EnabledResourcesWhitelist.IsEmpty() || EnabledResourcesWhitelist.Contains(Uri);
+}
+
+void FUnrealMcpResourceRegistry::RecomputeEnablement()
+{
+	bool bAnyChanged = false;
+	for (TPair<FString, FUnrealMcpRegisteredResource>& Pair : Resources)
+	{
+		const bool bShouldEnable = ShouldResourceBeEnabled(Pair.Key);
+		if (Pair.Value.bEnabled != bShouldEnable)
+		{
+			Pair.Value.bEnabled = bShouldEnable;
+			bAnyChanged = true;
+		}
+	}
+	if (bAnyChanged)
+		++Revision;
+}
+
+void FUnrealMcpResourceRegistry::SetEnabledResourcesFilter(const TArray<FString>& EnabledResources)
+{
+	EnabledResourcesWhitelist = TSet<FString>(EnabledResources);
+	RecomputeEnablement();
+}
+
+void FUnrealMcpResourceRegistry::ApplyDisabledResources(const TArray<FString>& DisabledUris)
+{
+	DisabledResourceUris = TSet<FString>(DisabledUris);
+	RecomputeEnablement();
+}
+
+FUnrealMcpResourceResult FUnrealMcpResourceRegistry::Read(const FString& Uri) const
+{
+	const FUnrealMcpRegisteredResource* Found = Resources.Find(Uri);
+	if (Found == nullptr || !Found->Handler)
+		return FUnrealMcpResourceResult::MakeError(FString::Printf(TEXT("Unknown resource '%s'."), *Uri));
+
+	// Gate disabled resources at the read boundary (mirror the tool/prompt registries): a disabled resource is
+	// dropped from BuildManifestJson, but a stale resources/list could still dispatch it by uri.
+	if (!Found->bEnabled)
+		return FUnrealMcpResourceResult::MakeError(FString::Printf(TEXT("Resource '%s' is disabled."), *Uri));
+
+	return Found->Handler(Uri);
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
@@ -6,8 +6,10 @@
 #include "UnrealMcpLog.h"
 #include "UnrealMcpRuntimeCoreTools.h"
 #include "UnrealMcpRuntimeCorePrompts.h"
+#include "UnrealMcpRuntimeCoreResources.h"
 #include "UnrealMcpToolRegistry.h"
 #include "UnrealMcpPromptRegistry.h"
+#include "UnrealMcpResourceRegistry.h"
 #include "Config/UnrealMcpConfig.h"
 #include "Dispatch/UnrealMcpGameThreadDispatcher.h"
 #include "Bridge/UnrealMcpBridgeServer.h"
@@ -16,6 +18,7 @@
 #include "Tools/UnrealMcpWorldProvider.h"
 #include "IUnrealMcpToolProvider.h"
 #include "IUnrealMcpPromptProvider.h"
+#include "IUnrealMcpResourceProvider.h"
 
 #include "Features/IModularFeatures.h"
 #include "Engine/GameInstance.h"
@@ -39,6 +42,7 @@ struct UUnrealMcpRuntimeSubsystem::FRuntimeImpl
 {
 	TUniquePtr<FUnrealMcpToolRegistry> Registry;
 	TUniquePtr<FUnrealMcpPromptRegistry> PromptRegistry;
+	TUniquePtr<FUnrealMcpResourceRegistry> ResourceRegistry;
 	TUniquePtr<FUnrealMcpGameThreadDispatcher> Dispatcher;
 	TUniquePtr<FUnrealMcpBridgeServer> BridgeServer;
 	TUniquePtr<FUnrealMcpSidecarManager> SidecarManager;
@@ -76,8 +80,15 @@ void UUnrealMcpRuntimeSubsystem::Initialize(FSubsystemCollectionBase& Collection
 	Impl->PromptRegistry = MakeUnique<FUnrealMcpPromptRegistry>();
 	UnrealMcpCorePrompts::Register(*Impl->PromptRegistry);
 
+	// §A.1 resource registry (P2): the resource sibling of the tool/prompt registries, built on the SAME Model A
+	// path. The core resource family registers before the bridge arms so the first resource-manifest a v2 sidecar
+	// reads on handshake already includes it. No §7/§8 resource filters here (the runtime path applies none).
+	Impl->ResourceRegistry = MakeUnique<FUnrealMcpResourceRegistry>();
+	UnrealMcpCoreResources::Register(*Impl->ResourceRegistry);
+
 	Impl->Dispatcher = MakeUnique<FUnrealMcpGameThreadDispatcher>();
-	Impl->BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(*Impl->Registry, *Impl->Dispatcher, Impl->PromptRegistry.Get());
+	Impl->BridgeServer = MakeUnique<FUnrealMcpBridgeServer>(
+		*Impl->Registry, *Impl->Dispatcher, Impl->PromptRegistry.Get(), Impl->ResourceRegistry.Get());
 
 	// Discover §5 extension providers and merge them BEFORE the bridge arms, so the first manifest a sidecar
 	// reads on a later Connect already includes them; a late register/unregister re-pushes the manifest.
@@ -96,7 +107,8 @@ void UUnrealMcpRuntimeSubsystem::Initialize(FSubsystemCollectionBase& Collection
 			}
 		},
 		/*InConfigPath*/ FString(),
-		Impl->PromptRegistry.Get()); // §A.2 kind-aware: also merge prompt-provider extensions into the prompt registry
+		Impl->PromptRegistry.Get(), // §A.2 kind-aware: also merge prompt-provider extensions into the prompt registry
+		Impl->ResourceRegistry.Get()); // §A.2 kind-aware: also merge resource-provider extensions into the resource registry
 	Impl->ExtensionManager->Startup();
 
 	const FString ProjectPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
@@ -161,6 +173,7 @@ void UUnrealMcpRuntimeSubsystem::Deinitialize()
 		}
 
 		Impl->Dispatcher.Reset();
+		Impl->ResourceRegistry.Reset(); // after ExtensionManager (holds a raw pointer to it) is torn down above
 		Impl->PromptRegistry.Reset();
 		Impl->Registry.Reset();
 		Impl.Reset();
@@ -369,6 +382,30 @@ void UUnrealMcpRuntimeSubsystem::UnregisterPromptProvider(IUnrealMcpPromptProvid
 
 	IModularFeatures::Get().UnregisterModularFeature(IUnrealMcpPromptProvider::GetModularFeatureName(), Provider);
 	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] runtime prompt provider '%s' unregistered."), *Provider->GetExtensionId());
+}
+
+void UUnrealMcpRuntimeSubsystem::RegisterResourceProvider(IUnrealMcpResourceProvider* Provider)
+{
+	if (!Provider)
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] RegisterResourceProvider: null provider ignored."));
+		return;
+	}
+
+	// Thin wrapper over IModularFeatures (§A.2): the extension manager subscribed to the resource register event
+	// in Initialize(), so this triggers the same resource-registry rebuild + manifest re-push a plugin-load-time
+	// registration does. Not owned — the caller keeps the provider alive and must UnregisterResourceProvider.
+	IModularFeatures::Get().RegisterModularFeature(IUnrealMcpResourceProvider::GetModularFeatureName(), Provider);
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] runtime resource provider '%s' registered."), *Provider->GetExtensionId());
+}
+
+void UUnrealMcpRuntimeSubsystem::UnregisterResourceProvider(IUnrealMcpResourceProvider* Provider)
+{
+	if (!Provider)
+		return; // null is a harmless no-op
+
+	IModularFeatures::Get().UnregisterModularFeature(IUnrealMcpResourceProvider::GetModularFeatureName(), Provider);
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] runtime resource provider '%s' unregistered."), *Provider->GetExtensionId());
 }
 
 bool UUnrealMcpRuntimeSubsystem::IsLoopbackHost(const FString& Host)

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpResourceProvider.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpResourceProvider.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Features/IModularFeature.h"
+
+class FUnrealMcpResourceRegistry;
+
+/**
+ * The Unreal-MCP RESOURCE extension contract (docs/ARCHITECTURE.md §5 / §A.2) — the resource sibling of
+ * IUnrealMcpToolProvider / IUnrealMcpPromptProvider. To declare resources you also include
+ * UnrealMcpResourceRegistry.h, and to register the provider as a modular feature you include
+ * Features/IModularFeatures.h (mirrors the tool/prompt paths).
+ *
+ * An extension is any UE plugin that implements this interface and registers an instance as a modular
+ * feature under GetModularFeatureName():
+ *
+ *     IModularFeatures::Get().RegisterModularFeature(
+ *         IUnrealMcpResourceProvider::GetModularFeatureName(), MyProviderInstance);
+ *
+ * Unreal-MCP discovers every registered provider on boot (and subscribes to register/unregister events
+ * for late-loaded / hot-unloaded plugins), merges their resources into the single resource registry in
+ * deterministic order (sorted by ExtensionId), and surfaces the merged manifest to the sidecar (§A.1).
+ *
+ * MVP scope: static fixed-URI resources only (templated/parameterized URIs are deferred, §A.1). A
+ * resource's URI is its identity (the registry dedup/registration key).
+ *
+ * Isolation (§5): identical to the tool/prompt contract — descriptor-level, not body-level (UE builds
+ * without C++ exceptions). Each resource a provider declares is validated (uri non-empty, mime/handler
+ * present). Invalid entries are dropped and a duplicate resource uri across providers rejects the later
+ * registration (first-wins by the ExtensionId sort). Other extensions are never affected.
+ */
+class IUnrealMcpResourceProvider : public IModularFeature
+{
+public:
+	virtual ~IUnrealMcpResourceProvider() = default;
+
+	/** The modular-feature name every resource provider registers under. Stable across the plugin's lifetime. */
+	static FName GetModularFeatureName()
+	{
+		return FName(TEXT("UnrealMcpResourceProvider"));
+	}
+
+	/**
+	 * Stable, unique extension identifier — reverse-DNS recommended (e.g. "com.foo.niagara-ai"). Used as
+	 * the deterministic sort key and as the manifest's per-resource extensionId. Two providers with the
+	 * same id is an authoring error (the second's duplicate resources are rejected).
+	 */
+	virtual FString GetExtensionId() const = 0;
+
+	/** Human-readable name shown in the extensions UI row (§7). */
+	virtual FText GetDisplayName() const = 0;
+
+	/** Free-form version string of the extension (independent of the Unreal-MCP plugin version). */
+	virtual FString GetExtensionVersion() const = 0;
+
+	/**
+	 * Declare the extension's resources into @p Registry using the fluent FUnrealMcpResourceBuilder
+	 * (Registry.Resource("unreal://my/uri").Name(...).MimeType(...).Read(...)). Called on the game thread.
+	 * Resources are automatically stamped with this provider's ExtensionId — do not call .ExtensionId().
+	 * Invalid or duplicate entries are dropped/rejected and recorded; valid entries register normally.
+	 */
+	virtual void RegisterResources(FUnrealMcpResourceRegistry& Registry) = 0;
+};

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpResourceRegistry.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpResourceRegistry.h
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+#include "Templates/Function.h"
+// The resource registry reuses the §5 extension-registration result struct (FUnrealMcpExtensionRegistrationResult)
+// from the tool registry verbatim — include that header rather than re-declaring it (mirror, don't fork).
+#include "UnrealMcpToolRegistry.h"
+
+/**
+ * Core resource-registration types for the Unreal-MCP plugin (docs/ARCHITECTURE.md §A.1 / §A.2). The exact
+ * resource sibling of UnrealMcpToolRegistry.h / UnrealMcpPromptRegistry.h: the registry is the plugin-owned
+ * source of truth for the resource set; each family declares its resources through the fluent
+ * FUnrealMcpResourceBuilder; the registry compiles each declaration into a JSON descriptor (the
+ * resource-manifest shape) and dispatches incoming resource-read requests to the declared handler. The
+ * sidecar mirrors the manifest into MCP ProxyResources.
+ *
+ * MVP scope (§A.1): static fixed-URI resources. A resource's URI is its identity (the registry key) AND the
+ * MCP route. Templated / parameterized URIs are deferred (upstream McpPlugin has the template types). A
+ * resource read returns one or more content blocks: each is Text(string) XOR Blob(base64) + mimeType, so
+ * binary content rides as base64 like screenshot images.
+ */
+
+/** One content block of a resource read, mirroring the IPC resource-response contents[] shape (§A.1). */
+struct UNREALMCPRUNTIME_API FUnrealMcpResourceContent
+{
+	FString Uri;        // the resource uri this block belongs to (echoed back; usually the requested uri)
+	FString MimeType;   // optional MIME type of this block
+	FString Text;       // text content (XOR Blob)
+	FString Blob;       // base64-encoded binary content (XOR Text)
+	bool bIsBlob = false;
+
+	static FUnrealMcpResourceContent MakeText(const FString& InUri, const FString& InText, const FString& InMimeType = FString())
+	{
+		FUnrealMcpResourceContent Content;
+		Content.Uri = InUri;
+		Content.Text = InText;
+		Content.MimeType = InMimeType;
+		Content.bIsBlob = false;
+		return Content;
+	}
+
+	static FUnrealMcpResourceContent MakeBlob(const FString& InUri, const FString& InBase64, const FString& InMimeType = FString())
+	{
+		FUnrealMcpResourceContent Content;
+		Content.Uri = InUri;
+		Content.Blob = InBase64;
+		Content.MimeType = InMimeType;
+		Content.bIsBlob = true;
+		return Content;
+	}
+};
+
+/** Terminal result of a resource-read, mirroring the IPC resource-response shape (§A.1). */
+struct UNREALMCPRUNTIME_API FUnrealMcpResourceResult
+{
+	bool bSuccess = true;
+	FString Error;                                   // human-readable reason on failure (never a secret)
+	TArray<FUnrealMcpResourceContent> Contents;      // the returned content blocks
+
+	/** A single-text-block success — the common JSON/string resource (mimeType e.g. "application/json"). */
+	static FUnrealMcpResourceResult Text(const FString& Uri, const FString& InText, const FString& MimeType = FString())
+	{
+		FUnrealMcpResourceResult Result;
+		Result.bSuccess = true;
+		Result.Contents.Add(FUnrealMcpResourceContent::MakeText(Uri, InText, MimeType));
+		return Result;
+	}
+
+	/** A single-blob-block success — binary content carried as base64 (mimeType e.g. "image/png"). */
+	static FUnrealMcpResourceResult Blob(const FString& Uri, const FString& InBase64, const FString& MimeType = FString())
+	{
+		FUnrealMcpResourceResult Result;
+		Result.bSuccess = true;
+		Result.Contents.Add(FUnrealMcpResourceContent::MakeBlob(Uri, InBase64, MimeType));
+		return Result;
+	}
+
+	/** A multi-block success (the caller assembled the content list). */
+	static FUnrealMcpResourceResult Success(const TArray<FUnrealMcpResourceContent>& InContents)
+	{
+		FUnrealMcpResourceResult Result;
+		Result.bSuccess = true;
+		Result.Contents = InContents;
+		return Result;
+	}
+
+	static FUnrealMcpResourceResult MakeError(const FString& InError)
+	{
+		FUnrealMcpResourceResult Result;
+		Result.bSuccess = false;
+		Result.Error = InError;
+		return Result;
+	}
+};
+
+/**
+ * Signature of a resource handler: runs on the game thread (the dispatcher guarantees it, §4), returns a
+ * terminal result synchronously. The requested URI is passed in (for a static MVP resource it equals the
+ * descriptor's uri; the parameter keeps the signature forward-compatible with templated URIs, §A.1).
+ */
+using FUnrealMcpResourceHandler = TFunction<FUnrealMcpResourceResult(const FString& /*Uri*/)>;
+
+/** A fully compiled resource: descriptor (manifest shape) + handler. */
+struct UNREALMCPRUNTIME_API FUnrealMcpRegisteredResource
+{
+	FString Uri;        // the resource's MCP uri — its identity (registry key) and route
+	FString Name;
+	FString Description;
+	FString MimeType;
+	bool bEnabled = true;
+	FString ExtensionId = TEXT("core");
+	FString SchemaHash;
+	FUnrealMcpResourceHandler Handler;
+
+	/** The resource-manifest descriptor object (one entry in resource-manifest.resources[]). */
+	TSharedPtr<FJsonObject> ToDescriptorJson() const;
+};
+
+class FUnrealMcpResourceRegistry;
+
+/** Fluent declaration builder (§3.3 resource analog). One per resource; commits on Read(). */
+class UNREALMCPRUNTIME_API FUnrealMcpResourceBuilder
+{
+public:
+	FUnrealMcpResourceBuilder(FUnrealMcpResourceRegistry& InRegistry, const FString& InUri);
+
+	FUnrealMcpResourceBuilder& Name(const FString& InName);
+	FUnrealMcpResourceBuilder& Description(const FString& InDescription);
+	FUnrealMcpResourceBuilder& MimeType(const FString& InMimeType);
+	FUnrealMcpResourceBuilder& ExtensionId(const FString& InExtensionId);
+
+	/** Bind the read handler and commit the resource into the registry. */
+	void Read(FUnrealMcpResourceHandler InHandler);
+
+private:
+	FUnrealMcpResourceRegistry& Registry;
+	FUnrealMcpRegisteredResource Resource;
+};
+
+/**
+ * The plugin-owned resource registry (docs/ARCHITECTURE.md §A.1) — the exact resource sibling of
+ * FUnrealMcpToolRegistry / FUnrealMcpPromptRegistry. Holds the compiled resource set, produces the JSON
+ * manifest snapshot for the bridge, and dispatches resource-read requests by URI. A monotonic Revision
+ * bumps on every change so the sidecar's manifest diff can reason about ordering. Not thread-safe (same
+ * contract as the tool/prompt registries): all mutation happens at startup before the bridge accepts; any
+ * DYNAMIC re-registration MUST marshal both the mutation and the manifest read through the game-thread
+ * dispatcher (§4).
+ */
+class UNREALMCPRUNTIME_API FUnrealMcpResourceRegistry
+{
+public:
+	/** Begin declaring a resource (the §3.3 fluent API, resource analog). @p Uri is the resource's identity. */
+	FUnrealMcpResourceBuilder Resource(const FString& Uri);
+
+	/**
+	 * Commit a fully-built resource (called by the builder's Read()).
+	 * - Core path (default): replaces any same-uri resource — core families are trusted.
+	 * - Extension scope (inside RegisterExtension): the resource is stamped with the scope's ExtensionId,
+	 *   validated (§5), and deduped. An invalid entry is DROPPED and a duplicate is REJECTED (first-wins).
+	 */
+	void Commit(FUnrealMcpRegisteredResource&& InResource);
+
+	/**
+	 * Register an extension provider's resources (§5). Opens an "extension scope": every Commit during
+	 * @p RegisterFn is stamped with @p ExtensionId, validated, and deduped. Reuses the tool registry's
+	 * FUnrealMcpExtensionRegistrationResult (its `ToolsRegistered` count here means "entries registered").
+	 * Scopes never nest.
+	 */
+	FUnrealMcpExtensionRegistrationResult RegisterExtension(const FString& ExtensionId, TFunctionRef<void(FUnrealMcpResourceRegistry&)> RegisterFn);
+
+	/** Remove every resource stamped with @p ExtensionId (hot-unload / rebuild, §5). Bumps revision if any removed. Returns count removed. */
+	int32 RemoveResourcesForExtension(const FString& ExtensionId);
+
+	/** True iff @p Uri is a valid resource URI (non-empty, no control/whitespace chars). */
+	static bool IsValidResourceUri(const FString& Uri);
+
+	/** Validate a resource descriptor for the §5 isolation contract. Returns false + a reason on the first problem. */
+	static bool ValidateResource(const FUnrealMcpRegisteredResource& InResource, FString& OutError);
+
+	bool HasResource(const FString& Uri) const { return Resources.Contains(Uri); }
+	int32 Num() const { return Resources.Num(); }
+	const FUnrealMcpRegisteredResource* Find(const FString& Uri) const { return Resources.Find(Uri); }
+
+	/** Every registered resource URI, sorted. */
+	TArray<FString> GetResourceUrisSorted() const;
+
+	/** Count of resources whose bEnabled flag is set. */
+	int32 NumEnabled() const;
+
+	/** True iff @p Uri passes the §8 EnabledResources whitelist gate (empty whitelist, or the uri is listed). */
+	bool PassesEnabledResourcesWhitelist(const FString& Uri) const;
+
+	/**
+	 * Set one resource's enabled flag directly — a GRANULAR helper, NOT a production §7 toggle. Does NOT
+	 * update the retained whitelist/blocklist. Disabled resources are EXCLUDED from BuildManifestJson.
+	 * Bumps the revision on a real change. Unknown uri / no-op change: returns false, no bump. Game-thread only.
+	 */
+	bool SetResourceEnabled(const FString& Uri, bool bEnabled);
+
+	/** Set the §8 env whitelist. Mirrors the tool registry's SetEnabledToolsFilter exactly. Game-thread only. */
+	void SetEnabledResourcesFilter(const TArray<FString>& EnabledResources);
+
+	/** Apply the persisted §7 per-resource enable-map (blocklist). Mirrors the tool registry's ApplyDisabledTools. Game-thread only. */
+	void ApplyDisabledResources(const TArray<FString>& DisabledUris);
+
+	/** Current manifest revision (bumps on every registry mutation). */
+	int32 GetRevision() const { return Revision; }
+
+	/** Build the full resource-manifest message body (revision + resources[]) for the bridge (§A.1). Disabled resources excluded, sorted by uri. */
+	TSharedPtr<FJsonObject> BuildManifestJson() const;
+
+	/**
+	 * Read a resource by URI on the CURRENT thread (the dispatcher has already marshalled to the game
+	 * thread). Returns an error result for an unknown / disabled resource. The handler owns content production.
+	 */
+	FUnrealMcpResourceResult Read(const FString& Uri) const;
+
+	/** Compute the stable schema hash for a resource descriptor (excludes the enabled flag). */
+	static FString ComputeSchemaHash(const FUnrealMcpRegisteredResource& InResource);
+
+private:
+	TMap<FString, FUnrealMcpRegisteredResource> Resources;
+	int32 Revision = 0;
+
+	// --- Retained §7/§8 enablement filters (mirror the tool/prompt registries exactly). ---
+	TSet<FString> EnabledResourcesWhitelist; // §8 whitelist; empty = no filter
+	TSet<FString> DisabledResourceUris;      // §7 persisted blocklist
+
+	/** The combined §8 effective-served predicate: enabled iff (whitelist empty OR member) AND NOT blocklisted. */
+	bool ShouldResourceBeEnabled(const FString& Uri) const;
+
+	/** Re-evaluate every registered resource's bEnabled against ShouldResourceBeEnabled; bumps the revision once if any changed. */
+	void RecomputeEnablement();
+
+	// --- Extension-scope state (active only inside RegisterExtension; scopes never nest) ----------
+	bool bExtensionScope = false;
+	FString ScopeExtensionId;
+	int32 ScopeResourcesRegistered = 0;
+	TArray<FString> ScopeErrors;
+};

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeCoreResources.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeCoreResources.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FUnrealMcpResourceRegistry;
+
+/**
+ * Registration entry point for the core RESOURCE family (docs/ARCHITECTURE.md §A.1 / §A.2) — the resource
+ * sibling of UnrealMcpRuntimeCoreTools.h / UnrealMcpRuntimeCorePrompts.h. Exported with UNREALMCPRUNTIME_API
+ * so the editor coordinator and the runtime bootstrap subsystem wire it on boot (Model A — editor + runtime
+ * register on the SAME resource registry) AND the Automation specs can register + exercise it in isolation.
+ *
+ * The MVP registers two self-contained static-URI resources, both compiling+linking in the editor and the
+ * non-editor Game target (Engine-only APIs, no UnrealEd symbols):
+ *  - unreal://project/levels — a JSON (application/json) snapshot of the active world + its loaded levels.
+ *  - unreal://project/icon   — a tiny base64 PNG blob (image/png), covering the Text-vs-Blob round-trip.
+ */
+namespace UnrealMcpCoreResources
+{
+	UNREALMCPRUNTIME_API void Register(FUnrealMcpResourceRegistry& Registry);
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeSubsystem.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeSubsystem.h
@@ -13,6 +13,8 @@
 class IUnrealMcpToolProvider;
 // Forward-declared for the same reason: RegisterPromptProvider/UnregisterPromptProvider take it by pointer.
 class IUnrealMcpPromptProvider;
+// Forward-declared for the same reason: RegisterResourceProvider/UnregisterResourceProvider take it by pointer.
+class IUnrealMcpResourceProvider;
 
 // The runtime-owned machinery (registry/dispatcher/bridge/sidecar/extensions) is held behind a PImpl
 // (FRuntimeImpl, defined in the .cpp) so this PUBLIC header forward-declares nothing module-private and the
@@ -155,6 +157,19 @@ public:
 
 	/** Unregister a prompt provider previously registered via RegisterPromptProvider (or directly via IModularFeatures). Null / unknown is a harmless no-op. */
 	void UnregisterPromptProvider(IUnrealMcpPromptProvider* Provider);
+
+	/**
+	 * Register a custom gameplay RESOURCE provider at runtime (§A.2) — the resource sibling of
+	 * RegisterToolProvider / RegisterPromptProvider. A thin wrapper over
+	 * `IModularFeatures::Get().RegisterModularFeature(IUnrealMcpResourceProvider::GetModularFeatureName(), Provider)`:
+	 * the extension manager subscribed to the resource modular-feature events in Initialize(), so the
+	 * registration rebuilds the resource registry and re-pushes the manifest. OWNERSHIP: not owned — the caller
+	 * keeps @p Provider alive and must UnregisterResourceProvider before destroying it. Null is a no-op.
+	 */
+	void RegisterResourceProvider(IUnrealMcpResourceProvider* Provider);
+
+	/** Unregister a resource provider previously registered via RegisterResourceProvider (or directly via IModularFeatures). Null / unknown is a harmless no-op. */
+	void UnregisterResourceProvider(IUnrealMcpResourceProvider* Provider);
 
 	/** Whether the loopback listener armed (a port is bound). False means Initialize failed to bind. */
 	bool IsListenerArmed() const { return BoundPort > 0; }

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -75,6 +75,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         // §A.1 (P1) prompt manifest registrar. Null when the built McpPlugin has no PromptManager (defensive —
         // the empty-then-manifest model means the manager is normally present, like ToolManager).
         private PromptManifestRegistrar? _promptRegistrar;
+        // §A.1 (P2) resource manifest registrar. Null when the built McpPlugin has no ResourceManager (defensive
+        // — same empty-then-manifest model as the prompt registrar).
+        private ResourceManifestRegistrar? _resourceRegistrar;
         private Reflector? _reflector;
         private int _signalRConnectStarted;
 
@@ -262,6 +265,25 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             else
             {
                 _logger?.LogWarning("Built McpPlugin has no PromptManager; prompts disabled this session.");
+            }
+
+            // §A.1 (P2) resources: wire the resource manifest registrar to the live ResourceManager, mirroring the
+            // prompt wiring. The manager is NULLABLE on IMcpManager; the empty-then-manifest model (no WithResources*
+            // at build, the plugin's resource-manifest populates it) means it is normally present.
+            // ResourceManifestRegistrar implements IManifestSink<ResourceManifestMessage>, so this satisfies
+            // IpcClient.ResourceRegistrar directly. A v1-negotiated link never delivers a resource-manifest.
+            var resourceManager = _plugin.McpManager.ResourceManager;
+            if (resourceManager != null)
+            {
+                _resourceRegistrar = new ResourceManifestRegistrar(
+                    new ResourceManagerSink(resourceManager),
+                    _ipc,
+                    _loggerProvider?.CreateLogger(nameof(ResourceManifestRegistrar)));
+                _ipc.ResourceRegistrar = _resourceRegistrar;
+            }
+            else
+            {
+                _logger?.LogWarning("Built McpPlugin has no ResourceManager; resources disabled this session.");
             }
 
             // §7 (issue #109): subscribe to the connected-AI-agent roster so the plugin's "AI agents" status row

--- a/bridge/src/Ipc/IpcClient.cs
+++ b/bridge/src/Ipc/IpcClient.cs
@@ -29,7 +29,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
     /// reader thread (RunContinuationsAsynchronously). One mutex-guarded writer serializes every send so
     /// messages never interleave (§1.2).
     /// </summary>
-    public sealed class IpcClient : IToolCallChannel, IPromptCallChannel, IAsyncDisposable
+    public sealed class IpcClient : IToolCallChannel, IPromptCallChannel, IResourceCallChannel, IAsyncDisposable
     {
         private readonly string _host;
         private readonly int _port;

--- a/bridge/src/Tools/ProxyResource.cs
+++ b/bridge/src/Tools/ProxyResource.cs
@@ -1,0 +1,60 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Text.Json.Serialization;
+using com.IvanMurzak.McpPlugin;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// An <see cref="IRunResource"/> whose metadata is supplied externally at runtime (the plugin's resource
+    /// manifest, §A.1) and whose content/list runners are IPC-backed proxies. The resource sibling of
+    /// <see cref="ProxyTool"/> / <see cref="ProxyPrompt"/> — the building block for the sidecar's dynamic,
+    /// manifest-driven resource set. MVP scope is STATIC fixed-URI resources (the <see cref="Route"/> is the
+    /// concrete URI; templated URIs are deferred, §A.1).
+    /// </summary>
+    public sealed class ProxyResource : IRunResource
+    {
+        /// <summary>The resource's MCP URI — its route AND identity (the manager keys resources by route).</summary>
+        public string Route { get; set; }
+        public string Name { get; set; }
+        public string? Description { get; set; }
+        public string? MimeType { get; set; }
+
+        /// <summary>
+        /// Whether this resource is exposed to MCP clients. Settable so the manifest registrar can toggle a
+        /// runtime resource on/off (mirrors <see cref="ProxyTool.Enabled"/> / <see cref="ProxyPrompt.Enabled"/>).
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+
+        [JsonIgnore]
+        public IRunResourceContent RunGetContent { get; set; }
+
+        [JsonIgnore]
+        public IRunResourceList RunListContext { get; set; }
+
+        public ProxyResource(
+            string route,
+            string name,
+            string? description,
+            string? mimeType,
+            IRunResourceContent runGetContent,
+            IRunResourceList runListContext)
+        {
+            Route = route ?? throw new ArgumentNullException(nameof(route));
+            Name = name ?? string.Empty;
+            Description = description;
+            MimeType = mimeType;
+            RunGetContent = runGetContent ?? throw new ArgumentNullException(nameof(runGetContent));
+            RunListContext = runListContext ?? throw new ArgumentNullException(nameof(runListContext));
+        }
+    }
+}

--- a/bridge/src/Tools/ProxyResourceContent.cs
+++ b/bridge/src/Tools/ProxyResourceContent.cs
@@ -1,0 +1,78 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// The <see cref="IRunResourceContent"/> half of a <see cref="ProxyResource"/> (docs/ARCHITECTURE.md §A.1)
+    /// — its body round-trips a <c>resource-read</c> over IPC and maps the terminal <c>resource-response</c> to
+    /// <see cref="ResponseResourceContent"/>[] (text XOR base64 blob). The resource sibling of the
+    /// <see cref="ProxyPrompt"/> get-handler. On an IPC disconnect the read throws so the manager surfaces a
+    /// fail-fast error rather than hanging to the timeout (§2.2 step 4).
+    /// </summary>
+    public sealed class ProxyResourceContent : IRunResourceContent
+    {
+        private readonly string _uri;
+        private readonly IResourceCallChannel _channel;
+        private readonly int _timeoutMs;
+
+        public ProxyResourceContent(string uri, IResourceCallChannel channel, int timeoutMs)
+        {
+            _uri = uri ?? throw new ArgumentNullException(nameof(uri));
+            _channel = channel ?? throw new ArgumentNullException(nameof(channel));
+            _timeoutMs = timeoutMs;
+        }
+
+        // IRunResourceContent is schema-blind here: a static-URI MVP resource takes no parameters, so both Run
+        // overloads ignore their args and read the fixed uri (templated URIs are deferred, §A.1).
+        public Task<ResponseResourceContent[]> Run(params object?[] parameters) => ReadAsync(CancellationToken.None);
+        public Task<ResponseResourceContent[]> Run(IDictionary<string, object?>? namedParameters) => ReadAsync(CancellationToken.None);
+
+        private async Task<ResponseResourceContent[]> ReadAsync(CancellationToken cancellationToken)
+        {
+            // Round-trip the read; an IpcDisconnectedException propagates so the manager fails fast (never hangs).
+            var response = await _channel.ReadResourceAsync(_uri, _timeoutMs, cancellationToken).ConfigureAwait(false);
+
+            if (string.Equals(response.Status, IpcProtocol.Status.Error, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException(response.Error ?? $"Resource '{_uri}' read failed.");
+
+            return MapContents(response, _uri);
+        }
+
+        /// <summary>
+        /// Map an IPC <c>resource-response</c>'s contents[] onto <see cref="ResponseResourceContent"/>[]: each
+        /// entry becomes a text block (<see cref="ResponseResourceContent.CreateText"/>) or, when a base64
+        /// <c>blob</c> is present, a blob block (<see cref="ResponseResourceContent.CreateBlob"/>). The blob
+        /// branch is preferred when both are set (a binary resource), mirroring the plugin's Text-XOR-Blob shape.
+        /// </summary>
+        internal static ResponseResourceContent[] MapContents(ResourceResponseMessage response, string fallbackUri)
+        {
+            if (response.Contents == null || response.Contents.Count == 0)
+                return Array.Empty<ResponseResourceContent>();
+
+            return response.Contents.Select(c =>
+            {
+                var uri = string.IsNullOrEmpty(c.Uri) ? fallbackUri : c.Uri!;
+                if (!string.IsNullOrEmpty(c.Blob))
+                    return ResponseResourceContent.CreateBlob(uri, c.Blob!, c.MimeType);
+                return ResponseResourceContent.CreateText(uri, c.Text ?? string.Empty, c.MimeType);
+            }).ToArray();
+        }
+    }
+}

--- a/bridge/src/Tools/ProxyResourceFactory.cs
+++ b/bridge/src/Tools/ProxyResourceFactory.cs
@@ -1,0 +1,49 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// Builds a <see cref="ProxyResource"/> from a manifest <see cref="ResourceDescriptor"/>
+    /// (docs/ARCHITECTURE.md §A.1) — the resource sibling of <see cref="ProxyToolFactory"/> /
+    /// <see cref="ProxyPromptFactory"/>. The resource's content runner round-trips a <c>resource-read</c> on the
+    /// supplied <see cref="IResourceCallChannel"/>; its list runner is a static single-element synthesis from
+    /// the descriptor (MVP fixed-URI scope, NO IPC — see <see cref="ProxyResourceList"/>).
+    /// </summary>
+    public static class ProxyResourceFactory
+    {
+        public static ProxyResource Create(ResourceDescriptor descriptor, IResourceCallChannel channel)
+        {
+            var uri = descriptor.Uri;
+            // The McpResourceManager keys resources by IRunResource.Name (its dictionary key) AND looks content
+            // up by Route (URI match). To make the URI the single identity — the dedup key the registrar diffs on
+            // AND the route a resources/read resolves — set BOTH Name and Route to the uri. The descriptor's
+            // human-friendly `name` is surfaced as the resources/list display name via ProxyResourceList instead.
+            var displayName = string.IsNullOrEmpty(descriptor.Name) ? uri : descriptor.Name!;
+            var timeoutMs = IpcProtocol.DefaultToolTimeoutMs;
+
+            var content = new ProxyResourceContent(uri, channel, timeoutMs);
+            var list = new ProxyResourceList(uri, displayName, descriptor.Enabled, descriptor.MimeType, descriptor.Description);
+
+            return new ProxyResource(
+                route: uri,
+                name: uri, // manager key == route == uri (single identity)
+                description: descriptor.Description,
+                mimeType: descriptor.MimeType,
+                runGetContent: content,
+                runListContext: list)
+            {
+                Enabled = descriptor.Enabled,
+            };
+        }
+    }
+}

--- a/bridge/src/Tools/ProxyResourceList.cs
+++ b/bridge/src/Tools/ProxyResourceList.cs
@@ -1,0 +1,66 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.Common.Model;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// The <see cref="IRunResourceList"/> half of a <see cref="ProxyResource"/> (docs/ARCHITECTURE.md §A.1).
+    /// MVP scope is STATIC fixed-URI resources, so the list is synthesized DIRECTLY from the manifest
+    /// descriptor — a single-element <see cref="ResponseListResource"/>[] — with NO IPC round-trip (a static
+    /// resource has exactly one concrete URI; only templated URIs, deferred per §A.1, would need a live
+    /// enumeration). The resource sibling shape of <see cref="ProxyPrompt"/>'s no-IPC metadata.
+    /// </summary>
+    public sealed class ProxyResourceList : IRunResourceList
+    {
+        private readonly ResourceDescriptorSnapshot _snapshot;
+
+        public ProxyResourceList(string uri, string name, bool enabled, string? mimeType, string? description)
+            => _snapshot = new ResourceDescriptorSnapshot(uri, name, enabled, mimeType, description);
+
+        public Task<ResponseListResource[]> Run(params object?[] parameters) => ListAsync();
+        public Task<ResponseListResource[]> Run(IDictionary<string, object?>? namedParameters) => ListAsync();
+
+        private Task<ResponseListResource[]> ListAsync()
+        {
+            // Static MVP: one entry, the resource's own descriptor. No IPC — the URI is fixed and known.
+            var entry = new ResponseListResource(
+                uri: _snapshot.Uri,
+                name: _snapshot.Name,
+                enabled: _snapshot.Enabled,
+                mimeType: _snapshot.MimeType,
+                description: _snapshot.Description);
+            return Task.FromResult(new[] { entry });
+        }
+
+        private readonly struct ResourceDescriptorSnapshot
+        {
+            public readonly string Uri;
+            public readonly string Name;
+            public readonly bool Enabled;
+            public readonly string? MimeType;
+            public readonly string? Description;
+
+            public ResourceDescriptorSnapshot(string uri, string name, bool enabled, string? mimeType, string? description)
+            {
+                Uri = uri ?? throw new ArgumentNullException(nameof(uri));
+                Name = name ?? string.Empty;
+                Enabled = enabled;
+                MimeType = mimeType;
+                Description = description;
+            }
+        }
+    }
+}

--- a/bridge/src/Tools/ResourceCallChannel.cs
+++ b/bridge/src/Tools/ResourceCallChannel.cs
@@ -1,0 +1,39 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// The channel a <see cref="ProxyResourceContent"/> uses to round-trip a resource-read over IPC: serialize
+    /// a <c>resource-read</c>, await the matching <c>resource-response</c>, and forward cancellation as the
+    /// generic <c>tool-cancel</c> (docs/ARCHITECTURE.md §A.1). The resource sibling of
+    /// <see cref="IPromptCallChannel"/>; implemented by the IPC client (which already exposes
+    /// <c>ReadResourceAsync</c> with this exact signature), kept as an interface so the proxy/registration path
+    /// is unit-testable with a fake channel.
+    /// </summary>
+    public interface IResourceCallChannel
+    {
+        /// <summary>
+        /// Send a <c>resource-read</c> and await its terminal <c>resource-response</c>.
+        /// </summary>
+        /// <exception cref="IpcDisconnectedException">
+        /// The IPC link is down — the proxy must fail fast with the structured "bridge disconnected"
+        /// error (§A.1 / §2.2 step 4), never hang to <paramref name="timeoutMs"/>.
+        /// </exception>
+        Task<ResourceResponseMessage> ReadResourceAsync(
+            string uri,
+            int timeoutMs,
+            CancellationToken ct);
+    }
+}

--- a/bridge/src/Tools/ResourceManifestRegistrar.cs
+++ b/bridge/src/Tools/ResourceManifestRegistrar.cs
@@ -1,0 +1,166 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Collections.Generic;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
+{
+    /// <summary>
+    /// The minimal resource-set mutation surface the registrar needs (the resource sibling of
+    /// <see cref="IProxyToolSink"/> / <see cref="IProxyPromptSink"/>). Abstracts <see cref="IResourceManager"/>
+    /// (adapted by <see cref="ResourceManagerSink"/>) so the manifest-application logic is unit-tested with a
+    /// fake sink. The <c>key</c> is the resource's URI (which the proxy uses as both Name and Route, so the
+    /// manager's Name-keyed dictionary lines up with the registrar's uri-keyed diff).
+    /// </summary>
+    public interface IProxyResourceSink
+    {
+        bool HasResource(string key);
+        bool AddResource(string key, ProxyResource resource);
+        bool RemoveResource(string key);
+        bool SetResourceEnabled(string key, bool enabled);
+    }
+
+    /// <summary>Adapts the reused <see cref="IResourceManager"/> to <see cref="IProxyResourceSink"/>.</summary>
+    public sealed class ResourceManagerSink : IProxyResourceSink
+    {
+        private readonly IResourceManager _resourceManager;
+        public ResourceManagerSink(IResourceManager resourceManager) => _resourceManager = resourceManager;
+
+        // The manager keys by IRunResource.Name; ProxyResourceFactory sets Name == Route == uri, so the `key`
+        // (the descriptor uri) the registrar passes is exactly the manager's key.
+        public bool HasResource(string key) => _resourceManager.HasResource(key);
+
+        // IResourceManager.AddResource takes ONLY the runner (its name == resource.Name == the uri key); the
+        // key param is kept on the sink interface for symmetry/testability with the tool/prompt sinks.
+        public bool AddResource(string key, ProxyResource resource) => _resourceManager.AddResource(resource);
+
+        public bool RemoveResource(string key) => _resourceManager.RemoveResource(key);
+        public bool SetResourceEnabled(string key, bool enabled) => _resourceManager.SetResourceEnabled(key, enabled);
+    }
+
+    /// <summary>
+    /// The resource-specific differ (docs/ARCHITECTURE.md §A.1) — the resource sibling of
+    /// <see cref="ManifestDiffer"/> / <see cref="PromptManifestDiffer"/>: compare by <c>uri</c> +
+    /// <c>schemaHash</c> (the hash excludes the enabled flag), with a structural-signature fallback when a hash
+    /// is absent on either side.
+    /// </summary>
+    internal static class ResourceManifestDiffer
+    {
+        public static ManifestDiff<ResourceDescriptor> Compute(
+            IReadOnlyDictionary<string, ResourceDescriptor> previous,
+            IReadOnlyList<ResourceDescriptor> next)
+        {
+            var diff = new ManifestDiff<ResourceDescriptor>();
+            var nextByUri = new Dictionary<string, ResourceDescriptor>();
+
+            foreach (var desc in next)
+            {
+                if (string.IsNullOrEmpty(desc.Uri))
+                    continue;
+                nextByUri[desc.Uri] = desc;
+
+                if (!previous.TryGetValue(desc.Uri, out var prev))
+                {
+                    diff.Added.Add(desc);
+                    continue;
+                }
+
+                if (!SchemaEquals(prev, desc))
+                    diff.Changed.Add(desc);
+                else if (prev.Enabled != desc.Enabled)
+                    diff.EnabledChanged.Add((desc.Uri, desc.Enabled));
+                // else: identical → no-op.
+            }
+
+            foreach (var uri in previous.Keys)
+            {
+                if (!nextByUri.ContainsKey(uri))
+                    diff.Removed.Add(uri);
+            }
+
+            return diff;
+        }
+
+        private static bool SchemaEquals(ResourceDescriptor a, ResourceDescriptor b)
+        {
+            if (!string.IsNullOrEmpty(a.SchemaHash) || !string.IsNullOrEmpty(b.SchemaHash))
+                return a.SchemaHash == b.SchemaHash;
+
+            return Signature(a) == Signature(b);
+        }
+
+        private static string Signature(ResourceDescriptor d)
+        {
+            // Structural fallback: everything that defines the resource's surface EXCEPT the enabled flag.
+            return string.Join("", d.Uri, d.Name, d.Description, d.MimeType, d.ExtensionId);
+        }
+    }
+
+    /// <summary>
+    /// Applies resource manifests (docs/ARCHITECTURE.md §A.1) to an <see cref="IProxyResourceSink"/> — the
+    /// resource sibling of <see cref="ManifestRegistrar"/> / <see cref="PromptManifestRegistrar"/>. Derives from
+    /// the shared, kind-agnostic <see cref="ManifestRegistrarBase{TDescriptor}"/> (the revision guard / reconnect
+    /// reset / diff-application loop) and supplies the resource-specific bits: the <see cref="ProxyResource"/>
+    /// sink + the <see cref="ResourceManifestDiffer"/>. Implements
+    /// <see cref="IManifestSink{ResourceManifestMessage}"/> so the IPC client routes a <c>resource-manifest</c>
+    /// to it without knowing the descriptor type. NOT thread-safe by itself: the IPC client invokes Apply from
+    /// its single reader loop (same contract as the tool/prompt registrars).
+    /// </summary>
+    public sealed class ResourceManifestRegistrar : ManifestRegistrarBase<ResourceDescriptor>, IManifestSink<ResourceManifestMessage>
+    {
+        private readonly IProxyResourceSink _sink;
+        private readonly IResourceCallChannel _channel;
+
+        public ResourceManifestRegistrar(IProxyResourceSink sink, IResourceCallChannel channel, ILogger? logger = null)
+            : base(logger)
+        {
+            _sink = sink;
+            _channel = channel;
+        }
+
+        /// <summary>URIs of the resources currently registered by this registrar (test/inspection aid).</summary>
+        public IReadOnlyCollection<string> AppliedResourceUris => Applied.Keys;
+
+        /// <summary>A snapshot of the currently-applied resource descriptors (copied list; caller mutation-safe).</summary>
+        public IReadOnlyList<ResourceDescriptor> AppliedDescriptors => new List<ResourceDescriptor>(Applied.Values);
+
+        /// <summary>Apply a resource manifest. Returns the diff that was applied (empty when ignored/no-op).</summary>
+        public ManifestDiff<ResourceDescriptor> Apply(ResourceManifestMessage manifest)
+            => ApplyEntries(manifest.Revision, manifest.Resources);
+
+        // --- IManifestSink<ResourceManifestMessage> (the type-erased route the IPC client holds) ----------
+        public void ApplyManifest(ResourceManifestMessage manifest) => ApplyEntries(manifest.Revision, manifest.Resources);
+        // ResetForReconnect is provided by the base (public).
+
+        protected override string KindLabel => "resource";
+
+        protected override string KeyOf(ResourceDescriptor descriptor) => descriptor.Uri;
+
+        protected override ManifestDiff<ResourceDescriptor> ComputeDiff(IReadOnlyList<ResourceDescriptor> next)
+            => ResourceManifestDiffer.Compute(Applied, next);
+
+        protected override void SinkRemove(string key) => _sink.RemoveResource(key);
+
+        protected override void SinkAdd(ResourceDescriptor descriptor) =>
+            _sink.AddResource(descriptor.Uri, ProxyResourceFactory.Create(descriptor, _channel));
+
+        protected override void SinkSetEnabled(string key, bool enabled) => _sink.SetResourceEnabled(key, enabled);
+
+        protected override ResourceDescriptor WithEnabled(ResourceDescriptor descriptor, bool enabled)
+        {
+            // Mutate in place + return the same instance (preserves the tool/prompt-registrar behaviour exactly).
+            descriptor.Enabled = enabled;
+            return descriptor;
+        }
+    }
+}

--- a/bridge/tests/Fakes.cs
+++ b/bridge/tests/Fakes.cs
@@ -229,6 +229,66 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         }
     }
 
+    /// <summary>A scripted <see cref="IResourceCallChannel"/> for testing the resource proxy/registration path.</summary>
+    public sealed class FakeResourceCallChannel : IResourceCallChannel
+    {
+        private readonly Func<string, ResourceResponseMessage>? _responder;
+        public bool Connected { get; set; } = true;
+
+        public string? LastUri { get; private set; }
+        public int Calls { get; private set; }
+
+        public FakeResourceCallChannel(Func<string, ResourceResponseMessage>? responder = null)
+            => _responder = responder;
+
+        public Task<ResourceResponseMessage> ReadResourceAsync(string uri, int timeoutMs, CancellationToken ct)
+        {
+            Calls++;
+            LastUri = uri;
+            if (!Connected)
+                throw new IpcDisconnectedException();
+
+            var response = _responder?.Invoke(uri) ?? new ResourceResponseMessage
+            {
+                RequestId = "fake",
+                Status = IpcProtocol.Status.Success,
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    /// <summary>An in-memory <see cref="IProxyResourceSink"/> recording the resource registrar's mutations.</summary>
+    public sealed class FakeResourceSink : IProxyResourceSink
+    {
+        public readonly Dictionary<string, ProxyResource> Resources = new();
+        public readonly Dictionary<string, bool> Enabled = new();
+
+        public bool HasResource(string key) => Resources.ContainsKey(key);
+
+        public bool AddResource(string key, ProxyResource resource)
+        {
+            if (Resources.ContainsKey(key))
+                return false;
+            Resources[key] = resource;
+            Enabled[key] = resource.Enabled;
+            return true;
+        }
+
+        public bool RemoveResource(string key)
+        {
+            Enabled.Remove(key);
+            return Resources.Remove(key);
+        }
+
+        public bool SetResourceEnabled(string key, bool enabled)
+        {
+            if (!Resources.ContainsKey(key))
+                return false;
+            Enabled[key] = enabled;
+            return true;
+        }
+    }
+
     /// <summary>
     /// A controllable <see cref="IMcpManager"/> for driving the connected-AI-agent roster path (issue #109): the
     /// test pushes new rosters through <see cref="PushClients"/> (an R3 <see cref="Subject{T}"/> backing

--- a/bridge/tests/ProxyResourceTests.cs
+++ b/bridge/tests/ProxyResourceTests.cs
@@ -1,7 +1,7 @@
 /*
 ┌───────────────────────────────────────────────────────────────────┐
 │  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
-│  Repository: GitHub (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
 │  Copyright (c) 2026 Ivan Murzak                                   │
 │  Licensed under the Apache License, Version 2.0.                  │
 │  See the LICENSE file in the project root for more information.   │

--- a/bridge/tests/ProxyResourceTests.cs
+++ b/bridge/tests/ProxyResourceTests.cs
@@ -1,0 +1,169 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak)              │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>
+    /// The §A.1 resource proxy: content round-trip (text + base64 blob), the no-IPC static list synthesis, and
+    /// the §2.2 step-4 disconnect fail-fast — the resource sibling of <see cref="ProxyPromptFactoryTests"/>.
+    /// </summary>
+    public class ProxyResourceFactoryTests
+    {
+        [Fact]
+        public async Task Create_RoundTripsReadThroughChannel_MapsTextContent()
+        {
+            var channel = new FakeResourceCallChannel(uri => new ResourceResponseMessage
+            {
+                RequestId = "x",
+                Status = IpcProtocol.Status.Success,
+                Contents = new List<ResourceContentEntry>
+                {
+                    new() { Uri = uri, MimeType = "application/json", Text = "{\"hasWorld\":true}" },
+                },
+            });
+
+            var proxy = ProxyResourceFactory.Create(
+                new ResourceDescriptor { Uri = "unreal://project/levels", Name = "Project Levels", MimeType = "application/json" },
+                channel);
+
+            var contents = await proxy.RunGetContent.Run(new object?[0]);
+
+            Assert.Equal("unreal://project/levels", channel.LastUri);
+            Assert.Single(contents);
+            Assert.Equal("unreal://project/levels", contents[0].Uri);
+            Assert.Equal("application/json", contents[0].MimeType);
+            Assert.Equal("{\"hasWorld\":true}", contents[0].Text);
+            Assert.Null(contents[0].Blob);
+        }
+
+        [Fact]
+        public async Task Create_RoundTripsRead_MapsBase64BlobContent()
+        {
+            // A base64 blob (binary content) must round-trip as a Blob block, NOT a Text block — the Text-vs-Blob
+            // discrimination the brief calls out. Encode a known PNG-ish byte sequence so the assertion is exact.
+            var rawBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+            var base64 = Convert.ToBase64String(rawBytes);
+
+            var channel = new FakeResourceCallChannel(uri => new ResourceResponseMessage
+            {
+                RequestId = "x",
+                Status = IpcProtocol.Status.Success,
+                Contents = new List<ResourceContentEntry>
+                {
+                    new() { Uri = uri, MimeType = "image/png", Blob = base64 },
+                },
+            });
+
+            var proxy = ProxyResourceFactory.Create(
+                new ResourceDescriptor { Uri = "unreal://project/icon", Name = "Project Icon", MimeType = "image/png" },
+                channel);
+
+            var contents = await proxy.RunGetContent.Run(new object?[0]);
+
+            Assert.Single(contents);
+            Assert.Equal("image/png", contents[0].MimeType);
+            Assert.Equal(base64, contents[0].Blob);
+            Assert.Null(contents[0].Text);
+            // The blob decodes back to the original bytes — proves the binary survived the round-trip intact.
+            Assert.Equal(rawBytes, Convert.FromBase64String(contents[0].Blob!));
+        }
+
+        [Fact]
+        public async Task Create_ErrorStatus_ThrowsSoManagerFailsFast()
+        {
+            var channel = new FakeResourceCallChannel(uri => new ResourceResponseMessage
+            {
+                RequestId = "x",
+                Status = IpcProtocol.Status.Error,
+                Error = "Unknown resource 'unreal://nope'.",
+            });
+
+            var proxy = ProxyResourceFactory.Create(new ResourceDescriptor { Uri = "unreal://nope" }, channel);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => proxy.RunGetContent.Run(new object?[0]));
+            Assert.Contains("Unknown resource", ex.Message);
+        }
+
+        [Fact]
+        public async Task Create_DisconnectedChannel_FailsFast()
+        {
+            var channel = new FakeResourceCallChannel { Connected = false };
+            var proxy = ProxyResourceFactory.Create(new ResourceDescriptor { Uri = "unreal://project/levels" }, channel);
+
+            // The disconnect surfaces as the structured IpcDisconnectedException — never hangs to the timeout.
+            await Assert.ThrowsAsync<IpcDisconnectedException>(() => proxy.RunGetContent.Run(new object?[0]));
+        }
+
+        [Fact]
+        public async Task Create_ListContext_SynthesizesSingleStaticEntry_NoIpc()
+        {
+            // The static MVP list is synthesized from the descriptor with NO IPC round-trip: the channel must
+            // never be touched by RunListContext (only RunGetContent reads over IPC).
+            var channel = new FakeResourceCallChannel();
+            var proxy = ProxyResourceFactory.Create(
+                new ResourceDescriptor
+                {
+                    Uri = "unreal://project/levels",
+                    Name = "Project Levels",
+                    Description = "Levels snapshot",
+                    MimeType = "application/json",
+                    Enabled = true,
+                },
+                channel);
+
+            var list = await proxy.RunListContext.Run(new object?[0]);
+
+            Assert.Equal(0, channel.Calls); // NO IPC for the static list
+            Assert.Single(list);
+            Assert.Equal("unreal://project/levels", list[0].Uri);
+            Assert.Equal("Project Levels", list[0].Name); // the friendly display name, not the uri
+            Assert.Equal("application/json", list[0].MimeType);
+            Assert.Equal("Levels snapshot", list[0].Description);
+            Assert.True(list[0].Enabled);
+        }
+
+        [Fact]
+        public void Create_MapsRouteAndNameToUri_AndPropagatesEnabledFlag()
+        {
+            var channel = new FakeResourceCallChannel();
+            var proxy = ProxyResourceFactory.Create(
+                new ResourceDescriptor { Uri = "unreal://project/levels", Name = "Project Levels", Enabled = false },
+                channel);
+
+            // Name == Route == uri so the manager's Name-key and route lookup share one identity.
+            Assert.Equal("unreal://project/levels", proxy.Route);
+            Assert.Equal("unreal://project/levels", proxy.Name);
+            Assert.False(proxy.Enabled);
+        }
+
+        [Fact]
+        public async Task Create_EmptyContents_MapsToEmptyArray()
+        {
+            var channel = new FakeResourceCallChannel(uri => new ResourceResponseMessage
+            {
+                Status = IpcProtocol.Status.Success,
+                Contents = new List<ResourceContentEntry>(),
+            });
+            var proxy = ProxyResourceFactory.Create(new ResourceDescriptor { Uri = "unreal://empty" }, channel);
+
+            var contents = await proxy.RunGetContent.Run(new object?[0]);
+            Assert.Empty(contents);
+        }
+    }
+}

--- a/bridge/tests/ResourceManifestRegistrarTests.cs
+++ b/bridge/tests/ResourceManifestRegistrarTests.cs
@@ -1,7 +1,7 @@
 /*
 ┌───────────────────────────────────────────────────────────────────┐
 │  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
-│  Repository: GitHub (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
 │  Copyright (c) 2026 Ivan Murzak                                   │
 │  Licensed under the Apache License, Version 2.0.                  │
 │  See the LICENSE file in the project root for more information.   │

--- a/bridge/tests/ResourceManifestRegistrarTests.cs
+++ b/bridge/tests/ResourceManifestRegistrarTests.cs
@@ -1,0 +1,118 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak)              │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Linq;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using com.IvanMurzak.Unreal.MCP.Bridge.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>Resource manifest application + the §A.1 revision guard + the §1.5 reconnect reset (resource sibling).</summary>
+    public class ResourceManifestRegistrarTests
+    {
+        private static ResourceDescriptor Resource(string uri, string hash, bool enabled = true) =>
+            new() { Uri = uri, Name = uri, SchemaHash = hash, MimeType = "application/json", Enabled = enabled };
+
+        private static ResourceManifestMessage Manifest(int revision, params ResourceDescriptor[] resources) =>
+            new() { Revision = revision, Resources = resources.ToList() };
+
+        private static (ResourceManifestRegistrar reg, FakeResourceSink sink) New()
+        {
+            var sink = new FakeResourceSink();
+            var reg = new ResourceManifestRegistrar(sink, new FakeResourceCallChannel());
+            return (reg, sink);
+        }
+
+        [Fact]
+        public void Apply_RegistersAddedResourcesAsProxies()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(1, Resource("unreal://project/levels", "h1"), Resource("unreal://project/icon", "h2")));
+            Assert.True(sink.HasResource("unreal://project/levels"));
+            Assert.True(sink.HasResource("unreal://project/icon"));
+            Assert.Equal(2, sink.Resources.Count);
+        }
+
+        [Fact]
+        public void Apply_RemovesDroppedResources()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(1, Resource("unreal://project/levels", "h1"), Resource("unreal://doomed", "h2")));
+            reg.Apply(Manifest(2, Resource("unreal://project/levels", "h1")));
+            Assert.True(sink.HasResource("unreal://project/levels"));
+            Assert.False(sink.HasResource("unreal://doomed"));
+        }
+
+        [Fact]
+        public void Apply_ReregistersChangedResource()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(1, Resource("unreal://project/levels", "h1")));
+            var first = sink.Resources["unreal://project/levels"];
+            reg.Apply(Manifest(2, Resource("unreal://project/levels", "h2")));
+            Assert.NotSame(first, sink.Resources["unreal://project/levels"]); // remove+add produced a fresh proxy
+        }
+
+        [Fact]
+        public void Apply_TogglesEnabledOnly()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(1, Resource("unreal://project/levels", "h1", enabled: true)));
+            reg.Apply(Manifest(2, Resource("unreal://project/levels", "h1", enabled: false)));
+            Assert.True(sink.HasResource("unreal://project/levels"));
+            Assert.False(sink.Enabled["unreal://project/levels"]);
+        }
+
+        [Fact]
+        public void Apply_IgnoresStaleOrEqualRevision()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(5, Resource("unreal://project/levels", "h1")));
+            var diff = reg.Apply(Manifest(5, Resource("unreal://project/levels", "h1"), Resource("unreal://late", "h2")));
+            Assert.True(diff.IsEmpty);          // revision 5 <= last applied 5 → ignored
+            Assert.False(sink.HasResource("unreal://late"));
+        }
+
+        [Fact]
+        public void ResetForReconnect_AllowsUnchangedRevisionReapply()
+        {
+            var (reg, sink) = New();
+            reg.Apply(Manifest(3, Resource("unreal://project/levels", "h1")));
+            Assert.Equal(3, reg.LastAppliedRevision);
+
+            reg.ResetForReconnect();
+            Assert.Equal(-1, reg.LastAppliedRevision);
+
+            var diff = reg.Apply(Manifest(3, Resource("unreal://project/levels", "h1"), Resource("unreal://added-offline", "h2")));
+            Assert.False(diff.IsEmpty);
+            Assert.True(sink.HasResource("unreal://added-offline"));
+            Assert.Equal(3, reg.LastAppliedRevision);
+        }
+
+        [Fact]
+        public void AppliedResourceUris_TracksRegistrations()
+        {
+            var (reg, _) = New();
+            reg.Apply(Manifest(1, Resource("unreal://a", "h1"), Resource("unreal://b", "h2")));
+            Assert.Equal(new[] { "unreal://a", "unreal://b" }, reg.AppliedResourceUris.OrderBy(u => u));
+        }
+
+        [Fact]
+        public void ApplyManifest_TypeErasedRoute_RegistersResources()
+        {
+            // The IpcClient holds the registrar as IManifestSink<ResourceManifestMessage>; exercise that route.
+            var (reg, sink) = New();
+            IManifestSink<ResourceManifestMessage> sinkRoute = reg;
+            sinkRoute.ApplyManifest(Manifest(1, Resource("unreal://project/levels", "h1")));
+            Assert.True(sink.HasResource("unreal://project/levels"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- End-to-end custom MCP **resource** registration (static fixed-URI MVP), the resource sibling of P1's prompt path (Model A: contracts/registry/runtime families in `UnrealMcpRuntime`, editor + runtime register on the same registry).
- C++: `IUnrealMcpResourceProvider` + `FUnrealMcpResourceRegistry`/`Builder` (`.Name().Description().MimeType().Read(handler(uri)→Text/Blob)`); `UUnrealMcpRuntimeSubsystem::Register/UnregisterResourceProvider`; both coordinators build the resource registry, register the core family, hand it to the bridge; kind-aware extension-manager resource pass.
- `FUnrealMcpBridgeServer`: real `SendResourceManifestLocked` (v2-gated push on Ready + OnChanged) and `HandleResourceRead` (marshals the registry read through the existing GameThread dispatcher; reuses the P1 pack/unpack-through-tool-dispatcher transport).
- Bridge: `ProxyResource : IRunResource` + `ProxyResourceContent : IRunResourceContent` (`resource-read`→`ResponseResourceContent[]`, text XOR base64 blob) + `ProxyResourceList : IRunResourceList` (static MVP, 1-element, no IPC) + `ProxyResourceFactory` + `ResourceManifestRegistrar` + `ResourceManagerSink` over `IResourceManager.AddResource`; `SidecarHost.Build()` wires the nullable `ResourceManager` (guard+log).
- Sample core resources: `unreal://project/levels` (JSON, `application/json`) and `unreal://project/icon` (base64 PNG blob, `image/png`) — covering the Text vs Blob round-trip.
- **Out of scope:** templated/parameterized URIs (deferred per design §A.1); the §7 Prompts/Resources UI windows (P4); README (P3).

## Test plan
- [x] Bridge xUnit green — 211/211 (ProxyResource content round-trip incl. base64 blob decode-back, static no-IPC list synthesis, error/disconnect fail-fast, resource registrar diff/revision-guard/reconnect-reset).
- [x] CLEAN editor build green (module-graph change → full wipe + junction + UBT, exit 0).
- [x] RunUAT BuildPlugin green (Game+Editor, UnrealGame Shipping, `-WarningsAsErrors`, short `-Package`, exit 0) — caught + fixed a Game-build lost-transitive-include (`Dom/JsonObject.h`/`UObject/Package.h`).
- [x] Boot smoke green — `[Unreal-MCP] plugin loaded`, 0 crashes.
- [x] Full `UnrealMcp.*` Automation — **297 succeeded / 0 failed** (new `UnrealMcp.Resources.Registry` incl. base64-blob decode + `UnrealMcp.Resources.ExtensionPass`; existing tool/prompt/extension specs still pass).
- [x] Live e2e (gamedev-mcp-server 8.0.0, Custom mode): `resources/list` shows `unreal://project/levels` + `unreal://project/icon`; `resources/read unreal://project/levels` returns the JSON. The plugin emits correct base64 for the blob (verified decode-back at the xUnit + Automation layers); the final MCP-wire blob encoding surfaced a serialization quirk in the **shared GameDev-MCP-Server / MCP-Plugin-dotnet** (`ExtensionsReadResource.ToResourceContents`), which is outside this repo.

Closes #135