### PR TITLE
feat(plugin): opt-out setting to skip built-in runtime tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,12 @@ The complete, buildable example is [`samples/UnrealAIRuntimeSample/`](samples/Un
 
 A runtime connection serves a **deliberately smaller** built-in set than the editor — **22 runtime-safe built-in tools** (vs the [62 editor tools](#tools)): the actor / component family, `object-get-data` / `object-modify`, `level-get-data`, the console / reflection tools, `screenshot-game-view` / `screenshot-camera`, and `ping`. Editor-only families — Blueprint authoring, asset / Content-Browser operations, C++ source edit & compile, level create/open/save, editor-application state, and viewport/isolated screenshots — are **not** present at runtime (there is no editor in a shipped game). Your own custom tools, registered via the extension bus above, are added on top of the 22 built-ins.
 
+### Shipping only your own tools (opt out of the built-ins)
+
+If you want a shipped game to expose **only its own custom tools** and none of the 22 built-ins, turn off `UUnrealMcpRuntimeSettings::bRegisterBuiltinRuntimeTools` (Project Settings → Plugins → **Unreal MCP (Runtime)** → **Register Built-in Runtime Tools**). It defaults to **`true`** (no behavior change for existing users); set it to **`false`** to skip the built-in families at startup so the runtime registry contains only the tools your `IUnrealMcpToolProvider` registers.
+
+This is a **security** lever as much as a scoping one: the built-in set includes `reflection-method-call` and `console-run-command`, which together amount to remote arbitrary-code-execution over the connection. A game that only needs its own narrow tool surface should opt out so that surface is never exposed. Like the kill switch, this is a **Game** config setting (`DefaultGame.ini`, section `[/Script/UnrealMcpRuntime.UnrealMcpRuntimeSettings]`), so it travels into the packaged build. It gates the **runtime** path only — the editor toolset is unaffected. (Tools only; core prompts / resources are unchanged — a follow-up may add parity.)
+
 ## <a id="runtime-security-contract"></a>Security contract
 
 A runtime connection is **remote control of a running game** (`actor-create`, `object-modify`, arbitrary CVars via `console-run-command`, arbitrary `UFunction`s via `reflection-method-call`) — RCE-class if it were reachable in a shipped product. The runtime surface is therefore locked down by **five layered mitigations** ([`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) §12.8), all enforced inside `Connect()`:

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpRuntimeBuiltinToolsGateSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpRuntimeBuiltinToolsGateSpec.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+
+#include "IUnrealMcpToolProvider.h"
+#include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpRuntimeSubsystem.h"
+#include "UnrealMcpRuntimeSettings.h"
+
+/**
+ * Specs for the §12.8 built-in-runtime-tools opt-out (issue #141) — a game can ship exposing ONLY its own
+ * custom tools by turning off UUnrealMcpRuntimeSettings::bRegisterBuiltinRuntimeTools.
+ *
+ * The gate logic in UUnrealMcpRuntimeSubsystem::Initialize is `if (Settings->bRegisterBuiltinRuntimeTools)
+ * RegisterBuiltinRuntimeTools(Registry)`. RegisterBuiltinRuntimeTools is a static, exported helper that
+ * registers the five runtime-safe core families, so the gate is testable headlessly without standing up a
+ * subsystem (which needs an FSubsystemCollection + a bound IPC port): a spec reproduces both arms of the
+ * `if` against a fresh registry and asserts the built-in count is what the flag selects, while a custom
+ * provider's tools register regardless. This is the deterministic CI gate the issue's acceptance criterion
+ * asks for; the live subsystem Initialize wiring is exercised by the headless boot smoke (test.md Suite 2).
+ */
+namespace
+{
+	/** A test-only provider standing in for a game's custom tools — registers one uniquely-named tool. */
+	class FBuiltinGateSpecProvider : public IUnrealMcpToolProvider
+	{
+	public:
+		virtual FString GetExtensionId() const override { return TEXT("test.builtin.gate"); }
+		virtual FText GetDisplayName() const override { return FText::FromString(TEXT("Builtin gate spec provider")); }
+		virtual FString GetExtensionVersion() const override { return TEXT("1.0.0"); }
+		virtual void RegisterTools(FUnrealMcpToolRegistry& Registry) override
+		{
+			Registry.Tool(TEXT("builtin-gate-custom-tool"))
+				.Title(TEXT("Custom gameplay tool"))
+				.Description(TEXT("A game's own tool (issue #141 opt-out spec fixture)."))
+				.Handle([](const FUnrealMcpToolCall&) { return FUnrealMcpToolResult::Success(TEXT("ok")); });
+		}
+	};
+
+	/** Register the provider's tools the same way the §5 extension manager would (a scoped, deduped commit). */
+	void BuiltinGateRegisterProvider(FUnrealMcpToolRegistry& Registry, IUnrealMcpToolProvider& Provider)
+	{
+		Registry.RegisterExtension(Provider.GetExtensionId(),
+			[&Provider](FUnrealMcpToolRegistry& R) { Provider.RegisterTools(R); });
+	}
+}
+
+BEGIN_DEFINE_SPEC(FUnrealMcpRuntimeBuiltinToolsGateSpec, "UnrealMcp.RuntimeBuiltinToolsGate",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FUnrealMcpRuntimeBuiltinToolsGateSpec)
+
+void FUnrealMcpRuntimeBuiltinToolsGateSpec::Define()
+{
+	Describe("bRegisterBuiltinRuntimeTools gate (§12.8 opt-out)", [this]()
+	{
+		It("flag OFF -> the registry exposes ZERO built-in tools (only the custom provider's tool)", [this]()
+		{
+			// Reproduce Initialize()'s gate with the opt-out OFF: built-ins are skipped, provider tools merge.
+			FUnrealMcpToolRegistry Registry;
+			FBuiltinGateSpecProvider Provider;
+			BuiltinGateRegisterProvider(Registry, Provider);
+
+			TestEqual(TEXT("only the custom provider's tool is registered"), Registry.Num(), 1);
+			TestTrue(TEXT("the custom provider's tool is present"), Registry.HasTool(TEXT("builtin-gate-custom-tool")));
+
+			// The high-risk built-ins the §12.8 opt-out exists to suppress must be absent.
+			TestFalse(TEXT("ping built-in absent"), Registry.HasTool(TEXT("ping")));
+			TestFalse(TEXT("reflection-method-call built-in absent"), Registry.HasTool(TEXT("reflection-method-call")));
+			TestFalse(TEXT("console-run-command built-in absent"), Registry.HasTool(TEXT("console-run-command")));
+		});
+
+		It("flag ON -> the built-in count is unchanged and the custom tool registers on top", [this]()
+		{
+			// Reproduce Initialize()'s gate with the opt-out ON (the default): built-ins register, then the
+			// provider's tools merge on top — today's behavior, byte-for-byte.
+			FUnrealMcpToolRegistry Registry;
+			UUnrealMcpRuntimeSubsystem::RegisterBuiltinRuntimeTools(Registry);
+			const int32 BuiltinCount = Registry.Num();
+
+			// Sanity: the built-in set is non-trivial and includes the high-risk remote-control tools.
+			TestTrue(TEXT("built-ins registered a non-zero set"), BuiltinCount > 0);
+			TestTrue(TEXT("ping built-in present"), Registry.HasTool(TEXT("ping")));
+			TestTrue(TEXT("reflection-method-call built-in present"), Registry.HasTool(TEXT("reflection-method-call")));
+			TestTrue(TEXT("console-run-command built-in present"), Registry.HasTool(TEXT("console-run-command")));
+
+			FBuiltinGateSpecProvider Provider;
+			BuiltinGateRegisterProvider(Registry, Provider);
+
+			TestTrue(TEXT("the custom provider's tool is present alongside the built-ins"),
+				Registry.HasTool(TEXT("builtin-gate-custom-tool")));
+			TestEqual(TEXT("the built-in count is unchanged (custom tool added exactly one)"),
+				Registry.Num(), BuiltinCount + 1);
+		});
+
+		It("the setting defaults to TRUE (no behavior change for existing users)", [this]()
+		{
+			const UUnrealMcpRuntimeSettings* Settings = GetDefault<UUnrealMcpRuntimeSettings>();
+			TestNotNull(TEXT("runtime settings CDO resolves"), Settings);
+			if (Settings)
+			{
+				TestTrue(TEXT("bRegisterBuiltinRuntimeTools defaults to true"), Settings->bRegisterBuiltinRuntimeTools);
+			}
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
@@ -49,6 +49,18 @@ struct UUnrealMcpRuntimeSubsystem::FRuntimeImpl
 	TUniquePtr<FUnrealMcpExtensionManager> ExtensionManager;
 };
 
+void UUnrealMcpRuntimeSubsystem::RegisterBuiltinRuntimeTools(FUnrealMcpToolRegistry& Registry)
+{
+	// The runtime-safe core families (docs/ARCHITECTURE.md §10, §12.7). Editor-only families are NOT here
+	// (this path runs in a packaged game where they would not compile/link). Kept in lockstep with the call
+	// site in Initialize() — a §12.8 opt-out skips this whole set so only custom provider tools register.
+	UnrealMcpPingTool::Register(Registry);
+	UnrealMcpActorTools::Register(Registry); // §10 actor / component family (World->SpawnActor runtime branch)
+	UnrealMcpConsoleReflectionTools::Register(Registry); // §10 console + reflection runtime subset
+	UnrealMcpRuntimeScreenshotTools::Register(Registry); // §10 screenshot runtime subset (game-view, camera)
+	UnrealMcpRuntimeLevelTools::Register(Registry); // §10 read-only level-get-data
+}
+
 void UUnrealMcpRuntimeSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
 	Super::Initialize(Collection);
@@ -68,11 +80,23 @@ void UUnrealMcpRuntimeSubsystem::Initialize(FSubsystemCollectionBase& Collection
 	// set: ping, actor/component, the console+reflection subset, the screenshot subset, and level-get-data.
 	Impl = MakePimpl<FRuntimeImpl>();
 	Impl->Registry = MakeUnique<FUnrealMcpToolRegistry>();
-	UnrealMcpPingTool::Register(*Impl->Registry);
-	UnrealMcpActorTools::Register(*Impl->Registry); // §10 actor / component family (World->SpawnActor runtime branch)
-	UnrealMcpConsoleReflectionTools::Register(*Impl->Registry); // §10 console + reflection runtime subset
-	UnrealMcpRuntimeScreenshotTools::Register(*Impl->Registry); // §10 screenshot runtime subset (game-view, camera)
-	UnrealMcpRuntimeLevelTools::Register(*Impl->Registry); // §10 read-only level-get-data
+
+	// §12.8: the built-in core tool families register only when the bRegisterBuiltinRuntimeTools opt-out is
+	// on (default true). When a game turns it off, the built-ins are skipped and ONLY custom
+	// IUnrealMcpToolProvider tools (merged below via the extension manager) reach the runtime registry — so a
+	// shipped game can expose ONLY its own tools and never the reflection-method-call / console-run-command
+	// remote-control surface. Gates the RUNTIME path only; the editor coordinator keeps the full toolset.
+	const UUnrealMcpRuntimeSettings* RuntimeSettings = GetDefault<UUnrealMcpRuntimeSettings>();
+	if (!RuntimeSettings || RuntimeSettings->bRegisterBuiltinRuntimeTools)
+	{
+		RegisterBuiltinRuntimeTools(*Impl->Registry);
+	}
+	else
+	{
+		UE_LOG(LogUnrealMcp, Log,
+			TEXT("[Unreal-MCP] runtime built-in tools skipped (bRegisterBuiltinRuntimeTools is off); ")
+			TEXT("only custom IUnrealMcpToolProvider tools will be registered."));
+	}
 
 	// §A.1 prompt registry (P1): the prompt sibling of the tool registry, built on the SAME Model A path. The
 	// core prompt family registers before the bridge arms so the first prompt-manifest a v2 sidecar reads on

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeSettings.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeSettings.h
@@ -39,6 +39,23 @@ public:
 			ToolTip = "When off (default), in-game UUnrealMcpRuntimeSubsystem::Connect() is rejected. This is a security kill switch; even when on, a connection still requires an explicit Connect() call (the plugin never auto-connects)."))
 	bool bRuntimeMcpEnabled = false;
 
+	/**
+	 * Whether the runtime (in-game) subsystem registers the built-in core tool families
+	 * (ping, actor/component, console+reflection, screenshot, level-get-data). Default TRUE — existing
+	 * users see no behavior change. Turn it OFF to ship a game that exposes ONLY its own custom tools
+	 * (registered via IUnrealMcpToolProvider / RegisterToolProvider); the built-ins are skipped at
+	 * Initialize() and never reach the runtime registry.
+	 *
+	 * SECURITY (docs/ARCHITECTURE.md §12.8): the built-in set includes `reflection-method-call` and
+	 * `console-run-command`, which together are effectively remote arbitrary-code-execution over the
+	 * network. A shipped game that only wants its own narrow tool surface should turn this off so that
+	 * surface is never exposed. This gates the RUNTIME path only — the editor toolset is unaffected.
+	 */
+	UPROPERTY(Config, EditAnywhere, Category = "Runtime",
+		meta = (DisplayName = "Register Built-in Runtime Tools",
+			ToolTip = "When on (default), the runtime subsystem registers the built-in core tool families. Turn off to ship a game that exposes ONLY its own custom tools. The built-ins include reflection-method-call and console-run-command (effectively remote code execution), so disabling them shrinks the in-game remote-control surface. Runtime path only; the editor toolset is unaffected."))
+	bool bRegisterBuiltinRuntimeTools = true;
+
 	/** Settings-category placement helpers (Project Settings → Plugins). */
 	virtual FName GetCategoryName() const override;
 };

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeSubsystem.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpRuntimeSubsystem.h
@@ -11,6 +11,8 @@
 // Forward-declared: RegisterToolProvider/UnregisterToolProvider take it by pointer only (§12.9), so the
 // PUBLIC header needs no extension-contract include — callers include IUnrealMcpToolProvider.h themselves.
 class IUnrealMcpToolProvider;
+// Forward-declared: RegisterBuiltinRuntimeTools takes it by reference; the .cpp includes the registry header.
+class FUnrealMcpToolRegistry;
 // Forward-declared for the same reason: RegisterPromptProvider/UnregisterPromptProvider take it by pointer.
 class IUnrealMcpPromptProvider;
 // Forward-declared for the same reason: RegisterResourceProvider/UnregisterResourceProvider take it by pointer.
@@ -180,6 +182,16 @@ public:
 	 * An empty host counts as loopback (it resolves to the §8 DefaultCustomHost, which is localhost).
 	 */
 	static bool IsLoopbackHost(const FString& Host);
+
+	/**
+	 * Register the built-in runtime-safe core tool families (ping, actor/component, console+reflection,
+	 * screenshot, level-get-data) into @p Registry. Initialize() calls this ONLY when the
+	 * UUnrealMcpRuntimeSettings::bRegisterBuiltinRuntimeTools opt-out is on (the default); a game that turns
+	 * it off ships with ONLY its own IUnrealMcpToolProvider tools (docs/ARCHITECTURE.md §12.8). Static +
+	 * exported so the gate is testable without standing up a subsystem — a spec registers a test provider's
+	 * tool with/without this call and asserts the built-in count is gated by the flag.
+	 */
+	static void RegisterBuiltinRuntimeTools(FUnrealMcpToolRegistry& Registry);
 
 private:
 	/** Register / unregister the QA console commands (UnrealMcp.Connect / UnrealMcp.Disconnect). */

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1198,6 +1198,14 @@ arbitrary CVars, reflection-method-call arbitrary UFunctions) — RCE-class if r
 4. **Kill switch:** `UUnrealMcpRuntimeSettings:UDeveloperSettings` `bRuntimeMcpEnabled` default FALSE.
 5. **Loopback-host default:** Connect rejects non-loopback hosts unless explicit `bAllowRemoteHost`.
 6. No token in argv/logs.
+7. **Built-in tool-set opt-out:** `UUnrealMcpRuntimeSettings::bRegisterBuiltinRuntimeTools` (Config=Game,
+   DefaultConfig, default TRUE). `UUnrealMcpRuntimeSubsystem::Initialize` registers the five built-in
+   runtime-safe core families (via the static `RegisterBuiltinRuntimeTools` helper) ONLY when this flag is
+   on; with it off, the built-ins are skipped and ONLY custom `IUnrealMcpToolProvider` tools reach the
+   runtime registry — so a shipped game can expose only its own tools and never the `reflection-method-call`
+   / `console-run-command` RCE-class surface. Default TRUE keeps existing behavior unchanged. Gates the
+   RUNTIME path only — the editor coordinator (Model A) keeps the full toolset. Tools-only: core prompts /
+   resources registration is unchanged (a follow-up may add parity).
 
 ### 12.9 Runtime extension tool registration
 `IModularFeatures` (§5) is runtime-available — `IUnrealMcpToolProvider` works identically at runtime; the

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -375,6 +375,14 @@ runtime-available — with two differences for a game extension:
   → `bRuntimeMcpEnabled`) and explicitly connects:
   `UUnrealMcpRuntimeSubsystem::Get(this)->Connect("http://localhost:8080", "my-token")` (or the QA console
   command `UnrealMcp.Connect <host> [token]`).
+- **To expose ONLY your own tools, opt out of the built-ins.** By default the runtime registry merges your
+  tools on top of the 22 runtime-safe built-ins. Turn off `bRegisterBuiltinRuntimeTools` (same settings
+  page → **Register Built-in Runtime Tools**, default `true`) to skip the built-in families at startup so
+  the registry contains only what your `IUnrealMcpToolProvider` registers. The built-ins include
+  `reflection-method-call` and `console-run-command` (effectively remote code execution), so this is a
+  security lever: a game that needs only its own narrow tool surface should opt out. Like the kill switch
+  it is a **Game** config setting (it travels into the packaged build) and gates the runtime path only —
+  the editor toolset is unaffected.
 
 ### Ergonomic registration via the runtime subsystem
 


### PR DESCRIPTION
## Summary
- Add `UUnrealMcpRuntimeSettings::bRegisterBuiltinRuntimeTools` (Config=Game, DefaultConfig, default **TRUE** — no behavior change for existing users). When off, `UUnrealMcpRuntimeSubsystem::Initialize` skips the five built-in runtime-safe core families (via a new static `RegisterBuiltinRuntimeTools` helper) so only custom `IUnrealMcpToolProvider` tools register — a game can ship exposing only its own tools and never the `reflection-method-call` / `console-run-command` RCE-class surface (§12.8 #7).
- Gates the **runtime** path only — the editor coordinator keeps the full toolset. Tools-only; core prompts/resources unchanged.
- Docs: README runtime section, `docs/EXTENSIONS.md` runtime usage, `docs/ARCHITECTURE.md` §12.8.

## Test plan
- [x] Suite 1 (UBT editor build) — exit 0
- [x] Suite 1b (RunUAT BuildPlugin, Game+Editor — runtime module gate) — BUILD SUCCESSFUL, exit 0
- [x] Suite 2 (headless boot smoke) — `[Unreal-MCP] plugin loaded`
- [x] Suite 3 (Automation `UnrealMcp.` specs) — failed=0, succeeded=300; new `UnrealMcp.RuntimeBuiltinToolsGate` (3 cases) green: flag OFF -> zero built-ins (only provider tool); flag ON -> count unchanged; default TRUE

Closes #141