### PR TITLE
fix(cli): connection-mode flag, correct readiness probe, and UE 5.7 scaffold build settings

### DIFF
--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -16,6 +16,7 @@ export const openCommand = new Command('open')
   .option('--keep-connected', 'UNREAL_MCP_KEEP_CONNECTED=true')
   .option('--transport <t>', 'UNREAL_MCP_TRANSPORT: stdio | http')
   .option('--start-server', 'UNREAL_MCP_START_SERVER=true')
+  .option('--connection-mode <mode>', 'UNREAL_MCP_CONNECTION_MODE: Custom | Cloud | (default empty = plugin default)')
   .action(async (pathArg: string | undefined, opts) => {
     const result = await openProject({
       projectDir: pathArg,
@@ -29,6 +30,7 @@ export const openCommand = new Command('open')
       keepConnected: opts.keepConnected,
       transport: opts.transport as McpTransport | undefined,
       startServer: opts.startServer,
+      connectionMode: opts.connectionMode,
     });
     ui.printWarnings(result.warnings);
     if (result.kind === 'failure') {

--- a/cli/src/lib/create-project.ts
+++ b/cli/src/lib/create-project.ts
@@ -75,14 +75,13 @@ IMPLEMENT_PRIMARY_GAME_MODULE(FDefaultGameModuleImpl, ${name}, "${name}");
 
   const gameTarget = `// Copyright (c) 2026 Ivan Murzak (Apache-2.0)
 using UnrealBuildTool;
-using System.Collections.Generic;
 
 public class ${name}Target : TargetRules
 {
 \tpublic ${name}Target(TargetInfo Target) : base(Target)
 \t{
 \t\tType = TargetType.Game;
-\t\tDefaultBuildSettings = BuildSettingsVersion.V5;
+\t\tDefaultBuildSettings = BuildSettingsVersion.Latest;
 \t\tIncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 \t\tExtraModuleNames.Add("${name}");
 \t}
@@ -91,14 +90,13 @@ public class ${name}Target : TargetRules
 
   const editorTarget = `// Copyright (c) 2026 Ivan Murzak (Apache-2.0)
 using UnrealBuildTool;
-using System.Collections.Generic;
 
 public class ${name}EditorTarget : TargetRules
 {
 \tpublic ${name}EditorTarget(TargetInfo Target) : base(Target)
 \t{
 \t\tType = TargetType.Editor;
-\t\tDefaultBuildSettings = BuildSettingsVersion.V5;
+\t\tDefaultBuildSettings = BuildSettingsVersion.Latest;
 \t\tIncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 \t\tExtraModuleNames.Add("${name}");
 \t}

--- a/cli/src/lib/open.ts
+++ b/cli/src/lib/open.ts
@@ -45,6 +45,7 @@ export function buildOpenEnv(opts: OpenProjectOptions): Record<string, string> |
     env['UNREAL_MCP_TRANSPORT'] = opts.transport;
   }
   if (opts.startServer !== undefined) env['UNREAL_MCP_START_SERVER'] = opts.startServer ? 'true' : 'false';
+  if (opts.connectionMode !== undefined) env['UNREAL_MCP_CONNECTION_MODE'] = opts.connectionMode;
   return Object.keys(env).length > 0 ? env : undefined;
 }
 
@@ -86,6 +87,7 @@ export async function openProject(opts: OpenProjectOptions): Promise<OpenProject
       if (opts.keepConnected) ignored.push('keepConnected');
       if (opts.tools !== undefined) ignored.push('tools');
       if (opts.startServer !== undefined) ignored.push('startServer');
+      if (opts.connectionMode !== undefined) ignored.push('connectionMode');
       if (ignored.length > 0) {
         warnings.push(`Connection options are ignored under --no-connect: ${ignored.join(', ')}.`);
       }

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -102,6 +102,8 @@ export interface OpenProjectOptions {
   keepConnected?: boolean;
   transport?: McpTransport;
   startServer?: boolean;
+  /** UNREAL_MCP_CONNECTION_MODE — e.g. "Custom" for a local server. */
+  connectionMode?: string;
   /** Skip the persistent engine-path cache (forces a fresh discovery chain). */
   noCache?: boolean;
   /** Test injection — installed engines (defaults to launcher manifest). */

--- a/cli/src/utils/probe.ts
+++ b/cli/src/utils/probe.ts
@@ -1,14 +1,14 @@
 // HTTP readiness probe against a project's local MCP server. Used by
-// `status` and `wait-for-ready`. The `ping` system tool echoes back —
+// `status` and `wait-for-ready`. The `ping` MCP tool echoes back —
 // a 2xx means the server (and the plugin behind it) is reachable.
 
-// NOTE (doc/code reconciliation): docs/ARCHITECTURE.md's headless-e2e runbook
-// line still cites `POST /api/tools/ping` (the Godot testbed route). This
-// client deliberately uses `/api/system-tools/ping` to match unity-mcp-cli and
-// the `run-system-tool` route. The Unreal server does not exist yet, so the
-// discrepancy is unfalsifiable today; whoever lands the server reconciles it —
-// the doc line should move to `/api/system-tools/ping`.
-export const PING_ENDPOINT = '/api/system-tools/ping';
+// NOTE (doc/code reconciliation): The Unreal sidecar does NOT implement the
+// `ping` system-tool handler (`/api/system-tools/ping` returns null → HTTP 500),
+// so we route through `/api/tools/ping` (the MCP tool route). This was
+// verified manually: system-tools/ping → 500 (null response),
+// /api/tools/ping → 200 {"result":"pong"}. ARCHITECTURE.md §e2e runbook
+// already cited /api/tools/ping — this endpoint now matches it.
+export const PING_ENDPOINT = '/api/tools/ping';
 
 export interface ProbeSuccess {
   ok: true;


### PR DESCRIPTION
Three fixes to `unreal-mcp-cli`, all surfaced while manually verifying the full create → open → install-plugin → run-tool flow against a live UE 5.7 editor.

### 1. `create-project` — `BuildSettingsVersion.Latest` (was `.V5`)
The scaffolded `*.Target.cs` files hardcoded `BuildSettingsVersion.V5`, which conflicts with UE 5.7's V6 defaults (`UndefinedIdentifierWarningLevel: Off != Error`). UBT **refused to compile** every freshly-scaffolded project on first `open`. Now uses `.Latest` (matches the `Unreal-Test-Project` testbed) and drops the unused `using System.Collections.Generic;`.

### 2. `open` — new `--connection-mode <mode>` flag
`open` exposed every `UNREAL_MCP_*` connection var **except** `UNREAL_MCP_CONNECTION_MODE`. Without it the plugin defaults to `Cloud` mode and the sidecar dials `ai-game.dev` instead of the local server, so `--start-server` had no effect and local testing needed a manual shell `export`. Adds `--connection-mode Custom|Cloud` → `UNREAL_MCP_CONNECTION_MODE`.

### 3. `status` / `wait-for-ready` — probe `/api/tools/ping` (was `/api/system-tools/ping`)
The readiness probe hit `/api/system-tools/ping`, which the Unreal sidecar does not implement (returns null → HTTP 500), so `status` always reported `reachable: no` and `wait-for-ready` **never** succeeded even with a fully-working stack. The `ping` **MCP tool** at `/api/tools/ping` returns `pong`; the probe now uses it.

### Verification
Full clean-room pass against a live UE 5.7 editor + sidecar + `gamedev-mcp-server` (Custom mode): `create-project` → compiles; `open --connection-mode Custom` → `mode=Custom` with no env override; `wait-for-ready` → ready in <400ms; `status` → `reachable: yes`; and 61/62 MCP tools exercised end-to-end through the CLI. `npm run build && npm test` green (230 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)