### PR TITLE
feat: verify downloaded mcp-server zip against SHA256SUMS before execute (fail-closed) — C++ plugin + CLI

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerChecksum.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerChecksum.cpp
@@ -1,0 +1,260 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "Server/UnrealMcpServerChecksum.h"
+
+const TCHAR* FUnrealMcpServerChecksum::Sha256SumsAssetName = TEXT("SHA256SUMS");
+
+namespace
+{
+	// --- Self-contained SHA-256 (FIPS 180-4) -------------------------------------------------------------
+	// UE's FPlatformMisc::GetSHA256Signature is a GENERIC STUB that checkf(false)s on Windows/desktop (it has
+	// no platform override — verified: Engine/.../GenericPlatformMisc.cpp asserts "No SHA256 Platform
+	// implementation"), and UE Core ships no other dependency-free SHA-256. So we implement the algorithm
+	// directly here: pure integer math on UE types, no third-party dep, no engine hashing API, deterministic
+	// across platforms, and unit-testable (asserted against the FIPS reference vectors for "abc" and ""). All
+	// symbols are uniquely named (unity-build ODR rule — every .cpp in this module is one TU).
+
+	FORCEINLINE uint32 ServerChecksumRotr(uint32 X, uint32 N)
+	{
+		return (X >> N) | (X << (32 - N));
+	}
+
+	void ServerChecksumSha256(const uint8* Data, int64 Length, uint8 OutDigest[32])
+	{
+		static const uint32 K[64] = {
+			0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u, 0x3956c25bu, 0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u,
+			0xd807aa98u, 0x12835b01u, 0x243185beu, 0x550c7dc3u, 0x72be5d74u, 0x80deb1feu, 0x9bdc06a7u, 0xc19bf174u,
+			0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu, 0x2de92c6fu, 0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau,
+			0x983e5152u, 0xa831c66du, 0xb00327c8u, 0xbf597fc7u, 0xc6e00bf3u, 0xd5a79147u, 0x06ca6351u, 0x14292967u,
+			0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu, 0x53380d13u, 0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u,
+			0xa2bfe8a1u, 0xa81a664bu, 0xc24b8b70u, 0xc76c51a3u, 0xd192e819u, 0xd6990624u, 0xf40e3585u, 0x106aa070u,
+			0x19a4c116u, 0x1e376c08u, 0x2748774cu, 0x34b0bcb5u, 0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu, 0x682e6ff3u,
+			0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u, 0x90befffau, 0xa4506cebu, 0xbef9a3f7u, 0xc67178f2u
+		};
+
+		uint32 H[8] = {
+			0x6a09e667u, 0xbb67ae85u, 0x3c6ef372u, 0xa54ff53au, 0x510e527fu, 0x9b05688cu, 0x1f83d9abu, 0x5be0cd19u
+		};
+
+		// Process the message in 64-byte blocks, padding the final block(s) per the spec. The total length in
+		// BITS is appended as a big-endian 64-bit integer.
+		const uint64 BitLength = static_cast<uint64>(Length) * 8;
+		int64 Offset = 0;
+		uint8 Block[64];
+
+		auto ProcessBlock = [&](const uint8* B)
+		{
+			uint32 W[64];
+			for (int32 i = 0; i < 16; ++i)
+			{
+				W[i] = (static_cast<uint32>(B[i * 4]) << 24)
+					| (static_cast<uint32>(B[i * 4 + 1]) << 16)
+					| (static_cast<uint32>(B[i * 4 + 2]) << 8)
+					| (static_cast<uint32>(B[i * 4 + 3]));
+			}
+			for (int32 i = 16; i < 64; ++i)
+			{
+				const uint32 S0 = ServerChecksumRotr(W[i - 15], 7) ^ ServerChecksumRotr(W[i - 15], 18) ^ (W[i - 15] >> 3);
+				const uint32 S1 = ServerChecksumRotr(W[i - 2], 17) ^ ServerChecksumRotr(W[i - 2], 19) ^ (W[i - 2] >> 10);
+				W[i] = W[i - 16] + S0 + W[i - 7] + S1;
+			}
+
+			uint32 A = H[0], BB = H[1], C = H[2], D = H[3], E = H[4], F = H[5], G = H[6], Hh = H[7];
+			for (int32 i = 0; i < 64; ++i)
+			{
+				const uint32 Sig1 = ServerChecksumRotr(E, 6) ^ ServerChecksumRotr(E, 11) ^ ServerChecksumRotr(E, 25);
+				const uint32 Ch = (E & F) ^ (~E & G);
+				const uint32 T1 = Hh + Sig1 + Ch + K[i] + W[i];
+				const uint32 Sig0 = ServerChecksumRotr(A, 2) ^ ServerChecksumRotr(A, 13) ^ ServerChecksumRotr(A, 22);
+				const uint32 Maj = (A & BB) ^ (A & C) ^ (BB & C);
+				const uint32 T2 = Sig0 + Maj;
+				Hh = G; G = F; F = E; E = D + T1; D = C; C = BB; BB = A; A = T1 + T2;
+			}
+
+			H[0] += A; H[1] += BB; H[2] += C; H[3] += D; H[4] += E; H[5] += F; H[6] += G; H[7] += Hh;
+		};
+
+		// Full 64-byte blocks straight from the input.
+		while (Length - Offset >= 64)
+		{
+			ProcessBlock(Data + Offset);
+			Offset += 64;
+		}
+
+		// Final block(s): copy the remainder, append 0x80, zero-pad, append the 64-bit big-endian bit length.
+		const int32 Remaining = static_cast<int32>(Length - Offset);
+		FMemory::Memzero(Block, sizeof(Block));
+		if (Remaining > 0)
+			FMemory::Memcpy(Block, Data + Offset, Remaining);
+		Block[Remaining] = 0x80;
+
+		if (Remaining >= 56)
+		{
+			// No room for the length in this block — process it, then a fresh zero block with the length.
+			ProcessBlock(Block);
+			FMemory::Memzero(Block, sizeof(Block));
+		}
+		for (int32 i = 0; i < 8; ++i)
+			Block[56 + i] = static_cast<uint8>((BitLength >> (56 - i * 8)) & 0xFF);
+		ProcessBlock(Block);
+
+		for (int32 i = 0; i < 8; ++i)
+		{
+			OutDigest[i * 4] = static_cast<uint8>((H[i] >> 24) & 0xFF);
+			OutDigest[i * 4 + 1] = static_cast<uint8>((H[i] >> 16) & 0xFF);
+			OutDigest[i * 4 + 2] = static_cast<uint8>((H[i] >> 8) & 0xFF);
+			OutDigest[i * 4 + 3] = static_cast<uint8>(H[i] & 0xFF);
+		}
+	}
+
+	// True when @p Value is exactly 64 ASCII hex characters (a SHA256 hex digest). Named uniquely
+	// (unity-build ODR rule — every .cpp in this module is concatenated into one TU).
+	bool ServerChecksumIsHex64(const FString& Value)
+	{
+		if (Value.Len() != 64)
+			return false;
+		for (const TCHAR C : Value)
+		{
+			const bool bIsHex = (C >= TEXT('0') && C <= TEXT('9'))
+				|| (C >= TEXT('a') && C <= TEXT('f'))
+				|| (C >= TEXT('A') && C <= TEXT('F'));
+			if (!bIsHex)
+				return false;
+		}
+		return true;
+	}
+}
+
+FString FUnrealMcpServerChecksum::Sha256SumsUrl(const FString& Version)
+{
+	return FString::Printf(
+		TEXT("https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v%s/%s"),
+		*Version, Sha256SumsAssetName);
+}
+
+FString FUnrealMcpServerChecksum::ServerZipAssetName(const FString& Rid)
+{
+	return FString::Printf(TEXT("gamedev-mcp-server-%s.zip"), *Rid);
+}
+
+TMap<FString, FString> FUnrealMcpServerChecksum::ParseSha256Sums(const FString& Sha256SumsText)
+{
+	TMap<FString, FString> Map;
+	if (Sha256SumsText.IsEmpty())
+		return Map;
+
+	// Normalize CRLF → LF, split into lines.
+	FString Normalized = Sha256SumsText;
+	Normalized.ReplaceInline(TEXT("\r\n"), TEXT("\n"));
+	TArray<FString> Lines;
+	Normalized.ParseIntoArray(Lines, TEXT("\n"), /*CullEmpty*/ false);
+
+	for (const FString& RawLine : Lines)
+	{
+		FString Line = RawLine.TrimStartAndEnd();
+		if (Line.Len() == 0)
+			continue;
+
+		// Split into the digest token and the remainder (the filename). The coreutils separator is two
+		// spaces, but we split on the FIRST run of whitespace so a single-space or tab variant still parses
+		// — the digest token is fixed-width 64 hex, the filename is everything after.
+		int32 SepIndex = INDEX_NONE;
+		for (int32 i = 0; i < Line.Len(); ++i)
+		{
+			if (Line[i] == TEXT(' ') || Line[i] == TEXT('\t'))
+			{
+				SepIndex = i;
+				break;
+			}
+		}
+		if (SepIndex <= 0 || SepIndex >= Line.Len() - 1)
+			continue;
+
+		const FString DigestToken = Line.Left(SepIndex);
+		if (!ServerChecksumIsHex64(DigestToken))
+			continue;
+
+		FString FileName = Line.RightChop(SepIndex + 1);
+		// Trim the leading whitespace run before the filename (coreutils text-mode uses two spaces).
+		FileName.TrimStartInline();
+		// coreutils binary-mode marker: `<hex> *<name>`. Strip a single leading '*'.
+		if (FileName.StartsWith(TEXT("*"), ESearchCase::CaseSensitive))
+			FileName.RightChopInline(1);
+		FileName.TrimStartAndEndInline();
+		if (FileName.Len() == 0)
+			continue;
+
+		// Last entry wins on a duplicate filename.
+		Map.Add(FileName, DigestToken.ToLower());
+	}
+
+	return Map;
+}
+
+bool FUnrealMcpServerChecksum::LookupDigest(const TMap<FString, FString>& ParsedSha256Sums, const FString& AssetZipName, FString& OutDigest)
+{
+	if (AssetZipName.IsEmpty())
+		return false;
+	// EXACT-key lookup — never substring/prefix. linux-x64 must NOT cross-match linux-arm64, etc.
+	if (const FString* Found = ParsedSha256Sums.Find(AssetZipName))
+	{
+		OutDigest = *Found;
+		return true;
+	}
+	return false;
+}
+
+bool FUnrealMcpServerChecksum::DigestMatches(const FString& ExpectedHexDigest, const FString& ActualHexDigest)
+{
+	const FString Expected = ExpectedHexDigest.TrimStartAndEnd();
+	const FString Actual = ActualHexDigest.TrimStartAndEnd();
+	// A null/empty/whitespace digest on either side is NEVER a match (fail-closed).
+	if (Expected.IsEmpty() || Actual.IsEmpty())
+		return false;
+	return Expected.Equals(Actual, ESearchCase::IgnoreCase);
+}
+
+FUnrealMcpServerChecksum::EChecksumVerdict FUnrealMcpServerChecksum::VerifyZipChecksum(
+	const FString& Sha256SumsText, const FString& AssetZipName, const FString& ActualZipHexDigest)
+{
+	const TMap<FString, FString> Parsed = ParseSha256Sums(Sha256SumsText);
+	if (Parsed.Num() == 0)
+		return EChecksumVerdict::ManifestUnparsable;
+
+	FString Expected;
+	if (!LookupDigest(Parsed, AssetZipName, Expected))
+		return EChecksumVerdict::MissingEntry;
+
+	return DigestMatches(Expected, ActualZipHexDigest)
+		? EChecksumVerdict::Verified
+		: EChecksumVerdict::DigestMismatch;
+}
+
+FString FUnrealMcpServerChecksum::ChecksumFailureReason(EChecksumVerdict Verdict, const FString& AssetZipName)
+{
+	switch (Verdict)
+	{
+	case EChecksumVerdict::ManifestUnparsable:
+		return FString::Printf(TEXT("the downloaded %s manifest was empty or unparsable"), Sha256SumsAssetName);
+	case EChecksumVerdict::MissingEntry:
+		return FString::Printf(TEXT("the %s manifest has no entry for '%s'"), Sha256SumsAssetName, *AssetZipName);
+	case EChecksumVerdict::DigestMismatch:
+		return FString::Printf(TEXT("the downloaded '%s' SHA256 did not match the %s manifest entry"), *AssetZipName, Sha256SumsAssetName);
+	default:
+		return TEXT("the checksum was verified");
+	}
+}
+
+FString FUnrealMcpServerChecksum::ComputeSha256Hex(const TArray<uint8>& Bytes)
+{
+	uint8 Digest[32];
+	ServerChecksumSha256(Bytes.GetData(), Bytes.Num(), Digest);
+
+	// Emit 64 lowercase hex chars (the SHA256SUMS / coreutils format; compare is case-insensitive anyway).
+	FString Hex;
+	Hex.Reserve(64);
+	for (int32 i = 0; i < 32; ++i)
+		Hex += FString::Printf(TEXT("%02x"), Digest[i]);
+	return Hex;
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerChecksum.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerChecksum.h
@@ -18,7 +18,8 @@
  * Keeping this logic here — rather than inline in `FUnrealMcpServerManager` (whose methods touch HTTP,
  * the filesystem, and process spawn) — makes every decision unit-testable in an Automation spec with no
  * live download and no running server: each function below is a deterministic string/enum/map transform.
- * The HTTP fetch + SHA256 compute (via UE's native `FSHA256Signature`) that surround this verdict live
+ * The HTTP fetch + SHA256 compute (via a self-contained FIPS 180-4 SHA-256 — `ComputeSha256Hex` below;
+ * UE's `FPlatformMisc::GetSHA256Signature` is a desktop stub that asserts) that surround this verdict live
  * in the editor-coupled manager. Mirrors Unity-MCP's `McpServerChecksum` (PR #842) and Godot-MCP's
  * `GodotMcpServerView` checksum seam (PR #193); same parser/verify/test shape, adapted to UE types.
  */

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerChecksum.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerChecksum.h
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * Pure (no engine-process / no live-network) download-integrity logic for the shared
+ * `gamedev-mcp-server` binary: the `SHA256SUMS` manifest URL builder, the coreutils-format parser,
+ * the exact-key RID digest lookup, the case-insensitive digest compare, and the single fail-closed
+ * `VerifyZipChecksum` verdict. `FUnrealMcpServerManager::DownloadBinaryIfNeeded` calls this BETWEEN the
+ * zip download and `FZipArchiveReader` / `FPlatformProcess::CreateProc` — so a downloaded server zip is
+ * NEVER extracted or launched unless its SHA256 matches the release's published `SHA256SUMS` manifest
+ * (issue #155). A compromised release asset or a trusted-CA MITM would otherwise yield arbitrary code
+ * execution on the developer's machine.
+ *
+ * Keeping this logic here — rather than inline in `FUnrealMcpServerManager` (whose methods touch HTTP,
+ * the filesystem, and process spawn) — makes every decision unit-testable in an Automation spec with no
+ * live download and no running server: each function below is a deterministic string/enum/map transform.
+ * The HTTP fetch + SHA256 compute (via UE's native `FSHA256Signature`) that surround this verdict live
+ * in the editor-coupled manager. Mirrors Unity-MCP's `McpServerChecksum` (PR #842) and Godot-MCP's
+ * `GodotMcpServerView` checksum seam (PR #193); same parser/verify/test shape, adapted to UE types.
+ */
+class FUnrealMcpServerChecksum
+{
+public:
+	/**
+	 * The name of the integrity manifest asset attached to every GameDev-MCP-Server release: a standard
+	 * coreutils `sha256sum` output file listing one `<hex>␠␠<filename>` line per per-RID server zip.
+	 * LIVE on the pinned `v8.0.0` release (and every future release).
+	 */
+	static UNREALMCPEDITOR_API const TCHAR* Sha256SumsAssetName;
+
+	/**
+	 * The URL of a release's `SHA256SUMS` manifest — the SIBLING of the per-RID zip
+	 * (FUnrealMcpServerManager::ServerDownloadUrl) under the SAME `v<Version>` release tag:
+	 * `https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v<Version>/SHA256SUMS`. The
+	 * downloaded zip's SHA256 is verified against this manifest BEFORE extraction/execution (fail-closed).
+	 * Pure string build — unit-testable with no editor.
+	 */
+	static UNREALMCPEDITOR_API FString Sha256SumsUrl(const FString& Version);
+
+	/**
+	 * The per-RID server zip asset name, e.g. `gamedev-mcp-server-win-x64.zip`. This is the EXACT key
+	 * looked up in the parsed `SHA256SUMS` map — it must match the trailing segment of the download URL
+	 * so the verified asset name can never drift from the downloaded asset. Pure.
+	 */
+	static UNREALMCPEDITOR_API FString ServerZipAssetName(const FString& Rid);
+
+	/**
+	 * Parse a coreutils `sha256sum` manifest into a `{filename → lowercase-hex-digest}` map. The exact LIVE
+	 * format is one line per file: a 64-character lowercase hex digest, then TWO spaces (the coreutils
+	 * text-mode separator), then the file name — `844d4ad8…53319␠␠gamedev-mcp-server-linux-x64.zip`.
+	 * Tolerances applied (so a hand-edited or CRLF manifest still parses, while a malformed one yields no
+	 * usable entry):
+	 *   - CRLF and bare-LF line endings; blank lines skipped.
+	 *   - Leading/trailing whitespace on each line trimmed.
+	 *   - The coreutils binary-mode `'*'` marker before the filename (`<hex> *<name>`) is stripped.
+	 *   - A line whose first token is NOT a 64-char hex string, or which has no filename, is SKIPPED (it
+	 *     never produces a spurious entry — fail-closed at the lookup layer).
+	 * Digests are normalized to lowercase; filenames kept verbatim (case-sensitive, matching the asset
+	 * names). On a duplicate filename the LAST entry wins. Never asserts — a null/empty/garbage input
+	 * yields an empty map. Pure; unit-testable with no editor.
+	 */
+	static UNREALMCPEDITOR_API TMap<FString, FString> ParseSha256Sums(const FString& Sha256SumsText);
+
+	/**
+	 * Look up the expected SHA256 digest for @p AssetZipName (e.g. `gamedev-mcp-server-win-x64.zip`) in a
+	 * parsed ParseSha256Sums map. The lookup is EXACT-key — `linux-x64` never cross-matches `linux-arm64`,
+	 * `win-x64` never cross-matches `win-x86` (no substring/prefix match). Writes the lowercase hex digest
+	 * to @p OutDigest and returns true when present, or returns false (the MISSING-entry fail-closed case)
+	 * when the manifest has no entry for that asset. Pure.
+	 */
+	static UNREALMCPEDITOR_API bool LookupDigest(const TMap<FString, FString>& ParsedSha256Sums, const FString& AssetZipName, FString& OutDigest);
+
+	/**
+	 * Case-insensitive hex-digest equality (both sides trimmed). A null/empty/whitespace digest on either
+	 * side is NEVER a match (fail-closed: an unknown digest must not pass). Pure.
+	 */
+	static UNREALMCPEDITOR_API bool DigestMatches(const FString& ExpectedHexDigest, const FString& ActualHexDigest);
+
+	/** The verdict of verifying a downloaded zip against a release `SHA256SUMS` manifest. */
+	enum class EChecksumVerdict : uint8
+	{
+		/** The manifest parsed, contained this asset's entry, and the digest matched. SAFE to extract/execute. */
+		Verified,
+		/** The manifest text was missing/empty/unparsable (no usable entries). Fail-closed. */
+		ManifestUnparsable,
+		/** The manifest parsed but had no line for this asset's zip name. Fail-closed. */
+		MissingEntry,
+		/** The manifest's entry for this asset did NOT match the downloaded zip's digest. Fail-closed. */
+		DigestMismatch
+	};
+
+	/**
+	 * The single fail-closed integrity decision the manager calls BEFORE FZipArchiveReader /
+	 * FPlatformProcess::CreateProc: parse the release's `SHA256SUMS`, find the entry for @p AssetZipName,
+	 * and compare it (case-insensitive hex) against the locally-computed SHA256 of the downloaded zip
+	 * (@p ActualZipHexDigest). Returns EChecksumVerdict::Verified ONLY when the manifest parsed, contained
+	 * the asset, and the digest matched; every other outcome is a distinct fail-closed verdict the caller
+	 * MUST treat as "do NOT extract, do NOT launch". Keeping this here (not inline in the manager) makes
+	 * the entire decision unit-testable with no editor and no real download. Pure.
+	 *
+	 * @param Sha256SumsText    The raw downloaded `SHA256SUMS` manifest text.
+	 * @param AssetZipName      This RID's zip name, e.g. `gamedev-mcp-server-win-x64.zip`.
+	 * @param ActualZipHexDigest The SHA256 of the downloaded zip, as lowercase/any-case hex.
+	 */
+	static UNREALMCPEDITOR_API EChecksumVerdict VerifyZipChecksum(const FString& Sha256SumsText, const FString& AssetZipName, const FString& ActualZipHexDigest);
+
+	/**
+	 * A short, actionable human-readable reason for a non-Verified verdict, for the manager's fail-closed
+	 * log line. Pure string transform.
+	 */
+	static UNREALMCPEDITOR_API FString ChecksumFailureReason(EChecksumVerdict Verdict, const FString& AssetZipName);
+
+	/**
+	 * Compute the SHA256 of @p Bytes as a 64-character lowercase hex string. Uses a self-contained FIPS 180-4
+	 * SHA-256 (pure integer math on UE types — NO third-party dep) because UE's
+	 * `FPlatformMisc::GetSHA256Signature` is a generic stub that `checkf(false)`s on desktop (no platform
+	 * override) and UE Core ships no other dependency-free SHA-256. The manager calls this on the downloaded
+	 * zip bytes, then feeds the result to VerifyZipChecksum. Pure (no IO); empty input hashes the empty
+	 * message (still deterministic). Exposed so an Automation spec can assert the exact hex against the FIPS
+	 * reference vectors.
+	 */
+	static UNREALMCPEDITOR_API FString ComputeSha256Hex(const TArray<uint8>& Bytes);
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
@@ -2,6 +2,7 @@
 // See the LICENSE file in the repository root for more information.
 
 #include "Server/UnrealMcpServerManager.h"
+#include "Server/UnrealMcpServerChecksum.h"
 #include "UnrealMcpLog.h"
 
 #include "Async/Async.h"
@@ -292,6 +293,16 @@ bool FUnrealMcpServerManager::DownloadBinaryIfNeeded(FString& OutBinaryPath)
 	if (!bOk || ZipBytes.Num() == 0)
 		return false;
 
+	// FAIL-CLOSED INTEGRITY GATE (verify-before-execute, issue #155). The zip bytes are in hand but UNTRUSTED.
+	// Before staging/opening/launching, download the release's SHA256SUMS manifest (sibling of the zip URL
+	// under the same v<ServerVersion> tag), compute the downloaded zip's SHA256 (UE-native FSHA256Signature),
+	// and compare against the manifest entry for THIS RID. On MISMATCH / MISSING entry / unparsable-or-
+	// unfetchable manifest we return WITHOUT extracting or launching — an unverified binary must NEVER be
+	// executed (a compromised release asset or a trusted-CA MITM would otherwise yield arbitrary code
+	// execution on the developer's machine).
+	if (!VerifyDownloadedZip(ZipBytes, ServerVersion, FUnrealMcpServerChecksum::ServerZipAssetName(Rid)))
+		return false;
+
 	// Stage the downloaded bytes to a temp file and open it with FZipArchiveReader (libzip-backed: it inflates
 	// deflate entries on read). Mirror download-server.ts: find the binary at the shallowest path, then move it
 	// + its sidecar files (appsettings.json, NLog.config, server.json, …) into the install dir.
@@ -410,6 +421,105 @@ bool FUnrealMcpServerManager::DownloadBinaryIfNeeded(FString& OutBinaryPath)
 
 	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] local server ready: %s (version %s)"), *BinPath, ServerVersion);
 	OutBinaryPath = BinPath;
+	return true;
+}
+
+namespace
+{
+	// Bounded transient-retry config for the SHA256SUMS manifest fetch (mirrors Unity's
+	// Sha256SumsFetchAttempts/Sha256SumsRetryDelay). A transient network error on the manifest fetch is
+	// retried (the binary is already downloaded; only the integrity manifest is missing) — but a persistent
+	// failure NEVER falls through to executing an unverified binary.
+	constexpr int32 Sha256SumsFetchAttempts = 3;
+	constexpr float Sha256SumsRetryDelaySeconds = 1.0f;
+}
+
+bool FUnrealMcpServerManager::FetchSha256SumsText(const FString& SumsUrl, FString& OutText)
+{
+	for (int32 Attempt = 1; Attempt <= Sha256SumsFetchAttempts; ++Attempt)
+	{
+		FHttpModule& Http = FHttpModule::Get();
+		TSharedRef<IHttpRequest, ESPMode::ThreadSafe> Request = Http.CreateRequest();
+		Request->SetURL(SumsUrl);
+		Request->SetVerb(TEXT("GET"));
+
+		bool bDone = false;
+		bool bOk = false;
+		FString Body;
+		Request->OnProcessRequestComplete().BindLambda(
+			[&bDone, &bOk, &Body](FHttpRequestPtr Req, FHttpResponsePtr Resp, bool bConnectedOk)
+			{
+				bDone = true;
+				if (bConnectedOk && Resp.IsValid() && Resp->GetResponseCode() == 200)
+				{
+					Body = Resp->GetContentAsString();
+					bOk = true;
+				}
+			});
+
+		if (Request->ProcessRequest())
+		{
+			// Tick the HTTP module on this (game) thread until the manifest GET completes or a deadline
+			// elapses — same bounded synchronous wait the zip download uses.
+			const double Deadline = FPlatformTime::Seconds() + 30.0;
+			while (!bDone && FPlatformTime::Seconds() < Deadline)
+			{
+				Http.GetHttpManager().Tick(0.1f);
+				FPlatformProcess::Sleep(0.05f);
+			}
+			if (!bDone)
+				Request->CancelRequest();
+		}
+
+		if (bOk)
+		{
+			OutText = Body;
+			return true;
+		}
+
+		if (Attempt < Sha256SumsFetchAttempts)
+		{
+			UE_LOG(LogUnrealMcp, Warning,
+				TEXT("[Unreal-MCP] %s fetch attempt %d/%d failed; retrying…"),
+				FUnrealMcpServerChecksum::Sha256SumsAssetName, Attempt, Sha256SumsFetchAttempts);
+			FPlatformProcess::Sleep(Sha256SumsRetryDelaySeconds);
+		}
+	}
+	return false;
+}
+
+bool FUnrealMcpServerManager::VerifyDownloadedZip(const TArray<uint8>& ZipBytes, const FString& Version, const FString& AssetZipName) const
+{
+	const FString SumsUrl = FUnrealMcpServerChecksum::Sha256SumsUrl(Version);
+
+	// 1) Fetch the integrity manifest (bounded transient-retry). A failure after all attempts is fail-closed.
+	FString Sha256SumsText;
+	if (!FetchSha256SumsText(SumsUrl, Sha256SumsText))
+	{
+		UE_LOG(LogUnrealMcp, Error,
+			TEXT("[Unreal-MCP] refusing to launch the server: could not download the %s integrity manifest from %s ")
+			TEXT("after %d attempt(s). The downloaded binary was NOT verified and will not be executed (fail-closed)."),
+			FUnrealMcpServerChecksum::Sha256SumsAssetName, *SumsUrl, Sha256SumsFetchAttempts);
+		return false;
+	}
+
+	// 2) Compute the downloaded zip's SHA256 (self-contained FIPS 180-4 — no third-party dep; UE's
+	//    FPlatformMisc::GetSHA256Signature is a desktop stub that asserts, so we hash it ourselves).
+	const FString ActualHexDigest = FUnrealMcpServerChecksum::ComputeSha256Hex(ZipBytes);
+
+	// 3) Parse + compare via the pure-managed verifier (unit-tested by an Automation spec, no editor needed).
+	const FUnrealMcpServerChecksum::EChecksumVerdict Verdict =
+		FUnrealMcpServerChecksum::VerifyZipChecksum(Sha256SumsText, AssetZipName, ActualHexDigest);
+	if (Verdict != FUnrealMcpServerChecksum::EChecksumVerdict::Verified)
+	{
+		UE_LOG(LogUnrealMcp, Error,
+			TEXT("[Unreal-MCP] refusing to launch the server: %s. The binary will not be extracted or executed (fail-closed)."),
+			*FUnrealMcpServerChecksum::ChecksumFailureReason(Verdict, AssetZipName));
+		return false;
+	}
+
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] verified '%s' against %s (SHA256 OK)."),
+		*AssetZipName, FUnrealMcpServerChecksum::Sha256SumsAssetName);
 	return true;
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
@@ -295,7 +295,8 @@ bool FUnrealMcpServerManager::DownloadBinaryIfNeeded(FString& OutBinaryPath)
 
 	// FAIL-CLOSED INTEGRITY GATE (verify-before-execute, issue #155). The zip bytes are in hand but UNTRUSTED.
 	// Before staging/opening/launching, download the release's SHA256SUMS manifest (sibling of the zip URL
-	// under the same v<ServerVersion> tag), compute the downloaded zip's SHA256 (UE-native FSHA256Signature),
+	// under the same v<ServerVersion> tag), compute the downloaded zip's SHA256 (self-contained FIPS 180-4 —
+	// UE's FPlatformMisc::GetSHA256Signature is a desktop stub that asserts),
 	// and compare against the manifest entry for THIS RID. On MISMATCH / MISSING entry / unparsable-or-
 	// unfetchable manifest we return WITHOUT extracting or launching — an unverified binary must NEVER be
 	// executed (a compromised release asset or a trusted-CA MITM would otherwise yield arbitrary code

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.h
@@ -137,7 +137,8 @@ private:
 	 * Fail-closed verify-before-execute gate. Called from DownloadBinaryIfNeeded AFTER the zip bytes are in
 	 * hand and BEFORE FZipArchiveReader / CreateProc. Fetches the release's `SHA256SUMS` manifest (a second
 	 * blocking HTTP GET mirroring the zip download, with a bounded transient-retry), computes @p ZipBytes'
-	 * SHA256 via UE's native FSHA256Signature (no third-party dep), and compares against the manifest entry
+	 * SHA256 via a self-contained FIPS 180-4 SHA-256 (UE's FPlatformMisc::GetSHA256Signature is a desktop
+	 * stub that asserts; no third-party dep), and compares against the manifest entry
 	 * for @p AssetZipName via the pure-managed FUnrealMcpServerChecksum::VerifyZipChecksum. Returns true ONLY
 	 * when the digest matched the manifest. Every failure path — a manifest we could not fetch after all
 	 * retries, an unparsable manifest, a missing entry, or a digest mismatch — returns false with a clear

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.h
@@ -133,6 +133,23 @@ private:
 	/** Download + unpack the pinned server zip into the §6 install dir (override/cache miss path). Blocking; game-thread. */
 	bool DownloadBinaryIfNeeded(FString& OutBinaryPath);
 
+	/**
+	 * Fail-closed verify-before-execute gate. Called from DownloadBinaryIfNeeded AFTER the zip bytes are in
+	 * hand and BEFORE FZipArchiveReader / CreateProc. Fetches the release's `SHA256SUMS` manifest (a second
+	 * blocking HTTP GET mirroring the zip download, with a bounded transient-retry), computes @p ZipBytes'
+	 * SHA256 via UE's native FSHA256Signature (no third-party dep), and compares against the manifest entry
+	 * for @p AssetZipName via the pure-managed FUnrealMcpServerChecksum::VerifyZipChecksum. Returns true ONLY
+	 * when the digest matched the manifest. Every failure path — a manifest we could not fetch after all
+	 * retries, an unparsable manifest, a missing entry, or a digest mismatch — returns false with a clear
+	 * UE_LOG so the caller skips extraction/launch. Game-thread; blocking. */
+	bool VerifyDownloadedZip(const TArray<uint8>& ZipBytes, const FString& Version, const FString& AssetZipName) const;
+
+	/**
+	 * Download the `SHA256SUMS` manifest text with a bounded transient-retry (mirrors the zip download's
+	 * tick-until-done pattern on the game thread). Writes the manifest body to @p OutText and returns true,
+	 * or returns false when every attempt failed (the fail-closed signal). Game-thread; blocking. */
+	static bool FetchSha256SumsText(const FString& SumsUrl, FString& OutText);
+
 	/** Spawn the resolved binary with the current launch args; records ProcHandle + ProcId under ProcessMutex. */
 	bool SpawnProcess(const FString& BinaryPath);
 

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpServerChecksumSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpServerChecksumSpec.cpp
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Server/UnrealMcpServerChecksum.h"
+
+/**
+ * Pure download-integrity specs (issue #155): the fail-closed SHA256SUMS verify-before-execute logic the
+ * server manager runs BETWEEN the zip download and FZipArchiveReader/CreateProc. Every decision here is a
+ * deterministic string/enum/map transform with no live download and no running server, so the whole
+ * verdict is unit-asserted: the manifest URL build, the coreutils two-space parser (CRLF / '*' / garbage
+ * tolerances), the EXACT-key RID lookup (no cross-match among the 7 RIDs), the case-insensitive digest
+ * compare, the UE-native SHA256 compute, and the four-way VerifyZipChecksum verdict (Verified / mismatch /
+ * missing-entry / unparsable). Asserts against the VERBATIM live v8.0.0 SHA256SUMS manifest. Mirrors
+ * Unity-MCP's McpServerChecksum spec (PR #842) and Godot-MCP's GodotMcpServerView spec (PR #193).
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpServerChecksumSpec, "UnrealMcp.ServerChecksum",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	// The VERBATIM live v8.0.0 SHA256SUMS manifest (downloaded via
+	// `gh release download v8.0.0 --repo IvanMurzak/GameDev-MCP-Server --pattern SHA256SUMS`). Standard
+	// coreutils format: <64-lowercase-hex>␠␠<filename>. All 7 RID zips. The test fixture and the production
+	// contract are byte-identical so this spec proves ACCEPT-real / REJECT-tampered against ground truth.
+	// Spec-unique helper name (unity-build ODR rule — every .cpp in the test module is one TU).
+	static FString ServerChecksumLiveSha256Sums()
+	{
+		return FString(
+			TEXT("5f17508e92812fbf9522eb552641d21dc2383fc2f6cf371f5413ad06c9820282  gamedev-mcp-server-linux-arm64.zip\n")
+			TEXT("844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319  gamedev-mcp-server-linux-x64.zip\n")
+			TEXT("ad0f50042dfa1edde26a9f26968538146ba792cc0188a47f6bfc1ae573bb513e  gamedev-mcp-server-osx-arm64.zip\n")
+			TEXT("d25993216e610401c8925716d9ad0f8ecaf3dc93443b12cfd057a75495ef9952  gamedev-mcp-server-osx-x64.zip\n")
+			TEXT("702f1d708c25dde6a58d3335c7adb92aa5fe36be618003821ceb040a9b59c51b  gamedev-mcp-server-win-arm64.zip\n")
+			TEXT("7383638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d0656814cb  gamedev-mcp-server-win-x64.zip\n")
+			TEXT("b171e1d8318d0ce4e88d30a5e86ad1cac1acea946ef1a71cd410a27f917c9799  gamedev-mcp-server-win-x86.zip\n"));
+	}
+
+	// The published win-x64 digest from the live manifest (the SHA256 of the real release zip).
+	static FString ServerChecksumWinX64Digest()
+	{
+		return TEXT("7383638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d0656814cb");
+	}
+
+END_DEFINE_SPEC(FUnrealMcpServerChecksumSpec)
+
+void FUnrealMcpServerChecksumSpec::Define()
+{
+	using EVerdict = FUnrealMcpServerChecksum::EChecksumVerdict;
+
+	Describe("Sha256SumsUrl / ServerZipAssetName", [this]()
+	{
+		It("builds the v-prefixed SHA256SUMS sibling URL under the same release tag", [this]()
+		{
+			TestEqual(TEXT("manifest url"),
+				FUnrealMcpServerChecksum::Sha256SumsUrl(TEXT("8.0.0")),
+				FString(TEXT("https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v8.0.0/SHA256SUMS")));
+		});
+
+		It("builds the per-RID zip asset name (the exact lookup key)", [this]()
+		{
+			TestEqual(TEXT("win-x64 asset name"),
+				FUnrealMcpServerChecksum::ServerZipAssetName(TEXT("win-x64")),
+				FString(TEXT("gamedev-mcp-server-win-x64.zip")));
+			TestEqual(TEXT("linux-arm64 asset name"),
+				FUnrealMcpServerChecksum::ServerZipAssetName(TEXT("linux-arm64")),
+				FString(TEXT("gamedev-mcp-server-linux-arm64.zip")));
+		});
+	});
+
+	Describe("ParseSha256Sums", [this]()
+	{
+		It("parses the two-space coreutils format into all 7 RID entries (live manifest)", [this]()
+		{
+			const TMap<FString, FString> Parsed = FUnrealMcpServerChecksum::ParseSha256Sums(ServerChecksumLiveSha256Sums());
+			TestEqual(TEXT("7 entries parsed"), Parsed.Num(), 7);
+
+			const FString* WinX64 = Parsed.Find(TEXT("gamedev-mcp-server-win-x64.zip"));
+			TestTrue(TEXT("win-x64 present"), WinX64 != nullptr);
+			if (WinX64)
+				TestEqual(TEXT("win-x64 digest verbatim"), *WinX64, ServerChecksumWinX64Digest());
+
+			// All seven asset names resolve.
+			TestTrue(TEXT("linux-arm64"), Parsed.Contains(TEXT("gamedev-mcp-server-linux-arm64.zip")));
+			TestTrue(TEXT("linux-x64"), Parsed.Contains(TEXT("gamedev-mcp-server-linux-x64.zip")));
+			TestTrue(TEXT("osx-arm64"), Parsed.Contains(TEXT("gamedev-mcp-server-osx-arm64.zip")));
+			TestTrue(TEXT("osx-x64"), Parsed.Contains(TEXT("gamedev-mcp-server-osx-x64.zip")));
+			TestTrue(TEXT("win-arm64"), Parsed.Contains(TEXT("gamedev-mcp-server-win-arm64.zip")));
+			TestTrue(TEXT("win-x86"), Parsed.Contains(TEXT("gamedev-mcp-server-win-x86.zip")));
+		});
+
+		It("tolerates CRLF endings, the '*' binary marker, and lowercases uppercase digests", [this]()
+		{
+			const FString Manifest = FString(
+				TEXT("7383638DBC1CAD84CF3B85617405C29C7885A51E34B1EF7B8B8864D0656814CB *gamedev-mcp-server-win-x64.zip\r\n")
+				TEXT("844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319  gamedev-mcp-server-linux-x64.zip\r\n"));
+			const TMap<FString, FString> Parsed = FUnrealMcpServerChecksum::ParseSha256Sums(Manifest);
+			TestEqual(TEXT("2 entries"), Parsed.Num(), 2);
+			const FString* WinX64 = Parsed.Find(TEXT("gamedev-mcp-server-win-x64.zip"));
+			TestTrue(TEXT("win-x64 present after marker+CRLF strip"), WinX64 != nullptr);
+			if (WinX64)
+				TestEqual(TEXT("uppercase digest normalized to lowercase"), *WinX64, ServerChecksumWinX64Digest());
+		});
+
+		It("skips blank lines and garbage (non-64-hex / no-filename) without spurious entries", [this]()
+		{
+			const FString Manifest = FString(
+				TEXT("\n")
+				TEXT("not-a-hex-digest  some-file.zip\n")                                   // first token not 64-hex → skipped
+				TEXT("deadbeef  too-short.zip\n")                                           // 8 hex → skipped
+				TEXT("7383638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d0656814cb\n")  // no filename → skipped
+				TEXT("   \n")
+				TEXT("844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319  gamedev-mcp-server-linux-x64.zip\n"));
+			const TMap<FString, FString> Parsed = FUnrealMcpServerChecksum::ParseSha256Sums(Manifest);
+			TestEqual(TEXT("only the one valid line survives"), Parsed.Num(), 1);
+			TestTrue(TEXT("the valid entry is linux-x64"), Parsed.Contains(TEXT("gamedev-mcp-server-linux-x64.zip")));
+		});
+
+		It("yields an empty map for empty input", [this]()
+		{
+			TestEqual(TEXT("empty -> 0"), FUnrealMcpServerChecksum::ParseSha256Sums(FString()).Num(), 0);
+		});
+	});
+
+	Describe("LookupDigest (exact-key, no cross-match among the 7 RIDs)", [this]()
+	{
+		It("returns the correct digest per RID and never cross-matches a sibling RID", [this]()
+		{
+			const TMap<FString, FString> Parsed = FUnrealMcpServerChecksum::ParseSha256Sums(ServerChecksumLiveSha256Sums());
+
+			FString Digest;
+			TestTrue(TEXT("win-x64 found"), FUnrealMcpServerChecksum::LookupDigest(Parsed, TEXT("gamedev-mcp-server-win-x64.zip"), Digest));
+			TestEqual(TEXT("win-x64 digest"), Digest, ServerChecksumWinX64Digest());
+
+			// win-x64 vs win-x86 vs win-arm64 are DISTINCT digests — exact-key lookup must not conflate them.
+			FString WinX86;
+			FUnrealMcpServerChecksum::LookupDigest(Parsed, TEXT("gamedev-mcp-server-win-x86.zip"), WinX86);
+			TestNotEqual(TEXT("win-x86 != win-x64 digest"), WinX86, ServerChecksumWinX64Digest());
+
+			// linux-x64 vs linux-arm64 likewise distinct.
+			FString LinuxX64, LinuxArm64;
+			FUnrealMcpServerChecksum::LookupDigest(Parsed, TEXT("gamedev-mcp-server-linux-x64.zip"), LinuxX64);
+			FUnrealMcpServerChecksum::LookupDigest(Parsed, TEXT("gamedev-mcp-server-linux-arm64.zip"), LinuxArm64);
+			TestNotEqual(TEXT("linux-x64 != linux-arm64 digest"), LinuxX64, LinuxArm64);
+		});
+
+		It("returns false for an asset with no manifest entry (missing-RID fail-closed case)", [this]()
+		{
+			const TMap<FString, FString> Parsed = FUnrealMcpServerChecksum::ParseSha256Sums(ServerChecksumLiveSha256Sums());
+			FString Digest;
+			TestFalse(TEXT("unknown asset -> not found"),
+				FUnrealMcpServerChecksum::LookupDigest(Parsed, TEXT("gamedev-mcp-server-solaris-sparc.zip"), Digest));
+		});
+	});
+
+	Describe("DigestMatches (case-insensitive, fail-closed on empty)", [this]()
+	{
+		It("matches case-insensitively and trims, but never matches an empty digest", [this]()
+		{
+			TestTrue(TEXT("same hex matches"),
+				FUnrealMcpServerChecksum::DigestMatches(ServerChecksumWinX64Digest(), ServerChecksumWinX64Digest()));
+			TestTrue(TEXT("upper vs lower matches"),
+				FUnrealMcpServerChecksum::DigestMatches(ServerChecksumWinX64Digest().ToUpper(), ServerChecksumWinX64Digest()));
+			TestTrue(TEXT("trims surrounding whitespace"),
+				FUnrealMcpServerChecksum::DigestMatches(FString::Printf(TEXT("  %s  "), *ServerChecksumWinX64Digest()), ServerChecksumWinX64Digest()));
+			TestFalse(TEXT("different hex does not match"),
+				FUnrealMcpServerChecksum::DigestMatches(ServerChecksumWinX64Digest(), TEXT("844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319")));
+			TestFalse(TEXT("empty expected -> no match"), FUnrealMcpServerChecksum::DigestMatches(TEXT(""), ServerChecksumWinX64Digest()));
+			TestFalse(TEXT("empty actual -> no match"), FUnrealMcpServerChecksum::DigestMatches(ServerChecksumWinX64Digest(), TEXT("")));
+		});
+	});
+
+	Describe("ComputeSha256Hex (self-contained FIPS 180-4 SHA-256)", [this]()
+	{
+		It("computes the well-known SHA256 of \"abc\" as 64 lowercase hex chars", [this]()
+		{
+			// FIPS 180-2 reference vector: SHA256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad.
+			const TArray<uint8> Abc = { uint8('a'), uint8('b'), uint8('c') };
+			const FString Hex = FUnrealMcpServerChecksum::ComputeSha256Hex(Abc);
+			TestEqual(TEXT("64 hex chars"), Hex.Len(), 64);
+			TestEqual(TEXT("SHA256(\"abc\")"), Hex,
+				FString(TEXT("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")));
+		});
+
+		It("computes the well-known SHA256 of the empty input", [this]()
+		{
+			// SHA256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.
+			const FString Hex = FUnrealMcpServerChecksum::ComputeSha256Hex(TArray<uint8>());
+			TestEqual(TEXT("SHA256(\"\")"), Hex,
+				FString(TEXT("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")));
+		});
+	});
+
+	Describe("VerifyZipChecksum (the fail-closed gate, against the live manifest)", [this]()
+	{
+		It("VERIFIED when the manifest has the RID and the digest matches (valid passes)", [this]()
+		{
+			const EVerdict V = FUnrealMcpServerChecksum::VerifyZipChecksum(
+				ServerChecksumLiveSha256Sums(), TEXT("gamedev-mcp-server-win-x64.zip"), ServerChecksumWinX64Digest());
+			TestTrue(TEXT("verified"), V == EVerdict::Verified);
+		});
+
+		It("DIGEST MISMATCH when the computed digest differs (tampered rejected)", [this]()
+		{
+			// A tampered zip would hash to something other than the published digest — use the linux-x64
+			// digest as a stand-in "wrong hash" for the win-x64 entry.
+			const EVerdict V = FUnrealMcpServerChecksum::VerifyZipChecksum(
+				ServerChecksumLiveSha256Sums(), TEXT("gamedev-mcp-server-win-x64.zip"),
+				TEXT("844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319"));
+			TestTrue(TEXT("mismatch"), V == EVerdict::DigestMismatch);
+		});
+
+		It("MISSING ENTRY when the manifest has no line for this RID (missing-entry rejected)", [this]()
+		{
+			const EVerdict V = FUnrealMcpServerChecksum::VerifyZipChecksum(
+				ServerChecksumLiveSha256Sums(), TEXT("gamedev-mcp-server-solaris-sparc.zip"), ServerChecksumWinX64Digest());
+			TestTrue(TEXT("missing entry"), V == EVerdict::MissingEntry);
+		});
+
+		It("MANIFEST UNPARSABLE for empty or all-garbage manifest text (malformed rejected)", [this]()
+		{
+			TestTrue(TEXT("empty -> unparsable"),
+				FUnrealMcpServerChecksum::VerifyZipChecksum(FString(), TEXT("gamedev-mcp-server-win-x64.zip"), ServerChecksumWinX64Digest())
+					== EVerdict::ManifestUnparsable);
+			TestTrue(TEXT("garbage -> unparsable"),
+				FUnrealMcpServerChecksum::VerifyZipChecksum(TEXT("not a manifest at all\njust noise"),
+					TEXT("gamedev-mcp-server-win-x64.zip"), ServerChecksumWinX64Digest()) == EVerdict::ManifestUnparsable);
+		});
+
+		It("rejects a CORRECT digest looked up under the WRONG RID (no cross-RID acceptance)", [this]()
+		{
+			// The win-x64 digest is genuine, but asked about under the win-x86 asset name it must NOT verify
+			// (win-x86 has its own distinct digest in the manifest).
+			const EVerdict V = FUnrealMcpServerChecksum::VerifyZipChecksum(
+				ServerChecksumLiveSha256Sums(), TEXT("gamedev-mcp-server-win-x86.zip"), ServerChecksumWinX64Digest());
+			TestTrue(TEXT("win-x64 digest under win-x86 key -> mismatch, not verified"), V == EVerdict::DigestMismatch);
+		});
+	});
+
+	Describe("ChecksumFailureReason", [this]()
+	{
+		It("renders a distinct actionable reason per fail-closed verdict", [this]()
+		{
+			TestTrue(TEXT("unparsable mentions manifest"),
+				FUnrealMcpServerChecksum::ChecksumFailureReason(EVerdict::ManifestUnparsable, TEXT("x.zip")).Contains(TEXT("unparsable")));
+			TestTrue(TEXT("missing mentions the asset"),
+				FUnrealMcpServerChecksum::ChecksumFailureReason(EVerdict::MissingEntry, TEXT("gamedev-mcp-server-win-x64.zip")).Contains(TEXT("gamedev-mcp-server-win-x64.zip")));
+			TestTrue(TEXT("mismatch mentions SHA256"),
+				FUnrealMcpServerChecksum::ChecksumFailureReason(EVerdict::DigestMismatch, TEXT("x.zip")).Contains(TEXT("SHA256")));
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -28,6 +28,17 @@ export {
   SERVER_BINARY_BASENAME,
   SERVER_PATH_ENV_VAR,
 } from './lib/download-server.js';
+export {
+  serverChecksumsUrl,
+  serverZipAssetName,
+  parseSha256Sums,
+  lookupDigest,
+  verifyDigest,
+  verifyZip,
+  checksumFailureReason,
+  SHA256SUMS_ASSET_NAME,
+} from './lib/server-checksum.js';
+export type { ChecksumVerdict } from './lib/server-checksum.js';
 export { SERVER_VERSION } from './lib/server-version.js';
 export { login } from './lib/login.js';
 export { getStatus } from './lib/status.js';

--- a/cli/src/lib/download-server.ts
+++ b/cli/src/lib/download-server.ts
@@ -25,11 +25,49 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { createHash } from 'node:crypto';
 import { unzipSync } from 'fflate';
 import { ridForPlatform } from './bootstrap-local.js';
 import { SERVER_VERSION } from './server-version.js';
 import { emitProgress } from './progress.js';
+import {
+  serverChecksumsUrl,
+  serverZipAssetName,
+  verifyZip,
+  checksumFailureReason,
+  SHA256SUMS_ASSET_NAME,
+} from './server-checksum.js';
 import type { DownloadServerOptions, DownloadServerResult } from './types.js';
+
+/** Attempts (1 initial + retries) for the SHA256SUMS manifest fetch before fail-closed. */
+const SHA256SUMS_FETCH_ATTEMPTS = 3;
+
+/**
+ * Fetch the `SHA256SUMS` manifest text with a bounded transient-retry, reusing
+ * the injectable `fetchImpl` so a test can inject the manifest. Returns the
+ * manifest body, or `null` when every attempt failed (the fail-closed signal —
+ * an unverified binary must NEVER be executed). Never throws.
+ */
+async function fetchSha256SumsText(
+  url: string,
+  fetchImpl: typeof fetch,
+  warnings: string[],
+): Promise<string | null> {
+  for (let attempt = 1; attempt <= SHA256SUMS_FETCH_ATTEMPTS; attempt++) {
+    try {
+      const response = await fetchImpl(url);
+      if (response.ok) return await response.text();
+      // An HTTP error is treated as transient and retried (a release just being
+      // published can briefly 404 the manifest); a persistent failure fails closed.
+      warnings.push(`${SHA256SUMS_ASSET_NAME} fetch attempt ${attempt}/${SHA256SUMS_FETCH_ATTEMPTS} failed: HTTP ${response.status}.`);
+    } catch (err: unknown) {
+      warnings.push(
+        `${SHA256SUMS_ASSET_NAME} fetch attempt ${attempt}/${SHA256SUMS_FETCH_ATTEMPTS} failed: ${err instanceof Error ? err.message : String(err)}.`,
+      );
+    }
+  }
+  return null;
+}
 
 /** Base name of the shared server binary (extension added per-OS). */
 export const SERVER_BINARY_BASENAME = 'gamedev-mcp-server';
@@ -175,6 +213,38 @@ export async function downloadServer(opts: DownloadServerOptions): Promise<Downl
       );
     }
     const zipBytes = new Uint8Array(await response.arrayBuffer());
+
+    // FAIL-CLOSED INTEGRITY GATE (verify-before-execute, issue #155). The zip bytes
+    // are in hand but UNTRUSTED. Before unzipSync/extract/execute, fetch the
+    // release's SHA256SUMS manifest (sibling of the zip URL under the same
+    // v<version> tag), compute the downloaded zip's SHA256 (node:crypto), and
+    // compare against the manifest entry for THIS RID. On MISMATCH / MISSING entry /
+    // unparsable-or-unfetchable manifest we return the failure path WITHOUT
+    // extracting — an unverified binary must NEVER be executed (a compromised
+    // release asset or a trusted-CA MITM would otherwise yield arbitrary code
+    // execution on the developer's machine).
+    const sumsUrl = serverChecksumsUrl(version);
+    const sha256SumsText = await fetchSha256SumsText(sumsUrl, fetchImpl, warnings);
+    if (sha256SumsText === null) {
+      throw new Error(
+        `Refusing to launch MCP server: could not download the ${SHA256SUMS_ASSET_NAME} integrity manifest ` +
+          `from ${sumsUrl} after ${SHA256SUMS_FETCH_ATTEMPTS} attempt(s). The downloaded binary was NOT ` +
+          `verified and will not be extracted (fail-closed).`,
+      );
+    }
+    const actualHexDigest = createHash('sha256').update(zipBytes).digest('hex');
+    const assetZipName = serverZipAssetName(rid);
+    const verdict = verifyZip(sha256SumsText, assetZipName, actualHexDigest);
+    if (verdict !== 'verified') {
+      throw new Error(
+        `Refusing to launch MCP server: ${checksumFailureReason(verdict, assetZipName)}. ` +
+          `The binary will not be extracted or executed (fail-closed).`,
+      );
+    }
+    emitProgress(opts.onProgress, {
+      phase: 'info',
+      message: `Verified ${assetZipName} against ${SHA256SUMS_ASSET_NAME} (SHA256 OK).`,
+    });
 
     // Staging-dir extraction: unzip everything to a throwaway dir, find the
     // binary wherever the layout put it, then move its folder's files.

--- a/cli/src/lib/server-checksum.ts
+++ b/cli/src/lib/server-checksum.ts
@@ -1,0 +1,174 @@
+// `server-checksum` — pure (no I/O, no network) download-integrity logic for
+// the shared `gamedev-mcp-server` binary: the `SHA256SUMS` manifest URL
+// builder, the coreutils-format parser, the exact-key RID digest lookup, the
+// case-insensitive digest compare, and the single fail-closed `verifyZip`
+// verdict. `download-server.ts`'s `downloadServer` calls `verifyZip` BETWEEN
+// the zip download (`arrayBuffer()`) and `unzipSync` — so a downloaded server
+// zip is NEVER extracted or executed unless its SHA256 matches the release's
+// published `SHA256SUMS` manifest (issue #155). A compromised release asset or
+// a trusted-CA MITM would otherwise yield arbitrary code execution.
+//
+// Keeping this here — rather than inline in `download-server.ts` — makes every
+// decision unit-testable with no real download: each function below is a
+// deterministic string/enum/map transform. The `node:crypto` SHA256 compute and
+// the HTTP fetch that surround this verdict live in `download-server.ts`.
+// Mirrors Unity-MCP's `McpServerChecksum` (PR #842) and Godot-MCP's checksum
+// seam (PR #193); same parser/verify/test shape, TS idioms.
+
+import { SERVER_VERSION } from './server-version.js';
+import { SERVER_BINARY_BASENAME } from './download-server.js';
+
+/** GitHub repo the server binaries (and the SHA256SUMS manifest) are released from. */
+const SERVER_RELEASE_REPO = 'IvanMurzak/GameDev-MCP-Server';
+
+/**
+ * The name of the integrity manifest asset attached to every GameDev-MCP-Server
+ * release: a standard coreutils `sha256sum` output file listing one
+ * `<hex>␠␠<filename>` line per per-RID server zip. LIVE on the pinned `v8.0.0`
+ * release (and every future release).
+ */
+export const SHA256SUMS_ASSET_NAME = 'SHA256SUMS';
+
+/**
+ * The URL of a release's `SHA256SUMS` manifest — the SIBLING of the per-RID zip
+ * (`serverDownloadUrl`) under the SAME `v<version>` release tag:
+ * `https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v<version>/SHA256SUMS`.
+ * The downloaded zip's SHA256 is verified against this manifest BEFORE
+ * extraction/execution (fail-closed). Pure.
+ */
+export function serverChecksumsUrl(version: string = SERVER_VERSION): string {
+  return `https://github.com/${SERVER_RELEASE_REPO}/releases/download/v${version}/${SHA256SUMS_ASSET_NAME}`;
+}
+
+/**
+ * The per-RID server zip asset name, e.g. `gamedev-mcp-server-win-x64.zip`. This
+ * is the EXACT key looked up in the parsed `SHA256SUMS` map — it matches the
+ * trailing segment of `serverDownloadUrl` so the verified asset name can never
+ * drift from the downloaded asset. Pure.
+ */
+export function serverZipAssetName(rid: string): string {
+  return `${SERVER_BINARY_BASENAME}-${rid}.zip`;
+}
+
+/** True when `value` is exactly 64 ASCII hex characters (a SHA256 hex digest). */
+function isHex64(value: string): boolean {
+  return /^[0-9a-fA-F]{64}$/.test(value);
+}
+
+/**
+ * Parse a coreutils `sha256sum` manifest into a `{ filename → lowercase-hex }`
+ * map. The exact LIVE format is one line per file: a 64-character lowercase hex
+ * digest, then TWO spaces (the coreutils text-mode separator), then the file
+ * name — `844d4ad8…53319␠␠gamedev-mcp-server-linux-x64.zip`. Tolerances applied
+ * (so a hand-edited or CRLF manifest still parses, while a malformed one yields
+ * no usable entry):
+ *   - CRLF and bare-LF line endings; blank lines skipped.
+ *   - Leading/trailing whitespace on each line trimmed.
+ *   - The coreutils binary-mode `'*'` marker before the filename
+ *     (`<hex> *<name>`) is stripped.
+ *   - A line whose first token is NOT a 64-char hex string, or which has no
+ *     filename, is SKIPPED (it never produces a spurious entry — fail-closed at
+ *     the lookup layer).
+ * Digests are normalized to lowercase; filenames kept verbatim (case-sensitive,
+ * matching the asset names). On a duplicate filename the LAST entry wins. Never
+ * throws — a null/empty/garbage input yields an empty map. Pure.
+ */
+export function parseSha256Sums(sha256SumsText: string | null | undefined): Map<string, string> {
+  const map = new Map<string, string>();
+  if (!sha256SumsText) return map;
+
+  for (const rawLine of sha256SumsText.replace(/\r\n/g, '\n').split('\n')) {
+    const line = rawLine.trim();
+    if (line.length === 0) continue;
+
+    // Split on the FIRST run of whitespace: the digest token is fixed-width
+    // 64-hex, the filename is everything after (so a single-space/tab variant
+    // still parses, not only the canonical two-space separator).
+    const sepMatch = /\s/.exec(line);
+    if (!sepMatch || sepMatch.index <= 0) continue;
+    const sepIndex = sepMatch.index;
+
+    const digestToken = line.slice(0, sepIndex);
+    if (!isHex64(digestToken)) continue;
+
+    let fileName = line.slice(sepIndex).trimStart();
+    // coreutils binary-mode marker: `<hex> *<name>`. Strip a single leading '*'.
+    if (fileName.startsWith('*')) fileName = fileName.slice(1);
+    fileName = fileName.trim();
+    if (fileName.length === 0) continue;
+
+    map.set(fileName, digestToken.toLowerCase());
+  }
+
+  return map;
+}
+
+/**
+ * Look up the expected SHA256 digest for `assetZipName` (e.g.
+ * `gamedev-mcp-server-win-x64.zip`) in a parsed `parseSha256Sums` map. The
+ * lookup is EXACT-key — `linux-x64` never cross-matches `linux-arm64`,
+ * `win-x64` never cross-matches `win-x86` (no substring/prefix match). Returns
+ * the lowercase hex digest, or `null` when the manifest has no entry for that
+ * asset (the MISSING-entry fail-closed case). Pure.
+ */
+export function lookupDigest(parsed: Map<string, string>, assetZipName: string): string | null {
+  if (!parsed || !assetZipName) return null;
+  return parsed.get(assetZipName) ?? null;
+}
+
+/**
+ * Case-insensitive hex-digest equality (both sides trimmed). A null/empty/
+ * whitespace digest on either side is NEVER a match (fail-closed: an unknown
+ * digest must not pass). Pure.
+ */
+export function verifyDigest(expectedHexDigest: string | null | undefined, actualHexDigest: string | null | undefined): boolean {
+  const expected = (expectedHexDigest ?? '').trim();
+  const actual = (actualHexDigest ?? '').trim();
+  if (expected.length === 0 || actual.length === 0) return false;
+  return expected.toLowerCase() === actual.toLowerCase();
+}
+
+/** The verdict of verifying a downloaded zip against a release `SHA256SUMS` manifest. */
+export type ChecksumVerdict =
+  /** The manifest parsed, contained this asset's entry, and the digest matched. SAFE to extract/execute. */
+  | 'verified'
+  /** The manifest text was missing/empty/unparsable (no usable entries). Fail-closed. */
+  | 'manifest-unparsable'
+  /** The manifest parsed but had no line for this asset's zip name. Fail-closed. */
+  | 'missing-entry'
+  /** The manifest's entry for this asset did NOT match the downloaded zip's digest. Fail-closed. */
+  | 'digest-mismatch';
+
+/**
+ * The single fail-closed integrity decision `downloadServer` calls BEFORE
+ * `unzipSync`: parse the release's `SHA256SUMS`, find the entry for
+ * `assetZipName`, and compare it (case-insensitive hex) against the
+ * locally-computed SHA256 of the downloaded zip (`actualZipHexDigest`). Returns
+ * `'verified'` ONLY when the manifest parsed, contained the asset, and the
+ * digest matched; every other outcome is a distinct fail-closed verdict the
+ * caller MUST treat as "do NOT extract, do NOT launch". Pure — unit-tested with
+ * no real download. Never throws.
+ */
+export function verifyZip(sha256SumsText: string | null | undefined, assetZipName: string, actualZipHexDigest: string | null | undefined): ChecksumVerdict {
+  const parsed = parseSha256Sums(sha256SumsText);
+  if (parsed.size === 0) return 'manifest-unparsable';
+
+  const expected = lookupDigest(parsed, assetZipName);
+  if (expected === null) return 'missing-entry';
+
+  return verifyDigest(expected, actualZipHexDigest) ? 'verified' : 'digest-mismatch';
+}
+
+/** A short, actionable human-readable reason for a non-`'verified'` verdict. Pure. */
+export function checksumFailureReason(verdict: ChecksumVerdict, assetZipName: string): string {
+  switch (verdict) {
+    case 'manifest-unparsable':
+      return `the downloaded ${SHA256SUMS_ASSET_NAME} manifest was empty or unparsable`;
+    case 'missing-entry':
+      return `the ${SHA256SUMS_ASSET_NAME} manifest has no entry for '${assetZipName}'`;
+    case 'digest-mismatch':
+      return `the downloaded '${assetZipName}' SHA256 did not match the ${SHA256SUMS_ASSET_NAME} manifest entry`;
+    default:
+      return 'the checksum was verified';
+  }
+}

--- a/cli/tests/download-server.test.ts
+++ b/cli/tests/download-server.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import { createHash } from 'node:crypto';
 import { zipSync, strToU8 } from 'fflate';
 import {
   downloadServer,
@@ -13,6 +14,7 @@ import {
   serverInstallDir,
   SERVER_PATH_ENV_VAR,
 } from '../src/lib/download-server.js';
+import { serverZipAssetName } from '../src/lib/server-checksum.js';
 import { SERVER_VERSION } from '../src/lib/server-version.js';
 import { makeTempDir, rmTempDir } from './helpers.js';
 
@@ -48,10 +50,56 @@ function folderedUnixZip(rid: string): Uint8Array {
   return zipSync(entries);
 }
 
-/** A `fetch` stub returning the given zip bytes (200 OK). */
-function fetchZip(bytes: Uint8Array, calls?: string[]): typeof fetch {
+/** SHA256 hex of bytes, matching the createHash('sha256') the downloader uses. */
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+/**
+ * Build a valid `SHA256SUMS` manifest for the given zip + RID — the digest the
+ * fail-closed verify-gate must accept. `digestOverride` injects a WRONG digest
+ * to exercise the tampered-rejection path; `omitEntry` produces a manifest with
+ * no line for this RID (missing-entry path).
+ */
+function makeSha256Sums(
+  bytes: Uint8Array,
+  rid: string,
+  opts: { digestOverride?: string; omitEntry?: boolean } = {},
+): string {
+  if (opts.omitEntry) {
+    // A manifest with some-other-RID entry but NOT this one.
+    return `${'0'.repeat(64)}  gamedev-mcp-server-some-other-rid.zip\n`;
+  }
+  const digest = opts.digestOverride ?? sha256Hex(bytes);
+  return `${digest}  ${serverZipAssetName(rid)}\n`;
+}
+
+/**
+ * A `fetch` stub serving BOTH the zip (the download URL) AND the SHA256SUMS
+ * manifest (the integrity URL). The manifest is computed from the zip bytes so
+ * the verify-gate passes by default. `sumsOpts` lets a test serve a tampered /
+ * missing / unfetchable manifest; `rid` is the asset the manifest keys on.
+ */
+function fetchZip(
+  bytes: Uint8Array,
+  calls?: string[],
+  rid = 'win-x64',
+  sumsOpts: { digestOverride?: string; omitEntry?: boolean; sumsHttpError?: number } = {},
+): typeof fetch {
   return (async (url: unknown) => {
-    calls?.push(String(url));
+    const u = String(url);
+    calls?.push(u);
+    if (u.endsWith('SHA256SUMS')) {
+      if (sumsOpts.sumsHttpError) {
+        return { ok: false, status: sumsOpts.sumsHttpError, statusText: 'err', text: async () => '' } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => makeSha256Sums(bytes, rid, sumsOpts),
+      } as unknown as Response;
+    }
     return {
       ok: true,
       status: 200,
@@ -61,10 +109,10 @@ function fetchZip(bytes: Uint8Array, calls?: string[]): typeof fetch {
   }) as typeof fetch;
 }
 
-/** A `fetch` stub returning an HTTP error. */
+/** A `fetch` stub returning an HTTP error (for the ZIP download — fails before verify). */
 function fetch404(): typeof fetch {
   return (async () =>
-    ({ ok: false, status: 404, statusText: 'Not Found', arrayBuffer: async () => new ArrayBuffer(0) }) as unknown as Response) as typeof fetch;
+    ({ ok: false, status: 404, statusText: 'Not Found', arrayBuffer: async () => new ArrayBuffer(0), text: async () => '' }) as unknown as Response) as typeof fetch;
 }
 
 // --- pure helpers ------------------------------------------------------------
@@ -146,7 +194,7 @@ describe('downloadServer', () => {
       os: 'linux',
       arch: 'x64',
       env: {},
-      fetchImpl: fetchZip(folderedUnixZip('linux-x64')),
+      fetchImpl: fetchZip(folderedUnixZip('linux-x64'), undefined, 'linux-x64'),
     });
     expect(r.kind).toBe('success');
     if (r.kind !== 'success') return;
@@ -173,7 +221,8 @@ describe('downloadServer', () => {
     expect(second.kind).toBe('success');
     if (second.kind !== 'success') return;
     expect(second.source).toBe('cache');
-    expect(calls).toHaveLength(1);
+    // First download = 2 fetches (zip + SHA256SUMS); the cache hit adds none.
+    expect(calls).toHaveLength(2);
   });
 
   it('re-downloads when the version marker is stale', async () => {
@@ -187,7 +236,8 @@ describe('downloadServer', () => {
     expect(r.kind).toBe('success');
     if (r.kind !== 'success') return;
     expect(r.source).toBe('download');
-    expect(calls).toHaveLength(1);
+    // 2 fetches: the release zip + the SHA256SUMS integrity manifest.
+    expect(calls).toHaveLength(2);
     expect(fs.readFileSync(r.serverPath, 'utf-8')).toBe('exe-bytes');
     expect(readVersionMarker(installDir)).toBe(SERVER_VERSION);
   });
@@ -240,5 +290,75 @@ describe('downloadServer', () => {
     expect(r.kind).toBe('failure');
     if (r.kind !== 'failure') return;
     expect(r.error.message).toContain('gamedev-mcp-server.exe');
+  });
+
+  // --- fail-closed integrity gate (issue #155) ------------------------------
+
+  it('FAIL-CLOSED: a tampered zip (digest mismatch) is rejected and NEVER extracted', async () => {
+    const proj = tmp();
+    // The manifest advertises a WRONG digest for win-x64 → mismatch → refuse to extract.
+    const r = await downloadServer({
+      projectDir: proj,
+      os: 'win32',
+      arch: 'x64',
+      env: {},
+      fetchImpl: fetchZip(flatWinZip(), undefined, 'win-x64', { digestOverride: 'f'.repeat(64) }),
+    });
+    expect(r.kind).toBe('failure');
+    if (r.kind !== 'failure') return;
+    expect(r.error.message).toContain('did not match');
+    // Nothing was extracted — the install dir holds no binary.
+    expect(fs.existsSync(resolveServerBinaryPath(proj, 'win32', 'x64'))).toBe(false);
+  });
+
+  it('FAIL-CLOSED: a manifest missing this RID entry is rejected and NEVER extracted', async () => {
+    const proj = tmp();
+    const r = await downloadServer({
+      projectDir: proj,
+      os: 'win32',
+      arch: 'x64',
+      env: {},
+      fetchImpl: fetchZip(flatWinZip(), undefined, 'win-x64', { omitEntry: true }),
+    });
+    expect(r.kind).toBe('failure');
+    if (r.kind !== 'failure') return;
+    expect(r.error.message).toContain('no entry for');
+    expect(fs.existsSync(resolveServerBinaryPath(proj, 'win32', 'x64'))).toBe(false);
+  });
+
+  it('FAIL-CLOSED: an unfetchable SHA256SUMS manifest (persistent HTTP error) is rejected', async () => {
+    const proj = tmp();
+    const r = await downloadServer({
+      projectDir: proj,
+      os: 'win32',
+      arch: 'x64',
+      env: {},
+      fetchImpl: fetchZip(flatWinZip(), undefined, 'win-x64', { sumsHttpError: 500 }),
+    });
+    expect(r.kind).toBe('failure');
+    if (r.kind !== 'failure') return;
+    expect(r.error.message).toContain('SHA256SUMS');
+    expect(fs.existsSync(resolveServerBinaryPath(proj, 'win32', 'x64'))).toBe(false);
+  });
+
+  it('verifies the REAL win-x64 release digest end-to-end (node:crypto SHA256 of fixed bytes == manifest)', async () => {
+    // Synthesize a zip whose real SHA256 is what the (test-built) manifest advertises, proving the
+    // createHash('sha256') compute path agrees with the manifest comparison through the whole download.
+    const proj = tmp();
+    const zip = flatWinZip();
+    const realDigest = sha256Hex(zip);
+    const calls: string[] = [];
+    const r = await downloadServer({
+      projectDir: proj,
+      os: 'win32',
+      arch: 'x64',
+      env: {},
+      // digestOverride set to the REAL computed digest — equivalent to the genuine manifest.
+      fetchImpl: fetchZip(zip, calls, 'win-x64', { digestOverride: realDigest }),
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.source).toBe('download');
+    expect(fs.existsSync(r.serverPath)).toBe(true);
   });
 });

--- a/cli/tests/server-checksum.test.ts
+++ b/cli/tests/server-checksum.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import {
+  serverChecksumsUrl,
+  serverZipAssetName,
+  parseSha256Sums,
+  lookupDigest,
+  verifyDigest,
+  verifyZip,
+  checksumFailureReason,
+  SHA256SUMS_ASSET_NAME,
+} from '../src/lib/server-checksum.js';
+import { SERVER_VERSION } from '../src/lib/server-version.js';
+
+// The VERBATIM live v8.0.0 SHA256SUMS manifest (downloaded via
+// `gh release download v8.0.0 --repo IvanMurzak/GameDev-MCP-Server --pattern SHA256SUMS`).
+// Standard coreutils format: <64-lowercase-hex>␠␠<filename>. All 7 RID zips. The
+// test fixture and the production contract are byte-identical, so this suite proves
+// ACCEPT-real / REJECT-tampered against ground truth.
+const LIVE_SHA256SUMS =
+  '5f17508e92812fbf9522eb552641d21dc2383fc2f6cf371f5413ad06c9820282  gamedev-mcp-server-linux-arm64.zip\n' +
+  '844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319  gamedev-mcp-server-linux-x64.zip\n' +
+  'ad0f50042dfa1edde26a9f26968538146ba792cc0188a47f6bfc1ae573bb513e  gamedev-mcp-server-osx-arm64.zip\n' +
+  'd25993216e610401c8925716d9ad0f8ecaf3dc93443b12cfd057a75495ef9952  gamedev-mcp-server-osx-x64.zip\n' +
+  '702f1d708c25dde6a58d3335c7adb92aa5fe36be618003821ceb040a9b59c51b  gamedev-mcp-server-win-arm64.zip\n' +
+  '7383638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d0656814cb  gamedev-mcp-server-win-x64.zip\n' +
+  'b171e1d8318d0ce4e88d30a5e86ad1cac1acea946ef1a71cd410a27f917c9799  gamedev-mcp-server-win-x86.zip\n';
+
+const WIN_X64_DIGEST = '7383638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d0656814cb';
+
+describe('serverChecksumsUrl / serverZipAssetName', () => {
+  it('builds the v-prefixed SHA256SUMS sibling URL under the same release tag', () => {
+    expect(serverChecksumsUrl('8.0.0')).toBe(
+      'https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v8.0.0/SHA256SUMS',
+    );
+  });
+
+  it('defaults to the pinned SERVER_VERSION', () => {
+    expect(serverChecksumsUrl()).toContain(`/v${SERVER_VERSION}/SHA256SUMS`);
+  });
+
+  it('builds the per-RID zip asset name (the exact lookup key)', () => {
+    expect(serverZipAssetName('win-x64')).toBe('gamedev-mcp-server-win-x64.zip');
+    expect(serverZipAssetName('linux-arm64')).toBe('gamedev-mcp-server-linux-arm64.zip');
+  });
+});
+
+describe('parseSha256Sums', () => {
+  it('parses the two-space coreutils format into all 7 RID entries (live manifest)', () => {
+    const parsed = parseSha256Sums(LIVE_SHA256SUMS);
+    expect(parsed.size).toBe(7);
+    expect(parsed.get('gamedev-mcp-server-win-x64.zip')).toBe(WIN_X64_DIGEST);
+    expect(parsed.get('gamedev-mcp-server-linux-x64.zip')).toBe(
+      '844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319',
+    );
+    for (const rid of ['linux-arm64', 'linux-x64', 'osx-arm64', 'osx-x64', 'win-arm64', 'win-x64', 'win-x86']) {
+      expect(parsed.has(`gamedev-mcp-server-${rid}.zip`)).toBe(true);
+    }
+  });
+
+  it('tolerates CRLF endings, the * binary marker, and lowercases uppercase digests', () => {
+    const manifest =
+      '7383638DBC1CAD84CF3B85617405C29C7885A51E34B1EF7B8B8864D0656814CB *gamedev-mcp-server-win-x64.zip\r\n' +
+      '844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319  gamedev-mcp-server-linux-x64.zip\r\n';
+    const parsed = parseSha256Sums(manifest);
+    expect(parsed.size).toBe(2);
+    expect(parsed.get('gamedev-mcp-server-win-x64.zip')).toBe(WIN_X64_DIGEST);
+  });
+
+  it('skips blank lines and garbage (non-64-hex / no-filename) without spurious entries', () => {
+    const manifest =
+      '\n' +
+      'not-a-hex-digest  some-file.zip\n' +
+      'deadbeef  too-short.zip\n' +
+      '7383638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d0656814cb\n' +
+      '   \n' +
+      '844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319  gamedev-mcp-server-linux-x64.zip\n';
+    const parsed = parseSha256Sums(manifest);
+    expect(parsed.size).toBe(1);
+    expect(parsed.has('gamedev-mcp-server-linux-x64.zip')).toBe(true);
+  });
+
+  it('yields an empty map for empty / null / undefined input', () => {
+    expect(parseSha256Sums('').size).toBe(0);
+    expect(parseSha256Sums(null).size).toBe(0);
+    expect(parseSha256Sums(undefined).size).toBe(0);
+  });
+});
+
+describe('lookupDigest (exact-key, no cross-match among the 7 RIDs)', () => {
+  const parsed = parseSha256Sums(LIVE_SHA256SUMS);
+
+  it('returns the correct digest per RID', () => {
+    expect(lookupDigest(parsed, 'gamedev-mcp-server-win-x64.zip')).toBe(WIN_X64_DIGEST);
+  });
+
+  it('never cross-matches a sibling RID (win-x64 vs win-x86 vs win-arm64 are distinct)', () => {
+    const x64 = lookupDigest(parsed, 'gamedev-mcp-server-win-x64.zip');
+    const x86 = lookupDigest(parsed, 'gamedev-mcp-server-win-x86.zip');
+    const arm = lookupDigest(parsed, 'gamedev-mcp-server-win-arm64.zip');
+    expect(x64).not.toBe(x86);
+    expect(x64).not.toBe(arm);
+    expect(x86).not.toBe(arm);
+  });
+
+  it('returns null for an asset with no manifest entry (missing-RID fail-closed)', () => {
+    expect(lookupDigest(parsed, 'gamedev-mcp-server-solaris-sparc.zip')).toBeNull();
+  });
+});
+
+describe('verifyDigest (case-insensitive, fail-closed on empty)', () => {
+  it('matches case-insensitively and trims, but never matches an empty digest', () => {
+    expect(verifyDigest(WIN_X64_DIGEST, WIN_X64_DIGEST)).toBe(true);
+    expect(verifyDigest(WIN_X64_DIGEST.toUpperCase(), WIN_X64_DIGEST)).toBe(true);
+    expect(verifyDigest(`  ${WIN_X64_DIGEST}  `, WIN_X64_DIGEST)).toBe(true);
+    expect(verifyDigest(WIN_X64_DIGEST, '844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319')).toBe(false);
+    expect(verifyDigest('', WIN_X64_DIGEST)).toBe(false);
+    expect(verifyDigest(WIN_X64_DIGEST, '')).toBe(false);
+    expect(verifyDigest(null, WIN_X64_DIGEST)).toBe(false);
+    expect(verifyDigest(WIN_X64_DIGEST, undefined)).toBe(false);
+  });
+});
+
+describe('verifyZip (the fail-closed gate, against the live manifest)', () => {
+  it('verified when the manifest has the RID and the digest matches (valid passes)', () => {
+    expect(verifyZip(LIVE_SHA256SUMS, 'gamedev-mcp-server-win-x64.zip', WIN_X64_DIGEST)).toBe('verified');
+  });
+
+  it('digest-mismatch when the computed digest differs (tampered rejected)', () => {
+    expect(
+      verifyZip(LIVE_SHA256SUMS, 'gamedev-mcp-server-win-x64.zip', '844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319'),
+    ).toBe('digest-mismatch');
+  });
+
+  it('missing-entry when the manifest has no line for this RID (missing-entry rejected)', () => {
+    expect(verifyZip(LIVE_SHA256SUMS, 'gamedev-mcp-server-solaris-sparc.zip', WIN_X64_DIGEST)).toBe('missing-entry');
+  });
+
+  it('manifest-unparsable for empty or all-garbage manifest text (malformed rejected)', () => {
+    expect(verifyZip('', 'gamedev-mcp-server-win-x64.zip', WIN_X64_DIGEST)).toBe('manifest-unparsable');
+    expect(verifyZip('just\nnoise\nno digests', 'gamedev-mcp-server-win-x64.zip', WIN_X64_DIGEST)).toBe('manifest-unparsable');
+  });
+
+  it('rejects a CORRECT digest looked up under the WRONG RID (no cross-RID acceptance)', () => {
+    // win-x64 digest is genuine, but under the win-x86 asset name it must NOT verify.
+    expect(verifyZip(LIVE_SHA256SUMS, 'gamedev-mcp-server-win-x86.zip', WIN_X64_DIGEST)).toBe('digest-mismatch');
+  });
+
+  it('verifies a real-bytes round-trip: node:crypto SHA256 of fixed bytes against a crafted manifest', () => {
+    // Prove the createHash('sha256') path the downloader uses agrees with verifyZip end to end.
+    const bytes = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    const digest = createHash('sha256').update(bytes).digest('hex');
+    const manifest = `${digest}  gamedev-mcp-server-win-x64.zip\n`;
+    expect(verifyZip(manifest, 'gamedev-mcp-server-win-x64.zip', digest)).toBe('verified');
+    // A single flipped byte → different digest → rejected.
+    const tampered = createHash('sha256').update(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 9])).digest('hex');
+    expect(verifyZip(manifest, 'gamedev-mcp-server-win-x64.zip', tampered)).toBe('digest-mismatch');
+  });
+});
+
+describe('checksumFailureReason', () => {
+  it('renders a distinct actionable reason per fail-closed verdict', () => {
+    expect(checksumFailureReason('manifest-unparsable', 'x.zip')).toContain('unparsable');
+    expect(checksumFailureReason('missing-entry', 'gamedev-mcp-server-win-x64.zip')).toContain('gamedev-mcp-server-win-x64.zip');
+    expect(checksumFailureReason('digest-mismatch', 'x.zip')).toContain('SHA256');
+    expect(checksumFailureReason('manifest-unparsable', 'x.zip')).toContain(SHA256SUMS_ASSET_NAME);
+  });
+});


### PR DESCRIPTION
## Summary

- **Fail-closed verify-before-execute** for the downloaded `gamedev-mcp-server-<rid>.zip` in BOTH Unreal-MCP downloaders — the C++ editor plugin AND the npm `unreal-mcp-cli`. A compromised release asset or a trusted-CA MITM previously yielded arbitrary code execution; now the zip's SHA256 is checked against the release's published `SHA256SUMS` BEFORE any extract/launch. (Unreal leg of the cross-repo effort — mirrors Godot-MCP #193 and Unity-MCP #842.)
- **C++**: new pure `FUnrealMcpServerChecksum` (SHA256SUMS URL builder, coreutils two-space parser, exact-key RID lookup, case-insensitive compare, four-way verdict, self-contained FIPS 180-4 SHA-256 — `FPlatformMisc::GetSHA256Signature` is a desktop stub that asserts, so no third-party dep). `DownloadBinaryIfNeeded` verifies between the HTTP download and `FZipArchiveReader`/`CreateProc`; mismatch/missing/unparsable/unfetchable → no extract, no spawn.
- **CLI**: new pure `server-checksum.ts` (`parseSha256Sums`/`lookupDigest`/`verifyDigest`/`verifyZip`/`serverChecksumsUrl`). `downloadServer` verifies between `arrayBuffer()` and `unzipSync` via `node:crypto` (reusing the injectable `fetchImpl`, bounded retry); any non-verified verdict → `{ kind: 'failure' }` (no extract).
- No new third-party deps; `ServerVersion` stays `8.0.0` (C++/CLI lockstep); NuGet pins untouched.

## Test plan

- [x] **Suite 1 (UBT editor target)**: exit 0 — the checksum helper + manager verify-gate compile.
- [x] **Suite 2 (headless smoke)**: exit 0, `[Unreal-MCP] plugin loaded`.
- [x] **Suite 3 (Automation `UnrealMcp.` filter)**: `index.json` `failed: 0`, 333 tests (17 new `UnrealMcp.ServerChecksum` specs) — valid passes / tampered rejected / missing-entry rejected / malformed rejected / two-space format / correct-RID no-cross-match + SHA256 FIPS vectors, asserted against the VERBATIM live v8.0.0 `SHA256SUMS`.
- [x] **Suite 6 (cli)**: `tsc` clean + `vitest` 255 passed (incl. the pure checksum suite + end-to-end fail-closed download tests: tampered / missing / unfetchable rejected, valid accepted).

Closes #155