### PR TITLE
chore(release): 0.4.1 — bump server pin to 8.0.1

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
@@ -38,7 +38,7 @@
 
 // Single source of the consumed shared-server version. Kept in lockstep with cli/src/lib/server-version.ts
 // (SERVER_VERSION) and Unity's McpServerManager.ServerVersion — the three plugins consume the SAME server.
-const TCHAR* FUnrealMcpServerManager::ServerVersion = TEXT("8.0.0");
+const TCHAR* FUnrealMcpServerManager::ServerVersion = TEXT("8.0.1");
 const TCHAR* FUnrealMcpServerManager::ServerPathEnvVar = TEXT("UNREAL_MCP_SERVER_PATH");
 
 namespace

--- a/UnrealMCP/UnrealMCP.uplugin
+++ b/UnrealMCP/UnrealMCP.uplugin
@@ -1,7 +1,7 @@
 {
   "FileVersion": 3,
   "Version": 1,
-  "VersionName": "0.4.0",
+  "VersionName": "0.4.1",
   "FriendlyName": "Unreal MCP (AI Game Developer)",
   "Description": "Model Context Protocol (MCP) integration for the Unreal Editor. Exposes editor operations as AI Tools so MCP-aware AI assistants (Claude, Cursor, Copilot, ...) can inspect and drive your Unreal project. Requires Unreal Engine 5.5+ (no EngineVersion pin: UE treats that field as an exact-build match, not a floor, and would refuse to load on newer engines).",
   "Category": "AI",

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>com.IvanMurzak.Unreal.MCP.Bridge</RootNamespace>
     <AssemblyName>unreal-mcp-bridge</AssemblyName>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2026 Ivan Murzak</Copyright>

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unreal-mcp-cli",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^13.1.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Cross-platform CLI tool for Unreal-MCP (Skills & MCP). Resolves and launches the Unreal editor with MCP connection env vars, runs MCP/system tools over HTTP, probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and manages the UnrealMCP plugin. Works with Claude Code, Cursor, Copilot, and any MCP client.",
   "type": "module",
   "main": "dist/lib.js",

--- a/cli/src/lib/server-version.ts
+++ b/cli/src/lib/server-version.ts
@@ -9,4 +9,4 @@
 // (with all `gamedev-mcp-server-<rid>.zip` assets) MUST already exist on
 // GameDev-MCP-Server BEFORE a CLI release that pins it (docs/RELEASING.md).
 
-export const SERVER_VERSION = '8.0.0';
+export const SERVER_VERSION = '8.0.1';


### PR DESCRIPTION
Patch release. Bumps the pinned shared gamedev-mcp-server v8.0.0 -> v8.0.1 (chiseled-base CVE fix + McpPlugin.Server 6.10.0 maintenance) in BOTH pins (C++ UnrealMcpServerManager.cpp + cli server-version.ts). v8.0.1 publishes the full 7-RID zip set + SHA256SUMS (verified), so the fail-closed download-verify resolves. Plugin/CLI API unchanged; checksum specs use static 8.0.0 fixtures by design and stay valid. release.yml auto-cuts on merge.