### PR TITLE
fix(tools): stop asset-import hard-crashing the editor (Interchange TaskGraph re-entrancy)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpAssetTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpAssetTools.cpp
@@ -12,6 +12,8 @@
 #include "UObject/TopLevelAssetPath.h"
 #include "UObject/GCObjectScopeGuard.h"
 #include "Misc/Paths.h"
+#include "Misc/ScopeExit.h"
+#include "HAL/IConsoleManager.h"
 #include "ScopedTransaction.h"
 
 #include "AssetRegistry/AssetRegistryModule.h"
@@ -968,6 +970,35 @@ namespace UnrealMcpAssetTools
 				Task->bReplaceExisting = bReplaceExisting;
 				Task->bSave = bSave;
 				Task->bAsync = false;
+
+				// asset-import runs SYNCHRONOUSLY on the game thread inside the §4 dispatcher, which
+				// delivers handler bodies as game-thread TaskGraph tasks (AsyncTask(GameThread)). UE5's
+				// Interchange importer pumps the game-thread TaskGraph while waiting on its own async
+				// pipeline, RE-ENTERING the named-thread queue we are already executing inside — which
+				// trips `++Queue(QueueIndex).RecursionGuard == 1` (TaskGraph.cpp) and HARD-CRASHES the
+				// editor (assertion + minidump, no recovery). Force the legacy (non-Interchange) UFactory
+				// import path for the duration of this call: it imports inline without pumping the
+				// TaskGraph, so there is no re-entrancy. The decision is gated by the
+				// `Interchange.FeatureFlags.Import.Enable` CVar (AssetTools::ShouldUseInterchangeFramework
+				// reads UInterchangeManager::IsInterchangeImportEnabled()), so we flip it off and restore
+				// it unconditionally via ON_SCOPE_EXIT. FBX/textures/etc. resolve to their legacy
+				// factories; an Interchange-only format would fail gracefully ("produced no assets")
+				// instead of crashing. Keeping Interchange would require an async-handler surface (§4),
+				// tracked separately.
+				IConsoleVariable* const InterchangeImportCVar =
+					IConsoleManager::Get().FindConsoleVariable(TEXT("Interchange.FeatureFlags.Import.Enable"));
+				const bool bInterchangeWasEnabled = InterchangeImportCVar != nullptr && InterchangeImportCVar->GetBool();
+				if (bInterchangeWasEnabled)
+				{
+					InterchangeImportCVar->Set(false, ECVF_SetByCode);
+				}
+				ON_SCOPE_EXIT
+				{
+					if (bInterchangeWasEnabled)
+					{
+						InterchangeImportCVar->Set(true, ECVF_SetByCode);
+					}
+				};
 
 				GetAssetTools().ImportAssetTasks({ Task });
 


### PR DESCRIPTION
## Problem

`asset-import` **hard-crashes the Unreal Editor on every import** (reproduced with a valid PNG). Observed in the project log:

```
LogInterchangeEngine: Display: Interchange start importing source [...png]
LogWindows: Error: appError called: Assertion failed: ++Queue(QueueIndex).RecursionGuard == 1 [TaskGraph.cpp:689]
=== Critical error === ... (crash dump UECC-Windows-...)
```

## Root cause

The handler ran a **synchronous Interchange import** (`ImportAssetTasks`, `bAsync=false`) directly on the game thread. The §4 dispatcher delivers handler bodies as game-thread TaskGraph tasks (`AsyncTask(ENamedThreads::GameThread, …)`), so the handler executes **inside the game thread's task-processing loop**. UE5's Interchange importer pumps that same named-thread queue while waiting on its own async pipeline, **re-entering** the queue and tripping `++Queue(QueueIndex).RecursionGuard == 1` → assertion + minidump, no recovery.

## Fix

Force the legacy (non-Interchange) `UFactory` import path for the duration of the call by toggling the `Interchange.FeatureFlags.Import.Enable` CVar off, restored unconditionally via `ON_SCOPE_EXIT`. `AssetTools::ShouldUseInterchangeFramework` reads `UInterchangeManager::IsInterchangeImportEnabled()`, so this redirects to the legacy factory, which imports **inline without pumping the TaskGraph** — no re-entrancy. Contained to the one handler; the dispatcher and the other 61 tools are untouched.

## Verification (UE 5.7, live)

- UBT build of the testbed with the patched plugin: compiles + links clean (no ODR/unity-build collision).
- Headless boot smoke: plugin loads, clean exit, no crash.
- **Live e2e (the exact crash repro)**: `Unreal-Test-Project` + sidecar + `gamedev-mcp-server` in Custom mode → importing a valid PNG returns `{"status":"success"}` with a real `Texture2D` at the destination, and **the editor stays alive**. `asset-find` confirms the imported asset. Prior code crashed the editor every time.

> Note: the `UnrealMcpEditorTests` automation specs were not exercised in the quick project-editor UBT build (the test module is built via `BuildPlugin` on the self-hosted runner); CI provides that signal. The `asset-import` error-path spec is logically unaffected by this change.

## Trade-off

Interchange-only formats (e.g. some glTF/USD configs) now **fail gracefully** ("produced no assets") instead of crashing. Preserving Interchange would require an async-handler surface in the §4 dispatcher (run bodies off the TaskGraph processing loop) — tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)