### PR TITLE
refactor(cli): behavior-preserving /simplify cleanup (shared utils, dead-code removal)

### DIFF
--- a/cli/src/lib/bootstrap-local.ts
+++ b/cli/src/lib/bootstrap-local.ts
@@ -22,6 +22,7 @@ import * as path from 'path';
 import { spawn } from 'child_process';
 import { platform } from 'os';
 import { emitProgress } from './progress.js';
+import { asError } from '../utils/error.js';
 import type { BootstrapLocalOptions, BootstrapLocalResult, BuildStep } from './types.js';
 
 const BRIDGE_CSPROJ = path.join('bridge', 'src', 'com.IvanMurzak.Unreal.MCP.Bridge.csproj');
@@ -95,7 +96,7 @@ export async function bootstrapLocal(opts: BootstrapLocalOptions): Promise<Boots
       kind: 'failure',
       success: false,
       warnings,
-      error: err instanceof Error ? err : new Error(String(err)),
+      error: asError(err),
     };
   }
 }

--- a/cli/src/lib/clean-plugin.ts
+++ b/cli/src/lib/clean-plugin.ts
@@ -16,6 +16,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { asError } from '../utils/error.js';
+import { isSymlink } from '../utils/fs.js';
 import { emitProgress } from './progress.js';
 import type { ProgressCallback } from './types.js';
 
@@ -49,15 +50,6 @@ export interface CleanPluginFailure {
 
 export type CleanPluginResult = CleanPluginSuccess | CleanPluginFailure;
 
-/** True when `p` is a symlink/junction (vs a real directory). */
-function isLink(p: string): boolean {
-  try {
-    return fs.lstatSync(p).isSymbolicLink();
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Delete the C++ module build cache (`Intermediate/` + `Binaries/` minus the
  * bundled-bridge subtree) inside an installed plugin so UE recompiles cleanly.
@@ -77,7 +69,7 @@ export async function cleanPluginBuildCache(opts: CleanPluginOptions): Promise<C
 
     // Defensive: refuse to clean through a junction — removing files via a
     // junction recurses into the live source the junction points at.
-    if (isLink(installedPath)) {
+    if (isSymlink(installedPath)) {
       warnings.push(
         `Refusing to clean ${installedPath}: it is a junction/symlink (dev install). ` +
           'Skipping build-cache clean to protect the live source outputs.',

--- a/cli/src/lib/clean-plugin.ts
+++ b/cli/src/lib/clean-plugin.ts
@@ -15,6 +15,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { asError } from '../utils/error.js';
 import { emitProgress } from './progress.js';
 import type { ProgressCallback } from './types.js';
 
@@ -128,7 +129,7 @@ export async function cleanPluginBuildCache(opts: CleanPluginOptions): Promise<C
       removed,
       preserved,
       warnings,
-      error: err instanceof Error ? err : new Error(String(err)),
+      error: asError(err),
     };
   }
 }

--- a/cli/src/lib/close.ts
+++ b/cli/src/lib/close.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { execFileSync } from 'child_process';
 import { platform } from 'os';
 import { findUProjectFile } from '../utils/project.js';
+import { asError } from '../utils/error.js';
 import { emitProgress } from './progress.js';
 import type { ProgressCallback } from './types.js';
 
@@ -115,7 +116,7 @@ export async function close(opts: CloseOptions = {}): Promise<CloseResult> {
         kill(m.pid);
         terminated.push(m.pid);
       } catch (err) {
-        warnings.push(`Failed to terminate PID ${m.pid}: ${err instanceof Error ? err.message : String(err)}`);
+        warnings.push(`Failed to terminate PID ${m.pid}: ${asError(err).message}`);
       }
     }
 
@@ -126,7 +127,7 @@ export async function close(opts: CloseOptions = {}): Promise<CloseResult> {
       kind: 'failure',
       success: false,
       warnings,
-      error: err instanceof Error ? err : new Error(String(err)),
+      error: asError(err),
     };
   }
 }

--- a/cli/src/lib/configure.ts
+++ b/cli/src/lib/configure.ts
@@ -6,6 +6,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { writeEnvFile, ensureEnvGitignored, type KnownEnvKey } from '../utils/env-file.js';
+import { asError } from '../utils/error.js';
 import { emitProgress } from './progress.js';
 import type { ConfigureOptions, ConfigureResult } from './types.js';
 
@@ -106,7 +107,7 @@ export async function configure(opts: ConfigureOptions): Promise<ConfigureResult
       kind: 'failure',
       success: false,
       warnings,
-      error: err instanceof Error ? err : new Error(String(err)),
+      error: asError(err),
     };
   }
 }

--- a/cli/src/lib/create-project.ts
+++ b/cli/src/lib/create-project.ts
@@ -8,6 +8,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { asError } from '../utils/error.js';
 import { emitProgress } from './progress.js';
 import type { CreateProjectOptions, CreateProjectResult } from './types.js';
 
@@ -213,7 +214,7 @@ export async function createProject(opts: CreateProjectOptions): Promise<CreateP
       warnings,
     };
   } catch (err: unknown) {
-    const error = err instanceof Error ? err : new Error(String(err));
+    const error = asError(err);
     return {
       kind: 'failure',
       success: false,

--- a/cli/src/lib/download-server.ts
+++ b/cli/src/lib/download-server.ts
@@ -76,8 +76,8 @@ export const SERVER_BINARY_BASENAME = 'gamedev-mcp-server';
 /** Env var that overrides the server binary path (skips download + version check). */
 export const SERVER_PATH_ENV_VAR = 'UNREAL_MCP_SERVER_PATH';
 
-/** GitHub repo the server binaries are released from. */
-const SERVER_RELEASE_REPO = 'IvanMurzak/GameDev-MCP-Server';
+/** GitHub repo the server binaries (and the SHA256SUMS manifest) are released from. */
+export const SERVER_RELEASE_REPO = 'IvanMurzak/GameDev-MCP-Server';
 
 /** Executable file name for an OS: `gamedev-mcp-server(.exe)`. Pure. */
 export function serverExecutableName(osPlatform: NodeJS.Platform): string {

--- a/cli/src/lib/download-server.ts
+++ b/cli/src/lib/download-server.ts
@@ -29,6 +29,7 @@ import { createHash } from 'node:crypto';
 import { unzipSync } from 'fflate';
 import { ridForPlatform } from './bootstrap-local.js';
 import { SERVER_VERSION } from './server-version.js';
+import { asError } from '../utils/error.js';
 import { emitProgress } from './progress.js';
 import {
   serverChecksumsUrl,
@@ -62,7 +63,7 @@ async function fetchSha256SumsText(
       warnings.push(`${SHA256SUMS_ASSET_NAME} fetch attempt ${attempt}/${SHA256SUMS_FETCH_ATTEMPTS} failed: HTTP ${response.status}.`);
     } catch (err: unknown) {
       warnings.push(
-        `${SHA256SUMS_ASSET_NAME} fetch attempt ${attempt}/${SHA256SUMS_FETCH_ATTEMPTS} failed: ${err instanceof Error ? err.message : String(err)}.`,
+        `${SHA256SUMS_ASSET_NAME} fetch attempt ${attempt}/${SHA256SUMS_FETCH_ATTEMPTS} failed: ${asError(err).message}.`,
       );
     }
   }
@@ -289,7 +290,7 @@ export async function downloadServer(opts: DownloadServerOptions): Promise<Downl
       try {
         fs.chmodSync(exePath, 0o755);
       } catch (err: unknown) {
-        warnings.push(`Could not mark the server binary executable: ${err instanceof Error ? err.message : String(err)}`);
+        warnings.push(`Could not mark the server binary executable: ${asError(err).message}`);
       }
     }
     fs.writeFileSync(path.join(installDir, 'version'), version, 'utf-8');
@@ -306,7 +307,7 @@ export async function downloadServer(opts: DownloadServerOptions): Promise<Downl
       success: false,
       url,
       warnings,
-      error: err instanceof Error ? err : new Error(String(err)),
+      error: asError(err),
     };
   }
 }

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { isUnrealProjectDir } from '../utils/project.js';
+import { asError } from '../utils/error.js';
 import { emitProgress } from './progress.js';
 import type {
   InstallPluginOptions,
@@ -144,7 +145,7 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
         } catch {
           // Best-effort restore failed — surface the stash path on the error so
           // the user can recover the bridge manually instead of losing it.
-          const e = copyErr instanceof Error ? copyErr : new Error(String(copyErr));
+          const e = asError(copyErr);
           e.message += ` (the bundled sidecar bridge was stashed at ${stashedBridge} — recover it manually)`;
           throw e;
         }
@@ -172,7 +173,7 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
       kind: 'failure',
       success: false,
       warnings,
-      error: err instanceof Error ? err : new Error(String(err)),
+      error: asError(err),
     };
   }
 }
@@ -210,7 +211,7 @@ export async function removePlugin(opts: RemovePluginOptions): Promise<RemovePlu
       kind: 'failure',
       success: false,
       warnings,
-      error: err instanceof Error ? err : new Error(String(err)),
+      error: asError(err),
     };
   }
 }

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -10,6 +10,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { isUnrealProjectDir } from '../utils/project.js';
 import { asError } from '../utils/error.js';
+import { isSymlink } from '../utils/fs.js';
 import { emitProgress } from './progress.js';
 import type {
   InstallPluginOptions,
@@ -48,15 +49,6 @@ function copyFilter(srcAbs: string, pluginSourceDir: string): boolean {
     return rel === BUNDLED_BRIDGE_REL_POSIX || rel.startsWith(BUNDLED_BRIDGE_REL_POSIX + '/');
   }
   return true;
-}
-
-/** True when `p` is a symlink/junction (vs a real directory). */
-function isLink(p: string): boolean {
-  try {
-    return fs.lstatSync(p).isSymbolicLink();
-  } catch {
-    return false;
-  }
 }
 
 export async function installPlugin(opts: InstallPluginOptions): Promise<InstallPluginResult> {
@@ -105,7 +97,7 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     // path (the junction points at the live source — nothing to preserve).
     let stashedBridge: string | null = null;
     const priorBridge = path.join(installedPath, BUNDLED_BRIDGE_REL);
-    const installedIsRealDir = fs.existsSync(installedPath) && !isLink(installedPath);
+    const installedIsRealDir = fs.existsSync(installedPath) && !isSymlink(installedPath);
     if (!useJunction && installedIsRealDir && fs.existsSync(priorBridge)) {
       stashedBridge = fs.mkdtempSync(path.join(os.tmpdir(), 'unreal-mcp-bridge-stash-'));
       fs.cpSync(priorBridge, stashedBridge, { recursive: true });
@@ -113,8 +105,8 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
 
     // Clear any prior install (link or real dir) so the operation is
     // idempotent and never nests a copy inside a stale junction.
-    if (fs.existsSync(installedPath) || isLink(installedPath)) {
-      if (isLink(installedPath)) {
+    if (fs.existsSync(installedPath) || isSymlink(installedPath)) {
+      if (isSymlink(installedPath)) {
         fs.unlinkSync(installedPath);
       } else {
         fs.rmSync(installedPath, { recursive: true, force: true });
@@ -190,7 +182,7 @@ export async function removePlugin(opts: RemovePluginOptions): Promise<RemovePlu
       message: `Removing UnrealMCP plugin from ${installedPath}`,
     });
 
-    const present = fs.existsSync(installedPath) || isLink(installedPath);
+    const present = fs.existsSync(installedPath) || isSymlink(installedPath);
     if (!present) {
       emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin was not installed.' });
       return { kind: 'success', success: true, removed: false, installedPath, warnings };
@@ -198,7 +190,7 @@ export async function removePlugin(opts: RemovePluginOptions): Promise<RemovePlu
 
     // unlink a junction (never recurse through it into the live source);
     // rm a real directory.
-    if (isLink(installedPath)) {
+    if (isSymlink(installedPath)) {
       fs.unlinkSync(installedPath);
     } else {
       fs.rmSync(installedPath, { recursive: true, force: true });

--- a/cli/src/lib/login.ts
+++ b/cli/src/lib/login.ts
@@ -8,6 +8,7 @@
 import { writeEnvFile, ensureEnvGitignored } from '../utils/env-file.js';
 import * as path from 'path';
 import { asError } from '../utils/error.js';
+import { fetchWithTimeout } from '../utils/http.js';
 import { emitProgress } from './progress.js';
 import type { ProgressCallback } from './types.js';
 
@@ -69,11 +70,16 @@ export async function login(opts: LoginOptions = {}): Promise<LoginResult> {
   try {
     emitProgress(opts.onProgress, { phase: 'start', message: 'Requesting device authorization' });
 
-    const codeResp = await fetchWithTimeout(fetchImpl, `${baseUrl}${DEFAULT_DEVICE_PATH}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: '{}',
-    });
+    const codeResp = await fetchWithTimeout(
+      fetchImpl,
+      `${baseUrl}${DEFAULT_DEVICE_PATH}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      },
+      { timeoutMs: PER_REQUEST_TIMEOUT_MS },
+    );
     if (!codeResp.ok) {
       return fail('device-code-failed', `Device code request failed: HTTP ${codeResp.status}`);
     }
@@ -95,11 +101,16 @@ export async function login(opts: LoginOptions = {}): Promise<LoginResult> {
 
     while (now() < deadline) {
       await sleep(intervalMs);
-      const tokenResp = await fetchWithTimeout(fetchImpl, `${baseUrl}${DEFAULT_TOKEN_PATH}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ device_code: code.device_code }),
-      });
+      const tokenResp = await fetchWithTimeout(
+        fetchImpl,
+        `${baseUrl}${DEFAULT_TOKEN_PATH}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ device_code: code.device_code }),
+        },
+        { timeoutMs: PER_REQUEST_TIMEOUT_MS },
+      );
 
       if (tokenResp.ok) {
         const body = (await tokenResp.json()) as { access_token?: string };
@@ -154,25 +165,6 @@ function persistToken(projectDir: string | undefined, token: string): string | n
   ensureEnvGitignored(dir);
   writeEnvFile(envPath, { UNREAL_MCP_TOKEN: token, UNREAL_MCP_CONNECTION_MODE: 'Cloud' });
   return envPath;
-}
-
-/**
- * `fetch` with a per-request abort deadline so a hung endpoint cannot stall
- * the device flow indefinitely (the overall poll deadline only fires between
- * polls). Honors the injected `fetchImpl` for tests.
- */
-async function fetchWithTimeout(
-  fetchImpl: typeof fetch,
-  url: string,
-  init: RequestInit,
-): Promise<Response> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), PER_REQUEST_TIMEOUT_MS);
-  try {
-    return await fetchImpl(url, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timer);
-  }
 }
 
 function fail(reason: string, message: string): LoginFailure {

--- a/cli/src/lib/login.ts
+++ b/cli/src/lib/login.ts
@@ -7,6 +7,7 @@
 
 import { writeEnvFile, ensureEnvGitignored } from '../utils/env-file.js';
 import * as path from 'path';
+import { asError } from '../utils/error.js';
 import { emitProgress } from './progress.js';
 import type { ProgressCallback } from './types.js';
 
@@ -134,7 +135,7 @@ export async function login(opts: LoginOptions = {}): Promise<LoginResult> {
 
     return fail('timeout', `Login timed out after ${timeoutMs}ms.`);
   } catch (err) {
-    const error = err instanceof Error ? err : new Error(String(err));
+    const error = asError(err);
     // A per-request `fetchWithTimeout` deadline surfaces as an AbortError;
     // classify that as a timeout rather than a generic network error.
     const reason = error.name === 'AbortError' ? 'timeout' : 'network-error';

--- a/cli/src/lib/open.ts
+++ b/cli/src/lib/open.ts
@@ -8,6 +8,7 @@ import { spawn } from 'child_process';
 import { platform } from 'os';
 import { discoverEngine, invalidateCachedEngine } from './engine.js';
 import { readUProject } from '../utils/project.js';
+import { asError } from '../utils/error.js';
 import { emitProgress } from './progress.js';
 import type {
   AuthOption,
@@ -179,7 +180,7 @@ export async function openProject(opts: OpenProjectOptions): Promise<OpenProject
       warnings,
     };
   } catch (err: unknown) {
-    const error = err instanceof Error ? err : new Error(String(err));
+    const error = asError(err);
     return {
       kind: 'failure',
       success: false,

--- a/cli/src/lib/run-tool.ts
+++ b/cli/src/lib/run-tool.ts
@@ -5,7 +5,7 @@
 
 import { resolveConnection } from '../utils/config.js';
 import { asError } from '../utils/error.js';
-import { fetchWithTimeout } from '../utils/http.js';
+import { fetchWithTimeout, networkErrorCategory } from '../utils/http.js';
 import type {
   RunToolFailure,
   RunToolFailureReason,
@@ -148,12 +148,8 @@ function classifyFetchError(err: unknown, endpoint: string, timeoutMs: number, t
       ? makeFailure({ endpoint, reason: 'timeout', message: `Tool call timed out after ${timeoutMs}ms.`, error: err })
       : makeFailure({ endpoint, reason: 'aborted', message: 'Tool call was aborted by the caller.', error: err });
   }
-  const error = err instanceof Error ? err : new Error(String(err));
-  const cause = err instanceof Error && 'cause' in err ? (err.cause as { code?: string } | undefined) : undefined;
-  let reason: RunToolFailureReason = 'unknown';
-  if (cause?.code === 'ECONNREFUSED') reason = 'connection-refused';
-  else if (cause?.code === 'ECONNRESET') reason = 'connection-reset';
-  else if (cause?.code === 'ENOTFOUND' || cause?.code === 'EAI_AGAIN') reason = 'network-error';
+  const error = asError(err);
+  const reason: RunToolFailureReason = networkErrorCategory(err) ?? 'unknown';
   return makeFailure({ endpoint, reason, message: error.message, error });
 }
 

--- a/cli/src/lib/run-tool.ts
+++ b/cli/src/lib/run-tool.ts
@@ -5,6 +5,7 @@
 
 import { resolveConnection } from '../utils/config.js';
 import { asError } from '../utils/error.js';
+import { fetchWithTimeout } from '../utils/http.js';
 import type {
   RunToolFailure,
   RunToolFailureReason,
@@ -54,28 +55,22 @@ async function invokeTool(routePrefix: string, opts: RunToolOptions): Promise<Ru
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
   const timeoutMs = typeof opts.timeoutMs === 'number' && opts.timeoutMs > 0 ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
 
-  const controller = new AbortController();
+  // `timedOut` lets `classifyFetchError` tell OUR timeout's AbortError apart
+  // from a caller-supplied `opts.signal` cancellation: `fetchWithTimeout`
+  // invokes `onTimeout` only when its own deadline fires, never on an external
+  // abort.
   let timedOut = false;
-  const timer = setTimeout(() => {
-    timedOut = true;
-    controller.abort();
-  }, timeoutMs);
-  const externalAbort = (): void => controller.abort();
-  if (opts.signal) {
-    if (opts.signal.aborted) controller.abort();
-    else opts.signal.addEventListener('abort', externalAbort, { once: true });
-  }
 
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (token) headers['Authorization'] = `Bearer ${token}`;
 
   try {
-    const response = await fetchImpl(endpoint, {
-      method: 'POST',
-      headers,
-      body: body.json,
-      signal: controller.signal,
-    });
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      endpoint,
+      { method: 'POST', headers, body: body.json },
+      { timeoutMs, externalSignal: opts.signal, onTimeout: () => { timedOut = true; } },
+    );
     const text = await safeReadText(response);
     const data = parseJsonOrText(text);
     if (!response.ok) {
@@ -90,9 +85,6 @@ async function invokeTool(routePrefix: string, opts: RunToolOptions): Promise<Ru
     return { kind: 'success', success: true, endpoint, httpStatus: response.status, data };
   } catch (err) {
     return classifyFetchError(err, endpoint, timeoutMs, timedOut);
-  } finally {
-    clearTimeout(timer);
-    opts.signal?.removeEventListener('abort', externalAbort);
   }
 }
 

--- a/cli/src/lib/run-tool.ts
+++ b/cli/src/lib/run-tool.ts
@@ -4,6 +4,7 @@
 // Library-safe: errors are returned, never thrown.
 
 import { resolveConnection } from '../utils/config.js';
+import { asError } from '../utils/error.js';
 import type {
   RunToolFailure,
   RunToolFailureReason,
@@ -39,7 +40,7 @@ async function invokeTool(routePrefix: string, opts: RunToolOptions): Promise<Ru
     return makeFailure({
       endpoint: '',
       reason: 'invalid-input',
-      message: err instanceof Error ? err.message : String(err),
+      message: asError(err).message,
       error: err instanceof Error ? err : undefined,
     });
   }
@@ -117,7 +118,7 @@ function serializeInput(input: unknown): { json: string } | { error: Error } {
       JSON.parse(input);
       return { json: input };
     } catch (err) {
-      return { error: new Error(`input string is not valid JSON: ${err instanceof Error ? err.message : String(err)}`) };
+      return { error: new Error(`input string is not valid JSON: ${asError(err).message}`) };
     }
   }
   if (typeof input !== 'object') {
@@ -126,7 +127,7 @@ function serializeInput(input: unknown): { json: string } | { error: Error } {
   try {
     return { json: JSON.stringify(input) };
   } catch (err) {
-    return { error: new Error(`input could not be serialized to JSON: ${err instanceof Error ? err.message : String(err)}`) };
+    return { error: new Error(`input could not be serialized to JSON: ${asError(err).message}`) };
   }
 }
 

--- a/cli/src/lib/server-checksum.ts
+++ b/cli/src/lib/server-checksum.ts
@@ -16,10 +16,7 @@
 // seam (PR #193); same parser/verify/test shape, TS idioms.
 
 import { SERVER_VERSION } from './server-version.js';
-import { SERVER_BINARY_BASENAME } from './download-server.js';
-
-/** GitHub repo the server binaries (and the SHA256SUMS manifest) are released from. */
-const SERVER_RELEASE_REPO = 'IvanMurzak/GameDev-MCP-Server';
+import { SERVER_BINARY_BASENAME, SERVER_RELEASE_REPO } from './download-server.js';
 
 /**
  * The name of the integrity manifest asset attached to every GameDev-MCP-Server

--- a/cli/src/lib/setup-mcp.ts
+++ b/cli/src/lib/setup-mcp.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { platform } from 'os';
 import { resolveConnection } from '../utils/config.js';
+import { asError } from '../utils/error.js';
 import { generatePortFromDirectory } from '../utils/port.js';
 import {
   downloadServer,
@@ -200,7 +201,7 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
       success: false,
       warnings,
       nextSteps,
-      error: err instanceof Error ? err : new Error(String(err)),
+      error: asError(err),
     };
   }
 }

--- a/cli/src/lib/setup-skills.ts
+++ b/cli/src/lib/setup-skills.ts
@@ -5,6 +5,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { resolveConnection } from '../utils/config.js';
+import { asError } from '../utils/error.js';
 import { emitProgress } from './progress.js';
 import type { ProgressCallback } from './types.js';
 
@@ -85,7 +86,7 @@ export async function setupSkills(opts: SetupSkillsOptions = {}): Promise<SetupS
       kind: 'failure',
       success: false,
       warnings,
-      error: err instanceof Error ? err : new Error(String(err)),
+      error: asError(err),
     };
   }
 }

--- a/cli/src/lib/status.ts
+++ b/cli/src/lib/status.ts
@@ -8,6 +8,7 @@ import { PACKAGE_NAME, PACKAGE_VERSION } from '../version.js';
 import { readUProject } from '../utils/project.js';
 import { resolveConnection } from '../utils/config.js';
 import { probePing } from '../utils/probe.js';
+import { asError } from '../utils/error.js';
 import type { StatusOptions, StatusReport } from './types.js';
 
 /**
@@ -62,7 +63,7 @@ export async function getStatus(opts: StatusOptions = {}): Promise<StatusReport>
       }
     } catch (err) {
       report.connection = { url: '', source: 'unresolved', hasToken: false };
-      report.probeReason = err instanceof Error ? err.message : String(err);
+      report.probeReason = asError(err).message;
     }
   }
 

--- a/cli/src/lib/update.ts
+++ b/cli/src/lib/update.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { installPlugin } from './install-plugin.js';
 import { cleanPluginBuildCache } from './clean-plugin.js';
+import { asError } from '../utils/error.js';
 import { emitProgress } from './progress.js';
 import type { ProgressCallback } from './types.js';
 
@@ -166,7 +167,7 @@ export async function update(opts: UpdateOptions): Promise<UpdateResult> {
       kind: 'failure',
       success: false,
       warnings,
-      error: err instanceof Error ? err : new Error(String(err)),
+      error: asError(err),
     };
   }
 }

--- a/cli/src/lib/update.ts
+++ b/cli/src/lib/update.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { installPlugin } from './install-plugin.js';
 import { cleanPluginBuildCache } from './clean-plugin.js';
 import { asError } from '../utils/error.js';
+import { isSymlink } from '../utils/fs.js';
 import { emitProgress } from './progress.js';
 import type { ProgressCallback } from './types.js';
 
@@ -56,15 +57,6 @@ export interface UpdateFailure {
 }
 
 export type UpdateResult = UpdateSuccess | UpdateFailure;
-
-/** True when `p` is an existing symlink/junction (vs a real directory). */
-function isJunction(p: string): boolean {
-  try {
-    return fs.lstatSync(p).isSymbolicLink();
-  } catch {
-    return false;
-  }
-}
 
 /** Read `VersionName` from a `UnrealMCP.uplugin`. Pure. Returns null on miss. */
 export function readPluginVersion(upluginPath: string): string | null {
@@ -118,7 +110,7 @@ export async function update(opts: UpdateOptions): Promise<UpdateResult> {
     // Preserve the existing install mode: a dev junction install must stay a
     // junction across `update --force` rather than being silently replaced
     // with a copy (which would detach the project from the live source).
-    const installedAsJunction = isJunction(installedPath);
+    const installedAsJunction = isSymlink(installedPath);
     const installResult = await installPlugin({
       projectDir,
       pluginSourceDir,

--- a/cli/src/lib/wait-for-ready.ts
+++ b/cli/src/lib/wait-for-ready.ts
@@ -5,6 +5,7 @@
 
 import { resolveConnection } from '../utils/config.js';
 import { probePing } from '../utils/probe.js';
+import { asError } from '../utils/error.js';
 import { emitProgress } from './progress.js';
 import type { WaitForReadyOptions, WaitForReadyResult } from './types.js';
 
@@ -28,7 +29,7 @@ export async function waitForReady(opts: WaitForReadyOptions = {}): Promise<Wait
     url = conn.url;
     token = conn.token;
   } catch (err) {
-    const error = err instanceof Error ? err : new Error(String(err));
+    const error = asError(err);
     return { kind: 'failure', success: false, url, elapsedMs: 0, attempts: 0, lastReason: error.message, error };
   }
 

--- a/cli/src/utils/engine-discovery.ts
+++ b/cli/src/utils/engine-discovery.ts
@@ -23,7 +23,7 @@ import * as path from 'path';
 import { execFileSync } from 'child_process';
 import { homedir } from 'os';
 import { editorBinaryPath, pathFor } from './engine.js';
-import { compareEngineVersions, type EngineInstallation } from './launcher.js';
+import { byEngineVersionDesc, type EngineInstallation } from './launcher.js';
 import { verbose } from './ui.js';
 
 // ---------------------------------------------------------------------------
@@ -204,7 +204,7 @@ export function scanCommonLocationEngines(
     }
   }
 
-  found.sort((a, b) => compareEngineVersions(b.engineAssociation, a.engineAssociation));
+  found.sort(byEngineVersionDesc);
   return found;
 }
 

--- a/cli/src/utils/engine-discovery.ts
+++ b/cli/src/utils/engine-discovery.ts
@@ -34,6 +34,8 @@ export interface DiscoveryFs {
   existsImpl: (p: string) => boolean;
   /** List directory entry NAMES (not full paths); `[]` on any error. */
   readdirImpl: (p: string) => string[];
+  /** Read a UTF-8 file's contents; `null` on any error (absent/unreadable). */
+  readFileImpl: (p: string) => string | null;
 }
 
 function defaultFs(): DiscoveryFs {
@@ -44,6 +46,13 @@ function defaultFs(): DiscoveryFs {
         return fs.readdirSync(p);
       } catch {
         return [];
+      }
+    },
+    readFileImpl: (p: string): string | null => {
+      try {
+        return fs.readFileSync(p, 'utf-8');
+      } catch {
+        return null;
       }
     },
   };
@@ -221,12 +230,8 @@ export function readEngineAssociationFromBuildVersion(
   const pj = pathFor(os);
   const versionFile = pj.join(engineRoot, 'Engine', 'Build', 'Build.version');
   if (!fsImpl.existsImpl(versionFile)) return '';
-  let raw: string;
-  try {
-    raw = fs.readFileSync(versionFile, 'utf-8');
-  } catch {
-    return '';
-  }
+  const raw = fsImpl.readFileImpl(versionFile);
+  if (raw === null) return '';
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);

--- a/cli/src/utils/engine-discovery.ts
+++ b/cli/src/utils/engine-discovery.ts
@@ -22,7 +22,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
 import { homedir } from 'os';
-import { editorBinaryPath } from './engine.js';
+import { editorBinaryPath, pathFor } from './engine.js';
 import { compareEngineVersions, type EngineInstallation } from './launcher.js';
 import { verbose } from './ui.js';
 
@@ -106,7 +106,7 @@ export function commonEngineRoots(os: NodeJS.Platform, env: NodeJS.ProcessEnv = 
   // every OS — its PARENT, since the var points AT the engine dir.
   const ueRoot = env['UE_ROOT'];
   if (ueRoot && ueRoot.trim().length > 0) {
-    const pj = os === 'win32' ? path.win32 : path.posix;
+    const pj = pathFor(os);
     const parent = pj.dirname(ueRoot.trim());
     // Guard against promoting a filesystem-root parent (e.g. `UE_ROOT=/opt` ->
     // `/`, or a drive root `D:\`): readdir of `/` is wasteful and never holds a
@@ -152,7 +152,7 @@ export function scanCommonLocationEngines(
   fsImpl: DiscoveryFs = defaultFs(),
 ): EngineInstallation[] {
   const roots = commonEngineRoots(os, env);
-  const pj = os === 'win32' ? path.win32 : path.posix;
+  const pj = pathFor(os);
   const found: EngineInstallation[] = [];
   const seenRoots = new Set<string>();
 
@@ -219,7 +219,7 @@ export function readEngineAssociationFromBuildVersion(
   os: NodeJS.Platform,
   fsImpl: DiscoveryFs = defaultFs(),
 ): string {
-  const pj = os === 'win32' ? path.win32 : path.posix;
+  const pj = pathFor(os);
   const versionFile = pj.join(engineRoot, 'Engine', 'Build', 'Build.version');
   if (!fsImpl.existsImpl(versionFile)) return '';
   let raw: string;

--- a/cli/src/utils/engine-discovery.ts
+++ b/cli/src/utils/engine-discovery.ts
@@ -21,7 +21,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
-import { homedir } from 'os';
 import { editorBinaryPath, pathFor } from './engine.js';
 import { byEngineVersionDesc, type EngineInstallation } from './launcher.js';
 import { verbose } from './ui.js';

--- a/cli/src/utils/engine.ts
+++ b/cli/src/utils/engine.ts
@@ -14,6 +14,17 @@ import {
 } from './launcher.js';
 
 /**
+ * The `path` flavour to use for a TARGET platform, regardless of the host: the
+ * Windows backslash variant for `win32`, the POSIX forward-slash variant
+ * otherwise. Centralises the `os === 'win32' ? path.win32 : path.posix` idiom
+ * that engine-path resolution repeats so a cross-OS scan (e.g. resolving a
+ * Windows engine root on a Linux CI host) keeps correct separators. Pure.
+ */
+export function pathFor(os: NodeJS.Platform): path.PlatformPath {
+  return os === 'win32' ? path.win32 : path.posix;
+}
+
+/**
  * Build the absolute path to the `UnrealEditor` binary under an engine
  * install root, for the given platform. `cmd === true` returns the
  * headless console binary (`UnrealEditor-Cmd`) used by `wait-for-ready`
@@ -28,7 +39,7 @@ export function editorBinaryPath(
   // Use the path flavor for the TARGET os, not the host — so resolving a
   // macOS/Linux engine on a Windows host (and vice versa) yields correct
   // separators.
-  const pj = os === 'win32' ? path.win32 : path.posix;
+  const pj = pathFor(os);
   switch (os) {
     case 'win32':
       return pj.join(engineRoot, 'Engine', 'Binaries', 'Win64', `${exe}.exe`);
@@ -98,7 +109,7 @@ export function resolveEngine(input: ResolveEngineInput): ResolveEngineResult {
     // it would mangle a Windows engine root (`C:\Src\UE5` is not POSIX-absolute,
     // so posix.resolve prepends cwd) and the binary check would then miss. This
     // mirrors `editorBinaryPath`, which already picks the flavour by `os`.
-    const pj = os === 'win32' ? path.win32 : path.posix;
+    const pj = pathFor(os);
     const engineRoot = pj.resolve(input.engineRootOverride.trim());
     const editorPath = editorBinaryPath(engineRoot, os);
     if (!exists(editorPath)) {

--- a/cli/src/utils/error.ts
+++ b/cli/src/utils/error.ts
@@ -1,0 +1,18 @@
+// Error coercion helper shared across the CLI's library-safe boundaries.
+//
+// Every `lib/*` entry point returns errors rather than throwing, which means a
+// caught `unknown` must be normalised to a real `Error` (so `.message` /
+// `.name` are always available). This was open-coded as
+// `err instanceof Error ? err : new Error(String(err))` in ~14 files; centralise
+// it here so the coercion is written (and tested) once. Pure.
+
+/**
+ * Coerce an unknown caught value into an `Error`. Returns the value unchanged
+ * when it already is an `Error`; otherwise wraps its `String(...)` form in a
+ * fresh `Error`. Behaviour-identical to the inline
+ * `err instanceof Error ? err : new Error(String(err))` it replaces — use
+ * `asError(err).message` where only the message string is needed.
+ */
+export function asError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}

--- a/cli/src/utils/fs.ts
+++ b/cli/src/utils/fs.ts
@@ -1,0 +1,20 @@
+// Small filesystem helpers shared across the CLI's lib modules.
+
+import * as fs from 'fs';
+
+/**
+ * True when `p` is an existing symlink/junction (vs a real directory or file).
+ * Returns `false` on any `lstat` error (missing path, permission). This guard
+ * is load-bearing before destructive `rmSync`/`unlinkSync` of an installed
+ * plugin path: a junction must be `unlink`ed (never recursed into), a real dir
+ * must be `rm`ed. Centralised from the verbatim duplicates in
+ * `install-plugin.ts` / `update.ts` / `clean-plugin.ts`. Pure-ish (one
+ * `lstatSync` call).
+ */
+export function isSymlink(p: string): boolean {
+  try {
+    return fs.lstatSync(p).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}

--- a/cli/src/utils/http.ts
+++ b/cli/src/utils/http.ts
@@ -1,0 +1,63 @@
+// Shared HTTP helper: `fetch` with a per-request abort deadline.
+//
+// Three call sites (login's device-flow polls, the readiness `probe`, and
+// `run-tool`'s tool invocation) each hand-rolled the same AbortController +
+// setTimeout dance. Centralise it here. The helper re-throws on failure (it
+// does NOT classify the error) so each caller keeps its own error mapping —
+// login/probe rely on the thrown `AbortError`'s `name`, while run-tool needs
+// to tell its OWN timeout apart from a caller-supplied cancellation, which the
+// `onTimeout` callback surfaces.
+
+/** Options for {@link fetchWithTimeout}. */
+export interface FetchWithTimeoutOptions {
+  /** Per-request abort deadline in milliseconds. */
+  timeoutMs: number;
+  /**
+   * A caller-supplied abort signal (e.g. a CLI cancellation). When it fires,
+   * the request is aborted WITHOUT invoking `onTimeout` — so the caller can
+   * distinguish a deliberate cancellation from a timeout. An already-aborted
+   * signal aborts the request synchronously before the fetch starts.
+   */
+  externalSignal?: AbortSignal;
+  /**
+   * Invoked exactly when the internal timeout fires (NOT on an external-signal
+   * abort). Lets a caller flag "this abort was my timeout" so its catch block
+   * can map the resulting `AbortError` to a timeout rather than a cancellation.
+   */
+  onTimeout?: () => void;
+}
+
+/**
+ * `fetch` with a per-request abort deadline so a hung endpoint cannot stall a
+ * flow indefinitely. Honors the injected `fetchImpl` (for tests). On the
+ * deadline OR an `externalSignal` abort the underlying request is aborted and
+ * `fetchImpl` rejects with an `AbortError`, which propagates to the caller
+ * unchanged (the helper does not catch it). The timeout timer is always
+ * cleared and the external-signal listener always removed.
+ */
+export async function fetchWithTimeout(
+  fetchImpl: typeof fetch,
+  url: string,
+  init: RequestInit,
+  opts: FetchWithTimeoutOptions,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    opts.onTimeout?.();
+    controller.abort();
+  }, opts.timeoutMs);
+
+  const externalAbort = (): void => controller.abort();
+  const externalSignal = opts.externalSignal;
+  if (externalSignal) {
+    if (externalSignal.aborted) controller.abort();
+    else externalSignal.addEventListener('abort', externalAbort, { once: true });
+  }
+
+  try {
+    return await fetchImpl(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+    externalSignal?.removeEventListener('abort', externalAbort);
+  }
+}

--- a/cli/src/utils/http.ts
+++ b/cli/src/utils/http.ts
@@ -61,3 +61,36 @@ export async function fetchWithTimeout(
     externalSignal?.removeEventListener('abort', externalAbort);
   }
 }
+
+/**
+ * The canonical low-level network-failure category of a thrown fetch error,
+ * derived from its underlying `err.cause.code` (the Node/undici cause set):
+ *
+ *   - `ECONNREFUSED`            → `'connection-refused'`
+ *   - `ECONNRESET`             → `'connection-reset'`
+ *   - `ENOTFOUND` / `EAI_AGAIN` → `'network-error'` (DNS/name resolution)
+ *
+ * Returns `undefined` for anything else (including a non-`Error`, a missing
+ * cause, or an unrecognised code) so the caller can fall back to its own
+ * message/enum. Callers map this single category to their own surface —
+ * `run-tool` uses it directly as a failure-reason enum, `probe` maps it to
+ * human-readable text. Pure; does NOT classify an `AbortError` (a timeout /
+ * cancellation is the caller's concern, decided before this is consulted).
+ */
+export type NetworkErrorCategory = 'connection-refused' | 'connection-reset' | 'network-error';
+
+export function networkErrorCategory(err: unknown): NetworkErrorCategory | undefined {
+  const cause =
+    err instanceof Error && 'cause' in err ? (err.cause as { code?: string } | undefined) : undefined;
+  switch (cause?.code) {
+    case 'ECONNREFUSED':
+      return 'connection-refused';
+    case 'ECONNRESET':
+      return 'connection-reset';
+    case 'ENOTFOUND':
+    case 'EAI_AGAIN':
+      return 'network-error';
+    default:
+      return undefined;
+  }
+}

--- a/cli/src/utils/launcher.ts
+++ b/cli/src/utils/launcher.ts
@@ -89,7 +89,7 @@ export function parseLauncherManifest(content: string): EngineInstallation[] {
     });
   }
   // Highest version first so "no association" callers get the newest engine.
-  engines.sort((a, b) => compareEngineVersions(b.engineAssociation, a.engineAssociation));
+  engines.sort(byEngineVersionDesc);
   return engines;
 }
 
@@ -123,6 +123,18 @@ export function compareEngineVersions(a: string, b: string): number {
 }
 
 /**
+ * `Array.prototype.sort` comparator that orders engine installations
+ * highest-`engineAssociation`-version first, so "no association" callers get
+ * the newest engine. The single source for the
+ * `compareEngineVersions(b.engineAssociation, a.engineAssociation)` descending
+ * sort the manifest parse, the empty-association match, and the
+ * common-location scan all repeat. Pure.
+ */
+export function byEngineVersionDesc(a: EngineInstallation, b: EngineInstallation): number {
+  return compareEngineVersions(b.engineAssociation, a.engineAssociation);
+}
+
+/**
  * Match a project's `EngineAssociation` against the installed engines.
  *
  * - A launcher version association (`"5.7"`) matches the engine with that
@@ -145,9 +157,7 @@ export function matchEngineForAssociation(
     // `open`'s injectable `enginesImpl` may feed an unsorted list — so sort
     // here too rather than relying on the caller's ordering.
     if (engines.length === 0) return null;
-    return [...engines].sort((a, b) =>
-      compareEngineVersions(b.engineAssociation, a.engineAssociation),
-    )[0];
+    return [...engines].sort(byEngineVersionDesc)[0];
   }
   if (assoc.startsWith('{')) {
     // GUID — a registered source build; not in the launcher manifest.

--- a/cli/src/utils/probe.ts
+++ b/cli/src/utils/probe.ts
@@ -8,6 +8,9 @@
 // verified manually: system-tools/ping → 500 (null response),
 // /api/tools/ping → 200 {"result":"pong"}. ARCHITECTURE.md §e2e runbook
 // already cited /api/tools/ping — this endpoint now matches it.
+
+import { fetchWithTimeout } from './http.js';
+
 export const PING_ENDPOINT = '/api/tools/ping';
 
 export interface ProbeSuccess {
@@ -42,18 +45,16 @@ export async function probePing(baseUrl: string, opts: ProbeOptions = {}): Promi
   const timeoutMs = typeof opts.timeoutMs === 'number' && opts.timeoutMs > 0 ? opts.timeoutMs : 5000;
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
 
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (opts.token) headers['Authorization'] = `Bearer ${opts.token}`;
 
   try {
-    const response = await fetchImpl(endpoint, {
-      method: 'POST',
-      headers,
-      body: '{}',
-      signal: controller.signal,
-    });
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      endpoint,
+      { method: 'POST', headers, body: '{}' },
+      { timeoutMs },
+    );
     const text = await response.text().catch(() => '');
     if (response.ok) {
       let data: unknown;
@@ -67,8 +68,6 @@ export async function probePing(baseUrl: string, opts: ProbeOptions = {}): Promi
     return { ok: false, baseUrl, reason: `HTTP ${response.status}` };
   } catch (err) {
     return { ok: false, baseUrl, reason: classifyError(err) };
-  } finally {
-    clearTimeout(timer);
   }
 }
 

--- a/cli/src/utils/probe.ts
+++ b/cli/src/utils/probe.ts
@@ -9,7 +9,8 @@
 // /api/tools/ping → 200 {"result":"pong"}. ARCHITECTURE.md §e2e runbook
 // already cited /api/tools/ping — this endpoint now matches it.
 
-import { fetchWithTimeout } from './http.js';
+import { asError } from './error.js';
+import { fetchWithTimeout, networkErrorCategory, type NetworkErrorCategory } from './http.js';
 
 export const PING_ENDPOINT = '/api/tools/ping';
 
@@ -71,19 +72,16 @@ export async function probePing(baseUrl: string, opts: ProbeOptions = {}): Promi
   }
 }
 
+/** Human-readable text for each shared network-failure category. */
+const NETWORK_CATEGORY_TEXT: Record<NetworkErrorCategory, string> = {
+  'connection-refused': 'connection refused',
+  'connection-reset': 'connection reset',
+  'network-error': 'host not found',
+};
+
 function classifyError(err: unknown): string {
   if (err instanceof Error && err.name === 'AbortError') return 'timed out';
-  const cause =
-    err instanceof Error && 'cause' in err ? (err.cause as { code?: string } | undefined) : undefined;
-  switch (cause?.code) {
-    case 'ECONNREFUSED':
-      return 'connection refused';
-    case 'ECONNRESET':
-      return 'connection reset';
-    case 'ENOTFOUND':
-    case 'EAI_AGAIN':
-      return 'host not found';
-    default:
-      return err instanceof Error ? err.message : String(err);
-  }
+  const category = networkErrorCategory(err);
+  if (category) return NETWORK_CATEGORY_TEXT[category];
+  return asError(err).message;
 }

--- a/cli/tests/engine-chain.test.ts
+++ b/cli/tests/engine-chain.test.ts
@@ -165,6 +165,7 @@ describe('discoverEngine — layer ordering: launcher → registry → common-lo
     const discoveryFs: DiscoveryFs = {
       existsImpl: (p) => p === root || p === bin,
       readdirImpl: (p) => (p === root ? ['UE_5.7'] : []),
+      readFileImpl: () => null,
     };
     const r = discoverEngine({
       engineAssociation: '5.7',
@@ -188,6 +189,7 @@ describe('discoverEngine — layer ordering: launcher → registry → common-lo
     const discoveryFs: DiscoveryFs = {
       existsImpl: (p) => p === root || p === bin,
       readdirImpl: (p) => (p === root ? ['UnrealEngine'] : []),
+      readFileImpl: () => null,
     };
     const r = discoverEngine({
       engineAssociation: '',
@@ -211,7 +213,7 @@ describe('discoverEngine — layer ordering: launcher → registry → common-lo
       cacheIo: io,
       enginesImpl: () => [],
       registryQueryImpl: () => null,
-      discoveryFs: { existsImpl: () => false, readdirImpl: () => [] },
+      discoveryFs: { existsImpl: () => false, readdirImpl: () => [], readFileImpl: () => null },
     });
     expect(r.kind).toBe('unresolved');
     if (r.kind === 'unresolved') expect(r.source).toBeNull();
@@ -268,7 +270,7 @@ describe('openProject — forwards the discovery surfaces (hermetic, no home cac
           readImpl: (p) => store.get(p) ?? null,
           writeImpl: (p, c) => void store.set(p, c),
         },
-        discoveryFs: { existsImpl: () => false, readdirImpl: () => [] },
+        discoveryFs: { existsImpl: () => false, readdirImpl: () => [], readFileImpl: () => null },
         registryQueryImpl: () => null,
         spawnImpl: () => ({ pid: 99 }),
       });

--- a/cli/tests/engine-discovery.test.ts
+++ b/cli/tests/engine-discovery.test.ts
@@ -12,11 +12,19 @@ import {
 } from '../src/utils/engine-discovery.js';
 import { editorBinaryPath } from '../src/utils/engine.js';
 
-/** Build a DiscoveryFs from a set of existing paths + a dir->names listing. */
-function fakeFs(existing: Set<string>, dirs: Record<string, string[]> = {}): DiscoveryFs {
+/**
+ * Build a DiscoveryFs from a set of existing paths + a dir->names listing +
+ * an optional path->file-contents map (for the now-injectable file read).
+ */
+function fakeFs(
+  existing: Set<string>,
+  dirs: Record<string, string[]> = {},
+  files: Record<string, string> = {},
+): DiscoveryFs {
   return {
     existsImpl: (p) => existing.has(p),
     readdirImpl: (p) => dirs[p] ?? [],
+    readFileImpl: (p) => files[p] ?? null,
   };
 }
 
@@ -82,15 +90,17 @@ describe('scanCommonLocationEngines (Linux free-form layout — fixes the dead e
     const install = '/opt/UnrealEngine';
     const bin = editorBinaryPath(install, 'linux');
     const buildVersion = '/opt/UnrealEngine/Engine/Build/Build.version';
-    // Note: readEngineAssociationFromBuildVersion uses the REAL fs.readFileSync,
-    // so we can only assert the existsImpl-gated branch here; association falls
-    // back to '' when the file is not present on the real disk. The engine is
-    // still discovered (usable as the highest-installed fallback).
-    const fs = fakeFs(new Set(['/opt', bin]), { '/opt': ['UnrealEngine', 'other'] });
+    // The Build.version read now goes through the injected `readFileImpl`, so a
+    // hermetic test can supply its contents and assert the parsed association.
+    const fs = fakeFs(
+      new Set(['/opt', bin, buildVersion]),
+      { '/opt': ['UnrealEngine', 'other'] },
+      { [buildVersion]: JSON.stringify({ MajorVersion: 5, MinorVersion: 7 }) },
+    );
     const engines = scanCommonLocationEngines('linux', {}, fs);
     expect(engines).toHaveLength(1);
     expect(engines[0].installLocation).toBe(install);
-    void buildVersion;
+    expect(engines[0].engineAssociation).toBe('5.7');
   });
 
   it('finds a UE_5.7 dir on Linux too', () => {
@@ -105,6 +115,22 @@ describe('scanCommonLocationEngines (Linux free-form layout — fixes the dead e
 describe('readEngineAssociationFromBuildVersion', () => {
   it('returns "" when the file does not exist (injected fs)', () => {
     const fs = fakeFs(new Set());
+    expect(readEngineAssociationFromBuildVersion('/opt/UE', 'linux', fs)).toBe('');
+  });
+
+  it('reads "major.minor" through the injected readFileImpl', () => {
+    const versionFile = '/opt/UE/Engine/Build/Build.version';
+    const fs = fakeFs(
+      new Set([versionFile]),
+      {},
+      { [versionFile]: JSON.stringify({ MajorVersion: 5, MinorVersion: 7, PatchVersion: 4 }) },
+    );
+    expect(readEngineAssociationFromBuildVersion('/opt/UE', 'linux', fs)).toBe('5.7');
+  });
+
+  it('returns "" when the injected read yields malformed JSON', () => {
+    const versionFile = '/opt/UE/Engine/Build/Build.version';
+    const fs = fakeFs(new Set([versionFile]), {}, { [versionFile]: 'not json' });
     expect(readEngineAssociationFromBuildVersion('/opt/UE', 'linux', fs)).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

Behavior-preserving `/simplify` code-quality cleanup of the TypeScript CLI (`cli/` only — no `UnrealMCP/` or `bridge/` changes), pre-reviewed by a 4-agent audit. Each finding is one atomic commit; the full vitest suite stays green (263 passed, 1 skipped) with `npm ci && npm run build && npm test`.

Shared-util extractions + dead-code removal (no behavior change):

1. **`utils/error.ts` `asError(err)`** — replaces ~24 duplicated `err instanceof Error ? err : new Error(String(err))` coercions (and the `.message` sibling → `asError(err).message`) across the lib command modules.
2. **`utils/fs.ts` `isSymlink(p)`** — unifies the three verbatim-duplicated lstat junction guards (`install-plugin` `isLink`, `update` `isJunction`, `clean-plugin` `isLink`) that gate destructive `rmSync`/`unlinkSync`.
3. **`utils/http.ts` `fetchWithTimeout(...)`** — promotes login's private per-request-deadline fetch into a shared helper `{timeoutMs, externalSignal, onTimeout}`; reused by `probe` and `run-tool`. run-tool's timeout-vs-caller-abort disambiguation is preserved via the `onTimeout` callback feeding its local `timedOut` flag.
4. **`utils/http.ts` `networkErrorCategory(err)`** — one canonical `err.cause.code` classifier (`ECONNREFUSED`/`ECONNRESET`/`ENOTFOUND`/`EAI_AGAIN`); `run-tool` uses it as its failure-reason enum, `probe` maps it to human text.
5. **`utils/engine.ts` `pathFor(os)`** — `os==='win32' ? path.win32 : path.posix`; replaces 5 inline occurrences in `engine.ts` + `engine-discovery.ts`.
6. **`utils/launcher.ts` `byEngineVersionDesc`** — single highest-version-first sort comparator for the 3 inline engine sorts.
7. **`SERVER_RELEASE_REPO`** — exported from `download-server.ts` and imported in `server-checksum.ts` (dropping the duplicated literal).
8. **Dead `import { homedir } from 'os'`** removed from `engine-discovery.ts` (code reads `env['HOME']`).
9. **`DiscoveryFs.readFileImpl`** — `readEngineAssociationFromBuildVersion` read the real `fs.readFileSync` despite taking an injectable `DiscoveryFs`; now routed through the injected fs so the Linux `Build.version` path is hermetic. Tests that previously could only assert the existsImpl-gated branch now inject contents and assert the parsed association.

**Out of scope:** finding #10 (parallelizing the zip + SHA256SUMS fetch in `download-server.ts`) was deliberately NOT applied — it reorders the error path.

## Test plan
- [x] `npm ci && npm run build` (tsc, 0 errors)
- [x] `npm test` (vitest run) — 263 passed, 1 skipped, 0 failures
- [x] Diff confined to `cli/src` + `cli/tests` (no plugin/bridge legs); not a tool-family change, so Suite 7 N/A.

Closes #165