### PR TITLE
docs: teach custom tool + prompt + resource registration (Unity parity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Unlike Unity and Godot (C# engines that host the .NET `McpPlugin` in-process), U
 - ✔️ **Blueprint authoring** — Create, edit, and **compile** Blueprints with a structured error/warning feedback loop the AI can act on
 - ✔️ **C++ edit & compile** — Read, scaffold, and edit project C++, then compile (Live Coding or UBT) with a structured error report
 - ✔️ **Visual feedback** — Capture viewport, game-view, camera, and isolated-actor screenshots the LLM can inspect directly
-- ✔️ **Custom / extension AI Tools** — Register **your own** AI Tools from any UE plugin with **no fork** — a public, modular-feature contract ([Customize Tools](#customize-tools))
+- ✔️ **Custom Tools, Prompts & Resources** — Register **your own** AI Tools, prompt templates, and resources from any UE plugin with **no fork** — one public, modular-feature contract ([Customize Tools, Prompts & Resources](#customize-tools-prompts--resources))
 - ✔️ **Cloud or self-hosted** — Connect to `ai-game.dev` out of the box, or point at your own [GameDev-MCP-Server](https://github.com/IvanMurzak/GameDev-MCP-Server)
 - ✔️ **Per-tool enable / disable** — Flip any tool on or off from the **MCP Tools** window; the toggle is enforced at the execution boundary, not just hidden
 
@@ -63,7 +63,7 @@ Unlike Unity and Godot (C# engines that host the .NET `McpPlugin` in-process), U
 - [Tools](#tools) — all 8 families, 62 tools
 - [Per-tool enable / disable](#per-tool-enable--disable)
 - [`unreal-mcp-cli`](#unreal-mcp-cli)
-- [Customize Tools](#customize-tools)
+- [Customize Tools, Prompts & Resources](#customize-tools-prompts--resources)
 - [Runtime usage (in-game)](#runtime-usage-in-game)
 - [Configuration & environment variables](#configuration--environment-variables)
 - [Troubleshooting](#troubleshooting)
@@ -163,7 +163,7 @@ Connection settings persist to `<Project>/Saved/Config/UnrealMcp/ai-game-develop
 
 # Tools
 
-Unreal-MCP ships **62 built-in ("core") tools** across **8 families**. Tool ids are kebab-case (`actor-create`, `blueprint-compile`), matching the Unity/Godot naming convention. Extensions can add more (see [Customize Tools](#customize-tools)).
+Unreal-MCP ships **62 built-in ("core") tools** across **8 families**. Tool ids are kebab-case (`actor-create`, `blueprint-compile`), matching the Unity/Godot naming convention. Extensions can add more (see [Customize Tools, Prompts & Resources](#customize-tools-prompts--resources)).
 
 > This list is generated from the registration source (`UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcp*Tools.cpp`). Counts: actor 13, blueprint 11, asset 11, editor/reflection 9, level 7, source 6, screenshot 4, ping 1 = **62**.
 
@@ -346,11 +346,15 @@ The full 16-command surface:
 
 ![AI Game Developer — Unreal MCP](https://github.com/IvanMurzak/Unreal-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
 
-# Customize Tools
+# Customize Tools, Prompts & Resources
 
-**This is the headline extensibility feature.** Anyone can register their **own** AI Tools — from any third-party UE plugin — and have them appear in the MCP manifest alongside the 62 built-in tools. **No fork, no link-time coupling, no load-order assumptions.** Your tools are discovered automatically on editor boot (and on late-load / hot-unload), merged in deterministic order, and exposed to every connected AI agent.
+**This is the headline extensibility feature.** Anyone can register their **own** AI Tools, **prompts**, and **resources** — from any third-party UE plugin — and have them appear in the MCP manifest alongside the built-ins. **No fork, no link-time coupling, no load-order assumptions.** Your contributions are discovered automatically on editor boot (and on late-load / hot-unload), merged in deterministic order, and exposed to every connected AI agent.
 
-You contribute tools through a small, public, **modular-feature-based contract**: implement [`IUnrealMcpToolProvider`](UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpToolProvider.h) and declare your tools with the fluent [`FUnrealMcpToolRegistry`](UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpToolRegistry.h) builder (both headers live in the `UnrealMcpRuntime` module, re-exported by `UnrealMcpEditor`, so the same contract serves editor and [runtime](#runtime-usage-in-game) extensions):
+All three kinds use the **same** small, public, **modular-feature-based contract** — a provider interface plus a fluent registry builder, both living in the `UnrealMcpRuntime` module (re-exported by `UnrealMcpEditor`, so the same contract serves editor and [runtime](#runtime-usage-in-game) extensions). The full author guide is [`docs/EXTENSIONS.md`](docs/EXTENSIONS.md).
+
+## Tools
+
+Implement [`IUnrealMcpToolProvider`](UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpToolProvider.h) and declare your tools with the fluent [`FUnrealMcpToolRegistry`](UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpToolRegistry.h) builder:
 
 ```cpp
 #include "IUnrealMcpToolProvider.h"
@@ -388,17 +392,97 @@ IModularFeatures::Get().RegisterModularFeature(
     IUnrealMcpToolProvider::GetModularFeatureName(), Provider.Get());
 ```
 
-**How it behaves:**
+## Prompts
 
-- **Auto-discovery & hot-reload.** Unreal-MCP enumerates every registered `UnrealMcpToolProvider` on boot, and subscribes to register/unregister events — so loading or unloading your plugin at any time triggers a **registry rebuild** and a **manifest revision bump**, and the sidecar diffs the new manifest and adds/removes the affected MCP tools automatically. You never push anything yourself.
-- **Deterministic merge.** Providers are merged in ascending `GetExtensionId()` order; within one provider, tools register in declaration order. Your `GetExtensionId()` is stamped onto every tool you contribute (don't call `.ExtensionId(...)` yourself).
-- **Per-extension isolation.** Each tool descriptor is validated (kebab-case name, well-formed schema, bound handler). An **invalid** or **duplicate** tool is dropped/rejected and the reason is recorded on **your** extension's record — your other valid tools, and every other extension, are unaffected. (UE builds without C++ exceptions, so isolation is descriptor-level, not tool-body-level; validate inputs and fail gracefully with `FUnrealMcpToolResult::Error(...)`.)
-- **Toggles & enable/disable.** Extension-contributed tools are toggled in the same **MCP Tools** window as the built-ins; a disabled extension contributes **no tools to the manifest at all**.
+Prompts are reusable, parameterized prompt templates the agent fetches via `prompts/get`. Implement [`IUnrealMcpPromptProvider`](UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpPromptProvider.h) and declare prompts with [`FUnrealMcpPromptRegistry`](UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpPromptRegistry.h). Prompt arguments reuse the **same** `Param*` helpers as the tool builder; a handler returns role-tagged messages:
+
+```cpp
+#include "IUnrealMcpPromptProvider.h"
+#include "UnrealMcpPromptRegistry.h"
+
+class FMyPromptProvider : public IUnrealMcpPromptProvider
+{
+public:
+    virtual FString GetExtensionId() const override      { return TEXT("com.foo.my-extension"); }
+    virtual FText   GetDisplayName() const override      { return NSLOCTEXT("Foo", "Name", "My Extension"); }
+    virtual FString GetExtensionVersion() const override { return TEXT("1.0.0"); }
+
+    virtual void RegisterPrompts(FUnrealMcpPromptRegistry& Registry) override
+    {
+        Registry.Prompt(TEXT("level-design-brief"))
+            .Title(TEXT("Level Design Brief"))
+            .Description(TEXT("Generate a level design brief from a single 'theme' argument."))
+            .Role(EUnrealMcpPromptRole::User)
+            .ParamString(TEXT("theme"), TEXT("The level theme (e.g. 'haunted forest')."),
+                         EUnrealMcpParamRequirement::Required)
+            .Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpPromptResult
+            {
+                const FString Theme = Call.GetString(TEXT("theme"));
+                if (Theme.IsEmpty())
+                    return FUnrealMcpPromptResult::Error(TEXT("theme is required."));
+                const FString Text = FString::Printf(
+                    TEXT("Draft a level design brief for a \"%s\"-themed level."), *Theme);
+                return FUnrealMcpPromptResult::Success(Text, EUnrealMcpPromptRole::User);
+            });
+    }
+};
+
+// Register under the prompt modular-feature name (and unregister in ShutdownModule):
+IModularFeatures::Get().RegisterModularFeature(
+    IUnrealMcpPromptProvider::GetModularFeatureName(), PromptProvider.Get());
+```
+
+`level-design-brief` is the shipped **core** prompt — see [`UnrealMCP/Source/UnrealMcpRuntime/Private/Prompts/UnrealMcpCorePrompts.cpp`](UnrealMCP/Source/UnrealMcpRuntime/Private/Prompts/UnrealMcpCorePrompts.cpp).
+
+## Resources
+
+Resources are addressable, readable content the agent fetches via `resources/read` — the resource's **URI is its identity**. Implement [`IUnrealMcpResourceProvider`](UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpResourceProvider.h) and declare resources with [`FUnrealMcpResourceRegistry`](UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpResourceRegistry.h). A read returns content blocks — **text XOR a base64 blob** + a mime type:
+
+```cpp
+#include "IUnrealMcpResourceProvider.h"
+#include "UnrealMcpResourceRegistry.h"
+
+virtual void RegisterResources(FUnrealMcpResourceRegistry& Registry) override
+{
+    Registry.Resource(TEXT("unreal://project/levels"))                  // JSON (text) resource
+        .Name(TEXT("Project Levels"))
+        .Description(TEXT("A JSON snapshot of the active world and its levels."))
+        .MimeType(TEXT("application/json"))
+        .Read([](const FString& Uri) -> FUnrealMcpResourceResult
+        {
+            return FUnrealMcpResourceResult::Text(Uri, BuildLevelsJson(), TEXT("application/json"));
+        });
+
+    Registry.Resource(TEXT("unreal://project/icon"))                    // binary (blob) resource
+        .Name(TEXT("Project Icon"))
+        .Description(TEXT("A small PNG, returned as a base64 blob."))
+        .MimeType(TEXT("image/png"))
+        .Read([](const FString& Uri) -> FUnrealMcpResourceResult
+        {
+            const FString Base64 = FBase64::Encode(IconBytes, sizeof(IconBytes));
+            return FUnrealMcpResourceResult::Blob(Uri, Base64, TEXT("image/png"));
+        });
+}
+
+// Register under the resource modular-feature name (and unregister in ShutdownModule):
+IModularFeatures::Get().RegisterModularFeature(
+    IUnrealMcpResourceProvider::GetModularFeatureName(), ResourceProvider.Get());
+```
+
+`unreal://project/levels` and `unreal://project/icon` are the shipped **core** resources — see [`UnrealMCP/Source/UnrealMcpRuntime/Private/Resources/UnrealMcpCoreResources.cpp`](UnrealMCP/Source/UnrealMcpRuntime/Private/Resources/UnrealMcpCoreResources.cpp). Only **static, fixed-URI** resources are supported today (templated / parameterized URIs are deferred). A blob is base64 on the Unreal side and the IPC wire; a known **upstream** quirk in the shared GameDev-MCP-Server / MCP-Plugin-dotnet can mis-emit blob bytes on the final MCP wire to the client (text resources round-trip cleanly end-to-end) — that is an upstream issue, not the Unreal plugin or bridge.
+
+**How it behaves** (identical for tools, prompts, and resources):
+
+- **Auto-discovery & hot-reload.** Unreal-MCP enumerates every registered provider (`UnrealMcpToolProvider` / `UnrealMcpPromptProvider` / `UnrealMcpResourceProvider`) on boot, and subscribes to register/unregister events — so loading or unloading your plugin at any time triggers a **registry rebuild** and a **manifest revision bump**, and the sidecar diffs the new manifest and adds/removes the affected tools / prompts / resources automatically. You never push anything yourself.
+- **Deterministic merge.** Providers are merged in ascending `GetExtensionId()` order; within one provider, entries register in declaration order. Your `GetExtensionId()` is stamped onto everything you contribute (don't call `.ExtensionId(...)` yourself).
+- **Per-extension isolation.** Each descriptor is validated (a tool/prompt needs a kebab-case name + well-formed schema + bound handler; a resource needs a non-empty URI + handler). An **invalid** or **duplicate** entry (duplicate tool/prompt **name**, or duplicate resource **URI**) is dropped/rejected and the reason is recorded on **your** extension's record — your other valid entries, and every other extension, are unaffected. (UE builds without C++ exceptions, so isolation is descriptor-level, not handler-body-level; validate inputs and fail gracefully with the `Error(...)` result helpers.)
+- **Toggles & enable/disable.** Extension-contributed tools are toggled in the **MCP Tools** window like the built-ins; a disabled extension contributes nothing to any manifest. (The **MCP Prompts** / **MCP Resources** windows are wired but still render empty in this release — see [Per-tool enable / disable](#per-tool-enable--disable) — so prompt/resource toggling from the UI is a follow-up; registration and use work today.)
 
 **Learn more:**
 
-- **Full author guide:** [`docs/EXTENSIONS.md`](docs/EXTENSIONS.md) — the contract, the tool builder, lifecycle, ordering, isolation semantics, and versioning.
-- **Working samples:** [`samples/UnrealAITemplate/`](samples/UnrealAITemplate) — a complete, buildable **editor** extension plugin with a `hello-extension` tool and a compile-time switch (`UNREAL_AI_TEMPLATE_INVALID_SCHEMA=1`) that demonstrates the isolation behaviour first-hand; [`samples/UnrealAIRuntimeSample/`](samples/UnrealAIRuntimeSample) — the **runtime (in-game)** counterpart, a `Type=Runtime` plugin whose `game-time-dilation` tool reads/sets the live world's time dilation, callable in a running game over a runtime MCP connection ([`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) §12.9; see EXTENSIONS.md "Runtime usage").
+- **Full author guide:** [`docs/EXTENSIONS.md`](docs/EXTENSIONS.md) — the contract for tools, prompts, and resources, the builders, lifecycle, ordering, isolation semantics, and versioning.
+- **Design:** [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) §5 (tools) + **§A** (the prompt/resource registration path).
+- **Working samples:** [`samples/UnrealAITemplate/`](samples/UnrealAITemplate) — a complete, buildable **editor** extension plugin with a `hello-extension` tool and a compile-time switch (`UNREAL_AI_TEMPLATE_INVALID_SCHEMA=1`) that demonstrates the isolation behaviour first-hand; [`samples/UnrealAIRuntimeSample/`](samples/UnrealAIRuntimeSample) — the **runtime (in-game)** counterpart, a `Type=Runtime` plugin whose `game-time-dilation` tool reads/sets the live world's time dilation, callable in a running game over a runtime MCP connection ([`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) §12.9; see EXTENSIONS.md "Runtime usage"). For prompts and resources, the shipped **core** families ([`UnrealMcpCorePrompts.cpp`](UnrealMCP/Source/UnrealMcpRuntime/Private/Prompts/UnrealMcpCorePrompts.cpp) `level-design-brief`, [`UnrealMcpCoreResources.cpp`](UnrealMCP/Source/UnrealMcpRuntime/Private/Resources/UnrealMcpCoreResources.cpp) `unreal://project/levels` + `unreal://project/icon`) are the runnable reference.
 
 ![AI Game Developer — Unreal MCP](https://github.com/IvanMurzak/Unreal-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
 
@@ -441,18 +525,21 @@ UnrealMcp.Disconnect
 
 The console path always uses loopback + Custom mode.
 
-## Your own in-game tools
+## Your own in-game tools, prompts & resources
 
-A game ships its **own** gameplay tools and the AI drives them live — the UE analog of Unity's `WithToolsFromAssembly` / `[AiTool]` Chess-bot. You author tools exactly as for an editor extension (implement [`IUnrealMcpToolProvider`](UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpToolProvider.h), declare tools via [`FUnrealMcpToolRegistry`](UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpToolRegistry.h)), with two changes for a game module: make it **`Type=Runtime`** and depend on **`UnrealMcpRuntime`** (not `UnrealMcpEditor`). Register the provider at module startup, or use the subsystem's discoverable wrapper:
+A game ships its **own** gameplay tools (and, if useful, prompts and resources) and the AI drives them live — the UE analog of Unity's `WithToolsFromAssembly` / `[AiTool]` Chess-bot. You author all three exactly as for an editor extension (the [Customize Tools, Prompts & Resources](#customize-tools-prompts--resources) section above), with two changes for a game module: make it **`Type=Runtime`** and depend on **`UnrealMcpRuntime`** (not `UnrealMcpEditor`). Register your providers at module startup, or use the subsystem's discoverable wrappers — one register/unregister pair per kind:
 
 ```cpp
 if (UUnrealMcpRuntimeSubsystem* Mcp = UUnrealMcpRuntimeSubsystem::Get(this))
-    Mcp->RegisterToolProvider(MyProviderInstance);     // tools merge in; manifest re-pushed
-// ... before destroying the provider:
-    Mcp->UnregisterToolProvider(MyProviderInstance);   // tools drop out; manifest re-pushed
+{
+    Mcp->RegisterToolProvider(MyToolProvider);          // tools merge in; manifest re-pushed
+    Mcp->RegisterPromptProvider(MyPromptProvider);      // prompts merge in; manifest re-pushed
+    Mcp->RegisterResourceProvider(MyResourceProvider);  // resources merge in; manifest re-pushed
+}
+// ... before destroying the providers, call the matching Unregister*Provider(...) for each.
 ```
 
-The complete, buildable example is [`samples/UnrealAIRuntimeSample/`](samples/UnrealAIRuntimeSample) — a `Type=Runtime` plugin whose **`game-time-dilation`** tool reads/sets the live world's `AWorldSettings::TimeDilation` (slow-motion / fast-forward), callable in a running game over a runtime MCP connection. The author-side details (the contract, lifecycle, ordering, isolation) are in [`docs/EXTENSIONS.md` → Runtime usage](docs/EXTENSIONS.md#runtime-usage-in-game-extensions).
+The complete, buildable example is [`samples/UnrealAIRuntimeSample/`](samples/UnrealAIRuntimeSample) — a `Type=Runtime` plugin whose **`game-time-dilation`** tool reads/sets the live world's `AWorldSettings::TimeDilation` (slow-motion / fast-forward), callable in a running game over a runtime MCP connection. (It demonstrates the tool path; prompts and resources register through the same three-wrapper API shown above and the shipped core families are the runnable reference.) The author-side details (the contract, lifecycle, ordering, isolation) are in [`docs/EXTENSIONS.md` → Runtime usage](docs/EXTENSIONS.md#runtime-usage-in-game-extensions).
 
 ## Runtime tool set vs editor-only
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -223,7 +223,13 @@ Envelope: every message is a JSON object with a `type` field. `requestId` correl
 | plugin → sidecar | `tool-manifest` | full snapshot: `revision` (monotonic int) + array of tool descriptors (§2.2) |
 | sidecar → plugin | `tool-call` | `requestId`, `tool`, `arguments` (raw JSON object), `timeoutMs` |
 | plugin → sidecar | `tool-response` | `requestId`, `status: "success"\|"error"`, `content` (MCP content array), `structured` (object) |
-| sidecar → plugin | `tool-cancel` | `requestId` — cooperative cancellation (§4) |
+| plugin → sidecar | `prompt-manifest` | full snapshot: `revision` + array of prompt descriptors (§A.1) — IPC v2 |
+| sidecar → plugin | `prompt-get` | `requestId`, `prompt`, `arguments`, `timeoutMs` (§A.1) — IPC v2 |
+| plugin → sidecar | `prompt-response` | `requestId`, `status`, `messages[]` (role + text) (§A.1) — IPC v2 |
+| plugin → sidecar | `resource-manifest` | full snapshot: `revision` + array of resource descriptors (§A.1) — IPC v2 |
+| sidecar → plugin | `resource-read` | `requestId`, `uri`, `timeoutMs` (§A.1) — IPC v2 |
+| plugin → sidecar | `resource-response` | `requestId`, `status`, `contents[]` (text XOR base64 blob + mimeType) (§A.1) — IPC v2 |
+| sidecar → plugin | `tool-cancel` | `requestId` — cooperative cancellation (§4); reused for prompt-get / resource-read |
 | plugin → sidecar | `config` | UI/config changed: connect/disconnect, mode, host, token, enabled-tools map |
 | sidecar → plugin | `status` | SignalR state for the UI: `connectionState`, `keepConnected`, `cloudAuthState`, `serverProcessState`, `aiAgents[]` |
 | plugin → sidecar | `auth-start` | begin the device-code flow (UI Authorize button) |
@@ -949,8 +955,13 @@ BP state machines; Behavior Trees; plugin management family (`package-*` analog 
 IPluginManager); profiler family (`stat` capture analog); `tests-run` (Automation runner
 exposure); Skills generation (sidecar-side, free once prompts land — Godot generates them on boot).
 
-Prompts and resources ship empty-but-wired in MVP (the framework relays them already; counts show
-0 in the UI) — first content is backlog.
+Prompts and resources shipped **empty-but-wired** in the MVP (the framework relays them already;
+counts show 0 in the UI). The **M16** task chain then added the full developer→C++→IPC→bridge→manager
+registration path for **custom prompts and resources** (the appendix **§A** below is the authoritative
+design), with core samples `level-design-brief` (prompt) and `unreal://project/levels` +
+`unreal://project/icon` (resources). Still deferred after M16: **templated / parameterized resource URIs**
+(MVP is static fixed-URI only) and **populating the §7 Prompts / Resources aux windows** (registration and
+e2e work without the windows populated — see §A.5).
 
 ---
 
@@ -1235,3 +1246,111 @@ The 5.5 floor must be EXERCISED (packaged Development build on a 5.5 install) be
   out-of-order revision guard, handshake timeout-as-crash, FText/delegate/interface property
   exclusions, non-string TMap key convention, promise double-set guard, manifest re-push on
   reconnect idempotency.
+
+---
+
+## Appendix A — Custom prompts & resources (M16)
+
+> Authoritative design for the **M16** prompt/resource registration path — the exact siblings of the §2/§3/§5
+> tool path. M16 added the developer→C++→IPC→bridge→manager half on top of the existing empty-but-wired
+> server↔sidecar relay, consuming `com.IvanMurzak.McpPlugin` (`IPromptManager` / `IResourceManager` /
+> `IRunPrompt` / `IRunResource`) **as-is** — no upstream MCP-Plugin-dotnet change was required (the public
+> manager surface already mirrors the tools path `ProxyTool` rides). The C++ identifiers below are shipped in
+> `UnrealMcpRuntime/Public/`; the bridge types in `bridge/src/`.
+
+### A.1 IPC protocol (the §1.3 analog)
+
+Prompts/resources reuse the §1.2 NDJSON framing, the §2.2 revision-guarded full-snapshot diff, and the §1.5
+reconnect re-push. `ipcVersion` was bumped **1 → 2**; the handshake negotiates it, so an old sidecar/plugin
+pair still does tools-only. The new `type` discriminators are in the §1.3 message-schema table:
+
+- plugin → sidecar: `prompt-manifest {revision, prompts[]}`, `resource-manifest {revision, resources[]}`.
+- sidecar → plugin: `prompt-get {requestId, prompt, arguments, timeoutMs}`, `resource-read {requestId, uri, timeoutMs}`.
+- plugin → sidecar: `prompt-response {requestId, status, messages[]}` (≈ `ResponseGetPrompt`),
+  `resource-response {requestId, status, contents[]}` (≈ `ResponseResourceContent[]`).
+- The generic `tool-cancel` (by `requestId`) is reused for both — no new cancel verbs.
+
+**Prompt descriptor**: `{name (kebab), title, description, role ("user"|"assistant"), inputSchema (JSON Schema
+→ the manager flattens to `arguments[]`), enabled, extensionId, schemaHash}`.
+**Resource descriptor**: `{uri (→ the MCP route), name, description, mimeType, enabled, extensionId, schemaHash}`.
+
+**Content**: a resource read returns one or more content blocks; each is `Text` (string) **XOR** `Blob`
+(base64) + `mimeType`, so binary content (e.g. an image) rides as base64 exactly like a screenshot tool's
+image payload.
+
+**Scope (MVP)**: static fixed-URI resources only. Templated / parameterized resource URIs are **deferred**
+(upstream McpPlugin has `RunResourceTemplates` / `ResponseResourceTemplate`, later-additive). The
+list-changed notifications (`notifications/{prompts,resources}/list_changed`) are IN scope and free — the
+manager owns them: `AddPrompt` / `AddResource` fire `On*Updated`, so the bridge needs zero push machinery
+(same as tools).
+
+### A.2 C++ surface (Model-A: contracts + registries + runtime families in `UnrealMcpRuntime`)
+
+The prompt/resource contracts and registries live in the **runtime module** (re-exported by `UnrealMcpEditor`),
+so the same headers serve editor and runtime extensions — exactly like the tool path.
+
+- **Providers** — `IUnrealMcpPromptProvider` / `IUnrealMcpResourceProvider` (mirror `IUnrealMcpToolProvider`).
+  Modular-feature names `UnrealMcpPromptProvider` / `UnrealMcpResourceProvider`; declaration entry points
+  `RegisterPrompts(FUnrealMcpPromptRegistry&)` / `RegisterResources(FUnrealMcpResourceRegistry&)`. Both carry
+  the same `GetExtensionId()` / `GetDisplayName()` / `GetExtensionVersion()` triple as the tool provider. One
+  plugin may implement all three contracts.
+- **Registries + builders** —
+  - `FUnrealMcpPromptRegistry` / `FUnrealMcpPromptBuilder`: `Registry.Prompt("id").Title().Description().Role()
+    .ParamString/Int/Number/Bool/Vector/Param(...).Handle(call → FUnrealMcpPromptResult)`. The role enum is
+    **`EUnrealMcpPromptRole { User, Assistant }`**. The result is role-tagged messages
+    (`FUnrealMcpPromptResult::Success(text, role, description)` / `::Error(description)`). Prompt arguments
+    **reuse `FUnrealMcpParamSpec` + `EUnrealMcpParamRequirement` + the §3.2 schema generation verbatim**, and
+    a prompt handler receives the same `FUnrealMcpToolCall` args+cancel surface as a tool handler.
+  - `FUnrealMcpResourceRegistry` / `FUnrealMcpResourceBuilder`: `Registry.Resource("unreal://uri").Name()
+    .Description().MimeType().Read(handler(uri) → FUnrealMcpResourceResult)`. The result is content blocks
+    (`FUnrealMcpResourceResult::Text(uri, text, mimeType)` / `::Blob(uri, base64, mimeType)` /
+    `::Success(contents)` / `::MakeError(error)`). A resource's **URI is its identity** (the registry key and
+    the MCP route).
+  - Both registries clone the tool registry's machinery: monotonic `Revision`, `BuildManifestJson()`,
+    `Execute` / `Read`, `RegisterExtension` / `Remove*ForExtension`, `ComputeSchemaHash`, descriptor
+    validation, and the §7/§8 enable filters (`Set*EnabledFilter` whitelist + `ApplyDisabled*` blocklist).
+    They reuse the tool registry's `FUnrealMcpExtensionRegistrationResult` verbatim.
+- **Runtime subsystem** — `UUnrealMcpRuntimeSubsystem::RegisterPromptProvider` / `UnregisterPromptProvider`
+  and `RegisterResourceProvider` / `UnregisterResourceProvider` (thin `IModularFeatures::RegisterModularFeature`
+  wrappers with identical not-owned semantics to `RegisterToolProvider`).
+- **Extension manager** — `FUnrealMcpExtensionManager` is **kind-aware** (three registries + three
+  modular-feature subscriptions) rather than triplicated, so its re-entrancy guard / deferred-rebuild /
+  disabled-set persistence / ExtensionId sort are shared and load-bearing for §5 isolation. `OnChanged` fires
+  the tool, prompt, and resource manifest pushes together.
+- **Coordinator + bridge server** — the editor coordinator (and the runtime subsystem's PImpl) builds the
+  prompt + resource registries alongside the tool registry, registers the core families, and hands all three
+  to the single `FUnrealMcpBridgeServer`, which adds prompt/resource manifest pushes (on Ready + OnChanged)
+  and `HandlePromptGet` / `HandleResourceRead` marshalling through the **existing**
+  `FUnrealMcpGameThreadDispatcher` (§4 game-thread, no-modal-UI). No new threads or sockets.
+
+### A.3 Bridge (mirror `ProxyTool` / `ProxyToolFactory` / `ManifestRegistrar`)
+
+- **`ProxyPrompt : IRunPrompt`** — schema-blind; `Run` round-trips `prompt-get` → `ResponseGetPrompt`,
+  fail-fast on `IpcDisconnectedException`. Built by `ProxyPromptFactory`.
+- **`ProxyResource : IRunResource`** — composes `ProxyResourceContent : IRunResourceContent`
+  (`Run` → `resource-read` → `ResponseResourceContent[]`) + `ProxyResourceList : IRunResourceList` (static
+  MVP: a 1-element `ResponseListResource[]` synthesized from the descriptor, no IPC). Built by
+  `ProxyResourceFactory`.
+- **Registrars** — `PromptManifestRegistrar` / `ResourceManifestRegistrar` clone `ManifestRegistrar` (revision
+  guard, `ResetForReconnect`, add/remove/changed/enabled diff). Their sinks (`PromptManagerSink` over
+  `IPromptManager` / `ResourceManagerSink` over `IResourceManager`) forward to the manager's
+  `AddPrompt(prompt)` / `AddResource(resource)` — note the **runner-only** manager signature (the
+  name/route comes from the runner itself), unlike the tool path's `AddTool(name, runner)`.
+- **`SidecarHost.Build()`** grabs `_plugin.McpManager.PromptManager` / `.ResourceManager` (both **nullable** →
+  guard + log; default-constructed empty by `McpPluginBuilder.Build`, then filled by the registrar — the same
+  empty-then-manifest model as tools), builds the registrars, and wires them to the IPC client. `IpcClient`
+  routes the inbound manifests and owns the outbound `prompt-get` / `resource-read` channels (reusing the
+  existing `PendingCallRegistry`).
+
+### A.4 Schema / serialization
+
+Prompt arguments ride `FUnrealMcpParamSpec` → JSON Schema (§3.2, unchanged); resource content uses
+Text/Blob(base64) + mimeType; everything travels over the existing camelCase NDJSON `IpcProtocol.JsonOptions`.
+No new serializer configuration.
+
+### A.5 UI angle (deferred)
+
+Populating the §7 empty **Prompts** / **Resources** aux windows from each registry's `BuildManifestJson()`
+(parity with the Tools window) is a **follow-up** (M16-P4): name/title/description + role for prompts,
+uri + mimeType for resources, plus an enable toggle. Registration and end-to-end use work **without** the
+windows populated — the windows still render their subdued empty-state in this release.

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -1,9 +1,14 @@
 # Writing an Unreal-MCP Extension
 
-Unreal-MCP exposes the Unreal Editor to MCP-aware AI assistants as a set of **tools**. Any third-party
-UE plugin can contribute its own tools through a small, public, modular-feature-based contract — no
-fork, no link-time coupling, no load-order assumptions. This guide is the authoritative author
-reference. The design rationale lives in [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) §5.
+Unreal-MCP exposes the Unreal Editor to MCP-aware AI assistants as a set of **tools**, **prompts**, and
+**resources**. Any third-party UE plugin can contribute its own through a small, public,
+modular-feature-based contract — no fork, no link-time coupling, no load-order assumptions. This guide is the
+authoritative author reference. The tool design rationale lives in [`docs/ARCHITECTURE.md`](ARCHITECTURE.md)
+§5; the prompt/resource design is in §A.
+
+The tool contract is documented first and in full; **prompts** and **resources** follow the exact same
+shape (provider interface + fluent registry builder + modular-feature registration) and are documented in
+their own sections below — read the tool section first, then the deltas.
 
 A complete, buildable example accompanies this guide:
 [`samples/UnrealAITemplate/`](../samples/UnrealAITemplate).
@@ -188,6 +193,170 @@ version, and your `GetExtensionVersion()` is your own.
 
 ---
 
+## Custom prompts
+
+Beyond tools, an extension can contribute **MCP prompts** — reusable, parameterized prompt templates the AI
+agent can fetch via `prompts/get`. The contract is the exact prompt sibling of the tool contract: implement
+[`IUnrealMcpPromptProvider`](../UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpPromptProvider.h) and
+declare prompts with the fluent
+[`FUnrealMcpPromptRegistry`](../UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpPromptRegistry.h) builder
+(both headers in the `UnrealMcpRuntime` module). The architecture is in
+[`docs/ARCHITECTURE.md`](ARCHITECTURE.md) §A.
+
+```cpp
+class IUnrealMcpPromptProvider : public IModularFeature
+{
+public:
+    static FName GetModularFeatureName();          // FName("UnrealMcpPromptProvider")
+    virtual FString GetExtensionId() const = 0;    // stable, unique, reverse-DNS
+    virtual FText   GetDisplayName() const = 0;
+    virtual FString GetExtensionVersion() const = 0;
+    virtual void    RegisterPrompts(FUnrealMcpPromptRegistry& Registry) = 0;
+};
+```
+
+### The prompt builder
+
+`Registry.Prompt("prompt-id")` returns a fluent builder. Available calls:
+
+- `.Title(...)`, `.Description(...)` — human-/LLM-facing copy.
+- `.Role(EUnrealMcpPromptRole::User | ::Assistant)` — the default author role of the rendered message(s).
+- `.ParamString / .ParamInt / .ParamNumber / .ParamBool / .ParamVector(name, desc, requirement)` — declare a
+  prompt argument. These are the **same** param helpers and `EUnrealMcpParamRequirement` as the tool builder
+  (prompt args reuse the tool schema generation verbatim). `.Param(name, jsonType, desc, req, customSchema)`
+  is the generic escape hatch.
+- `.Handle(lambda)` — bind the handler and commit the prompt. The handler runs on the **game thread** and
+  receives the same `FUnrealMcpToolCall` args surface (`Call.GetString(...)`, `Call.Has(...)`); it returns a
+  `FUnrealMcpPromptResult`.
+
+A prompt handler returns role-tagged messages. The common one-shot shape is the static helper:
+
+```cpp
+#include "IUnrealMcpPromptProvider.h"
+#include "UnrealMcpPromptRegistry.h"
+
+virtual void RegisterPrompts(FUnrealMcpPromptRegistry& Registry) override
+{
+    Registry.Prompt(TEXT("level-design-brief"))
+        .Title(TEXT("Level Design Brief"))
+        .Description(TEXT("Generate a level design brief from a single 'theme' argument."))
+        .Role(EUnrealMcpPromptRole::User)
+        .ParamString(TEXT("theme"), TEXT("The level theme (e.g. 'haunted forest')."),
+                     EUnrealMcpParamRequirement::Required)
+        .Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpPromptResult
+        {
+            const FString Theme = Call.GetString(TEXT("theme"));
+            if (Theme.IsEmpty())
+                return FUnrealMcpPromptResult::Error(TEXT("theme is required."));
+
+            const FString Text = FString::Printf(
+                TEXT("Draft a level design brief for a \"%s\"-themed level. Cover layout, pacing, "
+                     "key encounters, and mood."), *Theme);
+            return FUnrealMcpPromptResult::Success(Text, EUnrealMcpPromptRole::User);
+        });
+}
+```
+
+This is the shipped core `level-design-brief` prompt
+([`UnrealMCP/Source/UnrealMcpRuntime/Private/Prompts/UnrealMcpCorePrompts.cpp`](../UnrealMCP/Source/UnrealMcpRuntime/Private/Prompts/UnrealMcpCorePrompts.cpp)).
+Register the provider as a modular feature exactly as for tools, but under
+`IUnrealMcpPromptProvider::GetModularFeatureName()`:
+
+```cpp
+IModularFeatures::Get().RegisterModularFeature(
+    IUnrealMcpPromptProvider::GetModularFeatureName(), PromptProvider.Get());
+// ... and UnregisterModularFeature(...) in ShutdownModule.
+```
+
+Prompt ids are **kebab-case**, the same rule as tool ids. Do **not** call `.ExtensionId(...)` yourself — your
+`GetExtensionId()` is stamped automatically. Lifecycle, ordering, isolation (descriptor-level: a duplicate
+prompt name across providers is rejected first-wins; an invalid descriptor is dropped), and per-extension
+enable/disable behave **identically** to the tool path described above.
+
+---
+
+## Custom resources
+
+An extension can also contribute **MCP resources** — addressable, readable content the AI agent fetches via
+`resources/read`. Implement
+[`IUnrealMcpResourceProvider`](../UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpResourceProvider.h) and
+declare resources with the fluent
+[`FUnrealMcpResourceRegistry`](../UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpResourceRegistry.h)
+builder.
+
+```cpp
+class IUnrealMcpResourceProvider : public IModularFeature
+{
+public:
+    static FName GetModularFeatureName();          // FName("UnrealMcpResourceProvider")
+    virtual FString GetExtensionId() const = 0;
+    virtual FText   GetDisplayName() const = 0;
+    virtual FString GetExtensionVersion() const = 0;
+    virtual void    RegisterResources(FUnrealMcpResourceRegistry& Registry) = 0;
+};
+```
+
+### The resource builder
+
+`Registry.Resource("unreal://your/uri")` returns a fluent builder — the resource's **URI is its identity**
+(the registry key and the MCP route). Available calls:
+
+- `.Name(...)`, `.Description(...)` — human-/LLM-facing copy.
+- `.MimeType(...)` — e.g. `"application/json"`, `"image/png"`.
+- `.Read(lambda)` — bind the read handler and commit the resource. The handler runs on the **game thread**,
+  receives the requested `FString Uri`, and returns a `FUnrealMcpResourceResult`.
+
+A read returns one or more content blocks. Each block is **text XOR a base64 blob** + a mime type — use the
+static helpers `FUnrealMcpResourceResult::Text(uri, text, mimeType)` or `::Blob(uri, base64, mimeType)` (and
+`::MakeError(reason)` on failure):
+
+```cpp
+#include "IUnrealMcpResourceProvider.h"
+#include "UnrealMcpResourceRegistry.h"
+
+virtual void RegisterResources(FUnrealMcpResourceRegistry& Registry) override
+{
+    // A JSON (text) resource:
+    Registry.Resource(TEXT("unreal://project/levels"))
+        .Name(TEXT("Project Levels"))
+        .Description(TEXT("A JSON snapshot of the active world and its levels."))
+        .MimeType(TEXT("application/json"))
+        .Read([](const FString& Uri) -> FUnrealMcpResourceResult
+        {
+            return FUnrealMcpResourceResult::Text(Uri, BuildLevelsJson(), TEXT("application/json"));
+        });
+
+    // A binary (blob) resource — carried as base64, like a screenshot image:
+    Registry.Resource(TEXT("unreal://project/icon"))
+        .Name(TEXT("Project Icon"))
+        .Description(TEXT("A small PNG, returned as a base64 blob."))
+        .MimeType(TEXT("image/png"))
+        .Read([](const FString& Uri) -> FUnrealMcpResourceResult
+        {
+            const FString Base64 = FBase64::Encode(IconBytes, sizeof(IconBytes));
+            return FUnrealMcpResourceResult::Blob(Uri, Base64, TEXT("image/png"));
+        });
+}
+```
+
+These are the shipped core resources
+([`UnrealMCP/Source/UnrealMcpRuntime/Private/Resources/UnrealMcpCoreResources.cpp`](../UnrealMCP/Source/UnrealMcpRuntime/Private/Resources/UnrealMcpCoreResources.cpp)).
+Register the provider under `IUnrealMcpResourceProvider::GetModularFeatureName()` (same modular-feature
+pattern as tools and prompts). Lifecycle, ordering, isolation (a duplicate **URI** across providers is
+rejected first-wins; an invalid descriptor is dropped), and per-extension enable/disable behave identically.
+
+> **Scope note (MVP).** Only **static, fixed-URI** resources are supported today —
+> templated / parameterized resource URIs are deferred (`docs/ARCHITECTURE.md` §A.1). Declare one resource per
+> concrete URI.
+
+> **Binary-content note.** A blob is base64 on the Unreal side and on the IPC wire (the C++ `Blob(...)`
+> helper and the bridge `ProxyResource` round-trip it correctly). A known **upstream** encoding quirk in the
+> shared GameDev-MCP-Server / MCP-Plugin-dotnet can re-emit blob bytes on the MCP wire to the client — text
+> resources round-trip cleanly end-to-end; if a binary resource arrives mis-encoded at the client, that
+> upstream issue is the cause, not the Unreal-MCP plugin or bridge.
+
+---
+
 ## Runtime usage (in-game extensions)
 
 Everything above also works **in a running game** (PIE, Standalone, packaged Development) — this is the
@@ -215,17 +384,27 @@ discoverable wrapper so you never have to touch `IModularFeatures` directly:
 ```cpp
 #include "UnrealMcpRuntimeSubsystem.h"
 #include "IUnrealMcpToolProvider.h"
+#include "IUnrealMcpPromptProvider.h"
+#include "IUnrealMcpResourceProvider.h"
 
 if (UUnrealMcpRuntimeSubsystem* Mcp = UUnrealMcpRuntimeSubsystem::Get(this))
-    Mcp->RegisterToolProvider(MyProviderInstance);     // tools merge into the live registry; manifest re-pushed
-// ... later, before destroying the provider:
-    Mcp->UnregisterToolProvider(MyProviderInstance);   // tools drop out; manifest re-pushed
+{
+    Mcp->RegisterToolProvider(MyToolProvider);          // tools merge in; manifest re-pushed
+    Mcp->RegisterPromptProvider(MyPromptProvider);      // prompts merge in; manifest re-pushed
+    Mcp->RegisterResourceProvider(MyResourceProvider);  // resources merge in; manifest re-pushed
+}
+// ... later, before destroying the providers:
+    Mcp->UnregisterToolProvider(MyToolProvider);
+    Mcp->UnregisterPromptProvider(MyPromptProvider);
+    Mcp->UnregisterResourceProvider(MyResourceProvider);
 ```
 
-Both paths feed the same extension manager: registering or unregistering at any time rebuilds the registry
-and **re-pushes the manifest**, so a connected sidecar's `tools/list` gains/loses your tools automatically.
-The subsystem does **not** take ownership of the provider — keep it alive while it is registered (typically
-a member of your game module or a `UGameInstanceSubsystem`) and unregister before destroying it.
+All three kinds feed the same kind-aware extension manager: registering or unregistering at any time rebuilds
+the relevant registry and **re-pushes the manifest**, so a connected sidecar's `tools/list` / `prompts/list`
+/ `resources/list` gains/loses your contributions automatically. The subsystem does **not** take ownership of
+a provider — keep it alive while it is registered (typically a member of your game module or a
+`UGameInstanceSubsystem`) and unregister before destroying it. The same provider object may implement more
+than one contract (tools + prompts + resources) and be registered under each.
 
 ## Reference examples
 

--- a/samples/UnrealAITemplate/README.md
+++ b/samples/UnrealAITemplate/README.md
@@ -38,4 +38,16 @@ an **invalid** tool (an empty-named parameter — a malformed schema). Unreal-MC
 entry and records the failure on this extension's record; `hello-extension` stays registered. This is
 the §5 descriptor-validation isolation guarantee in action.
 
-See [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) §5 and [`docs/EXTENSIONS.md`](../../docs/EXTENSIONS.md).
+## Prompts & resources
+
+This sample focuses on the **tool** contract. Prompts and resources use the exact sibling contracts —
+`IUnrealMcpPromptProvider` + `FUnrealMcpPromptRegistry` and `IUnrealMcpResourceProvider` +
+`FUnrealMcpResourceRegistry` (same `UnrealMcpRuntime` module, same modular-feature registration, same
+isolation rules). For runnable prompt/resource examples, see the shipped **core** families
+[`UnrealMcpCorePrompts.cpp`](../../UnrealMCP/Source/UnrealMcpRuntime/Private/Prompts/UnrealMcpCorePrompts.cpp)
+(`level-design-brief`) and
+[`UnrealMcpCoreResources.cpp`](../../UnrealMCP/Source/UnrealMcpRuntime/Private/Resources/UnrealMcpCoreResources.cpp)
+(`unreal://project/levels` + `unreal://project/icon`), and the authoring sections in
+[`docs/EXTENSIONS.md`](../../docs/EXTENSIONS.md).
+
+See [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) §5 + §A and [`docs/EXTENSIONS.md`](../../docs/EXTENSIONS.md).


### PR DESCRIPTION
## Summary
- The **M16 capstone** (final task, #137): extend the user-facing docs so developers can register custom MCP **tools, prompts, AND resources** — editor + runtime — at Unity-MCP parity. Docs-only, no code behaviour change.
- **README.md** — renamed section "Customize Tools, Prompts & Resources" with runnable inline examples for all three kinds (provider + fluent registry builder + modular-feature registration), both editor and runtime (`RegisterPromptProvider` / `RegisterResourceProvider`) paths; runtime security contract intact.
- **docs/EXTENSIONS.md** — new "Custom prompts" + "Custom resources" authoring sections mirroring the tool section; runtime-usage wrapper extended to all three kinds.
- **docs/ARCHITECTURE.md** — folded in **Appendix A** (IPC prompt/resource flows + `ipcVersion` 1→2, registries/providers/subsystem, bridge `ProxyPrompt`/`ProxyResource`, schema, deferred UI); updated the §1.3 message table and the §10 empty-but-wired note.
- **samples/UnrealAITemplate/README.md** — cross-references the shipped core prompt/resource families.

Every documented identifier was cross-checked against shipped source (provider interfaces, builder methods, `EUnrealMcpPromptRole`, subsystem register calls, bridge proxies, sample ids/uris `level-design-brief` + `unreal://project/levels` + `unreal://project/icon`, console commands, param helpers). Deferred features stated honestly: templated resource URIs unsupported, the §7 Prompts/Resources windows still empty, and the known upstream blob-encoding quirk in the shared GameDev-MCP-Server / MCP-Plugin-dotnet.

## Test plan
- [x] Docs-only change (4 `.md` files; no `UnrealMCP/**` source touched) → no build/smoke/Automation gate required per the target profile.
- [x] Doc-accuracy gate: all documented C++/bridge identifiers, builder methods, result helpers, modular-feature names, sample ids/uris, and console commands grep-verified present in shipped source.
- [x] No broken in-page cross-links (anchors validated, including the renamed section anchor).

Closes #137