### PR TITLE
chore(release): bump version to 0.3.2

### DIFF
--- a/UnrealMCP/UnrealMCP.uplugin
+++ b/UnrealMCP/UnrealMCP.uplugin
@@ -1,7 +1,7 @@
 {
   "FileVersion": 3,
   "Version": 1,
-  "VersionName": "0.3.1",
+  "VersionName": "0.3.2",
   "FriendlyName": "Unreal MCP (AI Game Developer)",
   "Description": "Model Context Protocol (MCP) integration for the Unreal Editor. Exposes editor operations as AI Tools so MCP-aware AI assistants (Claude, Cursor, Copilot, ...) can inspect and drive your Unreal project. Requires Unreal Engine 5.5+ (no EngineVersion pin: UE treats that field as an exact-build match, not a floor, and would refuse to load on newer engines).",
   "Category": "AI",

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>com.IvanMurzak.Unreal.MCP.Bridge</RootNamespace>
     <AssemblyName>unreal-mcp-bridge</AssemblyName>
-    <Version>0.3.1</Version>
+    <Version>0.3.2</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2026 Ivan Murzak</Copyright>

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unreal-mcp-cli",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^13.1.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Cross-platform CLI tool for Unreal-MCP (Skills & MCP). Resolves and launches the Unreal editor with MCP connection env vars, runs MCP/system tools over HTTP, probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and manages the UnrealMCP plugin. Works with Claude Code, Cursor, Copilot, and any MCP client.",
   "type": "module",
   "main": "dist/lib.js",


### PR DESCRIPTION
Release **0.3.2** (patch). Bumps `VersionName` across the `.uplugin`, bridge csproj, and `cli/package.json` (+ lock). Merging to `main` trips `release.yml` → tag `v0.3.2` + GitHub Release + `unreal-mcp-cli@0.3.2` on npm.

### Ships since 0.3.1
- **#151** Unreal Engine **5.8 support**: plugin compiles on UE 5.8 (`FJsonObject::TryGetField` instead of the internal `Values` map, whose key type changed `FString → FStringType`); `install-engine` now detects engines via the common-location scan (not just the launcher manifest), so a freshly-installed UE is no longer falsely reported "not installed"; README badge → `5.5 – 5.8`.

Verified end-to-end on a live UE 5.8 editor driven entirely through `unreal-mcp-cli` (create-project → install-plugin → build → open → all 62 AI tools: 59 working, 3 precondition-gated, 0 broken). CI green on 5.7 (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)