### PR TITLE
docs: fix stale CLAUDE.md (modules/version/architecture)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ the editor module that depends on it):
 
 | Path | What it is |
 | --- | --- |
-| `UnrealMCP/` | The UE **plugin**. `UnrealMCP/UnrealMCP.uplugin` `VersionName` is the version single-source (currently **`0.5.0`**). **No `EngineVersion` pin** (UE treats that field as an exact-build match, not a floor, and would refuse to load on newer engines); the **5.5+ floor** is a CI/doc claim (CI-tested against **5.7** and **5.8**). Declared modules: **`UnrealMcpRuntime` (Type `Runtime`)** + **`UnrealMcpEditor` (Type `Editor`)**, both LoadingPhase `Default`, runtime first |
+| `UnrealMCP/` | The UE **plugin**. `UnrealMCP/UnrealMCP.uplugin` `VersionName` is the version single-source (currently **`0.6.1`**). **No `EngineVersion` pin** (UE treats that field as an exact-build match, not a floor, and would refuse to load on newer engines); the **5.5+ floor** is a CI/doc claim (CI-tested against **5.7** and **5.8**). Declared modules: **`UnrealMcpRuntime` (Type `Runtime`)** + **`UnrealMcpEditor` (Type `Editor`)**, both LoadingPhase `Default`, runtime first |
 | `UnrealMCP/Source/UnrealMcpRuntime/Public/` | The **public** contracts — re-exported by `UnrealMcpEditor`, so the SAME headers serve editor and runtime extensions: the tool/prompt/resource provider interfaces (`IUnrealMcpToolProvider.h`, `IUnrealMcpPromptProvider.h`, `IUnrealMcpResourceProvider.h`) + their fluent registries (`UnrealMcpToolRegistry.h`, `UnrealMcpPromptRegistry.h`, `UnrealMcpResourceRegistry.h`); the runtime bootstrap (`UnrealMcpRuntimeSubsystem.h`); the kill-switch settings (`UnrealMcpRuntimeSettings.h`); and the runtime core-family `Register` entry points (`UnrealMcpRuntimeCoreTools.h` = `ping`, `UnrealMcpRuntimeCorePrompts.h`, `UnrealMcpRuntimeCoreResources.h`) |
 | `UnrealMCP/Source/UnrealMcpRuntime/Private/` | The infra that cooks into games: `Bridge/` (TCP listener + NDJSON), `Dispatch/` (game-thread dispatcher), `Tools/` (registry, object-ref, world provider, property-JSON, scoped-read, log collector, `ping`), `Sidecar/`, `Config/`, `Extensions/`, plus the core `Prompts/`/`Resources/` families |
 | `UnrealMCP/Source/UnrealMcpEditor/Private/` | The editor-only surface: `Tools/` (the 8 families = 62 tools), `UI/` (Slate main window + aux tabs), `Server/` (local `gamedev-mcp-server` manager), `DevControl/`, plus the renamed editor coordinator |
@@ -209,7 +209,7 @@ runtime module ships only `ping`.
 
 ## Versioning
 
-Single semver shared by plugin / bridge / cli, currently **0.5.0**. The `UnrealMCP/UnrealMCP.uplugin`
+Single semver shared by plugin / bridge / cli, currently **0.6.1**. The `UnrealMCP/UnrealMCP.uplugin`
 `VersionName` is the **single source of truth**. Bump with:
 
 ```powershell

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ the editor module that depends on it):
 > (b) the `UnrealMcpRuntime` module holds the engine-agnostic infra + the runtime-safe `ping`, and
 > `UnrealMcpEditor` depends on it; (c) a runtime connection is **explicit opt-in** — a shipped game NEVER
 > auto-connects. The 62 engine-development tools are all **editor-only**; a game brings its OWN gameplay
-> tools (see [Customize Tools, Prompts & Resources](#extensions--custom-tools-prompts--resources)).
+> tools via `IUnrealMcpToolProvider` (author guide: [`docs/EXTENSIONS.md`](docs/EXTENSIONS.md)).
 
 ## Layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,40 +1,114 @@
 # CLAUDE.md — Unreal-MCP
 
-Unreal-MCP bridges LLMs (Claude, Cursor, Copilot, …) with the [Unreal Engine](https://www.unrealengine.com/)
-editor via the [Model Context Protocol](https://modelcontextprotocol.io/) — the Unreal-engine sibling of
-Unity-MCP and Godot-MCP. **Status: beta** — the plugin, the .NET sidecar, the
-`unreal-mcp-cli`, the AI Game Developer editor UI, and **62 built-in tools across 8 families** have shipped
-and are covered by CI; nothing is published to a package registry yet. The local MCP server is the
-shared, engine-agnostic [GameDev-MCP-Server](https://github.com/IvanMurzak/GameDev-MCP-Server)
+Unreal-MCP bridges LLMs (Claude, Cursor, Copilot, …) with [Unreal Engine](https://www.unrealengine.com/)
+via the [Model Context Protocol](https://modelcontextprotocol.io/) — the Unreal-engine sibling of
+Unity-MCP and Godot-MCP. It works in **two modes**: an **editor** mode (the default — drive the Unreal
+**Editor**: spawn actors, edit levels, author/compile Blueprints, edit/compile C++, capture screenshots,
+…) and an opt-in **in-game runtime** mode (drive a running PIE / Standalone / packaged **Development**
+build so an AI can operate your live game). **Status: beta** — the plugin, the .NET sidecar, the
+`unreal-mcp-cli`, the AI Game Developer editor UI, and **62 built-in editor tools across 8 families**
+have shipped and are covered by CI. The `unreal-mcp-cli` is **published on npm** (the Fab / Epic
+Marketplace listing for the precompiled plugin is coming soon). The local MCP server is the shared,
+engine-agnostic [GameDev-MCP-Server](https://github.com/IvanMurzak/GameDev-MCP-Server)
 (binary `gamedev-mcp-server`) — no server source lives in this repo.
 
-**The authoritative design is [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).** Read the relevant
-section before implementing anything non-trivial — it locks the IPC protocol (§1), dynamic tool
-registration (§2), schema generation (§3), the game-thread dispatcher (§4), extensions (§5), sidecar
-lifecycle (§6), UI (§7), config (§8), repo/versioning/CI (§9), and the tool-family roadmap (§10). The
-user-facing entry point is [`README.md`](README.md); the release runbook is
+**The authoritative design is [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)** (defer to it on any
+conflict). Read the relevant section before implementing anything non-trivial — it locks the IPC
+protocol (§1), dynamic tool registration (§2), schema generation (§3), the game-thread dispatcher (§4),
+extensions (§5), sidecar lifecycle (§6), UI (§7), config (§8), repo/versioning/CI (§9), the tool-family
+roadmap (§10), risks (§11), **runtime (in-game) support (§12)**, and custom prompts & resources (§A).
+The user-facing entry point is [`README.md`](README.md); the release runbook is
 [`docs/RELEASING.md`](docs/RELEASING.md); the extension author guide is
-[`docs/EXTENSIONS.md`](docs/EXTENSIONS.md).
+[`docs/EXTENSIONS.md`](docs/EXTENSIONS.md); the in-game operator walkthrough is
+[`docs/RUNTIME-E2E.md`](docs/RUNTIME-E2E.md).
+
+## Architecture in one screen
+
+Unlike Unity/Godot (C# engines that host the .NET `McpPlugin`/ReflectorNet/SignalR stack **in-process**),
+Unreal's editor and runtime are **C++** and cannot host that .NET stack. So the McpPlugin host runs as an
+auto-managed **.NET 9 sidecar process** (`unreal-mcp-bridge`, `bridge/`) that is a **local child of
+whichever host loads the plugin** — the **Editor** in dev, or the **game process itself** in an opt-in
+packaged build. It is never remote: the C++ plugin **listens** on a loopback TCP port and the sidecar
+**dials** it, authenticating with a one-shot token delivered over **stdin** (never argv — §1.4). The
+sidecar relays IPC ⇄ SignalR to the MCP server (cloud `ai-game.dev` by default, or a local
+`gamedev-mcp-server`). See the §0 system-overview diagram.
+
+The plugin is split into two modules (`UnrealMCP/UnrealMCP.uplugin`, runtime FIRST so it loads before
+the editor module that depends on it):
+
+- **`UnrealMcpRuntime`** (Type **Runtime**, LoadingPhase Default) — the dependency-lean, engine-agnostic
+  machinery that cooks into packaged games: the tool **registry**, the game-thread **dispatcher**, the
+  loopback-TCP **bridge server** + NDJSON framing, the **sidecar manager**, the world provider, the
+  **extension manager**, config, the `IUnrealMcp*Provider` contracts + builders, and the runtime built-in
+  `ping`. NO UnrealEd / Slate / asset / blueprint / capture deps (deps: Core/CoreUObject/Engine/
+  DeveloperSettings public; Networking/Sockets/Json/JsonUtilities/Projects private). Also home to the
+  runtime bootstrap (`UUnrealMcpRuntimeSubsystem`) + kill-switch settings (`UUnrealMcpRuntimeSettings`).
+- **`UnrealMcpEditor`** (Type **Editor**, LoadingPhase Default) — depends on `UnrealMcpRuntime` and layers
+  the Slate UI + the **62 editor-only tools** (the 8 families below, several RCE-class) on the SAME
+  registry, plus the local-server manager and the dev-control bridge.
+
+> Three locked decisions (ARCHITECTURE §12): (a) reuse the .NET sidecar — no in-process C++ server;
+> (b) the `UnrealMcpRuntime` module holds the engine-agnostic infra + the runtime-safe `ping`, and
+> `UnrealMcpEditor` depends on it; (c) a runtime connection is **explicit opt-in** — a shipped game NEVER
+> auto-connects. The 62 engine-development tools are all **editor-only**; a game brings its OWN gameplay
+> tools (see [Customize Tools, Prompts & Resources](#extensions--custom-tools-prompts--resources)).
 
 ## Layout
 
 | Path | What it is |
 | --- | --- |
-| `UnrealMCP/` | The UE **editor plugin**. `UnrealMCP/UnrealMCP.uplugin` `VersionName` is the version single-source (currently `0.1.0`). **No `EngineVersion` pin** (UE treats it as exact-match, not a floor). Modules: `UnrealMcpEditor` + `UnrealMcpEditorTests` (both Type `Editor`, LoadingPhase `Default`) |
-| `UnrealMCP/Source/UnrealMcpRuntime/Public/` | The extension contract (`IUnrealMcpToolProvider.h`), the tool registry (`UnrealMcpToolRegistry.h`), the runtime bootstrap (`UnrealMcpRuntimeSubsystem.h`), the kill-switch settings (`UnrealMcpRuntimeSettings.h`), and the runtime core-family `Register` entry points (`UnrealMcpRuntimeCoreTools.h`). The headers are re-exported by `UnrealMcpEditor`, so the same contract serves editor and runtime extensions |
-| `UnrealMCP/Source/UnrealMcpEditor/Private/` | `Tools/` (the 8 families), `Config/`, `UI/`, plus Bridge/Schema/Dispatch/Sidecar code per ARCHITECTURE §9.1 |
-| `UnrealMCP/Source/UnrealMcpEditorTests/` | Automation specs behind `WITH_DEV_AUTOMATION_TESTS`, names under the **`UnrealMcp.`** filter prefix. **No top-level test folder** — tests live per-leg |
-| `bridge/` | .NET 9 **sidecar** `com.IvanMurzak.Unreal.MCP.Bridge` (binary `unreal-mcp-bridge`) — the McpPlugin host the plugin spawns; IPC ⇄ SignalR relay. xUnit tests in `bridge/tests/`. Hand-authored, TRACKED solution `bridge/Unreal-MCP-Bridge.sln` |
-| `cli/` | `unreal-mcp-cli` npm package (TypeScript, commander, vitest) — 16 commands. Publish-ready (metadata complete); the first version is published manually by the owner, then CI takes over — see `docs/RELEASING.md` |
-| `samples/UnrealAITemplate/` | The §5 extension template plugin (a `hello-extension` tool + an invalid-schema switch) |
+| `UnrealMCP/` | The UE **plugin**. `UnrealMCP/UnrealMCP.uplugin` `VersionName` is the version single-source (currently **`0.5.0`**). **No `EngineVersion` pin** (UE treats that field as an exact-build match, not a floor, and would refuse to load on newer engines); the **5.5+ floor** is a CI/doc claim (CI-tested against **5.7** and **5.8**). Declared modules: **`UnrealMcpRuntime` (Type `Runtime`)** + **`UnrealMcpEditor` (Type `Editor`)**, both LoadingPhase `Default`, runtime first |
+| `UnrealMCP/Source/UnrealMcpRuntime/Public/` | The **public** contracts — re-exported by `UnrealMcpEditor`, so the SAME headers serve editor and runtime extensions: the tool/prompt/resource provider interfaces (`IUnrealMcpToolProvider.h`, `IUnrealMcpPromptProvider.h`, `IUnrealMcpResourceProvider.h`) + their fluent registries (`UnrealMcpToolRegistry.h`, `UnrealMcpPromptRegistry.h`, `UnrealMcpResourceRegistry.h`); the runtime bootstrap (`UnrealMcpRuntimeSubsystem.h`); the kill-switch settings (`UnrealMcpRuntimeSettings.h`); and the runtime core-family `Register` entry points (`UnrealMcpRuntimeCoreTools.h` = `ping`, `UnrealMcpRuntimeCorePrompts.h`, `UnrealMcpRuntimeCoreResources.h`) |
+| `UnrealMCP/Source/UnrealMcpRuntime/Private/` | The infra that cooks into games: `Bridge/` (TCP listener + NDJSON), `Dispatch/` (game-thread dispatcher), `Tools/` (registry, object-ref, world provider, property-JSON, scoped-read, log collector, `ping`), `Sidecar/`, `Config/`, `Extensions/`, plus the core `Prompts/`/`Resources/` families |
+| `UnrealMCP/Source/UnrealMcpEditor/Private/` | The editor-only surface: `Tools/` (the 8 families = 62 tools), `UI/` (Slate main window + aux tabs), `Server/` (local `gamedev-mcp-server` manager), `DevControl/`, plus the renamed editor coordinator |
+| `UnrealMCP/Source/UnrealMcpEditorTests/` | Automation specs behind `WITH_DEV_AUTOMATION_TESTS`, names under the **`UnrealMcp.`** filter prefix. **This module is NOT declared in the distributed `UnrealMCP.uplugin`** (Fab flags shipped test modules, §6.7) — PR/dev CI transiently re-adds it via `commands/test-module-uplugin.ps1` around the Automation BuildPlugin, then reverts. **No top-level test folder** — tests live per-leg |
+| `bridge/` | .NET 9 **sidecar** `com.IvanMurzak.Unreal.MCP.Bridge` (binary `unreal-mcp-bridge`) — the self-contained McpPlugin host the plugin spawns; IPC ⇄ SignalR relay. xUnit tests in `bridge/tests/`. Hand-authored, TRACKED solution `bridge/Unreal-MCP-Bridge.sln` |
+| `cli/` | `unreal-mcp-cli` npm package (TypeScript, commander, vitest) — 16 commands. **Published on npm**; CI owns subsequent releases (see `docs/RELEASING.md`) |
+| `samples/UnrealAITemplate/` | The §5 **editor** extension template plugin (a `hello-extension` tool + an `UNREAL_AI_TEMPLATE_INVALID_SCHEMA` switch that demonstrates per-extension isolation) |
+| `samples/UnrealAIRuntimeSample/` | The **runtime (in-game)** extension sample — a `Type=Runtime` plugin whose `game-time-dilation` tool reads/sets the live world's `AWorldSettings::TimeDilation`, callable over a runtime MCP connection (§12.9) |
 | `commands/bump-version.ps1` | Rewrites the version across `.uplugin` / bridge csproj / `cli/package.json`. **Release-pipeline-owned — never run from a feature task**. It does NOT touch the consumed server pin (`cli/src/lib/server-version.ts` `SERVER_VERSION`) |
 
-Unlike Unity/Godot, the editor is C++: the .NET `McpPlugin` host lives in the **sidecar process**, not
-in-process. The plugin **listens** on a localhost TCP port; the sidecar **dials**, authenticating with a
-one-shot token delivered over **stdin** (never argv — §1.4). Two child processes must not be conflated:
-`unreal-mcp-bridge` (always required) and `gamedev-mcp-server` (Custom/local mode only — downloaded
-by the CLI from GameDev-MCP-Server releases, pinned by `cli/src/lib/server-version.ts`
-`SERVER_VERSION`; `UNREAL_MCP_SERVER_PATH` overrides the path for local builds).
+Two child processes must not be conflated: `unreal-mcp-bridge` (the sidecar; always required when a
+connection is live) and `gamedev-mcp-server` (Custom/local mode only — downloaded by the CLI from
+GameDev-MCP-Server releases, pinned by `cli/src/lib/server-version.ts` `SERVER_VERSION`;
+`UNREAL_MCP_SERVER_PATH` overrides the path for local builds; the editor can also Start/Stop it directly
+via `FUnrealMcpServerManager`, gated to Custom + http).
+
+## Editor vs runtime (in-game)
+
+- **Editor mode** (default, everything in §0–§11): the **Editor** loads the plugin, auto-spawns the
+  sidecar, and serves the 62 editor tools + the core `ping`/prompt/resource families. This is the
+  `unreal-mcp-cli` / AI Game Developer window flow.
+- **Runtime mode** (§12): a running game can host an MCP connection. The entry point is a
+  `UGameInstanceSubsystem`, `UUnrealMcpRuntimeSubsystem` (in `UnrealMcpRuntime`) — auto-instantiated per
+  `UGameInstance` but it **never auto-connects**; `Initialize()` only arms the listener (no sidecar spawn,
+  no dial). A connection is always an explicit opt-in `Connect(Host, Token, Mode, bAllowRemoteHost)` from
+  C++ / a Blueprint node / the `UnrealMcp.Connect` console command, which then spawns the sidecar.
+- **Runtime built-in surface = `ping` ONLY.** Every engine-development family (actor/component,
+  `object-*`, level, console/reflection, screenshot, blueprint, asset, source, editor-application/
+  selection) is **editor-only** — they drive the editor and several are RCE-class, so they are not
+  compiled into a shipped game. A game gets runtime tools by **bringing its own** via
+  `IUnrealMcpToolProvider` (see the §12.7 / §12.9 design; the deterministic
+  `UnrealMcp.RuntimeSubsystem` Automation gate asserts the runtime manifest is exactly `{ping}`).
+- **Runtime security gates** — all enforced inside `Connect()` (§12.8): (1) **opt-in only**, never
+  auto-connect; (2) **kill switch** `UUnrealMcpRuntimeSettings::bRuntimeMcpEnabled` (Project Settings →
+  Plugins → *Unreal MCP (Runtime)*, a **Game** config setting in `DefaultGame.ini`) defaults **false** —
+  while off every `Connect()` is rejected and no sidecar spawns; (3) **Shipping gate** — the
+  `bUnrealMcpAllowShipping` `*.Build.cs` flag defaults **false** (→ `UNREAL_MCP_ALLOW_SHIPPING=0`), so
+  `Connect()` returns false in a Shipping build unless deliberately compiled in (the same flag also gates
+  whether the sidecar is staged into a Shipping package); (4) **loopback-host default** — non-loopback
+  hosts rejected unless the caller passes `bAllowRemoteHost=true`; (5) **loopback IPC + one-shot stdin
+  token** (same model as the editor). Runtime MCP is **Desktop-only** (Win64/Mac/Linux) — console/mobile
+  cannot spawn the .NET sidecar.
+- **Excluding Unreal-MCP from packaged games (zero footprint).** A consumer who only wants the editor
+  tooling pins the plugin to the editor with a **`TargetDenyList`** in **their own `.uproject`** plugin
+  reference (NOT the plugin's `.uplugin`): `{ "Name": "UnrealMCP", "Enabled": true, "TargetDenyList":
+  ["Game","Client","Server"] }`. UE honours it (`PluginReferenceDescriptor::IsEnabledForTarget`), so the
+  `UnrealMcpRuntime` module + the bundled sidecar `RuntimeDependencies` are excluded from packaged
+  `Game`/`Client`/`Server` builds (editor modules are stripped by Type regardless). **Caveat:** a direct
+  `*.Build.cs` dependency on (or `#include` of) any `UnrealMcp*` module from a **game** module overrides
+  the deny-list and pulls the runtime module into the game anyway — a pure editor-only project references
+  nothing from the plugin, so it stays clean by construction.
 
 ## Build / test (per leg)
 
@@ -42,8 +116,9 @@ The repo is a three-leg mono-repo (plugin, bridge, cli). Run only the legs your 
 
 ### UE plugin (`UnrealMCP/**`)
 
-Needs UE 5.7 and a host C++ project with the plugin available (the infra repo's `Unreal-Test-Project/`
-junctions `Plugins/UnrealMCP → <repo>/UnrealMCP`). Quote engine paths — they contain spaces.
+Needs UE 5.7 and a host C++ project with the plugin available (the `software` testbed
+`engines/unreal/test-project/` junctions `Plugins/UnrealMCP → <repo>/UnrealMCP`). Quote engine paths —
+they contain spaces.
 
 ```bash
 # 1. Build (UBT). First build in a fresh checkout can take 10+ minutes; incremental 1-3 min.
@@ -60,6 +135,10 @@ junctions `Plugins/UnrealMCP → <repo>/UnrealMCP`). Quote engine paths — they
   "<host>/UnrealTestProject.uproject" -nullrhi -nosplash -unattended \
   -ExecCmds="Automation RunTests UnrealMcp; Quit" -ReportExportPath="<dir>" -log
 ```
+
+The `UnrealMcpEditorTests` module is **not** in the distributed `.uplugin` (§6.7); to run the Automation
+specs locally, transiently re-add it with `commands/test-module-uplugin.ps1` (idempotent add/remove around
+the Automation build), then revert — never commit the test module into the descriptor.
 
 **The exported JSON report is authoritative, not the exit code** (UnrealEditor-Cmd's exit code is
 unreliable across versions for test failures). Parse `<ReportExportPath>/index.json` — **note it is
@@ -92,6 +171,11 @@ Each `bridge/publish/<rid>/` holds exactly one apphost (`unreal-mcp-bridge[.exe]
 RID is supplied, so a plain `dotnet build`/`test` (no `-r`) stays framework-dependent at the flat
 `bin/<cfg>/net9.0/unreal-mcp-bridge.exe` path the live-e2e harness (`UNREAL_MCP_BRIDGE_PATH`) reads.
 
+The release job stages the signed per-RID slices into the plugin's Fab-surviving `Sidecar/<rid>/` folder
+(declared in `Config/FilterPlugin.ini`); `UnrealMcpRuntime.Build.cs` `RuntimeDependencies` (two-arg form)
+then stages them into `Binaries/ThirdParty/UnrealMcpBridge/<rid>/` at package time — the path the C++
+resolver reads. Binaries are **never** committed to git.
+
 ### server — none in this repo
 
 The MCP server lives in the shared [GameDev-MCP-Server](https://github.com/IvanMurzak/GameDev-MCP-Server)
@@ -113,20 +197,32 @@ returns HTTP 500 after `No connected clients`). Tool-set/manifest assertions nee
 `POST /mcp`, not the `/api/tools/<name>` REST passthrough (which only invokes one named tool and drops
 the `content[]` image array). `/api/tools/<name>` calls **require** `-H "Content-Type: application/json"`.
 
+## Tool / prompt / resource surface
+
+The editor ships **62 built-in ("core") tools across 8 families** (counts from the registration source:
+actor 13, blueprint 11, asset 11, editor/reflection 9, level 7, source 6, screenshot 4, ping 1 = 62).
+Tool ids are kebab-case (`actor-create`, `blueprint-compile`); the registry validates
+`^[a-z0-9]+(-[a-z0-9]+)*$`. The README carries the full, source-generated family-by-family list — treat
+it as the canonical inventory. Plus shipped **core prompt** `level-design-brief` and **core resources**
+`unreal://project/levels` + `unreal://project/icon` (static fixed-URI only; templated URIs deferred). The
+runtime module ships only `ping`.
+
 ## Versioning
 
-Single semver shared by plugin / bridge / cli, starting at **0.1.0**. The
-`UnrealMCP/UnrealMCP.uplugin` `VersionName` is the **single source of truth**. Bump with:
+Single semver shared by plugin / bridge / cli, currently **0.5.0**. The `UnrealMCP/UnrealMCP.uplugin`
+`VersionName` is the **single source of truth**. Bump with:
 
 ```powershell
-.\commands\bump-version.ps1 -NewVersion "0.2.0"        # add -WhatIf to preview
+.\commands\bump-version.ps1 -NewVersion "0.6.0"        # add -WhatIf to preview
 ```
 
 It rewrites the `.uplugin` `VersionName`, the bridge csproj `<Version>`, and
 `cli/package.json` (+ lock). **Never hand-edit one of them alone, and never bump from a feature task** —
 the release pipeline owns version changes. The consumed GameDev-MCP-Server version is pinned
-separately in `cli/src/lib/server-version.ts` (`SERVER_VERSION`); bumping it requires the
-corresponding shared release to already exist (see `docs/RELEASING.md`).
+separately in `cli/src/lib/server-version.ts` (`SERVER_VERSION`) and deliberately diverges (plugin 0.x,
+shared server 8.x); bumping it requires the corresponding shared release to already exist (see
+`docs/RELEASING.md`). The plugin↔sidecar handshake (`sidecarVersion` vs `pluginVersion`) is independent
+of the consumed server version, so a `SERVER_VERSION` bump never touches it.
 
 **Frozen NuGet pins** (lockstep with Godot-MCP; owned by the upstream release pipelines — NEVER bump
 here): `com.IvanMurzak.ReflectorNet` **5.3.1**, `com.IvanMurzak.McpPlugin` **6.10.0** (bridge — 6.10.0 also
@@ -134,46 +230,58 @@ supplies the shared engine-agnostic `com.IvanMurzak.McpPlugin.AgentConfig` modul
 keeps the ReflectorNet 5.3.1 dependency, so the Godot-MCP lockstep holds). This number drifts as upstream
 releases (it has gone 6.7.0 → 6.9.0 → 6.10.0); the authoritative pin is always whatever
 `bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj` declares — read it live, do not trust this line. The
-§2.3 `ProxyTool` lives in `bridge/` (`bridge/src/Tools/ProxyTool.cs` + `ProxyToolFactory.cs`) — `IRunTool`
-+ `ToolManager.AddTool` are already public, so no upstream API bump was required; a future upstream
-ProxyTool can replace the local copy through its own pipeline.
+§2.3 `ProxyTool` (and the §A `ProxyPrompt`/`ProxyResource`) live in `bridge/` (`bridge/src/Tools/`,
+`bridge/src/`) — `IRunTool`/`IRunPrompt`/`IRunResource` + the manager `Add*` APIs are already public, so no
+upstream API bump was required; a future upstream version can replace the local copies through its own
+pipeline.
 
 ## Conventions
 
-- **Naming:** plugin `UnrealMCP`, module `UnrealMcpEditor`; C++ prefixes `FUnrealMcp*` / `UUnrealMcp*` /
-  `SUnrealMcp*` (Slate) / `IUnrealMcp*` (interfaces). .NET root namespace
-  `com.IvanMurzak.Unreal.MCP.Bridge`. **Tool ids are kebab-case** (`actor-create`,
+- **Naming:** plugin `UnrealMCP`, modules `UnrealMcpRuntime` (Runtime) + `UnrealMcpEditor` (Editor);
+  C++ prefixes `FUnrealMcp*` / `UUnrealMcp*` / `SUnrealMcp*` (Slate) / `IUnrealMcp*` (interfaces). .NET
+  root namespace `com.IvanMurzak.Unreal.MCP.Bridge`. **Tool ids are kebab-case** (`actor-create`,
   `blueprint-compile`); the registry validates the pattern `^[a-z0-9]+(-[a-z0-9]+)*$`.
+- **Module boundary (load-bearing):** `UnrealMcpRuntime` must stay **GEditor-free and UnrealEd/Slate-free**
+  (it cooks into games — there is a CI grep gate). Engine-development tools, Slate UI, asset/blueprint/
+  capture deps, and the local-server manager all stay in `UnrealMcpEditor`. The editor coordinator
+  *builds* the runtime-owned types (registry/dispatcher/bridge/sidecar/extension-manager/config — all
+  `UNREALMCPRUNTIME_API`-exported) then layers the editor families + UI on the SAME registry; world
+  resolution goes through `FUnrealMcpWorldProvider` (the editor installs a `GEditor`-reading resolver, the
+  runtime subsystem a `GameInstance`-reading one), so the runtime module holds no GEditor reference.
 - **C++ style:** Unreal — **tabs**, braces on new lines, UE types (`FString`, `TArray`, `TSharedPtr`).
   Log via the dedicated `LogUnrealMcp` category. File header: the
   `// Copyright (c) 2026 Ivan Murzak ...` one-liner (copy from a neighbour).
-- **Unity-build ODR rule (load-bearing):** the `UnrealMcpEditor` / `UnrealMcpEditorTests` modules are
-  unity-built — every `.cpp` is concatenated into one translation unit — so an `anonymous namespace`
-  does **not** make a helper file-private. Give every per-family local helper a **family-unique** name
-  (e.g. `LevelMakeStringArraySchema`, not `MakeStringArraySchema`) and every per-spec `Run`/helper a
-  **spec-unique** name (or make it a `BEGIN_DEFINE_SPEC` member). A same-name/same-signature collision
-  across families fails the build — sometimes with a misleading cascade error at the call site (e.g.
-  `C2661: 'FAutomationTestBase::TestFalse': no overloaded function takes 1 arguments`) rather than a
-  redefinition error (`C2084`).
+- **Unity-build ODR rule (load-bearing):** the `UnrealMcpRuntime` / `UnrealMcpEditor` /
+  `UnrealMcpEditorTests` modules are unity-built — every `.cpp` is concatenated into one translation unit
+  — so an `anonymous namespace` does **not** make a helper file-private. Give every per-family local helper
+  a **family-unique** name (e.g. `LevelMakeStringArraySchema`, not `MakeStringArraySchema`) and every
+  per-spec `Run`/helper a **spec-unique** name (or make it a `BEGIN_DEFINE_SPEC` member). A
+  same-name/same-signature collision across families fails the build — sometimes with a misleading cascade
+  error at the call site (e.g. `C2661: 'FAutomationTestBase::TestFalse': no overloaded function takes 1
+  arguments`) rather than a redefinition error (`C2084`).
 - **C# style:** every `.cs` starts with the ASCII-art Apache-2.0 header (copy from a neighbour).
-- **Game-thread / no-modal-UI tool-handler contract:** all Unreal API calls from tool handlers run on
-  the game thread via the dispatcher (§4); the IPC reader thread never executes tool bodies. **A tool
-  handler must not pump modal UI and must not synchronously wait on bridge state** — doing either can
-  wedge the editor (ARCHITECTURE §11 risk 2). Tool handlers are **synchronous**
+- **Game-thread / no-modal-UI tool-handler contract:** all Unreal API calls from tool/prompt/resource
+  handlers run on the game thread via the dispatcher (§4); the IPC reader thread never executes handler
+  bodies. **A handler must not pump modal UI and must not synchronously wait on bridge state** — doing
+  either can wedge the host (ARCHITECTURE §11 risk 2). Tool handlers are **synchronous**
   (`FUnrealMcpToolHandler = TFunction<FUnrealMcpToolResult(const FUnrealMcpToolCall&)>`): long-running
   work (`source-compile`, `blueprint-compile`) runs inline on the game thread and blocks it for the
   duration (ARCHITECTURE §4 envisions an async-chaining `TFuture` handler surface once the registry
   grows one; until then a compile blocks). Only the dispatcher's `Dispatch()` returns a `TFuture` to
   the bridge, and the per-call timeout always completes it.
 - **Disabled tools are gated at `Execute()`**, not merely excluded from the manifest — a disabled tool
-  is rejected even if a stale `tools/list` dispatches it (`UnrealMcpToolRegistry::Execute`).
+  is rejected even if a stale `tools/list` dispatches it (`UnrealMcpToolRegistry::Execute`). A tool is
+  served **iff** it passes the `enabledTools` whitelist (empty = no filter; `UNREAL_MCP_TOOLS` overrides)
+  **and** is not in the `disabledTools` blocklist (the per-tool UI toggles); both sets are retained across
+  sessions and survive an extension hot-reload (a re-registered tool inherits the retained toggle).
 - **Secrets:** `.env` is gitignored and must stay that way (it can hold `UNREAL_MCP_TOKEN`); the sidecar
   IPC token travels via stdin, never argv, and is never logged.
 - **Commits:** `<type>(<scope>): <description>` conventional commits (scopes: plugin, bridge,
-  cli, ipc, tools, dispatcher, schema, ui, sidecar, config, samples, ci, docs). Reference issues with
-  `Closes #N`. Never `git add -A`. Never commit `Binaries/`/`Intermediate/`/`Saved/`/`bin/`/`obj/`/
-  `node_modules/`/`dist/`. The `.sln` at a `.uproject` root is generated — never commit it; the
-  hand-authored `bridge/Unreal-MCP-Bridge.sln` is the un-ignored exception.
+  cli, ipc, tools, dispatcher, schema, ui, sidecar, config, runtime, samples, ci, docs). Reference issues
+  with `Closes #N`. Never `git add -A`. Never commit `Binaries/`/`Intermediate/`/`Saved/`/`bin/`/`obj/`/
+  `node_modules/`/`dist/` or the `Sidecar/<rid>/` binary payloads. The `.sln` at a `.uproject` root is
+  generated — never commit it; the hand-authored `bridge/Unreal-MCP-Bridge.sln` is the un-ignored
+  exception.
 
 ## CI
 


### PR DESCRIPTION
## Summary

The plugin's `CLAUDE.md` had drifted out of sync with the shipped code on several load-bearing facts. This is a **documentation-only** change — only `CLAUDE.md` is touched. All corrections were re-derived from the authoritative sources (`UnrealMCP/UnrealMCP.uplugin`, `docs/ARCHITECTURE.md` — especially §12 — `README.md`, and the `*.Build.cs` files), deferring to `docs/ARCHITECTURE.md` on any conflict.

### Corrections

- **Module list (was wrong).** The doc claimed `UnrealMcpEditor` + `UnrealMcpEditorTests`, both Type `Editor`. Ground truth (`UnrealMCP.uplugin`) is **`UnrealMcpRuntime` (Type `Runtime`)** + **`UnrealMcpEditor` (Type `Editor`)**, runtime declared first. `UnrealMcpEditorTests` exists on disk but is a dev-only `WITH_DEV_AUTOMATION_TESTS` module that is **not** declared in the distributed `.uplugin` (Fab strips shipped test modules; CI re-adds it transiently).
- **Version (was wrong).** Said `VersionName 0.1.0`; the actual single-source version is **`0.5.0`**.
- **Architecture (was missing).** The doc described only an editor-time plugin. Added:
  - the **Runtime vs Editor module split** — `UnrealMcpRuntime` (dependency-lean registry/dispatcher/loopback-TCP bridge/sidecar-manager/extension bus + the `ping` built-in; cooks into packaged games, must stay GEditor/UnrealEd/Slate-free) vs `UnrealMcpEditor` (Slate UI + the 62 editor-only tools, several RCE-class, layered on the same registry);
  - the **sidecar model** — the bundled .NET 9 `unreal-mcp-bridge` is a **local child process of whichever host loads the plugin** (the Editor in dev; the game process in an opt-in packaged build), never remote; loopback TCP + one-shot stdin token; it exists because UE is C++ and can't host the .NET McpPlugin/ReflectorNet/SignalR stack in-process;
  - the **opt-in in-game runtime mode** and its **five security gates** (opt-in-only `Connect()`, `bRuntimeMcpEnabled` kill-switch default false, Shipping gate via `bUnrealMcpAllowShipping`, loopback-host default, loopback IPC + stdin token), plus Desktop-only;
  - the **`TargetDenyList` zero-footprint recipe** (exclude the runtime module + sidecar from packaged `Game`/`Client`/`Server` builds) and the direct-module-dependency caveat that overrides it;
  - the **prompt/resource extension surface** (`IUnrealMcp{Tool,Prompt,Resource}Provider` + the shipped core `level-design-brief` / `unreal://project/levels` / `unreal://project/icon`).
- **Refreshed:** EngineVersion floor wording (no descriptor pin; 5.5+ floor, CI-tested 5.7/5.8), the testbed path (`engines/unreal/test-project`), the local-Automation test-module re-add step, GameDev-MCP-Server version independence, and conventional-commit scopes (added `runtime`).
- **Preserved** the accurate build/test (plugin/bridge/cli + live e2e), publish, versioning, NuGet-pin, ODR-rule, and CI sections.

### Scope

`CLAUDE.md` only — no code, no `.uplugin`, no other docs. `git diff --stat`: `1 file changed, 163 insertions(+), 55 deletions(-)`.

---

**DO NOT MERGE — held for TD/owner review (do-not-merge).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)