### PR TITLE
feat(cli): infer Custom connection-mode from host in buildOpenEnv (#39)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -64,6 +64,17 @@ empty association falls back to the highest installed engine; a GUID (source bui
 `--engine-root`. `install-engine` enumerates the same manifest and, for a not-yet-installed version,
 hands back a `com.epicgames.launcher://` deep link rather than performing the multi-GB download.
 
+## Connection mode
+
+`open` (and the `openProject` library call) select the editor's MCP target via
+`UNREAL_MCP_CONNECTION_MODE`: `Custom` points the plugin's sidecar at a local/self-hosted server
+(`--host`), `Cloud` at ai-game.dev. Set it explicitly with `--connection-mode <Custom|Cloud>`. When
+you omit it, supplying a `--host` **infers `Custom`** — a host implies a non-Cloud target, and the
+plugin otherwise defaults to `Cloud` and ignores the host (silently dialing the cloud). An explicit
+`--connection-mode` always wins over that inference; with neither a host nor a mode the variable is
+left unset and the plugin default applies. Under `--no-connect` no `UNREAL_MCP_*` variables (the mode
+included) are wired onto the editor at all.
+
 ## Library export
 
 ```ts

--- a/cli/src/lib/open.ts
+++ b/cli/src/lib/open.ts
@@ -27,6 +27,14 @@ function isValidTransport(v: unknown): v is McpTransport {
  * Build the `UNREAL_MCP_*` env-var map propagated to the editor process.
  * Returns `undefined` when `noConnect` is set or nothing maps. Pure;
  * throws on invalid enum values (caught at the `openProject` boundary).
+ *
+ * Connection-mode resolution (`UNREAL_MCP_CONNECTION_MODE`): an explicit
+ * `connectionMode` always wins; otherwise an explicit `host` infers `Custom`
+ * (a host implies a non-Cloud target, and the plugin defaults to Cloud — so a
+ * host with no mode would silently dial the cloud). With neither set the var is
+ * omitted and the plugin default applies. Mirrors godot-cli's host-presence
+ * mode default. `noConnect` drops every var (including the mode).
+ *
  * Exported for tests.
  */
 export function buildOpenEnv(opts: OpenProjectOptions): Record<string, string> | undefined {
@@ -45,7 +53,14 @@ export function buildOpenEnv(opts: OpenProjectOptions): Record<string, string> |
     env['UNREAL_MCP_TRANSPORT'] = opts.transport;
   }
   if (opts.startServer !== undefined) env['UNREAL_MCP_START_SERVER'] = opts.startServer ? 'true' : 'false';
-  if (opts.connectionMode !== undefined) env['UNREAL_MCP_CONNECTION_MODE'] = opts.connectionMode;
+  // Connection mode: an explicit value always wins; otherwise infer `Custom`
+  // from the presence of an explicit host (the plugin defaults to Cloud, where
+  // a bare host is ignored). Neither set => omit (plugin default applies).
+  if (opts.connectionMode !== undefined) {
+    env['UNREAL_MCP_CONNECTION_MODE'] = opts.connectionMode;
+  } else if (opts.host !== undefined) {
+    env['UNREAL_MCP_CONNECTION_MODE'] = 'Custom';
+  }
   return Object.keys(env).length > 0 ? env : undefined;
 }
 

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -102,7 +102,13 @@ export interface OpenProjectOptions {
   keepConnected?: boolean;
   transport?: McpTransport;
   startServer?: boolean;
-  /** UNREAL_MCP_CONNECTION_MODE — e.g. "Custom" for a local server. */
+  /**
+   * UNREAL_MCP_CONNECTION_MODE — `"Custom"` for a local server, `"Cloud"` for
+   * ai-game.dev. When omitted, an explicit `host` infers `"Custom"` (a host
+   * implies a non-Cloud target; the plugin otherwise defaults to Cloud and
+   * ignores the host). An explicit value always wins; with neither `host` nor
+   * `connectionMode` the var is omitted and the plugin default applies.
+   */
   connectionMode?: string;
   /** Skip the persistent engine-path cache (forces a fresh discovery chain). */
   noCache?: boolean;

--- a/cli/tests/open.test.ts
+++ b/cli/tests/open.test.ts
@@ -38,6 +38,8 @@ describe('buildOpenEnv', () => {
       UNREAL_MCP_KEEP_CONNECTED: 'true',
       UNREAL_MCP_AUTH_OPTION: 'required',
       UNREAL_MCP_TRANSPORT: 'http',
+      // host present + no explicit mode => Custom inferred (see emission matrix below)
+      UNREAL_MCP_CONNECTION_MODE: 'Custom',
     });
   });
 
@@ -48,6 +50,47 @@ describe('buildOpenEnv', () => {
   it('throws on bad auth/transport enums', () => {
     expect(() => buildOpenEnv({ auth: 'bogus' as never })).toThrow();
     expect(() => buildOpenEnv({ transport: 'bogus' as never })).toThrow();
+  });
+
+  describe('UNREAL_MCP_CONNECTION_MODE emission matrix', () => {
+    it('emits an explicit Custom mode', () => {
+      expect(buildOpenEnv({ connectionMode: 'Custom' })).toEqual({
+        UNREAL_MCP_CONNECTION_MODE: 'Custom',
+      });
+    });
+
+    it('emits an explicit Cloud mode', () => {
+      expect(buildOpenEnv({ connectionMode: 'Cloud' })).toEqual({
+        UNREAL_MCP_CONNECTION_MODE: 'Cloud',
+      });
+    });
+
+    it('infers Custom from a host when no mode is given', () => {
+      expect(buildOpenEnv({ host: 'http://localhost:5220' })).toEqual({
+        UNREAL_MCP_HOST: 'http://localhost:5220',
+        UNREAL_MCP_CONNECTION_MODE: 'Custom',
+      });
+    });
+
+    it('lets an explicit mode win over the host-presence inference', () => {
+      expect(buildOpenEnv({ host: 'http://localhost:5220', connectionMode: 'Cloud' })).toEqual({
+        UNREAL_MCP_HOST: 'http://localhost:5220',
+        UNREAL_MCP_CONNECTION_MODE: 'Cloud',
+      });
+    });
+
+    it('omits the var when neither host nor mode is given', () => {
+      const env = buildOpenEnv({ token: 't' });
+      expect(env).toEqual({ UNREAL_MCP_TOKEN: 't' });
+      expect(env?.UNREAL_MCP_CONNECTION_MODE).toBeUndefined();
+    });
+
+    it('drops the var under --no-connect even with a host (no inference)', () => {
+      expect(buildOpenEnv({ noConnect: true, host: 'http://h' })).toBeUndefined();
+      expect(
+        buildOpenEnv({ noConnect: true, host: 'http://h', connectionMode: 'Custom' }),
+      ).toBeUndefined();
+    });
   });
 });
 


### PR DESCRIPTION
Completes the remaining Definition of Done for #39. The explicit `--connection-mode` flag and the explicit `connectionMode` → `UNREAL_MCP_CONNECTION_MODE` emission already shipped in PR #149; this PR adds the host-presence default plus tests and docs.

## Changes (cli leg only)

1. **Host-presence inference** — `cli/src/lib/open.ts` `buildOpenEnv` now resolves the connection mode as **explicit `connectionMode` > host-presence inference > omit**: when `host` is provided and `connectionMode` is omitted, it emits `UNREAL_MCP_CONNECTION_MODE=Custom` (a host implies a non-Cloud target; the plugin otherwise defaults to Cloud and silently dials the cloud — the documented "No connected clients → HTTP 500" trap). An explicit `connectionMode` always wins over the inference; with neither, the var is omitted (unchanged); `--no-connect` still drops every `UNREAL_MCP_*` var (no inference). `buildOpenEnv` stays pure/exported.
2. **Emission-matrix unit tests** — `cli/tests/open.test.ts` covers explicit `Custom`, explicit `Cloud`, `host` + no mode → `Custom`, explicit mode wins over host-inference (`host` + `Cloud` → `Cloud`), no host + no mode → omitted, and `--no-connect` drops it even with a host. The pre-existing host-bearing `maps options` test's `toEqual` expectation was updated to include the now-inferred `Custom`.
3. **Docs** — new "Connection mode" section in `cli/README.md` and an expanded `OpenProjectOptions.connectionMode` JSDoc documenting the host-presence default and explicit-wins precedence.

## Local test result

`cd cli && npm install && npm run build && npm test` — build clean (tsc, 0 errors); **vitest: 261 passed, 1 skipped** (the skipped one is the `UNREAL_MCP_CLI_INTEGRATION`-gated e2e). No version/NuGet/publishConfig changes.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)