### PR TITLE
ci(release): run the plugin Automation gate on a UE 5.7 + 5.8 matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,12 +280,22 @@ jobs:
   # skipped too — a safe default. For a dry-run the publish jobs are skipped
   # regardless. See docs/RELEASING.md.
   plugin:
-    name: plugin BuildPlugin + Automation (UE 5.7)
+    name: plugin BuildPlugin + Automation (UE ${{ matrix.ue }})
     needs: [check-version]
     if: needs.check-version.outputs.run_tests == 'true' && vars.UNREAL_RUNNER_READY == 'true'
+    # Matrix runs UE 5.7 and 5.8 as parallel jobs; the single self-hosted runner
+    # (label `unreal-5-7`, legacy) executes them sequentially. fail-fast:false so
+    # one engine's failure never cancels the other's leg. Downstream artifact /
+    # publish jobs that `needs: [plugin]` wait for BOTH legs — so a release is
+    # gated on the plugin passing Automation on both engines.
     runs-on: [self-hosted, windows, unreal-5-7]
+    strategy:
+      fail-fast: false
+      matrix:
+        ue: ['5.7', '5.8']
     env:
-      UE_ROOT: ${{ vars.UNREAL_ENGINE_PATH || 'C:\Program Files\Epic Games\UE_5.7' }}
+      # Engine path is driven by the matrix (standard Epic install layout).
+      UE_ROOT: C:\Program Files\Epic Games\UE_${{ matrix.ue }}
       HOST_UPROJECT: ${{ vars.UNREAL_HOST_PROJECT }}
     steps:
       - name: Checkout repository
@@ -339,6 +349,15 @@ jobs:
             if (Test-Path $package) { Remove-Item $package -Recurse -Force }
             & $runUAT BuildPlugin -Plugin="$uplugin" -Package="$package" -TargetPlatforms=Win64 -Rocket
             if ($LASTEXITCODE -ne 0) { throw "Automation BuildPlugin (with test module) failed with exit code $LASTEXITCODE" }
+            # Rebuild the host's OWN game module for THIS matrix engine so the editor
+            # opens without an out-of-date-modules failure (the host's committed
+            # Binaries may be built for a different UE version, and an -unattended
+            # editor will NOT interactively rebuild). The plugin is already current
+            # via the BuildPlugin into the host's Plugins junction above.
+            $hostBuild = Join-Path $env:UE_ROOT 'Engine\Build\BatchFiles\Build.bat'
+            $hostTarget = [System.IO.Path]::GetFileNameWithoutExtension($env:HOST_UPROJECT) + 'Editor'
+            & $hostBuild $hostTarget Win64 Development -project="$env:HOST_UPROJECT" -WaitMutex
+            if ($LASTEXITCODE -ne 0) { throw "Host editor target ($hostTarget) build failed for UE_ROOT=$env:UE_ROOT (exit $LASTEXITCODE)" }
             $editorCmd = Join-Path $env:UE_ROOT 'Engine\Binaries\Win64\UnrealEditor-Cmd.exe'
             $reportDir = Join-Path $env:RUNNER_TEMP 'AutomationReport'
             if (Test-Path $reportDir) { Remove-Item $reportDir -Recurse -Force }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -341,7 +341,9 @@ release-runner label so PR compiles do not starve release capacity.
 > `IvanMurzak/Unreal-MCP`, and the repository variable `UNREAL_RUNNER_READY` is
 > set to `true`. `UNREAL_HOST_PROJECT` is **also set**, so the Automation pass
 > runs against the packaged plugin (not just the BuildPlugin compile). The
-> `plugin BuildPlugin + Automation (UE 5.7)` leg now **runs**
+> `plugin BuildPlugin + Automation (UE <ver>)` leg — a `matrix.ue: ['5.7', '5.8']`
+> (the single runner has both engines installed and runs the legs sequentially;
+> the host game module is rebuilt for each matrix engine) — now **runs**
 > on every same-repo PR and on real releases — it is no longer skipped. The
 > registration steps below are retained for re-provisioning the runner.
 


### PR DESCRIPTION
Follow-up to #153 (which matrixed `test_pull_request.yml`): now `release.yml`'s self-hosted **plugin** gate (BuildPlugin packaging validation + Automation specs) also runs on **both UE 5.7 and 5.8** via `strategy.matrix.ue: ['5.7', '5.8']`.

- Engine path driven by the matrix (`UE_ROOT: …\UE_${{ matrix.ue }}`); the host game module is rebuilt for the matrix engine before the editor launch (so one host project serves both engines).
- `fail-fast: false` — one engine never cancels the other leg.
- `publish-release` `needs: [plugin]` and consumes no plugin output, so it now waits for **both** legs → **a real release is gated on the plugin passing Automation on both engines**.
- The publish-artifact jobs (signed bridge per RID, plugin zip) stay single-build — the distributed plugin is engine-agnostic source.

Both engines already verified green in #153's PR CI; this wires 5.8 into the release gate too. RELEASING.md updated in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)