### PR TITLE
fix(tests): ServerVersion lockstep guard 8.0.0 -> 8.0.1

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpServerManagerSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpServerManagerSpec.cpp
@@ -175,7 +175,7 @@ void FUnrealMcpServerManagerSpec::Define()
 	{
 		It("is pinned to the lockstep value (kept in sync with cli/src/lib/server-version.ts)", [this]()
 		{
-			TestEqual(TEXT("pinned server version"), FString(FUnrealMcpServerManager::ServerVersion), FString(TEXT("8.0.0")));
+			TestEqual(TEXT("pinned server version"), FString(FUnrealMcpServerManager::ServerVersion), FString(TEXT("8.0.1")));
 		});
 	});
 


### PR DESCRIPTION
The release run for #158 (0.4.1 server-pin bump) failed one Automation test: UnrealMcpServerManagerSpec asserts the pinned ServerVersion equals a hardcoded literal, which must move with the constant. Updates 8.0.0 -> 8.0.1. Test-only; no version/API change. Unblocks the v0.4.1 release (re-cut via workflow_dispatch dry_run=false once merged).