### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/UnrealMCP/UnrealMCP.uplugin
+++ b/UnrealMCP/UnrealMCP.uplugin
@@ -1,7 +1,7 @@
 {
   "FileVersion": 3,
   "Version": 1,
-  "VersionName": "0.4.1",
+  "VersionName": "0.5.0",
   "FriendlyName": "Unreal MCP (AI Game Developer)",
   "Description": "Model Context Protocol (MCP) integration for the Unreal Editor. Exposes editor operations as AI Tools so MCP-aware AI assistants (Claude, Cursor, Copilot, ...) can inspect and drive your Unreal project. Requires Unreal Engine 5.5+ (no EngineVersion pin: UE treats that field as an exact-build match, not a floor, and would refuse to load on newer engines).",
   "Category": "AI",

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>com.IvanMurzak.Unreal.MCP.Bridge</RootNamespace>
     <AssemblyName>unreal-mcp-bridge</AssemblyName>
-    <Version>0.4.1</Version>
+    <Version>0.5.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2026 Ivan Murzak</Copyright>

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unreal-mcp-cli",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^13.1.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Cross-platform CLI tool for Unreal-MCP (Skills & MCP). Resolves and launches the Unreal editor with MCP connection env vars, runs MCP/system tools over HTTP, probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and manages the UnrealMCP plugin. Works with Claude Code, Cursor, Copilot, and any MCP client.",
   "type": "module",
   "main": "dist/lib.js",


### PR DESCRIPTION
Release bump **0.4.1 → 0.5.0**. Merging to `main` triggers the version-gated `release.yml`: GitHub Release + `v0.5.0` tag, npm `unreal-mcp-cli@0.5.0`, and the code-signed self-contained bridge bundle (win-x64 / osx-arm64 / osx-x64 / linux-x64).

## Included since 0.4.1
- **feat(cli):** host-presence `Custom` connection-mode inference in `buildOpenEnv` — `host` set + no mode ⇒ `UNREAL_MCP_CONNECTION_MODE=Custom`, explicit always wins (#39, PR #160).
- **feat(ui):** proactive "no MCP bridge binary" state in the editor Connection section, with an actionable reinstall / `bootstrap-local` hint (#63, PR #161).

Version-only bump (`.uplugin` VersionName, bridge csproj `<Version>`, `cli/package.json` + lock). Consumed `SERVER_VERSION` pin untouched. Manually verified #63 in a real UE 5.7 editor (clean build, headless smoke, windowed `/state` + screenshot, 0 automation failures).