### PR TITLE
feat(ui): surface "no MCP bridge binary" state in the Connection section

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
@@ -316,11 +316,13 @@ int32 FUnrealMcpDevControlServer::RouteRequest(
 		OutResult->SetBoolField(TEXT("serverRunning"), ViewModelPtr->IsLocalServerRunning());
 		OutResult->SetStringField(TEXT("serverButtonLabel"), ViewModelPtr->GetLocalServerButtonText().ToString());
 		// The Connect/Disconnect/Stop button label + the "Unreal: <status>" label the dock renders for this state,
-		// so the smoke test asserts the exact text a screenshot would show without reading pixels.
+		// so the smoke test asserts the exact text a screenshot would show without reading pixels. The button keeps
+		// reading the RAW state (its tri-state is unchanged), but the status label reads the EFFECTIVE state so the
+		// harness reports the SAME "Unreal: No MCP bridge" text the dock now shows in the NoBinary case (issue #63).
 		OutResult->SetStringField(TEXT("buttonLabel"),
 			FUnrealMcpEditorViewModel::GetButtonText(ViewModelPtr->GetConnectionState()).ToString());
 		OutResult->SetStringField(TEXT("statusLabel"),
-			FUnrealMcpEditorViewModel::GetStatusLabel(ViewModelPtr->GetConnectionState()).ToString());
+			FUnrealMcpEditorViewModel::GetStatusLabel(ViewModelPtr->GetEffectiveConnectionState()).ToString());
 		// The Serialization Check window's tab id — lets the smoke test assert membership and (with a
 		// `check` click) drive the same footer "Check" button the dock renders.
 		OutResult->SetStringField(TEXT("serializationCheckTabId"), FUnrealMcpAuxWindows::SerializationCheckTabId.ToString());

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -291,17 +291,21 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildConnectionSection()
 
 TSharedRef<SWidget> SUnrealMcpMainWindow::BuildConnectionCluster()
 {
-	// The Unreal status dot — driven by the live connection state.
+	// The Unreal status dot — driven by the EFFECTIVE connection state so the proactive NoBinary overlay (issue #63)
+	// shows as a red Offline dot, not a green/amber one. GetEffectiveConnectionState only diverges from the raw
+	// state when the bridge binary is unresolvable AND we are not on a live link.
 	TAttribute<EDot> UnrealDot = TAttribute<EDot>::Create([this]()
 	{
 		if (!IsViewModelValid())
 			return EDot::Offline;
-		switch (ViewModel->GetConnectionState())
+		switch (ViewModel->GetEffectiveConnectionState())
 		{
 			case EUnrealMcpConnectionState::Connected:  return EDot::Online;
 			case EUnrealMcpConnectionState::Connecting:  return EDot::Ring;
 			// Degraded must NOT use the (green) Ring brush — that reads as healthy. Show Offline.
 			case EUnrealMcpConnectionState::Degraded:    return EDot::Offline;
+			// NoBinary (issue #63) is an install/config problem — red Offline dot, like Disconnected.
+			case EUnrealMcpConnectionState::NoBinary:    return EDot::Offline;
 			default:                                     return EDot::Offline;
 		}
 	});
@@ -399,33 +403,63 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildConnectionCluster()
 
 TSharedRef<SWidget> SUnrealMcpMainWindow::BuildUnrealStatusRow()
 {
-	// The "Unreal: <status>" row — underlined label + Connect/Disconnect/Stop. The dot for this row lives in the
-	// shared rail (BuildConnectionCluster), so this row carries only its content.
-	return SNew(SHorizontalBox)
-		// The underlined "Unreal: <status>" label — spans only the text (issue #80 item 3).
-		+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
+	// The "Unreal: <status>" row — underlined label + Connect/Disconnect/Stop, plus (issue #63) an actionable hint
+	// line shown only in the NoBinary state. The dot for this row lives in the shared rail (BuildConnectionCluster)
+	// and pins to the TOP label, so the optional hint below it does not disturb the dot alignment.
+	//
+	// The status LABEL + dot read the EFFECTIVE state (so NoBinary surfaces as "Unreal: No MCP bridge"); the
+	// Connect/Disconnect/Stop button keeps reading the RAW GetConnectionState() — its tri-state connect/disconnect
+	// semantics are unchanged by the proactive overlay (a missing binary does not change what Connect/Stop do).
+	return SNew(SVerticalBox)
+		+ SVerticalBox::Slot().AutoHeight()
 		[
-			UnderlinedLabel(TAttribute<FText>::Create([this]()
+			SNew(SHorizontalBox)
+			// The underlined "Unreal: <status>" label — spans only the text (issue #80 item 3).
+			+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
+			[
+				UnderlinedLabel(TAttribute<FText>::Create([this]()
+				{
+					return IsViewModelValid()
+						? FUnrealMcpEditorViewModel::GetStatusLabel(ViewModel->GetEffectiveConnectionState())
+						: FText::GetEmpty();
+				}))
+			]
+			// Connect / Disconnect / Stop button — right-aligned to the shared right edge.
+			+ SHorizontalBox::Slot().AutoWidth().HAlign(HAlign_Right).VAlign(VAlign_Center)
+			[
+				SNew(SBox).MinDesiredWidth(RightControlColumnWidth).HAlign(HAlign_Right)
+				[
+					UnrealMcpStyleWidgets::StyledButton("UnrealMcp.Button.Secondary",
+						SNew(STextBlock).Text_Lambda([this]()
+						{
+							return IsViewModelValid()
+								? FUnrealMcpEditorViewModel::GetButtonText(ViewModel->GetConnectionState())
+								: FText::GetEmpty();
+						}),
+						FOnClicked::CreateSP(this, &SUnrealMcpMainWindow::OnConnectClicked))
+				]
+			]
+		]
+		// Issue #63: the proactive "no MCP bridge binary" hint — the SAME actionable text the reactive Authorize
+		// failure shows (BridgeUnavailableMessage, issue #99), surfaced in the always-visible Connection section
+		// BEFORE the user clicks Connect/Authorize. Red (StatusOffline, matching the other alert/validation lines)
+		// and collapsed in every state but NoBinary, so a healthy/transient connection shows no extra row.
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
+		[
+			SNew(STextBlock)
+			.AutoWrapText(true)
+			.ColorAndOpacity(FSlateColor(FUnrealMcpStyle::StatusOffline()))
+			.Visibility_Lambda([this]()
+			{
+				return (IsViewModelValid() && ViewModel->GetEffectiveConnectionState() == EUnrealMcpConnectionState::NoBinary)
+					? EVisibility::Visible : EVisibility::Collapsed;
+			})
+			.Text_Lambda([this]()
 			{
 				return IsViewModelValid()
-					? FUnrealMcpEditorViewModel::GetStatusLabel(ViewModel->GetConnectionState())
+					? FUnrealMcpEditorViewModel::GetConnectionHint(ViewModel->GetEffectiveConnectionState())
 					: FText::GetEmpty();
-			}))
-		]
-		// Connect / Disconnect / Stop button — right-aligned to the shared right edge.
-		+ SHorizontalBox::Slot().AutoWidth().HAlign(HAlign_Right).VAlign(VAlign_Center)
-		[
-			SNew(SBox).MinDesiredWidth(RightControlColumnWidth).HAlign(HAlign_Right)
-			[
-				UnrealMcpStyleWidgets::StyledButton("UnrealMcp.Button.Secondary",
-					SNew(STextBlock).Text_Lambda([this]()
-					{
-						return IsViewModelValid()
-							? FUnrealMcpEditorViewModel::GetButtonText(ViewModel->GetConnectionState())
-							: FText::GetEmpty();
-					}),
-					FOnClicked::CreateSP(this, &SUnrealMcpMainWindow::OnConnectClicked))
-			]
+			})
 		];
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -602,6 +602,28 @@ FText FUnrealMcpEditorViewModel::GetLocalServerButtonText() const
 	return IsLocalServerRunning() ? LOCTEXT("ServerBtnStop", "Stop") : LOCTEXT("ServerBtnStart", "Start");
 }
 
+bool FUnrealMcpEditorViewModel::IsBridgeBinaryResolvable() const
+{
+	// Unknown (no sink wired) ⇒ assume resolvable so the NoBinary hint never false-alarms — only a sink that
+	// explicitly reports "not resolvable" surfaces the install/config state (issue #63).
+	return IsBridgeBinaryResolvableSink ? IsBridgeBinaryResolvableSink() : true;
+}
+
+EUnrealMcpConnectionState FUnrealMcpEditorViewModel::GetEffectiveConnectionState() const
+{
+	// A live or armed-and-recently-live link proves a sidecar (hence a binary) exists — the `status` feed that
+	// produced Connected/Degraded originates in the sidecar — so never overlay NoBinary on it; return the raw
+	// state untouched.
+	if (ConnectionState == EUnrealMcpConnectionState::Connected || ConnectionState == EUnrealMcpConnectionState::Degraded)
+		return ConnectionState;
+
+	// Otherwise (a plain Disconnected, or a Connecting that can never complete because no binary can spawn): when
+	// the bridge binary cannot be resolved, the sidecar can never come up, so surface NoBinary PROACTIVELY — the
+	// user sees the install/config problem before clicking Connect/Authorize, distinct from a transient
+	// Disconnected/Connecting. When it IS resolvable, the raw state stands (issue #63).
+	return IsBridgeBinaryResolvable() ? ConnectionState : EUnrealMcpConnectionState::NoBinary;
+}
+
 FText FUnrealMcpEditorViewModel::GetButtonText(EUnrealMcpConnectionState State)
 {
 	switch (State)
@@ -609,6 +631,9 @@ FText FUnrealMcpEditorViewModel::GetButtonText(EUnrealMcpConnectionState State)
 		case EUnrealMcpConnectionState::Connected:  return LOCTEXT("BtnDisconnect", "Disconnect");
 		case EUnrealMcpConnectionState::Connecting: return LOCTEXT("BtnStop", "Stop");
 		case EUnrealMcpConnectionState::Degraded:   return LOCTEXT("BtnStop", "Stop");
+		// NoBinary is a not-connected state: offer Connect as the fallback (the connect/disconnect button keeps
+		// reading the RAW state, so this case is mainly for switch-exhaustiveness + direct callers, issue #63).
+		case EUnrealMcpConnectionState::NoBinary:
 		case EUnrealMcpConnectionState::Disconnected:
 		default:                                    return LOCTEXT("BtnConnect", "Connect");
 	}
@@ -621,6 +646,9 @@ FText FUnrealMcpEditorViewModel::GetStatusLabel(EUnrealMcpConnectionState State)
 		case EUnrealMcpConnectionState::Connected:  return LOCTEXT("StatusConnected", "Unreal: Connected");
 		case EUnrealMcpConnectionState::Connecting: return LOCTEXT("StatusConnecting", "Unreal: Connecting…");
 		case EUnrealMcpConnectionState::Degraded:   return LOCTEXT("StatusDegraded", "Unreal: Reconnecting…");
+		// Issue #63: a distinct label (NOT the generic "Disconnected") so the user reads this as an install/config
+		// problem, not a transient stop. The actionable remedy is in GetConnectionHint's companion line.
+		case EUnrealMcpConnectionState::NoBinary:   return LOCTEXT("StatusNoBinary", "Unreal: No MCP bridge");
 		case EUnrealMcpConnectionState::Disconnected:
 		default:                                    return LOCTEXT("StatusDisconnected", "Unreal: Disconnected");
 	}
@@ -633,9 +661,22 @@ FLinearColor FUnrealMcpEditorViewModel::GetStatusColor(EUnrealMcpConnectionState
 		case EUnrealMcpConnectionState::Connected:  return FLinearColor(0.16f, 0.74f, 0.30f); // green
 		case EUnrealMcpConnectionState::Connecting: return FLinearColor(0.95f, 0.69f, 0.13f); // amber
 		case EUnrealMcpConnectionState::Degraded:   return FLinearColor(0.95f, 0.49f, 0.13f); // orange
+		// NoBinary is a not-working state — red, the same family as Disconnected (the distinct label + the
+		// actionable hint line carry the "no binary, not just stopped" distinction, issue #63).
+		case EUnrealMcpConnectionState::NoBinary:
 		case EUnrealMcpConnectionState::Disconnected:
 		default:                                    return FLinearColor(0.55f, 0.16f, 0.16f); // red
 	}
+}
+
+FText FUnrealMcpEditorViewModel::GetConnectionHint(EUnrealMcpConnectionState State)
+{
+	// Only NoBinary carries a hint. Reuse BridgeUnavailableMessage() — the SAME actionable text the reactive
+	// Authorize() failure shows (issue #99) — so the proactive Connection-section hint and the reactive auth
+	// failure never diverge (single source of truth). Every other state renders no hint line.
+	if (State == EUnrealMcpConnectionState::NoBinary)
+		return FText::FromString(BridgeUnavailableMessage());
+	return FText::GetEmpty();
 }
 
 EUnrealMcpConnectionState FUnrealMcpEditorViewModel::ParseConnectionState(const FString& Raw, bool bKeepConnected)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
@@ -22,7 +22,18 @@ enum class EUnrealMcpConnectionState : uint8
 	/** SignalR connected; tools are reachable end-to-end. */
 	Connected,
 	/** Was connected, lost the link, and is auto-retrying in the background (keepConnected=true). */
-	Degraded
+	Degraded,
+	/**
+	 * The sidecar bridge binary cannot be resolved at all (issue #63): no bundled binary for this host rid AND
+	 * no `UNREAL_MCP_BRIDGE_PATH` override pointing at an existing file (FUnrealMcpSidecarManager::
+	 * ResolveBridgeBinaryPath() is empty). The TCP listener is up but NO sidecar can ever spawn, so the link can
+	 * never come up — an install/config problem distinct from the transient Disconnected/Connecting. Surfaced
+	 * PROACTIVELY in the always-visible Connection section (before the user clicks Connect/Authorize) with an
+	 * actionable hint — the proactive complement of the reactive Authorize() failure (BridgeUnavailableMessage()).
+	 * This is a DERIVED display state (GetEffectiveConnectionState), never stored in ConnectionState and never
+	 * emitted by the sidecar `status` feed.
+	 */
+	NoBinary
 };
 
 /** Cloud device-code authorization progress (docs/ARCHITECTURE.md §7 item 4 / §1.3 `device-auth`). */
@@ -112,6 +123,15 @@ public:
 	/** Report whether the LOCAL gamedev-mcp-server is currently running. Wired to FUnrealMcpServerManager::IsRunning(); unset → false. */
 	TFunction<bool()> IsLocalServerRunningSink;
 
+	/**
+	 * Report whether the sidecar bridge binary can be resolved (issue #63): true when
+	 * FUnrealMcpSidecarManager::ResolveBridgeBinaryPath() yields a non-empty path (a bundled <rid> binary exists
+	 * OR `UNREAL_MCP_BRIDGE_PATH` points at a real file). Wired by the coordinator. Unset → treated as resolvable
+	 * (true) so an unwired host / a spec that does not care never spuriously shows the NoBinary state. Read by
+	 * GetEffectiveConnectionState to overlay the proactive NoBinary hint. Game-thread only.
+	 */
+	TFunction<bool()> IsBridgeBinaryResolvableSink;
+
 	// --- Local MCP-server gating + control (pure view-model surface over the sinks above). ---
 
 	/**
@@ -194,6 +214,25 @@ public:
 	// --- Connection control. ---
 
 	EUnrealMcpConnectionState GetConnectionState() const { return ConnectionState; }
+
+	/**
+	 * Whether the sidecar bridge binary is resolvable (issue #63). Reads IsBridgeBinaryResolvableSink; true when
+	 * the sink is unset (unknown ⇒ assume present, so the NoBinary hint never false-alarms in a spec / unwired
+	 * host). Game-thread only.
+	 */
+	UNREALMCPEDITOR_API bool IsBridgeBinaryResolvable() const;
+
+	/**
+	 * The connection state to DISPLAY in the always-visible Connection section (issue #63): overlays a proactive
+	 * NoBinary on the raw live state when the bridge binary cannot be resolved AND we are not on a live link. A
+	 * Connected/Degraded raw state proves a sidecar exists (the `status` feed originates there), so it is returned
+	 * unchanged — NoBinary never masks a real link. Otherwise — a plain Disconnected, or a Connecting that can
+	 * never complete because no binary can spawn — an unresolvable binary yields NoBinary, so the user sees the
+	 * install/config problem BEFORE clicking Connect/Authorize, distinct from the transient Disconnected/Connecting
+	 * (the §63 "distinguish no-binary from not-yet-handshaken" ask). The raw GetConnectionState() is deliberately
+	 * unchanged — it stays the live SignalR state the connect/disconnect logic and the status feed drive.
+	 */
+	UNREALMCPEDITOR_API EUnrealMcpConnectionState GetEffectiveConnectionState() const;
 
 	/** §7 Connect: keepConnected=true, optimistic Connecting state, push the config (sidecar (re)dials). */
 	UNREALMCPEDITOR_API void Connect();
@@ -328,6 +367,15 @@ public:
 	static UNREALMCPEDITOR_API FText GetStatusLabel(EUnrealMcpConnectionState State);
 	/** The status-dot colour for a connection state (green Connected / amber transitional / red off). */
 	static UNREALMCPEDITOR_API FLinearColor GetStatusColor(EUnrealMcpConnectionState State);
+
+	/**
+	 * The actionable hint shown beneath the Connection-section status for a state (issue #63). For NoBinary it
+	 * returns the SAME actionable "install the bridge" guidance as the reactive Authorize() failure
+	 * (BridgeUnavailableMessage) so the proactive and reactive surfaces never diverge; empty for every other state
+	 * (no hint line is rendered). Pure/static — a spec asserts NoBinary yields a non-empty actionable string and
+	 * the healthy states yield empty.
+	 */
+	static UNREALMCPEDITOR_API FText GetConnectionHint(EUnrealMcpConnectionState State);
 
 	/** Parse a §1.3 connectionState string ("Connected"/"Connecting"/"Degraded"/…) into the enum. */
 	static UNREALMCPEDITOR_API EUnrealMcpConnectionState ParseConnectionState(const FString& Raw, bool bKeepConnected);

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
@@ -224,6 +224,14 @@ void FUnrealMcpEditorCoordinator::Startup()
 		if (!Url.IsEmpty())
 			FPlatformProcess::LaunchURL(*Url, nullptr, nullptr);
 	};
+	// Issue #63: proactively surface the "no sidecar binary resolved" state in the always-visible Connection
+	// section. Snapshot resolvability ONCE here (the bundled-binary layout + UNREAL_MCP_BRIDGE_PATH env were both
+	// finalized above — ExportDotEnvToProcessEnv ran, and StartForPort already resolved against the same env), so
+	// the per-frame TAttribute that reads GetEffectiveConnectionState never walks the filesystem. A mid-session
+	// recovery (run `unreal-mcp-cli bootstrap-local`, then "Restart bridge") still clears the hint the instant the
+	// sidecar connects, because GetEffectiveConnectionState short-circuits NoBinary off a live Connected link.
+	const bool bBridgeBinaryResolvable = !FUnrealMcpSidecarManager::ResolveBridgeBinaryPath().IsEmpty();
+	ViewModel->IsBridgeBinaryResolvableSink = [bBridgeBinaryResolvable]() -> bool { return bBridgeBinaryResolvable; };
 
 	// §7 in-UI local-server (issue #95): wire the MCP-server card's Start/Stop to the local server manager. The
 	// view-model already gates these to Custom+http (ToggleLocalServer no-ops otherwise) — the sinks just execute.
@@ -478,6 +486,7 @@ void FUnrealMcpEditorCoordinator::Shutdown()
 		ViewModel->OnStartLocalServer = nullptr;
 		ViewModel->OnStopLocalServer = nullptr;
 		ViewModel->IsLocalServerRunningSink = nullptr;
+		ViewModel->IsBridgeBinaryResolvableSink = nullptr; // issue #63: captures only a bool, nulled for teardown symmetry
 	}
 	ViewModel.Reset();
 

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
@@ -40,6 +40,10 @@ BEGIN_DEFINE_SPEC(FUnrealMcpEditorViewModelSpec, "UnrealMcp.EditorViewModel",
 		int32 ServerStartCount = 0;
 		int32 ServerStopCount = 0;
 		bool bServerRunning = false;
+		// Issue #63: the fake "bridge binary resolvable" state the IsBridgeBinaryResolvableSink reads. Default true
+		// (resolvable) so every existing spec sees the raw connection state through GetEffectiveConnectionState; a
+		// NoBinary spec flips it false to assert the proactive overlay.
+		bool bBridgeBinaryResolvable = true;
 	};
 
 	static TSharedRef<FUnrealMcpEditorViewModel> MakeViewModel(TSharedRef<FRecording> Rec)
@@ -62,6 +66,7 @@ BEGIN_DEFINE_SPEC(FUnrealMcpEditorViewModelSpec, "UnrealMcp.EditorViewModel",
 		VM->OnStartLocalServer = [Rec]() -> bool { Rec->ServerStartCount++; Rec->bServerRunning = true; return true; };
 		VM->OnStopLocalServer = [Rec]() { Rec->ServerStopCount++; Rec->bServerRunning = false; };
 		VM->IsLocalServerRunningSink = [Rec]() -> bool { return Rec->bServerRunning; };
+		VM->IsBridgeBinaryResolvableSink = [Rec]() -> bool { return Rec->bBridgeBinaryResolvable; };
 		return VM;
 	}
 
@@ -127,6 +132,108 @@ void FUnrealMcpEditorViewModelSpec::Define()
 			TestEqual("Connected -> Connected",
 				static_cast<int32>(FUnrealMcpEditorViewModel::ParseConnectionState(TEXT("Connected"), true)),
 				static_cast<int32>(EUnrealMcpConnectionState::Connected));
+		});
+	});
+
+	Describe("Proactive 'no sidecar binary' surfacing (issue #63)", [this]()
+	{
+		It("leaves the effective state as the raw state and shows NO hint while the bridge binary resolves", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec); // bBridgeBinaryResolvable defaults true
+			// A fresh VM is Disconnected; with a resolvable binary the effective state equals the raw state.
+			TestEqual("effective == raw (Disconnected) while resolvable",
+				static_cast<int32>(VM->GetEffectiveConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Disconnected));
+			TestTrue("no hint while resolvable",
+				FUnrealMcpEditorViewModel::GetConnectionHint(VM->GetEffectiveConnectionState()).IsEmpty());
+		});
+
+		It("surfaces a distinct NoBinary state with an actionable hint when the binary cannot be resolved", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			Rec->bBridgeBinaryResolvable = false; // packaged-without-<rid> / unset UNREAL_MCP_BRIDGE_PATH (dev source)
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			// The raw live state is still the unchanged Disconnected — only the EFFECTIVE display state overlays NoBinary.
+			TestEqual("raw state unchanged (Disconnected)",
+				static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Disconnected));
+			TestEqual("effective state overlays NoBinary",
+				static_cast<int32>(VM->GetEffectiveConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::NoBinary));
+
+			// The label is DISTINCT from the generic Disconnected one ("not just 'Stopped'", per the issue).
+			TestNotEqual("NoBinary label differs from Disconnected",
+				FUnrealMcpEditorViewModel::GetStatusLabel(EUnrealMcpConnectionState::NoBinary).ToString(),
+				FUnrealMcpEditorViewModel::GetStatusLabel(EUnrealMcpConnectionState::Disconnected).ToString());
+
+			// The hint is non-empty and actionable — the SAME install guidance the reactive Authorize failure shows.
+			const FText Hint = FUnrealMcpEditorViewModel::GetConnectionHint(VM->GetEffectiveConnectionState());
+			TestFalse("hint is non-empty in NoBinary", Hint.IsEmpty());
+			TestTrue("hint is actionable (reinstall / bootstrap-local)",
+				Hint.ToString().Contains(TEXT("bootstrap-local")) || Hint.ToString().Contains(TEXT("reinstall")));
+		});
+
+		It("distinguishes NoBinary (install/config) from a transient Connecting (binary present, not yet handshaken)", [this]()
+		{
+			// Binary present: clicking Connect yields a transient Connecting, NOT NoBinary.
+			TSharedRef<FRecording> RecOk = MakeShared<FRecording>(); // resolvable
+			TSharedRef<FUnrealMcpEditorViewModel> VmOk = MakeViewModel(RecOk);
+			VmOk->Connect();
+			TestEqual("Connecting (not NoBinary) when the binary is present",
+				static_cast<int32>(VmOk->GetEffectiveConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connecting));
+			TestTrue("no hint while genuinely Connecting",
+				FUnrealMcpEditorViewModel::GetConnectionHint(VmOk->GetEffectiveConnectionState()).IsEmpty());
+
+			// Binary absent: the same Connect can never complete, so the effective state is NoBinary, not a perpetual
+			// Connecting — the user sees the install/config problem instead of a forever-spinner.
+			TSharedRef<FRecording> RecNo = MakeShared<FRecording>();
+			RecNo->bBridgeBinaryResolvable = false;
+			TSharedRef<FUnrealMcpEditorViewModel> VmNo = MakeViewModel(RecNo);
+			VmNo->Connect();
+			TestEqual("raw Connecting while armed",
+				static_cast<int32>(VmNo->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connecting));
+			TestEqual("effective NoBinary overlays the never-completing Connecting",
+				static_cast<int32>(VmNo->GetEffectiveConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::NoBinary));
+		});
+
+		It("never masks a live Connected/Degraded link even if resolvability reads false", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			// Drive to a live green link the way the runtime does (arm + apply a Connected status).
+			VM->Connect();
+			TSharedPtr<FJsonObject> Status = MakeShared<FJsonObject>();
+			Status->SetStringField(TEXT("connectionState"), TEXT("Connected"));
+			Status->SetBoolField(TEXT("keepConnected"), true);
+			VM->ApplyStatus(Status);
+			TestEqual("Connected before the resolvability flip",
+				static_cast<int32>(VM->GetEffectiveConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connected));
+
+			// A Connected link PROVES a sidecar (hence a binary) exists — a stale "unresolvable" read must not mask it.
+			Rec->bBridgeBinaryResolvable = false;
+			TestEqual("still Connected — NoBinary never masks a live link",
+				static_cast<int32>(VM->GetEffectiveConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Connected));
+
+			// Same guard for Degraded (armed + a reported Disconnected = background retry of a link that DID exist).
+			TSharedPtr<FJsonObject> Dropped = MakeShared<FJsonObject>();
+			Dropped->SetStringField(TEXT("connectionState"), TEXT("Disconnected"));
+			Dropped->SetBoolField(TEXT("keepConnected"), true);
+			VM->ApplyStatus(Dropped);
+			TestEqual("Degraded raw after an armed drop",
+				static_cast<int32>(VM->GetConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Degraded));
+			TestEqual("Degraded is not overlaid by NoBinary",
+				static_cast<int32>(VM->GetEffectiveConnectionState()), static_cast<int32>(EUnrealMcpConnectionState::Degraded));
+		});
+
+		It("emits a hint ONLY for NoBinary and a Connect button label for it", [this]()
+		{
+			// The hint line is rendered only in NoBinary — every other state yields an empty hint (no extra row).
+			TestFalse("NoBinary hint non-empty", FUnrealMcpEditorViewModel::GetConnectionHint(EUnrealMcpConnectionState::NoBinary).IsEmpty());
+			TestTrue("Disconnected hint empty", FUnrealMcpEditorViewModel::GetConnectionHint(EUnrealMcpConnectionState::Disconnected).IsEmpty());
+			TestTrue("Connected hint empty", FUnrealMcpEditorViewModel::GetConnectionHint(EUnrealMcpConnectionState::Connected).IsEmpty());
+			TestTrue("Connecting hint empty", FUnrealMcpEditorViewModel::GetConnectionHint(EUnrealMcpConnectionState::Connecting).IsEmpty());
+			// The static button helper offers Connect as the NoBinary fallback (exhaustive-switch coverage).
+			TestEqual("NoBinary button label is Connect",
+				FUnrealMcpEditorViewModel::GetButtonText(EUnrealMcpConnectionState::NoBinary).ToString(), FString(TEXT("Connect")));
 		});
 	});
 

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
@@ -119,6 +119,9 @@ void FUnrealMcpEditorViewModelSpec::Define()
 			const FLinearColor Connected = FUnrealMcpEditorViewModel::GetStatusColor(EUnrealMcpConnectionState::Connected);
 			const FLinearColor Disconnected = FUnrealMcpEditorViewModel::GetStatusColor(EUnrealMcpConnectionState::Disconnected);
 			TestFalse("connected colour != disconnected colour", Connected.Equals(Disconnected));
+			// NoBinary shares the Disconnected red (issue #63); the distinct label + hint carry the difference, not the colour.
+			TestTrue("NoBinary colour matches Disconnected (red)",
+				FUnrealMcpEditorViewModel::GetStatusColor(EUnrealMcpConnectionState::NoBinary).Equals(Disconnected));
 		});
 
 		It("treats a reported Disconnected-while-armed as Degraded, not a true stop", [this]()
@@ -231,6 +234,7 @@ void FUnrealMcpEditorViewModelSpec::Define()
 			TestTrue("Disconnected hint empty", FUnrealMcpEditorViewModel::GetConnectionHint(EUnrealMcpConnectionState::Disconnected).IsEmpty());
 			TestTrue("Connected hint empty", FUnrealMcpEditorViewModel::GetConnectionHint(EUnrealMcpConnectionState::Connected).IsEmpty());
 			TestTrue("Connecting hint empty", FUnrealMcpEditorViewModel::GetConnectionHint(EUnrealMcpConnectionState::Connecting).IsEmpty());
+			TestTrue("Degraded hint empty", FUnrealMcpEditorViewModel::GetConnectionHint(EUnrealMcpConnectionState::Degraded).IsEmpty());
 			// The static button helper offers Connect as the NoBinary fallback (exhaustive-switch coverage).
 			TestEqual("NoBinary button label is Connect",
 				FUnrealMcpEditorViewModel::GetButtonText(EUnrealMcpConnectionState::NoBinary).ToString(), FString(TEXT("Connect")));


### PR DESCRIPTION
## Summary
- Proactively surface the "no sidecar binary resolved" install/config problem in the **always-visible Connection section** (issue #63) — before the user clicks Connect/Authorize — instead of leaving it as a generic Disconnected that only the log explains.
- Adds a derived `EUnrealMcpConnectionState::NoBinary` shown via a new `GetEffectiveConnectionState()`: distinct from the transient Disconnected/Connecting (the issue's "no-binary vs not-yet-handshaken" distinction), rendered as a distinct status label ("Unreal: No MCP bridge") + a red actionable hint line reusing the same `BridgeUnavailableMessage()` the reactive Authorize() failure shows (issue #99 — single source of truth).
- Resolvability is snapshotted once from the coordinator (`FUnrealMcpSidecarManager::ResolveBridgeBinaryPath`), so the per-frame status TAttribute never walks the filesystem; a live Connected/Degraded link is never masked (a sidecar proves a binary exists). The live Connect/Disconnect button and the raw `status` feed are unchanged.
- The dev-control `/state` harness reports the **effective** status label so it stays 1:1 with the dock.

## Test plan
- [x] Suite 1 — UBT editor build (`UnrealTestProjectEditor`), exit 0.
- [x] Suite 2 — headless boot smoke, exit 0 + `[Unreal-MCP] plugin loaded`.
- [x] Suite 3 — `UnrealMcp.` Automation specs (test module toggled in via `commands/test-module-uplugin.ps1`): **0 failed / 315 succeeded**, including 5 new `Proactive 'no sidecar binary' surfacing (issue #63)` specs.
- Plugin-only editor-module change (no runtime-module / module-graph change), so Suite 1b BuildPlugin and Suite 7 live-e2e do not apply.
- NOTE: windowed/visual Slate appearance is not verifiable headless — **windowed verification pending operator**; the build + headless smoke + Automation specs validate the state machine and rendered label/hint text.

Closes #63