### PR TITLE
refactor(bridge): behavior-preserving code-quality cleanup

### DIFF
--- a/bridge/src/Ipc/IpcClient.cs
+++ b/bridge/src/Ipc/IpcClient.cs
@@ -424,65 +424,16 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
 
         // --- IToolCallChannel -------------------------------------------------------------------------
 
-        public async Task<ToolResponseMessage> CallToolAsync(string tool, JsonObject? arguments, int timeoutMs, CancellationToken cancellationToken)
-        {
-            // Gate on a COMPLETED handshake, not merely an open socket: _stream/_tcp are published right after
-            // the dial — BEFORE the handshake-ack — and on a reconnect epoch the ProxyTools from the prior
-            // epoch are still registered. A SignalR-driven call landing in that pre-ack window would win the
-            // write race against the handshake, hit the wire first, and be silently dropped by the plugin's
-            // pre-handshake auth gate, with no tool-response ever returning. Fail fast pre-ack instead.
-            var stream = _stream;
-            if (stream == null || !_ackAccepted || _tcp is not { Connected: true })
-                throw new IpcDisconnectedException();
-
-            var requestId = Guid.NewGuid().ToString("N");
-            var task = _pending.Register(requestId);
-
-            // Cancellation: forward the caller's token as tool-cancel and fail the pending call (§4).
-            using var registration = cancellationToken.Register(() =>
-            {
-                // Observe the send like the pong path: if the link is down this fire-and-forget faults, and an
-                // un-awaited faulted Task surfaces as an unobserved TaskException on the finalizer thread.
-                _ = SafeAwait(SendAsync(new ToolCancelMessage { RequestId = requestId }, CancellationToken.None));
-                _pending.TryFail(requestId, new OperationCanceledException(cancellationToken));
-            });
-
-            try
-            {
-                await SendAsync(new ToolCallMessage
-                {
-                    RequestId = requestId,
-                    Tool = tool,
-                    Arguments = arguments,
-                    TimeoutMs = timeoutMs,
-                }, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                _pending.TryFail(requestId, new IpcDisconnectedException());
-                throw new IpcDisconnectedException();
-            }
-
-            // Local timeout backstop: timeoutMs is also embedded in the message for the plugin to honour, but
-            // a silently-dropped call (or a peer that never answers) must still fail this task rather than
-            // hang forever on a healthy link. Arm a local deadline slightly beyond the request timeout so the
-            // plugin's own terminal response normally wins the race; only fire when nothing comes back.
-            if (timeoutMs > 0)
-            {
-                using var backstopCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                var completed = await Task.WhenAny(task, Task.Delay(timeoutMs + IpcProtocol.CallTimeoutGraceMs, backstopCts.Token)).ConfigureAwait(false);
-                backstopCts.Cancel(); // stop the backstop timer whichever side won
-                if (completed != task && !cancellationToken.IsCancellationRequested)
-                {
-                    var timeout = new TimeoutException($"Tool '{tool}' call timed out after {timeoutMs + IpcProtocol.CallTimeoutGraceMs} ms with no IPC response.");
-                    _ = SafeAwait(SendAsync(new ToolCancelMessage { RequestId = requestId }, CancellationToken.None));
-                    _pending.TryFail(requestId, timeout);
-                    throw timeout;
-                }
-            }
-
-            return await task.ConfigureAwait(false);
-        }
+        /// <summary>
+        /// Send a <c>tool-call</c> and await its terminal <c>tool-response</c> (§2.2). Delegates to the shared
+        /// <see cref="RoundTripAsync"/> round-trip — the same handshake gate, requestId correlation,
+        /// cancellation-as-<c>tool-cancel</c>, and local timeout backstop that <see cref="GetPromptAsync"/> and
+        /// <see cref="ReadResourceAsync"/> use. Throws <see cref="IpcDisconnectedException"/> when the link is down.
+        /// </summary>
+        public Task<ToolResponseMessage> CallToolAsync(string tool, JsonObject? arguments, int timeoutMs, CancellationToken cancellationToken)
+            => RoundTripAsync(_pending,
+                requestId => new ToolCallMessage { RequestId = requestId, Tool = tool, Arguments = arguments, TimeoutMs = timeoutMs },
+                $"Tool '{tool}'", timeoutMs, cancellationToken);
 
         // --- Prompt/Resource outbound channels (IPC v2, §A.1) ----------------------------------------
 
@@ -509,9 +460,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
                 $"Resource '{uri}'", timeoutMs, cancellationToken);
 
         /// <summary>
-        /// The shared request→response round-trip for the v2 prompt-get / resource-read channels: identical to
-        /// <see cref="CallToolAsync"/>'s body but parameterized over the pending registry + request factory, so
-        /// the handshake gate, requestId correlation, cancellation-as-tool-cancel, and local timeout backstop
+        /// The shared request→response round-trip for every correlated IPC channel — tool-call (via
+        /// <see cref="CallToolAsync"/>), prompt-get (<see cref="GetPromptAsync"/>), and resource-read
+        /// (<see cref="ReadResourceAsync"/>) — parameterized over the pending registry + request factory so the
+        /// handshake gate, requestId correlation, cancellation-as-<c>tool-cancel</c>, and local timeout backstop
         /// are written once. <typeparamref name="TResponse"/> is the matching terminal response type.
         /// </summary>
         private async Task<TResponse> RoundTripAsync<TResponse>(
@@ -521,7 +473,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
             int timeoutMs,
             CancellationToken cancellationToken)
         {
-            // Gate on a COMPLETED handshake, not merely an open socket — same race as CallToolAsync (§1.4).
+            // Gate on a COMPLETED handshake, not merely an open socket: _stream/_tcp are published right after
+            // the dial — BEFORE the handshake-ack — and on a reconnect epoch the proxies from the prior epoch
+            // are still registered. A SignalR-driven call landing in that pre-ack window would win the write
+            // race against the handshake, hit the wire first, and be silently dropped by the plugin's
+            // pre-handshake auth gate, with no response ever returning. Fail fast pre-ack instead (§1.4).
             var stream = _stream;
             if (stream == null || !_ackAccepted || _tcp is not { Connected: true })
                 throw new IpcDisconnectedException();

--- a/bridge/src/Ipc/IpcMessages.cs
+++ b/bridge/src/Ipc/IpcMessages.cs
@@ -43,8 +43,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
     /// <summary>
     /// The kind-agnostic manifest-entry contract the generic differ
     /// (<see cref="com.IvanMurzak.Unreal.MCP.Bridge.Tools.ManifestDiffer"/>) and the shared
-    /// <see cref="com.IvanMurzak.Unreal.MCP.Bridge.Tools.ManifestRegistrarBase{TDescriptor}"/> need to diff/apply a tool, prompt, or
-    /// resource descriptor without knowing its concrete shape (docs/ARCHITECTURE.md §2.2 / §A.1): the dedup
+    /// <see cref="com.IvanMurzak.Unreal.MCP.Bridge.Tools.ManifestRegistrarBase{TDescriptor}"/>
+    /// need to diff/apply a tool, prompt, or resource descriptor without knowing its concrete shape
+    /// (docs/ARCHITECTURE.md §2.2 / §A.1): the dedup
     /// <see cref="Key"/> (tool/prompt name or resource uri), the <see cref="SchemaHash"/> the diff compares on,
     /// the <see cref="Enabled"/> flag, and the <see cref="StructuralSignature"/> fallback used when a hash is
     /// absent on either side. The computed members carry <see cref="JsonIgnoreAttribute"/> — they are

--- a/bridge/src/Ipc/IpcMessages.cs
+++ b/bridge/src/Ipc/IpcMessages.cs
@@ -40,8 +40,35 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         [JsonPropertyName("config")] public JsonObject? Config { get; set; }
     }
 
+    /// <summary>
+    /// The kind-agnostic manifest-entry contract the generic differ (<see cref="Tools.ManifestDiffer"/>) and the
+    /// shared <see cref="Tools.ManifestRegistrarBase{TDescriptor}"/> need to diff/apply a tool, prompt, or
+    /// resource descriptor without knowing its concrete shape (docs/ARCHITECTURE.md §2.2 / §A.1): the dedup
+    /// <see cref="Key"/> (tool/prompt name or resource uri), the <see cref="SchemaHash"/> the diff compares on,
+    /// the <see cref="Enabled"/> flag, and the <see cref="StructuralSignature"/> fallback used when a hash is
+    /// absent on either side. The computed members carry <see cref="JsonIgnoreAttribute"/> — they are
+    /// projections of the existing wire fields, never serialized.
+    /// </summary>
+    public interface IManifestDescriptor
+    {
+        /// <summary>The dedup/registration key — tool/prompt <c>name</c> or resource <c>uri</c>.</summary>
+        string Key { get; }
+
+        /// <summary>The schema hash the diff compares on (the plugin excludes the enabled flag from it, §2.2).</summary>
+        string? SchemaHash { get; }
+
+        /// <summary>Whether the entry is exposed to MCP clients (toggled independently of the schema hash).</summary>
+        bool Enabled { get; set; }
+
+        /// <summary>
+        /// The structural fallback signature — everything defining the entry's surface EXCEPT the enabled flag —
+        /// used to diff deterministically when a <see cref="SchemaHash"/> is absent on either side.
+        /// </summary>
+        string StructuralSignature { get; }
+    }
+
     /// <summary>One entry in <see cref="ToolManifestMessage.Tools"/> — shaped to fill <c>IRunTool</c> 1:1 (§2.2).</summary>
-    public sealed class ToolDescriptor
+    public sealed class ToolDescriptor : IManifestDescriptor
     {
         [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
         [JsonPropertyName("title")] public string? Title { get; set; }
@@ -57,6 +84,25 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         [JsonPropertyName("enabled")] public bool Enabled { get; set; } = true;
         [JsonPropertyName("extensionId")] public string? ExtensionId { get; set; }
         [JsonPropertyName("schemaHash")] public string? SchemaHash { get; set; }
+
+        /// <inheritdoc />
+        [JsonIgnore] public string Key => Name;
+
+        /// <inheritdoc />
+        [JsonIgnore]
+        public string StructuralSignature
+        {
+            get
+            {
+                // Everything that defines the tool's surface EXCEPT the enabled flag.
+                var input = InputSchema?.ToJsonString() ?? "null";
+                var output = OutputSchema?.ToJsonString() ?? "null";
+                return string.Join("",
+                    Name, Title, Description, SkillDescription, SkillBody,
+                    input, output,
+                    ReadOnlyHint, DestructiveHint, IdempotentHint, OpenWorldHint, ExtensionId);
+            }
+        }
     }
 
     /// <summary>plugin → sidecar: full tool-set snapshot. The sidecar diffs it against the last applied (§2.2).</summary>
@@ -98,7 +144,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
     /// (§A.1). <c>inputSchema</c> is a JSON Schema the manager flattens to the prompt's arguments[];
     /// <c>role</c> is the message author role (<c>"user"</c> | <c>"assistant"</c>).
     /// </summary>
-    public sealed class PromptDescriptor
+    public sealed class PromptDescriptor : IManifestDescriptor
     {
         [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
         [JsonPropertyName("title")] public string? Title { get; set; }
@@ -109,6 +155,21 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         [JsonPropertyName("enabled")] public bool Enabled { get; set; } = true;
         [JsonPropertyName("extensionId")] public string? ExtensionId { get; set; }
         [JsonPropertyName("schemaHash")] public string? SchemaHash { get; set; }
+
+        /// <inheritdoc />
+        [JsonIgnore] public string Key => Name;
+
+        /// <inheritdoc />
+        [JsonIgnore]
+        public string StructuralSignature
+        {
+            get
+            {
+                // Everything that defines the prompt's surface EXCEPT the enabled flag.
+                var input = InputSchema?.ToJsonString() ?? "null";
+                return string.Join("", Name, Title, Description, Role, input, ExtensionId);
+            }
+        }
     }
 
     /// <summary>plugin → sidecar: full prompt-set snapshot (v2, §A.1). The sidecar diffs it against the last applied.</summary>
@@ -124,7 +185,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
     /// 1:1 (§A.1). <c>uri</c> is the resource's MCP URI (the manager's route); MVP resources are
     /// static fixed-URI (templated URIs are deferred — see §A.1).
     /// </summary>
-    public sealed class ResourceDescriptor
+    public sealed class ResourceDescriptor : IManifestDescriptor
     {
         [JsonPropertyName("uri")] public string Uri { get; set; } = string.Empty;
         [JsonPropertyName("name")] public string? Name { get; set; }
@@ -133,6 +194,13 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         [JsonPropertyName("enabled")] public bool Enabled { get; set; } = true;
         [JsonPropertyName("extensionId")] public string? ExtensionId { get; set; }
         [JsonPropertyName("schemaHash")] public string? SchemaHash { get; set; }
+
+        /// <inheritdoc />
+        [JsonIgnore] public string Key => Uri;
+
+        /// <inheritdoc />
+        // Everything that defines the resource's surface EXCEPT the enabled flag.
+        [JsonIgnore] public string StructuralSignature => string.Join("", Uri, Name, Description, MimeType, ExtensionId);
     }
 
     /// <summary>plugin → sidecar: full resource-set snapshot (v2, §A.1). The sidecar diffs it against the last applied.</summary>

--- a/bridge/src/Ipc/IpcMessages.cs
+++ b/bridge/src/Ipc/IpcMessages.cs
@@ -41,8 +41,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
     }
 
     /// <summary>
-    /// The kind-agnostic manifest-entry contract the generic differ (<see cref="Tools.ManifestDiffer"/>) and the
-    /// shared <see cref="Tools.ManifestRegistrarBase{TDescriptor}"/> need to diff/apply a tool, prompt, or
+    /// The kind-agnostic manifest-entry contract the generic differ
+    /// (<see cref="com.IvanMurzak.Unreal.MCP.Bridge.Tools.ManifestDiffer"/>) and the shared
+    /// <see cref="com.IvanMurzak.Unreal.MCP.Bridge.Tools.ManifestRegistrarBase{TDescriptor}"/> need to diff/apply a tool, prompt, or
     /// resource descriptor without knowing its concrete shape (docs/ARCHITECTURE.md §2.2 / §A.1): the dedup
     /// <see cref="Key"/> (tool/prompt name or resource uri), the <see cref="SchemaHash"/> the diff compares on,
     /// the <see cref="Enabled"/> flag, and the <see cref="StructuralSignature"/> fallback used when a hash is

--- a/bridge/src/Tools/ManifestDiff.cs
+++ b/bridge/src/Tools/ManifestDiff.cs
@@ -14,47 +14,31 @@ using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
 namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
 {
     /// <summary>
-    /// The result of diffing a freshly-received tool manifest against the previously applied set
-    /// (docs/ARCHITECTURE.md §2.2 step 1). Pure data; computed by <see cref="ManifestDiffer"/>.
-    /// </summary>
-    public sealed class ManifestDiff
-    {
-        /// <summary>Tools present in the new manifest but not the previous set → <c>AddTool</c>.</summary>
-        public List<ToolDescriptor> Added { get; } = new();
-
-        /// <summary>Tools whose schema hash changed → <c>RemoveTool</c> then <c>AddTool</c>.</summary>
-        public List<ToolDescriptor> Changed { get; } = new();
-
-        /// <summary>Tool names removed from the new manifest → <c>RemoveTool</c>.</summary>
-        public List<string> Removed { get; } = new();
-
-        /// <summary>Tools whose ONLY change is the enabled flag → <c>SetToolEnabled</c>.</summary>
-        public List<(string Name, bool Enabled)> EnabledChanged { get; } = new();
-
-        public bool IsEmpty =>
-            Added.Count == 0 && Changed.Count == 0 && Removed.Count == 0 && EnabledChanged.Count == 0;
-    }
-
-    /// <summary>
-    /// Pure manifest diffing (docs/ARCHITECTURE.md §2.2): compare by <c>name</c> + <c>schemaHash</c>
-    /// (the hash excludes the enabled flag, §2.2). This is the "manifest diff" xUnit target (§9.3).
+    /// Pure manifest diffing (docs/ARCHITECTURE.md §2.2 / §A.1): compare a freshly-received manifest against
+    /// the previously applied set by <c>key</c> + <c>schemaHash</c> (the hash excludes the enabled flag, §2.2),
+    /// falling back to the descriptor's <see cref="IManifestDescriptor.StructuralSignature"/> when a hash is
+    /// absent on either side. Generic over <typeparamref name="TDescriptor"/> through
+    /// <see cref="IManifestDescriptor"/> so the SAME diff serves the tool, prompt (§A.1), and resource (§A.1)
+    /// registrars — formerly three byte-identical per-kind differs. This is the "manifest diff" xUnit target (§9.3).
     /// </summary>
     public static class ManifestDiffer
     {
-        public static ManifestDiff Compute(
-            IReadOnlyDictionary<string, ToolDescriptor> previous,
-            IReadOnlyList<ToolDescriptor> next)
+        public static ManifestDiff<TDescriptor> Compute<TDescriptor>(
+            IReadOnlyDictionary<string, TDescriptor> previous,
+            IReadOnlyList<TDescriptor> next)
+            where TDescriptor : IManifestDescriptor
         {
-            var diff = new ManifestDiff();
-            var nextByName = new Dictionary<string, ToolDescriptor>();
+            var diff = new ManifestDiff<TDescriptor>();
+            var nextByKey = new Dictionary<string, TDescriptor>();
 
             foreach (var desc in next)
             {
-                if (string.IsNullOrEmpty(desc.Name))
+                var key = desc.Key;
+                if (string.IsNullOrEmpty(key))
                     continue;
-                nextByName[desc.Name] = desc;
+                nextByKey[key] = desc;
 
-                if (!previous.TryGetValue(desc.Name, out var prev))
+                if (!previous.TryGetValue(key, out var prev))
                 {
                     diff.Added.Add(desc);
                     continue;
@@ -66,42 +50,31 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
                 }
                 else if (prev.Enabled != desc.Enabled)
                 {
-                    diff.EnabledChanged.Add((desc.Name, desc.Enabled));
+                    diff.EnabledChanged.Add((key, desc.Enabled));
                 }
                 // else: identical → no-op.
             }
 
-            foreach (var name in previous.Keys)
+            foreach (var key in previous.Keys)
             {
-                if (!nextByName.ContainsKey(name))
-                    diff.Removed.Add(name);
+                if (!nextByKey.ContainsKey(key))
+                    diff.Removed.Add(key);
             }
 
             return diff;
         }
 
         /// <summary>
-        /// Two descriptors are schema-equal when their <c>schemaHash</c> matches (the enabled flag is
-        /// excluded from the hash by the plugin, §2.2). When a hash is absent on either side, fall back
-        /// to comparing the structural signature so a manifest without hashes still diffs deterministically.
+        /// Two descriptors are schema-equal when their <c>schemaHash</c> matches (the enabled flag is excluded
+        /// from the hash by the plugin, §2.2). When a hash is absent on either side, fall back to comparing the
+        /// structural signature so a manifest without hashes still diffs deterministically.
         /// </summary>
-        private static bool SchemaEquals(ToolDescriptor a, ToolDescriptor b)
+        private static bool SchemaEquals(IManifestDescriptor a, IManifestDescriptor b)
         {
             if (!string.IsNullOrEmpty(a.SchemaHash) || !string.IsNullOrEmpty(b.SchemaHash))
                 return a.SchemaHash == b.SchemaHash;
 
-            return Signature(a) == Signature(b);
-        }
-
-        private static string Signature(ToolDescriptor d)
-        {
-            // Structural fallback: everything that defines the tool's surface EXCEPT the enabled flag.
-            var input = d.InputSchema?.ToJsonString() ?? "null";
-            var output = d.OutputSchema?.ToJsonString() ?? "null";
-            return string.Join("",
-                d.Name, d.Title, d.Description, d.SkillDescription, d.SkillBody,
-                input, output,
-                d.ReadOnlyHint, d.DestructiveHint, d.IdempotentHint, d.OpenWorldHint, d.ExtensionId);
+            return a.StructuralSignature == b.StructuralSignature;
         }
     }
 }

--- a/bridge/src/Tools/ManifestRegistrar.cs
+++ b/bridge/src/Tools/ManifestRegistrar.cs
@@ -81,37 +81,13 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
         public IReadOnlyList<ToolDescriptor> AppliedDescriptors => new List<ToolDescriptor>(Applied.Values);
 
         /// <summary>Apply a tool manifest. Returns the diff that was applied (empty when ignored/no-op).</summary>
-        public ManifestDiff Apply(ToolManifestMessage manifest)
-        {
-            // ApplyEntries drives the shared remove/changed/add/enabled orchestration through the hooks below
-            // and returns the kind-agnostic diff; re-shape it into the concrete ManifestDiff the §7 callers and
-            // the existing xUnit suite consume (the lists are the same references — no copy of the descriptors).
-            var generic = ApplyEntries(manifest.Revision, manifest.Tools);
-
-            var diff = new ManifestDiff();
-            diff.Added.AddRange(generic.Added);
-            diff.Changed.AddRange(generic.Changed);
-            diff.Removed.AddRange(generic.Removed);
-            diff.EnabledChanged.AddRange(generic.EnabledChanged);
-            return diff;
-        }
+        public ManifestDiff<ToolDescriptor> Apply(ToolManifestMessage manifest)
+            => ApplyEntries(manifest.Revision, manifest.Tools);
 
         protected override string KindLabel => "tool";
 
-        protected override string KeyOf(ToolDescriptor descriptor) => descriptor.Name;
-
         protected override ManifestDiff<ToolDescriptor> ComputeDiff(IReadOnlyList<ToolDescriptor> next)
-        {
-            // Reuse the existing tool-specific differ (name + schemaHash, with the structural fallback), then
-            // re-shape its result into the kind-agnostic diff the base applies.
-            var toolDiff = ManifestDiffer.Compute(Applied, next);
-            var generic = new ManifestDiff<ToolDescriptor>();
-            generic.Added.AddRange(toolDiff.Added);
-            generic.Changed.AddRange(toolDiff.Changed);
-            generic.Removed.AddRange(toolDiff.Removed);
-            generic.EnabledChanged.AddRange(toolDiff.EnabledChanged);
-            return generic;
-        }
+            => ManifestDiffer.Compute(Applied, next);
 
         protected override void SinkRemove(string key) => _sink.RemoveTool(key);
 
@@ -119,13 +95,5 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
             _sink.AddTool(descriptor.Name, ProxyToolFactory.Create(descriptor, _channel));
 
         protected override void SinkSetEnabled(string key, bool enabled) => _sink.SetToolEnabled(key, enabled);
-
-        protected override ToolDescriptor WithEnabled(ToolDescriptor descriptor, bool enabled)
-        {
-            // Mutate in place + return the same instance — preserves the pre-generalization behaviour exactly
-            // (the retained snapshot's Enabled flag is updated on the existing descriptor object).
-            descriptor.Enabled = enabled;
-            return descriptor;
-        }
     }
 }

--- a/bridge/src/Tools/ManifestRegistrarBase.cs
+++ b/bridge/src/Tools/ManifestRegistrarBase.cs
@@ -9,6 +9,7 @@
 */
 
 using System.Collections.Generic;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
 using Microsoft.Extensions.Logging;
 
 namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
@@ -70,6 +71,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
     /// </para>
     /// </summary>
     public abstract class ManifestRegistrarBase<TDescriptor>
+        where TDescriptor : IManifestDescriptor
     {
         protected readonly ILogger? Logger;
 
@@ -93,8 +95,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
         /// <summary>The kind label used in log lines ("tool" / "prompt" / "resource").</summary>
         protected abstract string KindLabel { get; }
 
-        /// <summary>Extract the kind-specific dedup/registration key from a descriptor (tool name / resource uri).</summary>
-        protected abstract string KeyOf(TDescriptor descriptor);
+        /// <summary>The dedup/registration key for a descriptor — tool/prompt name or resource uri, via
+        /// <see cref="IManifestDescriptor.Key"/>.</summary>
+        protected string KeyOf(TDescriptor descriptor) => descriptor.Key;
 
         /// <summary>Compute the diff of <paramref name="next"/> against the retained <see cref="Applied"/> set.</summary>
         protected abstract ManifestDiff<TDescriptor> ComputeDiff(IReadOnlyList<TDescriptor> next);
@@ -108,9 +111,14 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
         /// <summary>Toggle the enabled flag for <paramref name="key"/> on the underlying manager.</summary>
         protected abstract void SinkSetEnabled(string key, bool enabled);
 
-        /// <summary>Return a copy of <paramref name="descriptor"/> with its enabled flag set to <paramref name="enabled"/>
-        /// (the retained snapshot is updated so a later diff sees the new flag).</summary>
-        protected abstract TDescriptor WithEnabled(TDescriptor descriptor, bool enabled);
+        /// <summary>Set the enabled flag on <paramref name="descriptor"/> and return it (the retained snapshot is
+        /// updated in place so a later diff sees the new flag). Mutate-in-place preserves the pre-generalization
+        /// behaviour of the former byte-identical per-kind overrides exactly.</summary>
+        protected TDescriptor WithEnabled(TDescriptor descriptor, bool enabled)
+        {
+            descriptor.Enabled = enabled;
+            return descriptor;
+        }
 
         /// <summary>
         /// Apply a manifest revision carrying <paramref name="entries"/>. Honours the out-of-order revision

--- a/bridge/src/Tools/PromptManifestRegistrar.cs
+++ b/bridge/src/Tools/PromptManifestRegistrar.cs
@@ -49,7 +49,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
     /// sibling of <see cref="ManifestRegistrar"/>. Derives from the shared, kind-agnostic
     /// <see cref="ManifestRegistrarBase{TDescriptor}"/> (the revision guard / reconnect reset / diff-application
     /// loop) and supplies the prompt-specific bits: the <see cref="ProxyPrompt"/> sink + the
-    /// <see cref="PromptManifestDiffer"/>. Implements <see cref="IManifestSink{PromptManifestMessage}"/> so the
+    /// <see cref="ManifestDiffer"/>. Implements <see cref="IManifestSink{PromptManifestMessage}"/> so the
     /// IPC client routes a <c>prompt-manifest</c> to it without knowing the descriptor type. NOT thread-safe by
     /// itself: the IPC client invokes Apply from its single reader loop (same contract as the tool registrar).
     /// </summary>

--- a/bridge/src/Tools/PromptManifestRegistrar.cs
+++ b/bridge/src/Tools/PromptManifestRegistrar.cs
@@ -45,64 +45,6 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
     }
 
     /// <summary>
-    /// The prompt-specific differ (docs/ARCHITECTURE.md §A.1) — the prompt sibling of
-    /// <see cref="ManifestDiffer"/>: compare by <c>name</c> + <c>schemaHash</c> (the hash excludes the enabled
-    /// flag), with a structural-signature fallback when a hash is absent on either side.
-    /// </summary>
-    internal static class PromptManifestDiffer
-    {
-        public static ManifestDiff<PromptDescriptor> Compute(
-            IReadOnlyDictionary<string, PromptDescriptor> previous,
-            IReadOnlyList<PromptDescriptor> next)
-        {
-            var diff = new ManifestDiff<PromptDescriptor>();
-            var nextByName = new Dictionary<string, PromptDescriptor>();
-
-            foreach (var desc in next)
-            {
-                if (string.IsNullOrEmpty(desc.Name))
-                    continue;
-                nextByName[desc.Name] = desc;
-
-                if (!previous.TryGetValue(desc.Name, out var prev))
-                {
-                    diff.Added.Add(desc);
-                    continue;
-                }
-
-                if (!SchemaEquals(prev, desc))
-                    diff.Changed.Add(desc);
-                else if (prev.Enabled != desc.Enabled)
-                    diff.EnabledChanged.Add((desc.Name, desc.Enabled));
-                // else: identical → no-op.
-            }
-
-            foreach (var name in previous.Keys)
-            {
-                if (!nextByName.ContainsKey(name))
-                    diff.Removed.Add(name);
-            }
-
-            return diff;
-        }
-
-        private static bool SchemaEquals(PromptDescriptor a, PromptDescriptor b)
-        {
-            if (!string.IsNullOrEmpty(a.SchemaHash) || !string.IsNullOrEmpty(b.SchemaHash))
-                return a.SchemaHash == b.SchemaHash;
-
-            return Signature(a) == Signature(b);
-        }
-
-        private static string Signature(PromptDescriptor d)
-        {
-            // Structural fallback: everything that defines the prompt's surface EXCEPT the enabled flag.
-            var input = d.InputSchema?.ToJsonString() ?? "null";
-            return string.Join("", d.Name, d.Title, d.Description, d.Role, input, d.ExtensionId);
-        }
-    }
-
-    /// <summary>
     /// Applies prompt manifests (docs/ARCHITECTURE.md §A.1) to an <see cref="IProxyPromptSink"/> — the prompt
     /// sibling of <see cref="ManifestRegistrar"/>. Derives from the shared, kind-agnostic
     /// <see cref="ManifestRegistrarBase{TDescriptor}"/> (the revision guard / reconnect reset / diff-application
@@ -139,10 +81,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
 
         protected override string KindLabel => "prompt";
 
-        protected override string KeyOf(PromptDescriptor descriptor) => descriptor.Name;
-
         protected override ManifestDiff<PromptDescriptor> ComputeDiff(IReadOnlyList<PromptDescriptor> next)
-            => PromptManifestDiffer.Compute(Applied, next);
+            => ManifestDiffer.Compute(Applied, next);
 
         protected override void SinkRemove(string key) => _sink.RemovePrompt(key);
 
@@ -150,12 +90,5 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
             _sink.AddPrompt(descriptor.Name, ProxyPromptFactory.Create(descriptor, _channel));
 
         protected override void SinkSetEnabled(string key, bool enabled) => _sink.SetPromptEnabled(key, enabled);
-
-        protected override PromptDescriptor WithEnabled(PromptDescriptor descriptor, bool enabled)
-        {
-            // Mutate in place + return the same instance (preserves the tool-registrar behaviour exactly).
-            descriptor.Enabled = enabled;
-            return descriptor;
-        }
     }
 }

--- a/bridge/src/Tools/ProxyResourceList.cs
+++ b/bridge/src/Tools/ProxyResourceList.cs
@@ -25,10 +25,20 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
     /// </summary>
     public sealed class ProxyResourceList : IRunResourceList
     {
-        private readonly ResourceDescriptorSnapshot _snapshot;
+        private readonly string _uri;
+        private readonly string _name;
+        private readonly bool _enabled;
+        private readonly string? _mimeType;
+        private readonly string? _description;
 
         public ProxyResourceList(string uri, string name, bool enabled, string? mimeType, string? description)
-            => _snapshot = new ResourceDescriptorSnapshot(uri, name, enabled, mimeType, description);
+        {
+            _uri = uri ?? throw new ArgumentNullException(nameof(uri));
+            _name = name ?? string.Empty;
+            _enabled = enabled;
+            _mimeType = mimeType;
+            _description = description;
+        }
 
         public Task<ResponseListResource[]> Run(params object?[] parameters) => ListAsync();
         public Task<ResponseListResource[]> Run(IDictionary<string, object?>? namedParameters) => ListAsync();
@@ -37,30 +47,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
         {
             // Static MVP: one entry, the resource's own descriptor. No IPC — the URI is fixed and known.
             var entry = new ResponseListResource(
-                uri: _snapshot.Uri,
-                name: _snapshot.Name,
-                enabled: _snapshot.Enabled,
-                mimeType: _snapshot.MimeType,
-                description: _snapshot.Description);
+                uri: _uri,
+                name: _name,
+                enabled: _enabled,
+                mimeType: _mimeType,
+                description: _description);
             return Task.FromResult(new[] { entry });
-        }
-
-        private readonly struct ResourceDescriptorSnapshot
-        {
-            public readonly string Uri;
-            public readonly string Name;
-            public readonly bool Enabled;
-            public readonly string? MimeType;
-            public readonly string? Description;
-
-            public ResourceDescriptorSnapshot(string uri, string name, bool enabled, string? mimeType, string? description)
-            {
-                Uri = uri ?? throw new ArgumentNullException(nameof(uri));
-                Name = name ?? string.Empty;
-                Enabled = enabled;
-                MimeType = mimeType;
-                Description = description;
-            }
         }
     }
 }

--- a/bridge/src/Tools/ProxyTool.cs
+++ b/bridge/src/Tools/ProxyTool.cs
@@ -26,12 +26,15 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
     /// dynamic, manifest-driven tool set.
     ///
     /// <para>
-    /// <b>TODO (upstream swap):</b> this is a local mirror of <c>MCP-Plugin-dotnet</c> PR #122's
-    /// <c>com.IvanMurzak.McpPlugin.ProxyTool</c> (docs/ARCHITECTURE.md §2.3). The §2.3 additive API
-    /// lands as <c>com.IvanMurzak.McpPlugin</c> &gt;= 6.8.0; when the pin is bumped (release-pipeline
-    /// owned), delete this file and use the upstream type — the public surface is identical. The pin
-    /// is FROZEN at 6.7.0 here, so the chars/4 token-count formula is inlined rather than reusing the
-    /// 6.8.0-only <c>ToolTokenCount.Calculate</c> helper. The behaviour is byte-identical.
+    /// <b>TODO (upstream swap):</b> this is a deliberate bridge-local mirror of the
+    /// <c>com.IvanMurzak.McpPlugin.ProxyTool</c> design (docs/ARCHITECTURE.md §2.3). <see cref="IRunTool"/> +
+    /// <c>IToolManager.AddTool</c> are already public, so hosting it here needed no upstream API bump. The
+    /// <c>com.IvanMurzak.McpPlugin</c> pin is currently 6.10.0 — read the live value from the bridge csproj;
+    /// it drifts as upstream releases (it has gone 6.7.0 → 6.9.0 → 6.10.0) — and ships no equivalent
+    /// <c>ProxyTool</c> yet, so the chars/4 token-count formula stays inlined below to keep this mirror
+    /// self-contained rather than depending on an upstream <c>ToolTokenCount.Calculate</c> helper. If a
+    /// future upstream ships an equivalent ProxyTool, the swap is release-pipeline owned: delete this file
+    /// and use the upstream type — the public surface is identical. The behaviour is byte-identical either way.
     /// </para>
     /// </summary>
     public sealed class ProxyTool : IRunTool

--- a/bridge/src/Tools/ResourceManifestRegistrar.cs
+++ b/bridge/src/Tools/ResourceManifestRegistrar.cs
@@ -53,7 +53,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
     /// resource sibling of <see cref="ManifestRegistrar"/> / <see cref="PromptManifestRegistrar"/>. Derives from
     /// the shared, kind-agnostic <see cref="ManifestRegistrarBase{TDescriptor}"/> (the revision guard / reconnect
     /// reset / diff-application loop) and supplies the resource-specific bits: the <see cref="ProxyResource"/>
-    /// sink + the <see cref="ResourceManifestDiffer"/>. Implements
+    /// sink + the <see cref="ManifestDiffer"/>. Implements
     /// <see cref="IManifestSink{ResourceManifestMessage}"/> so the IPC client routes a <c>resource-manifest</c>
     /// to it without knowing the descriptor type. NOT thread-safe by itself: the IPC client invokes Apply from
     /// its single reader loop (same contract as the tool/prompt registrars).

--- a/bridge/src/Tools/ResourceManifestRegistrar.cs
+++ b/bridge/src/Tools/ResourceManifestRegistrar.cs
@@ -49,64 +49,6 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
     }
 
     /// <summary>
-    /// The resource-specific differ (docs/ARCHITECTURE.md §A.1) — the resource sibling of
-    /// <see cref="ManifestDiffer"/> / <see cref="PromptManifestDiffer"/>: compare by <c>uri</c> +
-    /// <c>schemaHash</c> (the hash excludes the enabled flag), with a structural-signature fallback when a hash
-    /// is absent on either side.
-    /// </summary>
-    internal static class ResourceManifestDiffer
-    {
-        public static ManifestDiff<ResourceDescriptor> Compute(
-            IReadOnlyDictionary<string, ResourceDescriptor> previous,
-            IReadOnlyList<ResourceDescriptor> next)
-        {
-            var diff = new ManifestDiff<ResourceDescriptor>();
-            var nextByUri = new Dictionary<string, ResourceDescriptor>();
-
-            foreach (var desc in next)
-            {
-                if (string.IsNullOrEmpty(desc.Uri))
-                    continue;
-                nextByUri[desc.Uri] = desc;
-
-                if (!previous.TryGetValue(desc.Uri, out var prev))
-                {
-                    diff.Added.Add(desc);
-                    continue;
-                }
-
-                if (!SchemaEquals(prev, desc))
-                    diff.Changed.Add(desc);
-                else if (prev.Enabled != desc.Enabled)
-                    diff.EnabledChanged.Add((desc.Uri, desc.Enabled));
-                // else: identical → no-op.
-            }
-
-            foreach (var uri in previous.Keys)
-            {
-                if (!nextByUri.ContainsKey(uri))
-                    diff.Removed.Add(uri);
-            }
-
-            return diff;
-        }
-
-        private static bool SchemaEquals(ResourceDescriptor a, ResourceDescriptor b)
-        {
-            if (!string.IsNullOrEmpty(a.SchemaHash) || !string.IsNullOrEmpty(b.SchemaHash))
-                return a.SchemaHash == b.SchemaHash;
-
-            return Signature(a) == Signature(b);
-        }
-
-        private static string Signature(ResourceDescriptor d)
-        {
-            // Structural fallback: everything that defines the resource's surface EXCEPT the enabled flag.
-            return string.Join("", d.Uri, d.Name, d.Description, d.MimeType, d.ExtensionId);
-        }
-    }
-
-    /// <summary>
     /// Applies resource manifests (docs/ARCHITECTURE.md §A.1) to an <see cref="IProxyResourceSink"/> — the
     /// resource sibling of <see cref="ManifestRegistrar"/> / <see cref="PromptManifestRegistrar"/>. Derives from
     /// the shared, kind-agnostic <see cref="ManifestRegistrarBase{TDescriptor}"/> (the revision guard / reconnect
@@ -144,10 +86,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
 
         protected override string KindLabel => "resource";
 
-        protected override string KeyOf(ResourceDescriptor descriptor) => descriptor.Uri;
-
         protected override ManifestDiff<ResourceDescriptor> ComputeDiff(IReadOnlyList<ResourceDescriptor> next)
-            => ResourceManifestDiffer.Compute(Applied, next);
+            => ManifestDiffer.Compute(Applied, next);
 
         protected override void SinkRemove(string key) => _sink.RemoveResource(key);
 
@@ -155,12 +95,5 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tools
             _sink.AddResource(descriptor.Uri, ProxyResourceFactory.Create(descriptor, _channel));
 
         protected override void SinkSetEnabled(string key, bool enabled) => _sink.SetResourceEnabled(key, enabled);
-
-        protected override ResourceDescriptor WithEnabled(ResourceDescriptor descriptor, bool enabled)
-        {
-            // Mutate in place + return the same instance (preserves the tool/prompt-registrar behaviour exactly).
-            descriptor.Enabled = enabled;
-            return descriptor;
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Make `IpcClient.CallToolAsync` delegate to the shared `RoundTripAsync` round-trip, exactly like `GetPromptAsync`/`ReadResourceAsync` — removes a ~50-line duplicate; wire bytes and the timeout-exception text are unchanged.
- Collapse the three near-identical manifest differs (tool/prompt/resource) behind one generic `ManifestDiffer.Compute<TDescriptor>` via a new `IManifestDescriptor { Key, SchemaHash, Enabled, StructuralSignature }`; `ManifestRegistrarBase` now implements `KeyOf`/`WithEnabled` once (dropping the 3+3 byte-identical overrides); and delete the redundant non-generic `ManifestDiff` type (`Compute` / `Apply` return `ManifestDiff<ToolDescriptor>` directly).
- Correct the stale comment in `ProxyTool` claiming the McpPlugin pin is "FROZEN at 6.7.0" — the csproj pins 6.10.0 (comment-only; no upstream swap).
- Inline the single-use private `ResourceDescriptorSnapshot` struct in `ProxyResourceList`.

All changes are behavior-preserving and scoped strictly to `bridge/` (no `UnrealMCP/` or `cli/` changes).

## Test plan
- [x] `dotnet build bridge/Unreal-MCP-Bridge.sln --configuration Debug` — 0 warnings, 0 errors
- [x] `dotnet test bridge/Unreal-MCP-Bridge.sln --configuration Debug` — 211/211 passed (ManifestDifferTests + the registrar suites stay green)

Closes #163