### PR TITLE
chore(release): bump version to 0.3.1

### DIFF
--- a/UnrealMCP/UnrealMCP.uplugin
+++ b/UnrealMCP/UnrealMCP.uplugin
@@ -1,7 +1,7 @@
 {
   "FileVersion": 3,
   "Version": 1,
-  "VersionName": "0.3.0",
+  "VersionName": "0.3.1",
   "FriendlyName": "Unreal MCP (AI Game Developer)",
   "Description": "Model Context Protocol (MCP) integration for the Unreal Editor. Exposes editor operations as AI Tools so MCP-aware AI assistants (Claude, Cursor, Copilot, ...) can inspect and drive your Unreal project. Requires Unreal Engine 5.5+ (no EngineVersion pin: UE treats that field as an exact-build match, not a floor, and would refuse to load on newer engines).",
   "Category": "AI",

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>com.IvanMurzak.Unreal.MCP.Bridge</RootNamespace>
     <AssemblyName>unreal-mcp-bridge</AssemblyName>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2026 Ivan Murzak</Copyright>

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unreal-mcp-cli",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^13.1.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Cross-platform CLI tool for Unreal-MCP (Skills & MCP). Resolves and launches the Unreal editor with MCP connection env vars, runs MCP/system tools over HTTP, probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and manages the UnrealMCP plugin. Works with Claude Code, Cursor, Copilot, and any MCP client.",
   "type": "module",
   "main": "dist/lib.js",


### PR DESCRIPTION
Release **0.3.1** (patch) of Unreal-MCP. Bumps `VersionName` across the `.uplugin`, bridge csproj `<Version>`, and `cli/package.json` (+ lock) via `commands/bump-version.ps1`.

Merging this to `main` trips `release.yml`'s `check-version` gate → builds + signs the self-contained bridge per RID, bundles the signed sidecar into the packaged plugin, cuts the `v0.3.1` GitHub Release + tag, and publishes `unreal-mcp-cli@0.3.1` to npm.

### Ships since 0.3.0
- **#148** `fix(tools)`: stop `asset-import` hard-crashing the editor (Interchange TaskGraph re-entrancy) — force the legacy import path to avoid pumping the game-thread TaskGraph.
- **#149** `fix(cli)`: `--connection-mode` flag, correct readiness probe (`/api/tools/ping`), and UE 5.7 scaffold build settings (`BuildSettingsVersion.Latest`).

Both merged green (incl. the self-hosted UE 5.7 BuildPlugin + Automation leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)