### PR TITLE
refactor(plugin): behavior-preserving /simplify cleanup — STRUCTURAL wave

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
@@ -4,6 +4,7 @@
 #include "Server/UnrealMcpServerManager.h"
 #include "Server/UnrealMcpServerChecksum.h"
 #include "UnrealMcpLog.h"
+#include "UnrealMcpProcessUtil.h"   // shared ResolveDotNetRid + MakeExecutable
 
 #include "Async/Async.h"
 #include "HAL/PlatformProcess.h"
@@ -22,14 +23,6 @@
 
 #include "FileUtilities/ZipArchiveReader.h"
 
-#if PLATFORM_MAC || PLATFORM_LINUX
-#include <cerrno>
-#include <sys/stat.h>
-#endif
-#if PLATFORM_MAC
-#include <sys/sysctl.h>
-#endif
-
 #if PLATFORM_WINDOWS
 #include "Windows/AllowWindowsPlatformTypes.h"
 #include <Windows.h>
@@ -43,10 +36,7 @@ const TCHAR* FUnrealMcpServerManager::ServerPathEnvVar = TEXT("UNREAL_MCP_SERVER
 
 namespace
 {
-	// Restart backoff schedule (seconds) — mirrors the sidecar §1.5 watchdog.
-	const int32 ServerBackoffSeconds[] = { 1, 2, 5, 10, 30 };
-	constexpr int32 ServerMaxCrashesPerWindow = 5;
-	constexpr double ServerCrashWindowSeconds = 300.0;
+	// The §1.5 backoff schedule + crash-rate constants now live in FUnrealMcpSupervisedProcess.
 	const TCHAR* ServerProcessNameNeedle = TEXT("gamedev-mcp-server");
 
 	// GitHub release-asset URL for a rid + version (v-prefixed tags), matching the CLI's serverDownloadUrl.
@@ -85,24 +75,9 @@ FString FUnrealMcpServerManager::ServerBinaryBasename()
 
 FString FUnrealMcpServerManager::ResolveRid(bool bArm64DirExists)
 {
-#if PLATFORM_WINDOWS
-	(void)bArm64DirExists;
-	return TEXT("win-x64");
-#elif PLATFORM_MAC
-	int32 IsArm64 = 0;
-	size_t Size = sizeof(IsArm64);
-	if (sysctlbyname("hw.optional.arm64", &IsArm64, &Size, nullptr, 0) != 0)
-		IsArm64 = 0;
-	if (IsArm64 == 1 && bArm64DirExists)
-		return TEXT("osx-arm64");
-	return TEXT("osx-x64");
-#elif PLATFORM_LINUX
-	(void)bArm64DirExists;
-	return TEXT("linux-x64");
-#else
-	(void)bArm64DirExists;
-	return FString();
-#endif
+	// The RID resolver is shared with FUnrealMcpSidecarManager — see FUnrealMcpProcessUtil::ResolveDotNetRid
+	// (§6.2). This thin forwarder keeps the tested static-member entry point.
+	return FUnrealMcpProcessUtil::ResolveDotNetRid(bArm64DirExists);
 }
 
 FString FUnrealMcpServerManager::ServerInstallDir(const FString& ProjectDir, const FString& Rid)
@@ -195,18 +170,8 @@ bool FUnrealMcpServerManager::IsLaunchAllowed(bool bIsCustomMode, bool bIsHttpTr
 
 void FUnrealMcpServerManager::PrepareBinaryForSpawn(const FString& Path)
 {
-#if PLATFORM_MAC || PLATFORM_LINUX
-	if (Path.IsEmpty())
-		return;
-	const auto Utf8Path = StringCast<ANSICHAR>(*Path);
-	if (chmod(Utf8Path.Get(), 0755) != 0)
-	{
-		UE_LOG(LogUnrealMcp, Warning,
-			TEXT("[Unreal-MCP] could not set +x on the local server '%s' (errno=%d); spawn may fail."), *Path, errno);
-	}
-#else
-	(void)Path;
-#endif
+	// §6.6: ensure the apphost is executable (shared +x helper — no-op on Windows). Not fatal on failure.
+	FUnrealMcpProcessUtil::MakeExecutable(Path);
 }
 
 FString FUnrealMcpServerManager::ResolveBinaryPath() const
@@ -612,7 +577,6 @@ bool FUnrealMcpServerManager::Start(int32 Port, int32 PluginTimeoutMs, bool bAut
 	}
 
 	bStarting = true;
-	bStopRequested = false;
 	ListenPort = Port;
 	LaunchArgs = BuildLaunchArgs(Port, PluginTimeoutMs, bAuthRequired, Token);
 
@@ -645,9 +609,7 @@ bool FUnrealMcpServerManager::Start(int32 Port, int32 PluginTimeoutMs, bool bAut
 		return false;
 	}
 
-	WindowStartSeconds = FPlatformTime::Seconds();
-	CrashesInWindow = 0;
-	RestartCount.Reset();
+	Watchdog.ResetRestartCount();   // fresh Start zeroes the restart counter (Watchdog.Start resets the crash window).
 	StartWatchdog();
 	bStarting = false;
 	return true;
@@ -681,9 +643,7 @@ bool FUnrealMcpServerManager::ReattachIfRunning(int32 Port, int32 PluginTimeoutM
 	// Re-bind the adopted survivor to a kill-on-close job so it too dies with THIS editor session by any exit
 	// path (the original spawning session's job died with that session's editor).
 	BindProcessToKillOnCloseJob(Adopted.Get());
-	bStopRequested = false;
-	WindowStartSeconds = FPlatformTime::Seconds();
-	CrashesInWindow = 0;
+	// Reattach does NOT reset the restart counter (only a fresh Start does); Watchdog.Start resets the crash window.
 	StartWatchdog();
 	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] reattached to existing local server pid=%d on port=%d."), SavedPid, Port);
 	return true;
@@ -691,57 +651,18 @@ bool FUnrealMcpServerManager::ReattachIfRunning(int32 Port, int32 PluginTimeoutM
 
 void FUnrealMcpServerManager::StartWatchdog()
 {
-	if (WatchdogFuture.IsValid())
-		return;
-
-	WatchdogFuture = Async(EAsyncExecution::Thread, [this]()
-	{
-		int32 BackoffIndex = 0;
-		while (!bStopRequested)
+	// The §1.5 crash-restart loop lives in FUnrealMcpSupervisedProcess; supply the server-specific liveness probe
+	// + respawn + give-up. The liveness read and the dead-handle close both take ProcessMutex (the watchdog thread
+	// otherwise owns ProcHandle mutation); the respawn first frees any orphan squatting on the listen port, then
+	// re-spawns; give-up clears the pid file. All run ON the watchdog thread.
+	Watchdog.Start(
+		/*IsAlive*/ [this]() -> bool
 		{
-			FPlatformProcess::Sleep(1.0f);
-			if (bStopRequested)
-				break;
-
-			bool bAlive;
-			{
-				FScopeLock Lock(&ProcessMutex);
-				bAlive = ProcHandle.IsValid() && FPlatformProcess::IsProcRunning(ProcHandle);
-			}
-			if (bAlive)
-			{
-				BackoffIndex = 0;
-				continue;
-			}
-
-			// Process died unexpectedly — crash-restart with backoff + a crash-rate guard.
-			const double Now = FPlatformTime::Seconds();
-			if (Now - WindowStartSeconds > ServerCrashWindowSeconds)
-			{
-				WindowStartSeconds = Now;
-				CrashesInWindow = 0;
-			}
-			if (++CrashesInWindow > ServerMaxCrashesPerWindow)
-			{
-				UE_LOG(LogUnrealMcp, Error,
-					TEXT("[Unreal-MCP] local server crashed > %d times in %.0fs; giving up auto-restart."),
-					ServerMaxCrashesPerWindow, ServerCrashWindowSeconds);
-				ClearPidFile();
-				return;
-			}
-
-			const int32 DelaySeconds = ServerBackoffSeconds[FMath::Min(BackoffIndex, (int32)UE_ARRAY_COUNT(ServerBackoffSeconds) - 1)];
-			++BackoffIndex;
-			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] local server exited; restarting in %ds (restart #%d)."),
-				DelaySeconds, RestartCount.GetValue() + 1);
-
-			// Chunk the backoff so editor shutdown (which joins this thread) is not stalled by one long sleep.
-			const double BackoffUntil = FPlatformTime::Seconds() + DelaySeconds;
-			while (!bStopRequested && FPlatformTime::Seconds() < BackoffUntil)
-				FPlatformProcess::Sleep(0.5f);
-			if (bStopRequested)
-				break;
-
+			FScopeLock Lock(&ProcessMutex);
+			return ProcHandle.IsValid() && FPlatformProcess::IsProcRunning(ProcHandle);
+		},
+		/*Respawn*/ [this]() -> bool
+		{
 			{
 				FScopeLock Lock(&ProcessMutex);
 				if (ProcHandle.IsValid())
@@ -752,20 +673,15 @@ void FUnrealMcpServerManager::StartWatchdog()
 			}
 			if (ListenPort > 0)
 				KillOrphanedServerOnPort(ListenPort);
-			if (SpawnProcess(BinaryPath))
-				RestartCount.Increment();
-		}
-	});
+			return SpawnProcess(BinaryPath);
+		},
+		/*OnGiveUp*/ [this]() { ClearPidFile(); },
+		TEXT("local server"));
 }
 
 void FUnrealMcpServerManager::StopWatchdog()
 {
-	bStopRequested = true;
-	if (WatchdogFuture.IsValid())
-	{
-		WatchdogFuture.Wait();
-		WatchdogFuture = TFuture<void>();
-	}
+	Watchdog.Stop();
 }
 
 void FUnrealMcpServerManager::TerminateProcess(bool bForce)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.h
@@ -7,6 +7,7 @@
 #include "HAL/ThreadSafeBool.h"
 #include "HAL/CriticalSection.h"
 #include "GenericPlatform/GenericPlatformProcess.h"
+#include "UnrealMcpSupervisedProcess.h"   // the shared §1.5 crash-restart watchdog (FUnrealMcpSupervisedProcess Watchdog member below)
 
 /**
  * Owns the lifecycle of the LOCAL shared `gamedev-mcp-server` process (the engine-agnostic MCP server
@@ -60,7 +61,7 @@ public:
 	bool IsRunning() const;
 
 	/** Total auto-restarts the watchdog performed since the last Start (for the UI status string). */
-	int32 GetRestartCount() const { return RestartCount.GetValue(); }
+	int32 GetRestartCount() const { return Watchdog.GetRestartCount(); }
 
 	/**
 	 * Reattach to a server this plugin spawned in a PREVIOUS editor module load (a hot-reload / domain-reload
@@ -196,12 +197,11 @@ private:
 	// destructor. See BindProcessToKillOnCloseJob.
 	void* JobHandle = nullptr;
 
-	FThreadSafeBool bStopRequested = false;
 	FThreadSafeBool bStarting = false;
-	FThreadSafeCounter RestartCount;
-	TFuture<void> WatchdogFuture;
 
-	// Crash-rate guard (mirrors the sidecar §1.5): > 5 crashes in 5 minutes → stop restarting.
-	double WindowStartSeconds = 0.0;
-	int32 CrashesInWindow = 0;
+	// The §1.5 crash-restart watchdog (backoff {1,2,5,10,30}s + give-up after 5 crashes / 300s). Shared with
+	// FUnrealMcpSidecarManager via FUnrealMcpSupervisedProcess; this manager supplies the IsAlive / Respawn /
+	// OnGiveUp closures (the respawn kills an orphan on the port + re-spawns; give-up clears the pid file) in
+	// StartWatchdog().
+	FUnrealMcpSupervisedProcess Watchdog;
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpActorTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpActorTools.cpp
@@ -3,6 +3,8 @@
 
 #include "UnrealMcpCoreTools.h"
 #include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpSchema.h"          // shared §3.2 schema builders (FUnrealMcpSchema::Rotator/ObjectBag/StringArray)
+#include "UnrealMcpToolArgs.h"        // shared FUnrealMcpToolArgs::GetStringArray
 #include "Tools/UnrealMcpObjectRef.h"
 #include "Tools/UnrealMcpPropertyJson.h"
 
@@ -29,81 +31,9 @@
  */
 namespace
 {
-	// --- Local schema builders (the typed builder helpers don't cover rotators / property bags / lists) ---
-
-	/** `{pitch,yaw,roll: number}` — the §3.2 FRotator mapping (degrees). Read back via FUnrealMcpToolCall::GetRotator. */
-	TSharedPtr<FJsonObject> MakeRotatorSchema(const FString& Desc)
-	{
-		auto Num = []() { TSharedPtr<FJsonObject> N = MakeShared<FJsonObject>(); N->SetStringField(TEXT("type"), TEXT("number")); return N; };
-		TSharedPtr<FJsonObject> Props = MakeShared<FJsonObject>();
-		Props->SetObjectField(TEXT("pitch"), Num());
-		Props->SetObjectField(TEXT("yaw"), Num());
-		Props->SetObjectField(TEXT("roll"), Num());
-
-		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
-		Schema->SetStringField(TEXT("type"), TEXT("object"));
-		if (!Desc.IsEmpty())
-			Schema->SetStringField(TEXT("description"), Desc);
-		Schema->SetObjectField(TEXT("properties"), Props);
-		return Schema;
-	}
-
-	/** A free-form `{ key: value }` property bag — arbitrary FProperty writes (§3.2), additionalProperties allowed. */
-	TSharedPtr<FJsonObject> MakePropertyBagSchema(const FString& Desc)
-	{
-		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
-		Schema->SetStringField(TEXT("type"), TEXT("object"));
-		if (!Desc.IsEmpty())
-			Schema->SetStringField(TEXT("description"), Desc);
-		Schema->SetBoolField(TEXT("additionalProperties"), true);
-		return Schema;
-	}
-
-	/** An `array` of strings — used for the §3.2 scoped-read `paths` filter. */
-	TSharedPtr<FJsonObject> MakeStringArraySchema(const FString& Desc)
-	{
-		TSharedPtr<FJsonObject> Items = MakeShared<FJsonObject>();
-		Items->SetStringField(TEXT("type"), TEXT("string"));
-
-		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
-		Schema->SetStringField(TEXT("type"), TEXT("array"));
-		if (!Desc.IsEmpty())
-			Schema->SetStringField(TEXT("description"), Desc);
-		Schema->SetObjectField(TEXT("items"), Items);
-		return Schema;
-	}
-
-	// --- Small argument helpers ---
-
-	/**
-	 * Read a string array argument (the scoped-read `paths` filter); empty when absent or not an array.
-	 * A non-string entry is reported via OutError (and the array is left empty) rather than silently
-	 * dropped — a dropped entry would otherwise flip the scoped read to "identity only" / "full object"
-	 * (the opposite extremes of the requested scope) with no signal to the caller.
-	 */
-	TArray<FString> GetStringArray(const FUnrealMcpToolCall& Call, const FString& Key, FString& OutError)
-	{
-		TArray<FString> Out;
-		const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
-		if (Call.Arguments->TryGetArrayField(Key, Arr) && Arr)
-		{
-			for (const TSharedPtr<FJsonValue>& V : *Arr)
-			{
-				FString S;
-				if (V.IsValid() && V->TryGetString(S))
-				{
-					Out.Add(S);
-				}
-				else
-				{
-					OutError = FString::Printf(TEXT("'%s' must be an array of strings; a non-string entry was provided."), *Key);
-					Out.Reset();
-					return Out;
-				}
-			}
-		}
-		return Out;
-	}
+	// Schema builders (rotator / property bag / string-array) + the scoped-read `paths` reader are the shared
+	// FUnrealMcpSchema / FUnrealMcpToolArgs surfaces (UnrealMcpSchema.h / UnrealMcpToolArgs.h) — see their call
+	// sites below. Only family-specific helpers remain here.
 
 	/** The 'properties' object argument (the write property bag); null when absent. */
 	TSharedPtr<FJsonObject> GetPropertiesArg(const FUnrealMcpToolCall& Call)
@@ -167,7 +97,7 @@ namespace UnrealMcpActorTools
 			.ParamString(TEXT("classPath"), TEXT("Native class or Blueprint asset path/name."), EUnrealMcpParamRequirement::Required)
 			.ParamString(TEXT("name"), TEXT("Actor label. Auto-generated when omitted."))
 			.ParamVector(TEXT("location"), TEXT("World location {x,y,z}. Defaults to origin."))
-			.Param(TEXT("rotation"), TEXT("object"), TEXT("World rotation {pitch,yaw,roll} in degrees."), EUnrealMcpParamRequirement::Optional, MakeRotatorSchema(TEXT("World rotation {pitch,yaw,roll} in degrees.")))
+			.Param(TEXT("rotation"), TEXT("object"), TEXT("World rotation {pitch,yaw,roll} in degrees."), EUnrealMcpParamRequirement::Optional, FUnrealMcpSchema::Rotator(TEXT("World rotation {pitch,yaw,roll} in degrees.")))
 			.ParamString(TEXT("parentActor"), TEXT("Label/path of an actor to attach the new actor to."))
 			.DestructiveHint(false)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
@@ -323,7 +253,7 @@ namespace UnrealMcpActorTools
 			.ParamString(TEXT("labelFilter"), TEXT("Case-insensitive substring matched against actor labels."))
 			.ParamString(TEXT("pathFilter"), TEXT("Case-insensitive substring matched against full actor paths."))
 			.ParamString(TEXT("classFilter"), TEXT("Class path/name; matches actors of this class or a subclass."))
-			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include per actor (scoped read). Identity only when omitted."), EUnrealMcpParamRequirement::Optional, MakeStringArraySchema(TEXT("Dotted property paths to include per actor (scoped read).")))
+			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include per actor (scoped read). Identity only when omitted."), EUnrealMcpParamRequirement::Optional, FUnrealMcpSchema::StringArray(TEXT("Dotted property paths to include per actor (scoped read).")))
 			.ParamInt(TEXT("limit"), TEXT("Maximum number of actors to return. Defaults to 100."))
 			.ReadOnlyHint(true)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
@@ -336,7 +266,7 @@ namespace UnrealMcpActorTools
 				const FString PathFilter = Call.GetString(TEXT("pathFilter"));
 				const FString ClassFilter = Call.GetString(TEXT("classFilter"));
 				FString PathsError;
-				const TArray<FString> Paths = GetStringArray(Call, TEXT("paths"), PathsError);
+				const TArray<FString> Paths = FUnrealMcpToolArgs::GetStringArray(Call, TEXT("paths"), PathsError);
 				if (!PathsError.IsEmpty())
 					return FUnrealMcpToolResult::Error(PathsError);
 				const int32 Limit = static_cast<int32>(Call.GetInt(TEXT("limit"), 100));
@@ -386,7 +316,7 @@ namespace UnrealMcpActorTools
 			                  "'rotation' {pitch,yaw,roll}, and 'scale' {x,y,z} are routed to the transform "
 			                  "APIs; all other keys are set by name through FProperty reflection."))
 			.ParamString(TEXT("actor"), TEXT("Actor label / name / path to modify."), EUnrealMcpParamRequirement::Required)
-			.Param(TEXT("properties"), TEXT("object"), TEXT("Property bag of name -> value to write (incl. transform keys)."), EUnrealMcpParamRequirement::Required, MakePropertyBagSchema(TEXT("Property bag of name -> value to write.")))
+			.Param(TEXT("properties"), TEXT("object"), TEXT("Property bag of name -> value to write (incl. transform keys)."), EUnrealMcpParamRequirement::Required, FUnrealMcpSchema::ObjectBag(TEXT("Property bag of name -> value to write.")))
 			.DestructiveHint(false)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
@@ -580,7 +510,7 @@ namespace UnrealMcpActorTools
 			.Description(TEXT("Read a component's reflected properties, optionally scoped to the dotted 'paths' filter."))
 			.ParamString(TEXT("actor"), TEXT("Owning actor label / name / path."), EUnrealMcpParamRequirement::Required)
 			.ParamString(TEXT("component"), TEXT("Component name to read."), EUnrealMcpParamRequirement::Required)
-			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include (scoped read). Full object when omitted."), EUnrealMcpParamRequirement::Optional, MakeStringArraySchema(TEXT("Dotted property paths to include (scoped read).")))
+			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include (scoped read). Full object when omitted."), EUnrealMcpParamRequirement::Optional, FUnrealMcpSchema::StringArray(TEXT("Dotted property paths to include (scoped read).")))
 			.ReadOnlyHint(true)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
@@ -594,7 +524,7 @@ namespace UnrealMcpActorTools
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No component matched '%s' on '%s'."), *CompRef, *Actor->GetActorLabel()));
 
 				FString PathsError;
-				const TArray<FString> Paths = GetStringArray(Call, TEXT("paths"), PathsError);
+				const TArray<FString> Paths = FUnrealMcpToolArgs::GetStringArray(Call, TEXT("paths"), PathsError);
 				if (!PathsError.IsEmpty())
 					return FUnrealMcpToolResult::Error(PathsError);
 				TSharedPtr<FJsonObject> Data = FUnrealMcpObjectRef::ComponentIdentity(Comp);
@@ -612,7 +542,7 @@ namespace UnrealMcpActorTools
 			                  "'relativeScale3D' {x,y,z} routed to the relative-transform APIs."))
 			.ParamString(TEXT("actor"), TEXT("Owning actor label / name / path."), EUnrealMcpParamRequirement::Required)
 			.ParamString(TEXT("component"), TEXT("Component name to modify."), EUnrealMcpParamRequirement::Required)
-			.Param(TEXT("properties"), TEXT("object"), TEXT("Property bag of name -> value to write."), EUnrealMcpParamRequirement::Required, MakePropertyBagSchema(TEXT("Property bag of name -> value to write.")))
+			.Param(TEXT("properties"), TEXT("object"), TEXT("Property bag of name -> value to write."), EUnrealMcpParamRequirement::Required, FUnrealMcpSchema::ObjectBag(TEXT("Property bag of name -> value to write.")))
 			.DestructiveHint(false)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
@@ -694,7 +624,7 @@ namespace UnrealMcpActorTools
 			                  "('/Game/Folder/Asset.Asset') or, for scene objects, by actor label. Optionally "
 			                  "scoped to the dotted 'paths' filter."))
 			.ParamString(TEXT("object"), TEXT("Object path or actor label/name/path."), EUnrealMcpParamRequirement::Required)
-			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include (scoped read). Full object when omitted."), EUnrealMcpParamRequirement::Optional, MakeStringArraySchema(TEXT("Dotted property paths to include (scoped read).")))
+			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include (scoped read). Full object when omitted."), EUnrealMcpParamRequirement::Optional, FUnrealMcpSchema::StringArray(TEXT("Dotted property paths to include (scoped read).")))
 			.ReadOnlyHint(true)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
@@ -707,7 +637,7 @@ namespace UnrealMcpActorTools
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("No object matched '%s'."), *Ref));
 
 				FString PathsError;
-				const TArray<FString> Paths = GetStringArray(Call, TEXT("paths"), PathsError);
+				const TArray<FString> Paths = FUnrealMcpToolArgs::GetStringArray(Call, TEXT("paths"), PathsError);
 				if (!PathsError.IsEmpty())
 					return FUnrealMcpToolResult::Error(PathsError);
 				TSharedPtr<FJsonObject> Structured = MakeShared<FJsonObject>();
@@ -726,7 +656,7 @@ namespace UnrealMcpActorTools
 			.Description(TEXT("Write reflected properties on any UObject resolved by object path or actor label. "
 			                  "Transform keys are honored when the object is an actor or scene component."))
 			.ParamString(TEXT("object"), TEXT("Object path or actor label/name/path."), EUnrealMcpParamRequirement::Required)
-			.Param(TEXT("properties"), TEXT("object"), TEXT("Property bag of name -> value to write."), EUnrealMcpParamRequirement::Required, MakePropertyBagSchema(TEXT("Property bag of name -> value to write.")))
+			.Param(TEXT("properties"), TEXT("object"), TEXT("Property bag of name -> value to write."), EUnrealMcpParamRequirement::Required, FUnrealMcpSchema::ObjectBag(TEXT("Property bag of name -> value to write.")))
 			.DestructiveHint(false)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpAssetTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpAssetTools.cpp
@@ -4,6 +4,7 @@
 #include "UnrealMcpCoreTools.h"
 #include "UnrealMcpToolRegistry.h"
 #include "UnrealMcpLog.h"
+#include "UnrealMcpToolArgs.h"        // shared FUnrealMcpToolArgs::GetStringArray (strict: errors on a non-string / non-array)
 #include "Tools/UnrealMcpAssetScopedRead.h"
 
 #include "Dom/JsonObject.h"
@@ -110,29 +111,15 @@ namespace UnrealMcpAssetTools
 		return !(IsReservedRoot(TEXT("/Engine")) || IsReservedRoot(TEXT("/Script")) || IsReservedRoot(TEXT("/Temp")));
 	}
 
-	/** Read a string-array argument (returns empty when absent or not an array). */
-	static TArray<FString> GetStringArray(const FUnrealMcpToolCall& Call, const FString& Key)
+	/**
+	 * The §3.2 scoped-read field list (the `paths` argument) for read-only get-data tools. Delegates to the
+	 * shared strict reader: a non-string entry or a present-but-not-array `paths` is reported via @p OutError
+	 * (and an empty list returned), so a malformed filter errors rather than silently widening the read (this
+	 * family used to silently drop bad entries — converged to the strict contract the other families use).
+	 */
+	static TArray<FString> GetScopedReadPaths(const FUnrealMcpToolCall& Call, FString& OutError)
 	{
-		TArray<FString> Result;
-		const TArray<TSharedPtr<FJsonValue>>* Array;
-		if (Call.Arguments->TryGetArrayField(Key, Array))
-		{
-			for (const TSharedPtr<FJsonValue>& Value : *Array)
-			{
-				FString Str;
-				if (Value.IsValid() && Value->TryGetString(Str))
-				{
-					Result.Add(Str);
-				}
-			}
-		}
-		return Result;
-	}
-
-	/** The §3.2 scoped-read field list (the `paths` argument) for read-only get-data tools. */
-	static TArray<FString> GetScopedReadPaths(const FUnrealMcpToolCall& Call)
-	{
-		return GetStringArray(Call, TEXT("paths"));
+		return FUnrealMcpToolArgs::GetStringArray(Call, TEXT("paths"), OutError);
 	}
 
 	static TSharedPtr<FJsonObject> AssetDataToJson(const FAssetData& Data)
@@ -315,7 +302,12 @@ namespace UnrealMcpAssetTools
 				});
 				Full->SetObjectField(TEXT("tags"), Tags);
 
-				const TSharedPtr<FJsonObject> Structured = UnrealMcpAssetScopedRead::Apply(Full, GetScopedReadPaths(Call));
+				FString PathsError;
+				const TArray<FString> ScopedPaths = GetScopedReadPaths(Call, PathsError);
+				if (!PathsError.IsEmpty())
+					return FUnrealMcpToolResult::Error(PathsError);
+
+				const TSharedPtr<FJsonObject> Structured = UnrealMcpAssetScopedRead::Apply(Full, ScopedPaths);
 				return FUnrealMcpToolResult::Success(
 					FString::Printf(TEXT("Asset data for '%s'."), *Data.AssetName.ToString()), Structured);
 			});
@@ -541,7 +533,10 @@ namespace UnrealMcpAssetTools
 			.IdempotentHint(true)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
-				TArray<FString> Paths = GetStringArray(Call, TEXT("paths"));
+				FString PathsError;
+				TArray<FString> Paths = FUnrealMcpToolArgs::GetStringArray(Call, TEXT("paths"), PathsError);
+				if (!PathsError.IsEmpty())
+					return FUnrealMcpToolResult::Error(PathsError);
 				const FString SinglePath = Call.GetString(TEXT("path"));
 				const bool bForce = Call.GetBool(TEXT("force"), false);
 				if (!SinglePath.IsEmpty())
@@ -916,7 +911,12 @@ namespace UnrealMcpAssetTools
 				Full->SetObjectField(TEXT("vectors"), Vectors);
 				Full->SetObjectField(TEXT("textures"), Textures);
 
-				const TSharedPtr<FJsonObject> Structured = UnrealMcpAssetScopedRead::Apply(Full, GetScopedReadPaths(Call));
+				FString PathsError;
+				const TArray<FString> ScopedPaths = GetScopedReadPaths(Call, PathsError);
+				if (!PathsError.IsEmpty())
+					return FUnrealMcpToolResult::Error(PathsError);
+
+				const TSharedPtr<FJsonObject> Structured = UnrealMcpAssetScopedRead::Apply(Full, ScopedPaths);
 				return FUnrealMcpToolResult::Success(
 					FString::Printf(TEXT("Material parameters for '%s'."), *Material->GetName()), Structured);
 			});

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpBlueprintTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpBlueprintTools.cpp
@@ -4,6 +4,7 @@
 #include "UnrealMcpCoreTools.h"
 #include "UnrealMcpToolRegistry.h"
 #include "UnrealMcpLog.h"
+#include "Tools/UnrealMcpObjectRef.h"   // the de-facto standard class resolver (FUnrealMcpObjectRef::ResolveClass)
 
 #include "Engine/Blueprint.h"
 #include "Engine/BlueprintGeneratedClass.h"
@@ -43,23 +44,13 @@
 namespace
 {
 	// ---- Resolution helpers ----------------------------------------------------------------------
-
-	/** Resolve a UClass from a native class path ("/Script/Engine.Actor"), a short name ("Actor"), or a
-	 *  Blueprint asset path ("/Game/X/BP_Y.BP_Y" -> its GeneratedClass). Returns null when unresolved. */
-	UClass* ResolveClass(const FString& Path)
-	{
-		if (Path.IsEmpty())
-			return nullptr;
-		if (UClass* Found = UClass::TryFindTypeSlow<UClass>(Path))
-			return Found;
-		// LOAD_NoWarn|LOAD_Quiet: these are speculative probes run on every tool call with a fresh path;
-		// a miss is expected and must not spam the editor log with LoadPackage failure warnings.
-		if (UClass* Loaded = LoadObject<UClass>(nullptr, *Path, nullptr, LOAD_NoWarn | LOAD_Quiet))
-			return Loaded;
-		if (UBlueprint* BP = LoadObject<UBlueprint>(nullptr, *Path, nullptr, LOAD_NoWarn | LOAD_Quiet))
-			return BP->GeneratedClass;
-		return nullptr;
-	}
+	//
+	// Class resolution uses the shared FUnrealMcpObjectRef::ResolveClass (Tools/UnrealMcpObjectRef.h) — the
+	// de-facto standard the actor/asset/level families already use. It is a strict superset of the resolver this
+	// file once carried locally: it ADDS an FSoftClassPath::TryLoadClass step (resolves native + generated
+	// Blueprint class paths without a scan) and a FindFirstObject fallback on top of the
+	// TryFindTypeSlow + object/Blueprint-asset load chain. Broadening the Blueprint family's resolution to match
+	// is the intended convergence.
 
 	/** Resolve a UBlueprint by object path. Prefers an already-in-memory object (assets created earlier
 	 *  this session are registered with the AssetRegistry but not saved to disk), then falls back to load. */
@@ -135,7 +126,7 @@ namespace
 		else
 		{
 			// Object / class / struct path: resolve to a UClass (object ref) or a UScriptStruct.
-			if (UClass* Class = ResolveClass(Type))
+			if (UClass* Class = FUnrealMcpObjectRef::ResolveClass(Type))
 				Set(UEdGraphSchema_K2::PC_Object, NAME_None, Class);
 			else if (UScriptStruct* Struct = LoadObject<UScriptStruct>(nullptr, *Type, nullptr, LOAD_NoWarn | LOAD_Quiet))
 				Set(UEdGraphSchema_K2::PC_Struct, NAME_None, Struct);
@@ -216,7 +207,7 @@ namespace UnrealMcpBlueprintTools
 				if (Path.IsEmpty())
 					return FUnrealMcpToolResult::Error(TEXT("'path' is required."));
 
-				UClass* ParentClass = ResolveClass(ParentPath);
+				UClass* ParentClass = FUnrealMcpObjectRef::ResolveClass(ParentPath);
 				if (!ParentClass)
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("could not resolve parent class '%s'."), *ParentPath));
 				if (!FKismetEditorUtilities::CanCreateBlueprintOfClass(ParentClass))
@@ -413,7 +404,7 @@ namespace UnrealMcpBlueprintTools
 					return FUnrealMcpToolResult::Error(TEXT("Blueprint has no Simple Construction Script (not an Actor-based Blueprint?)."));
 
 				const FString CompName = Call.GetString(TEXT("name"));
-				UClass* CompClass = ResolveClass(Call.GetString(TEXT("componentClass")));
+				UClass* CompClass = FUnrealMcpObjectRef::ResolveClass(Call.GetString(TEXT("componentClass")));
 				if (!CompClass || !CompClass->IsChildOf(UActorComponent::StaticClass()))
 					return FUnrealMcpToolResult::Error(FString::Printf(TEXT("'%s' is not a UActorComponent subclass."), *Call.GetString(TEXT("componentClass"))));
 				// SCS CreateNode calls NewObject on the class; an abstract/deprecated class fatally asserts there

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpEditorTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpEditorTools.cpp
@@ -3,6 +3,8 @@
 
 #include "UnrealMcpCoreTools.h"
 #include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpSchema.h"          // shared §3.2 schema builders (FUnrealMcpSchema::StringArray/ObjectBag)
+#include "UnrealMcpToolArgs.h"        // shared FUnrealMcpToolArgs::GetStringArray
 #include "Tools/UnrealMcpObjectRef.h"
 #include "Tools/UnrealMcpLogCollector.h"
 
@@ -41,65 +43,10 @@
  */
 namespace
 {
-	// --- Local schema builders -------------------------------------------------------------------
-
-	/** An `array` of strings (the §3.2 refs list for editor-selection-set). */
-	TSharedPtr<FJsonObject> MakeEditorStringArraySchema(const FString& Desc)
-	{
-		TSharedPtr<FJsonObject> Items = MakeShared<FJsonObject>();
-		Items->SetStringField(TEXT("type"), TEXT("string"));
-
-		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
-		Schema->SetStringField(TEXT("type"), TEXT("array"));
-		if (!Desc.IsEmpty())
-			Schema->SetStringField(TEXT("description"), Desc);
-		Schema->SetObjectField(TEXT("items"), Items);
-		return Schema;
-	}
-
-	/** A free-form `{ key: value }` argument bag (reflection-method-call's `args`). */
-	TSharedPtr<FJsonObject> MakeArgsBagSchema(const FString& Desc)
-	{
-		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
-		Schema->SetStringField(TEXT("type"), TEXT("object"));
-		if (!Desc.IsEmpty())
-			Schema->SetStringField(TEXT("description"), Desc);
-		Schema->SetBoolField(TEXT("additionalProperties"), true);
-		return Schema;
-	}
-
-	// --- Small helpers ---------------------------------------------------------------------------
-
-	/** Read a string-array argument; non-string entries fail via OutError (the array is cleared). */
-	TArray<FString> GetEditorStringArray(const FUnrealMcpToolCall& Call, const FString& Key, FString& OutError)
-	{
-		TArray<FString> Out;
-		const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
-		if (Call.Arguments->TryGetArrayField(Key, Arr) && Arr)
-		{
-			for (const TSharedPtr<FJsonValue>& V : *Arr)
-			{
-				FString S;
-				if (V.IsValid() && V->TryGetString(S))
-				{
-					Out.Add(S);
-				}
-				else
-				{
-					OutError = FString::Printf(TEXT("'%s' must be an array of strings; a non-string entry was provided."), *Key);
-					Out.Reset();
-					return Out;
-				}
-			}
-		}
-		else if (Call.Arguments->HasField(Key))
-		{
-			// Present but not an array (a bare string/object/number): error rather than returning an empty
-			// list, which the caller would read as "select nothing" and use to silently clear the selection.
-			OutError = FString::Printf(TEXT("'%s' must be an array of strings."), *Key);
-		}
-		return Out;
-	}
+	// The string-array refs schema + reader (editor-selection-set) and the free-form args-bag schema
+	// (reflection-method-call) are the shared FUnrealMcpSchema::StringArray / FUnrealMcpSchema::ObjectBag /
+	// FUnrealMcpToolArgs::GetStringArray surfaces (UnrealMcpSchema.h / UnrealMcpToolArgs.h) — see the call sites
+	// below. Only editor-family-specific helpers remain in this namespace.
 
 	/** The §3.2 JSON-schema type token for a reflected FProperty (best-effort, for discovery output). */
 	FString PropertyTypeName(const FProperty* Prop)
@@ -347,7 +294,7 @@ namespace UnrealMcpEditorTools
 			.Title(TEXT("Set Editor Selection"))
 			.Description(TEXT("Replace the editor's actor selection with the actors named by 'actors' (label / "
 			                  "name / path refs, §3.2). Pass clear=true to deselect everything."))
-			.Param(TEXT("actors"), TEXT("array"), TEXT("Actor refs to select (label / name / path)."), EUnrealMcpParamRequirement::Optional, MakeEditorStringArraySchema(TEXT("Actor refs to select.")))
+			.Param(TEXT("actors"), TEXT("array"), TEXT("Actor refs to select (label / name / path)."), EUnrealMcpParamRequirement::Optional, FUnrealMcpSchema::StringArray(TEXT("Actor refs to select.")))
 			.ParamBool(TEXT("clear"), TEXT("Deselect all actors. When true, 'actors' is ignored."))
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
@@ -355,7 +302,7 @@ namespace UnrealMcpEditorTools
 					return FUnrealMcpToolResult::Error(TEXT("No editor available (not running in the editor)."));
 
 				FString ArrErr;
-				const TArray<FString> Refs = GetEditorStringArray(Call, TEXT("actors"), ArrErr);
+				const TArray<FString> Refs = FUnrealMcpToolArgs::GetStringArray(Call, TEXT("actors"), ArrErr);
 				if (!ArrErr.IsEmpty())
 					return FUnrealMcpToolResult::Error(ArrErr);
 
@@ -560,7 +507,7 @@ namespace UnrealMcpEditorTools
 			.ParamString(TEXT("target"), TEXT("Object/actor ref to call the method on (instance methods)."))
 			.ParamString(TEXT("class"), TEXT("Class ref whose CDO to call on (static/CallInEditor methods)."))
 			.ParamString(TEXT("method"), TEXT("The UFunction name to invoke."), EUnrealMcpParamRequirement::Required)
-			.Param(TEXT("args"), TEXT("object"), TEXT("Parameter name -> value map (§3.2)."), EUnrealMcpParamRequirement::Optional, MakeArgsBagSchema(TEXT("Parameter name -> value map.")))
+			.Param(TEXT("args"), TEXT("object"), TEXT("Parameter name -> value map (§3.2)."), EUnrealMcpParamRequirement::Optional, FUnrealMcpSchema::ObjectBag(TEXT("Parameter name -> value map.")))
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
 			{
 				const FString MethodName = Call.GetString(TEXT("method"));

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLevelTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpLevelTools.cpp
@@ -3,6 +3,8 @@
 
 #include "UnrealMcpCoreTools.h"
 #include "UnrealMcpToolRegistry.h"
+#include "UnrealMcpSchema.h"          // shared §3.2 schema builders (FUnrealMcpSchema::StringArray)
+#include "UnrealMcpToolArgs.h"        // shared FUnrealMcpToolArgs::GetStringArray
 #include "Tools/UnrealMcpObjectRef.h"
 #include "Tools/UnrealMcpPropertyJson.h"
 
@@ -43,52 +45,9 @@
  */
 namespace
 {
-	/** An `array` of strings — the §3.2 scoped-read `paths` filter (mirrors the actor family's local schema).
-	 *  Uniquely named (Level-prefixed): the UE unity build concatenates this TU with the other tool
-	 *  families' TUs, so a bare `MakeStringArraySchema` would ODR-collide with the actor family's copy. */
-	TSharedPtr<FJsonObject> LevelMakeStringArraySchema(const FString& Desc)
-	{
-		TSharedPtr<FJsonObject> Items = MakeShared<FJsonObject>();
-		Items->SetStringField(TEXT("type"), TEXT("string"));
-
-		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
-		Schema->SetStringField(TEXT("type"), TEXT("array"));
-		if (!Desc.IsEmpty())
-			Schema->SetStringField(TEXT("description"), Desc);
-		Schema->SetObjectField(TEXT("items"), Items);
-		return Schema;
-	}
-
-	/**
-	 * Read a string array argument (the scoped-read `paths` filter); empty when absent or not an array.
-	 * A non-string entry is reported via OutError (and the array is left empty) rather than silently
-	 * dropped — a dropped entry would otherwise flip the scoped read to "identity only" (the opposite of
-	 * the requested scope) with no signal to the caller. Same contract as the actor family's helper.
-	 * Uniquely named (Level-prefixed) to avoid a unity-build ODR collision with the actor family's copy.
-	 */
-	TArray<FString> LevelGetStringArray(const FUnrealMcpToolCall& Call, const FString& Key, FString& OutError)
-	{
-		TArray<FString> Out;
-		const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
-		if (Call.Arguments->TryGetArrayField(Key, Arr) && Arr)
-		{
-			for (const TSharedPtr<FJsonValue>& V : *Arr)
-			{
-				FString S;
-				if (V.IsValid() && V->TryGetString(S))
-				{
-					Out.Add(S);
-				}
-				else
-				{
-					OutError = FString::Printf(TEXT("'%s' must be an array of strings; a non-string entry was provided."), *Key);
-					Out.Reset();
-					return Out;
-				}
-			}
-		}
-		return Out;
-	}
+	// The scoped-read `paths` string-array schema + reader are the shared FUnrealMcpSchema::StringArray /
+	// FUnrealMcpToolArgs::GetStringArray surfaces (UnrealMcpSchema.h / UnrealMcpToolArgs.h) — see the call sites
+	// below. Only level-specific helpers remain in this namespace.
 
 	/** Long package name of a level's outermost package (e.g. /Game/Maps/Arena); empty when null. */
 	FString LevelPackageName(const ULevel* Level)
@@ -431,7 +390,7 @@ namespace UnrealMcpLevelTools
 			                  "(§3.2) to save tokens. Pass 'actor' to scope the read to a single actor instead of "
 			                  "the whole world."))
 			.ParamString(TEXT("actor"), TEXT("Label / name / path of a single actor to read. Omit to snapshot the whole world."))
-			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include per actor (scoped read). Identity only when omitted."), EUnrealMcpParamRequirement::Optional, LevelMakeStringArraySchema(TEXT("Dotted property paths to include per actor (scoped read).")))
+			.Param(TEXT("paths"), TEXT("array"), TEXT("Dotted property paths to include per actor (scoped read). Identity only when omitted."), EUnrealMcpParamRequirement::Optional, FUnrealMcpSchema::StringArray(TEXT("Dotted property paths to include per actor (scoped read).")))
 			.ParamInt(TEXT("limit"), TEXT("Maximum number of actors to return for a world snapshot. Defaults to 200; pass 0 or a negative value for no limit."))
 			.ReadOnlyHint(true)
 			.Handle([](const FUnrealMcpToolCall& Call) -> FUnrealMcpToolResult
@@ -441,7 +400,7 @@ namespace UnrealMcpLevelTools
 					return FUnrealMcpToolResult::Error(TEXT("No editor world available."));
 
 				FString PathsError;
-				const TArray<FString> Paths = LevelGetStringArray(Call, TEXT("paths"), PathsError);
+				const TArray<FString> Paths = FUnrealMcpToolArgs::GetStringArray(Call, TEXT("paths"), PathsError);
 				if (!PathsError.IsEmpty())
 					return FUnrealMcpToolResult::Error(PathsError);
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
@@ -528,11 +528,7 @@ TSharedRef<SWidget> SUnrealMcpAgentConfigurators::MakeLinksRow()
 		[
 			SNew(SButton)
 			.Text(LOCTEXT("DownloadAgent", "Download / Docs"))
-			.OnClicked_Lambda([DownloadUrl]()
-			{
-				FPlatformProcess::LaunchURL(*DownloadUrl, nullptr, nullptr);
-				return FReply::Handled();
-			})
+			.OnClicked(UnrealMcpStyleWidgets::OpenUrlClicked(DownloadUrl))
 		];
 	}
 	if (!TutorialUrl.IsEmpty())
@@ -541,11 +537,7 @@ TSharedRef<SWidget> SUnrealMcpAgentConfigurators::MakeLinksRow()
 		[
 			SNew(SButton)
 			.Text(LOCTEXT("TutorialAgent", "Tutorial"))
-			.OnClicked_Lambda([TutorialUrl]()
-			{
-				FPlatformProcess::LaunchURL(*TutorialUrl, nullptr, nullptr);
-				return FReply::Handled();
-			})
+			.OnClicked(UnrealMcpStyleWidgets::OpenUrlClicked(TutorialUrl))
 		];
 	}
 	return LinksRow;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentWidgets.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentWidgets.h
@@ -34,8 +34,7 @@
  *   - TemplateAlertLabel         → a RED wrapped label (Unity's .alert-label).
  *   - TemplateTextFieldReadOnly  → a read-only, selectable command field WITH a Copy button (Unity's read-only
  *                                  TextField the user copies a command out of).
- *   - TemplateFoldout / First    → an SExpandableArea (Unity's Foldout); "First" starts expanded.
- *   - SUnrealMcpAlertPanel       → title + message + bullet items + optional action button (Unity's AlertPanel).
+ *   - TemplateFoldout            → an SExpandableArea (Unity's Foldout).
  *   - MakeConfigurationStatusRow → "Configured (transport)" / "Not configured" + Configure/Reconfigure + Remove
  *                                  (Unity's ConfigurationElements).
  *
@@ -145,12 +144,6 @@ namespace UnrealMcpAgentWidgets
 			[
 				Body
 			];
-	}
-
-	/** Unity's TemplateFoldoutFirst — the first foldout, which starts EXPANDED. */
-	inline TSharedRef<SExpandableArea> TemplateFoldoutFirst(const FText& Heading, const TSharedRef<SWidget>& Body)
-	{
-		return TemplateFoldout(Heading, Body, /*bInitiallyExpanded*/ true);
 	}
 }
 
@@ -275,44 +268,14 @@ namespace UnrealMcpStyleWidgets
 		float DotTopPadding = 0.0f;
 	};
 
-	inline TSharedRef<SWidget> TimelineRail(const TArray<FTimelineRailDot>& Dots)
-	{
-		TSharedRef<SVerticalBox> Rail = SNew(SVerticalBox);
-		for (int32 DotIndex = 0; DotIndex < Dots.Num(); ++DotIndex)
-		{
-			const FTimelineRailDot& Point = Dots[DotIndex];
-			// The dot — AutoHeight, top-aligned so it pins to the top of its sibling content row.
-			Rail->AddSlot().AutoHeight().HAlign(HAlign_Center).Padding(0, Point.DotTopPadding, 0, 0)
-			[
-				SNew(SBox).Visibility(Point.DotVisibility)
-				[
-					StatusDot(Point.DotState)
-				]
-			];
-			// The connecting line BELOW it — FillHeight so it absorbs the slack down to the next dot. Only emit it
-			// BETWEEN consecutive dots: a trailing FillHeight slot after the last dot (even Collapsed) would still
-			// claim its STRETCH share of the rail's slack, so the inter-dot line would visibly absorb only part of it.
-			if (DotIndex < Dots.Num() - 1)
-			{
-				Rail->AddSlot().FillHeight(1.0f).HAlign(HAlign_Center).Padding(0, 2, 0, 2)
-				[
-					TimelineLineSegment(Point.LineBelowVisibility)
-				];
-			}
-		}
-		return SNew(SBox).WidthOverride(20.0f)
-		[
-			Rail
-		];
-	}
-
 	/**
 	 * A single connection-timeline ROW: a self-contained 20px rail cell on the LEFT (its status dot pinned to the
 	 * TOP, then a FillHeight connecting-line segment that fills the rest of THIS row's height) beside the row's
 	 * CONTENT on the right. The two cells share the row's AutoHeight, so the dot sits on the content's FIRST line
 	 * (its label) and the line spans from just below the dot to the row's bottom edge.
 	 *
-	 * Stacking these rows in an SVerticalBox yields BOTH properties the single-column TimelineRail could not give
+	 * Stacking these rows in an SVerticalBox yields BOTH properties a single-column rail (one SVerticalBox owning
+	 * every dot, with the content beside it) could not give
 	 * at once: (1) each dot is anchored to the TOP of its OWN content row — i.e. centred on its label — instead of
 	 * floating at the even-split midpoint of the whole cluster (which dragged the 2nd/3rd dots down into the middle
 	 * of tall rows like the MCP card); and (2) the line is still continuous, because each row's line runs from its
@@ -479,6 +442,13 @@ namespace UnrealMcpStyleWidgets
 			OnClicked);
 	}
 
+	/** The shared OnClicked delegate for a URL button: open @p Url in the system browser, handled. The single
+	 *  copy of the footer / agent-links open-URL click lambda (was repeated per button). */
+	inline FOnClicked OpenUrlClicked(const FString& Url)
+	{
+		return FOnClicked::CreateLambda([Url]() { FPlatformProcess::LaunchURL(*Url, nullptr, nullptr); return FReply::Handled(); });
+	}
+
 	/** A button with a leading icon brush + label (Unity .btn-with-icon) — Discord/GitHub footer buttons. */
 	inline TSharedRef<SButton> IconButton(const FName& StyleKey, const FName& IconBrush, const FText& Label, FOnClicked OnClicked)
 	{
@@ -494,98 +464,3 @@ namespace UnrealMcpStyleWidgets
 			OnClicked);
 	}
 }
-
-/**
- * Unity's AlertPanel.cs as a Slate compound widget (docs/ARCHITECTURE.md §7): a bordered notice with a bold title,
- * a wrapped message, an optional bulleted item list, and an optional action button. SetVisible toggles the whole
- * panel. Used for the §7 "Setup Required" / "Reconfiguration Required" / Cloud-auth alerts. Fluent AddItem/SetButton
- * mirror the Unity API 1:1 so callers read the same.
- */
-class SUnrealMcpAlertPanel : public SCompoundWidget
-{
-public:
-	SLATE_BEGIN_ARGS(SUnrealMcpAlertPanel) {}
-		SLATE_ARGUMENT(FText, Title)
-		SLATE_ARGUMENT(FText, Message)
-	SLATE_END_ARGS()
-
-	void Construct(const FArguments& InArgs)
-	{
-		ItemsBox = SNew(SVerticalBox);
-
-		ButtonBox = SNew(SHorizontalBox);
-
-		ChildSlot
-		[
-			SAssignNew(RootBorder, SBorder)
-			.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
-			.Padding(8.0f)
-			[
-				SNew(SVerticalBox)
-				+ SVerticalBox::Slot().AutoHeight()
-				[
-					SNew(STextBlock)
-					.Text(InArgs._Title)
-					.ColorAndOpacity(FSlateColor(UnrealMcpAgentWidgets::WarningColor()))
-					.Font(FCoreStyle::GetDefaultFontStyle("Bold", 11))
-				]
-				+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
-				[
-					SNew(STextBlock)
-					.AutoWrapText(true)
-					.Text(InArgs._Message)
-				]
-				+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
-				[
-					ItemsBox.ToSharedRef()
-				]
-				+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
-				[
-					ButtonBox.ToSharedRef()
-				]
-			]
-		];
-	}
-
-	/** Add a bulleted item line; bRecommended renders it green (Unity's "alert-frame-item-recommended"). */
-	SUnrealMcpAlertPanel& AddItem(const FText& Text, bool bRecommended = false)
-	{
-		ItemsBox->AddSlot().AutoHeight().Padding(0, 1, 0, 0)
-		[
-			SNew(STextBlock)
-			.AutoWrapText(true)
-			.ColorAndOpacity(FSlateColor(bRecommended ? UnrealMcpAgentWidgets::ConfiguredColor() : UnrealMcpAgentWidgets::DescriptionColor()))
-			.Text(Text)
-		];
-		return *this;
-	}
-
-	/** Configure the (single) action button. Calling again replaces the previous button. */
-	SUnrealMcpAlertPanel& SetButton(const FText& Text, FSimpleDelegate OnClick)
-	{
-		ButtonBox->ClearChildren();
-		ButtonBox->AddSlot().AutoWidth()
-		[
-			SNew(SButton)
-			.Text(Text)
-			.OnClicked_Lambda([OnClick]()
-			{
-				OnClick.ExecuteIfBound();
-				return FReply::Handled();
-			})
-		];
-		return *this;
-	}
-
-	/** Show / hide the whole panel (Unity's SetVisible). */
-	void SetVisible(bool bVisible)
-	{
-		if (RootBorder.IsValid())
-			RootBorder->SetVisibility(bVisible ? EVisibility::Visible : EVisibility::Collapsed);
-	}
-
-private:
-	TSharedPtr<SBorder> RootBorder;
-	TSharedPtr<SVerticalBox> ItemsBox;
-	TSharedPtr<SHorizontalBox> ButtonBox;
-};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -944,12 +944,12 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildFooterSection()
 			+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 8, 0)
 			[
 				UnrealMcpStyleWidgets::IconButton("UnrealMcp.Button.Secondary", "UnrealMcp.Discord", LOCTEXT("HelpTalk", "Help / Talk"),
-					FOnClicked::CreateLambda([]() { FPlatformProcess::LaunchURL(*DiscordUrl, nullptr, nullptr); return FReply::Handled(); }))
+					UnrealMcpStyleWidgets::OpenUrlClicked(DiscordUrl))
 			]
 			+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 8, 0)
 			[
 				UnrealMcpStyleWidgets::IconButton("UnrealMcp.Button.Secondary", "UnrealMcp.GitHub", LOCTEXT("BugReport", "Bug Report"),
-					FOnClicked::CreateLambda([]() { FPlatformProcess::LaunchURL(*IssuesUrl, nullptr, nullptr); return FReply::Handled(); }))
+					UnrealMcpStyleWidgets::OpenUrlClicked(IssuesUrl))
 			]
 			// "Check" — opens the Serialization Check window (Unity-MCP parity). Secondary style, beside the
 			// support links. Delegates to the static aux-window invoker so it focuses an already-open tab.
@@ -989,7 +989,7 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildFooterSection()
 			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(8, 0, 0, 0)
 			[
 				UnrealMcpStyleWidgets::IconButton("UnrealMcp.Button.Golden", "UnrealMcp.Star", LOCTEXT("GitHubStar", "GitHub Star"),
-					FOnClicked::CreateLambda([]() { FPlatformProcess::LaunchURL(*StarUrl, nullptr, nullptr); return FReply::Handled(); }))
+					UnrealMcpStyleWidgets::OpenUrlClicked(StarUrl))
 			]
 		];
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAgentConfigModels.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAgentConfigModels.h
@@ -69,13 +69,6 @@ struct FAiAgentRichContentItem
 	// The open-URL target for a Link-kind item (6.9.0); empty for every other kind.
 	FString Url;
 
-	static FAiAgentRichContentItem Description(const FString& InText)   { return { EKind::Description, InText }; }
-	static FAiAgentRichContentItem Warning(const FString& InText)       { return { EKind::Warning, InText }; }
-	static FAiAgentRichContentItem Alert(const FString& InText)         { return { EKind::Alert, InText }; }
-	static FAiAgentRichContentItem ReadOnlyField(const FString& InText) { return { EKind::ReadOnlyField, InText }; }
-	static FAiAgentRichContentItem EditableField(const FString& InText) { return { EKind::EditableField, InText }; }
-	static FAiAgentRichContentItem Link(const FString& InText, const FString& InUrl) { return { EKind::Link, InText, InUrl }; }
-
 	/** Parse a DTO kind string ("Description"/"Warning"/"Alert"/"ReadOnlyField"/"EditableField"/"Link") into the enum. */
 	static UNREALMCPEDITOR_API EKind ParseKind(const FString& Raw);
 

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.cpp
@@ -847,25 +847,37 @@ bool FUnrealMcpBridgeServer::SendMessage(const TSharedPtr<FJsonObject>& Message)
 	const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(Json);
 
 	FScopeLock WriteLock(&WriteMutex);
+	return SendFramedLocked(Framed, TEXT("socket send failed mid-frame"));
+}
+
+bool FUnrealMcpBridgeServer::SendFramedLocked(const TArray<uint8>& Framed, const TCHAR* Reason)
+{
+	// Caller holds WriteMutex. Acquire ConnectionMutex for the null-check + send + (on failure) drop, so the
+	// reader cannot free the socket under us. A genuine (non-would-block) failure mid-frame corrupts the stream —
+	// the peer would see a truncated line with the next frame concatenated, and a lost tool-response hangs the
+	// pending call until the heartbeat — so drop the connection for a clean sidecar reconnect.
 	FScopeLock ConnLock(&ConnectionMutex);
 	if (ClientSocket == nullptr)
 		return false;
 
 	if (!TrySendFramedLocked(Framed))
 	{
-		// A genuine (non-would-block) failure mid-frame corrupts the stream — the peer would see a truncated
-		// line with the next frame concatenated, and a lost tool-response hangs the pending call until the
-		// heartbeat. Drop the connection so the sidecar reconnects cleanly. We hold ConnectionMutex, so just
-		// park the socket for the reader to free (never DestroySocket from here) and clear flags.
-		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] socket send failed mid-frame; dropping connection."));
-		SocketsPendingDestroy.Add(ClientSocket);
-		ClientSocket = nullptr;
-		bClientConnected = false;
-		bHandshakeOk = false;
-		bHeartbeatStop = true;
+		DropConnectionLocked(Reason);
 		return false;
 	}
 	return true;
+}
+
+void FUnrealMcpBridgeServer::DropConnectionLocked(const TCHAR* Reason)
+{
+	// Caller holds ConnectionMutex. Park the socket for the reader to free (never DestroySocket from a send
+	// path — that is DrainPendingDestroy's single-owner job) and clear the connection/handshake/heartbeat flags.
+	UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] %s; dropping connection."), Reason);
+	SocketsPendingDestroy.Add(ClientSocket);
+	ClientSocket = nullptr;
+	bClientConnected = false;
+	bHandshakeOk = false;
+	bHeartbeatStop = true;
 }
 
 bool FUnrealMcpBridgeServer::TrySendFramedLocked(const TArray<uint8>& Framed)
@@ -934,23 +946,8 @@ void FUnrealMcpBridgeServer::SendManifestLocked()
 	// accepts), so the manifest is stable by the time any handshake arrives. Dynamic re-registration (the
 	// §2.2 hot-reload path) MUST instead marshal the manifest build through the game-thread dispatcher.
 	const TSharedPtr<FJsonObject> Manifest = Registry.BuildManifestJson();
-	const FString Json = SerializeCondensed(Manifest);
-	const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(Json);
-
-	FScopeLock ConnLock(&ConnectionMutex);
-	if (ClientSocket == nullptr)
-		return;
-
-	if (!TrySendFramedLocked(Framed))
-	{
-		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] manifest send failed mid-frame; dropping connection."));
-		SocketsPendingDestroy.Add(ClientSocket);
-		ClientSocket = nullptr;
-		bClientConnected = false;
-		bHandshakeOk = false;
-		bHeartbeatStop = true;
-		return;
-	}
+	const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(SerializeCondensed(Manifest));
+	SendFramedLocked(Framed, TEXT("manifest send failed mid-frame"));
 }
 
 void FUnrealMcpBridgeServer::PushManifest()
@@ -989,23 +986,8 @@ void FUnrealMcpBridgeServer::SendPromptManifestLocked()
 		return;
 
 	const TSharedPtr<FJsonObject> Manifest = PromptRegistry->BuildManifestJson();
-	const FString Json = SerializeCondensed(Manifest);
-	const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(Json);
-
-	FScopeLock ConnLock(&ConnectionMutex);
-	if (ClientSocket == nullptr)
-		return;
-
-	if (!TrySendFramedLocked(Framed))
-	{
-		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] prompt-manifest send failed mid-frame; dropping connection."));
-		SocketsPendingDestroy.Add(ClientSocket);
-		ClientSocket = nullptr;
-		bClientConnected = false;
-		bHandshakeOk = false;
-		bHeartbeatStop = true;
-		return;
-	}
+	const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(SerializeCondensed(Manifest));
+	SendFramedLocked(Framed, TEXT("prompt-manifest send failed mid-frame"));
 }
 
 void FUnrealMcpBridgeServer::SendResourceManifestLocked()
@@ -1020,23 +1002,8 @@ void FUnrealMcpBridgeServer::SendResourceManifestLocked()
 		return;
 
 	const TSharedPtr<FJsonObject> Manifest = ResourceRegistry->BuildManifestJson();
-	const FString Json = SerializeCondensed(Manifest);
-	const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(Json);
-
-	FScopeLock ConnLock(&ConnectionMutex);
-	if (ClientSocket == nullptr)
-		return;
-
-	if (!TrySendFramedLocked(Framed))
-	{
-		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] resource-manifest send failed mid-frame; dropping connection."));
-		SocketsPendingDestroy.Add(ClientSocket);
-		ClientSocket = nullptr;
-		bClientConnected = false;
-		bHandshakeOk = false;
-		bHeartbeatStop = true;
-		return;
-	}
+	const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(SerializeCondensed(Manifest));
+	SendFramedLocked(Framed, TEXT("resource-manifest send failed mid-frame"));
 }
 
 void FUnrealMcpBridgeServer::SendConfigLocked()
@@ -1057,22 +1024,8 @@ void FUnrealMcpBridgeServer::SendConfigLocked()
 	for (const TPair<FString, TSharedPtr<FJsonValue>>& Field : ConfigCopy->Values)
 		Message->SetField(Field.Key, Field.Value);
 
-	const FString Json = SerializeCondensed(Message);
-	const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(Json);
-
-	FScopeLock ConnLock(&ConnectionMutex);
-	if (ClientSocket == nullptr)
-		return;
-
-	if (!TrySendFramedLocked(Framed))
-	{
-		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] config send failed mid-frame; dropping connection."));
-		SocketsPendingDestroy.Add(ClientSocket);
-		ClientSocket = nullptr;
-		bClientConnected = false;
-		bHandshakeOk = false;
-		bHeartbeatStop = true;
-	}
+	const TArray<uint8> Framed = FUnrealMcpNdjsonAccumulator::Encode(SerializeCondensed(Message));
+	SendFramedLocked(Framed, TEXT("config send failed mid-frame"));
 }
 
 void FUnrealMcpBridgeServer::PushConfig()

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.h
@@ -172,6 +172,15 @@ private:
 	void SendResourceManifestLocked(); // v2: resource registry wired (P2); v2-gated + null-guarded
 	void SendConfigLocked(); // WriteMutex held: frame + send the §1.3 `config` message (no-op when no config)
 	bool TrySendFramedLocked(const TArray<uint8>& Framed); // WriteMutex+ConnectionMutex held, ClientSocket valid
+	// Caller holds WriteMutex. Acquires ConnectionMutex, no-ops (returns false) when no client is connected,
+	// otherwise sends @p Framed via TrySendFramedLocked; on a genuine mid-frame failure it drops the connection
+	// (DropConnectionLocked, @p Reason naming the failing send) and returns false. The single send-or-drop tail
+	// shared by SendMessage + the manifest/config senders. @p Reason is the human label logged on the drop.
+	bool SendFramedLocked(const TArray<uint8>& Framed, const TCHAR* Reason);
+	// Caller holds ConnectionMutex. Parks the live socket for the reader thread to free, clears the connection/
+	// handshake/heartbeat flags, and logs `[Unreal-MCP] <Reason>; dropping connection.`. The shared teardown the
+	// send paths run when a frame cannot be delivered (never DestroySocket from a send path — see DrainPendingDestroy).
+	void DropConnectionLocked(const TCHAR* Reason);
 	void CloseActiveConnection();
 	void DrainPendingDestroy();    // reader-/shutdown-owned: actually frees sockets parked for teardown
 	void StartHeartbeat();

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Config/UnrealMcpConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Config/UnrealMcpConfig.cpp
@@ -456,6 +456,32 @@ TSharedPtr<FJsonObject> FUnrealMcpConfig::BuildEffectiveConnectionConfig() const
 	return Obj;
 }
 
+bool FUnrealMcpConfig::ParseEnvLine(const FString& RawLine, FString& OutKey, FString& OutValue)
+{
+	OutKey.Reset();
+	OutValue.Reset();
+
+	FString Line = RawLine;
+	Line.TrimStartAndEndInline();
+	if (Line.IsEmpty() || Line[0] == TCHAR('#'))
+		return false;
+
+	int32 EqIndex = INDEX_NONE;
+	if (!Line.FindChar(TCHAR('='), EqIndex) || EqIndex <= 0)
+		return false;
+
+	FString Key = Line.Left(EqIndex);
+	Key.TrimStartAndEndInline();
+
+	const FString Value = SanitizeValue(Line.Mid(EqIndex + 1));
+	if (Value.IsEmpty())
+		return false;
+
+	OutKey = MoveTemp(Key);
+	OutValue = Value;
+	return true;
+}
+
 TMap<FString, FString> FUnrealMcpConfig::ParseEnvLines(const TArray<FString>& Lines)
 {
 	static const TCHAR* RecognizedKeys[] = {
@@ -466,17 +492,9 @@ TMap<FString, FString> FUnrealMcpConfig::ParseEnvLines(const TArray<FString>& Li
 	TMap<FString, FString> Result;
 	for (const FString& RawLine : Lines)
 	{
-		FString Line = RawLine;
-		Line.TrimStartAndEndInline();
-		if (Line.IsEmpty() || Line[0] == TCHAR('#'))
+		FString Key, Value;
+		if (!ParseEnvLine(RawLine, Key, Value))
 			continue;
-
-		int32 EqIndex = INDEX_NONE;
-		if (!Line.FindChar(TCHAR('='), EqIndex) || EqIndex <= 0)
-			continue;
-
-		FString Key = Line.Left(EqIndex);
-		Key.TrimStartAndEndInline();
 
 		bool bRecognized = false;
 		for (const TCHAR* Recognized : RecognizedKeys)
@@ -488,10 +506,6 @@ TMap<FString, FString> FUnrealMcpConfig::ParseEnvLines(const TArray<FString>& Li
 			}
 		}
 		if (!bRecognized)
-			continue;
-
-		const FString Value = SanitizeValue(Line.Mid(EqIndex + 1));
-		if (Value.IsEmpty())
 			continue;
 
 		Result.Add(Key, Value); // last occurrence wins
@@ -523,23 +537,11 @@ FString FUnrealMcpConfig::LookupEnvFileValue(const FString& Path, const FString&
 	FString Found; // last occurrence wins (matches ParseEnvLines)
 	for (const FString& RawLine : Lines)
 	{
-		FString Line = RawLine;
-		Line.TrimStartAndEndInline();
-		if (Line.IsEmpty() || Line[0] == TCHAR('#'))
+		FString LineKey, Value;
+		if (!ParseEnvLine(RawLine, LineKey, Value))
 			continue;
-
-		int32 EqIndex = INDEX_NONE;
-		if (!Line.FindChar(TCHAR('='), EqIndex) || EqIndex <= 0)
-			continue;
-
-		FString LineKey = Line.Left(EqIndex);
-		LineKey.TrimStartAndEndInline();
-		if (!LineKey.Equals(Key, ESearchCase::CaseSensitive))
-			continue;
-
-		const FString Value = SanitizeValue(Line.Mid(EqIndex + 1));
-		if (!Value.IsEmpty())
-			Found = Value;
+		if (LineKey.Equals(Key, ESearchCase::CaseSensitive))
+			Found = Value; // ParseEnvLine already dropped empty values
 	}
 	return Found;
 }

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Config/UnrealMcpConfig.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Config/UnrealMcpConfig.h
@@ -263,5 +263,13 @@ private:
 
 	static bool TryParseMode(const FString& Raw, EUnrealMcpConnectionMode& OutMode);
 	static bool TryParseAuthOption(const FString& Raw, EUnrealMcpAuthOption& OutOption);
+
+	/**
+	 * Parse one raw .env line into a trimmed key + sanitized value (the shared line grammar of ParseEnvLines /
+	 * LookupEnvFileValue): trim the line, skip a blank or `#`-comment line, split on the FIRST `=` (with a
+	 * non-empty key), and SanitizeValue the right side. Returns true only when a non-empty key AND a non-empty
+	 * value were parsed; false (with @p OutKey/@p OutValue left empty) for a skipped/blank/empty-value line.
+	 */
+	static bool ParseEnvLine(const FString& RawLine, FString& OutKey, FString& OutValue);
 	static bool TryParseBool(const FString& Raw, bool& OutValue);
 };

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Extensions/UnrealMcpExtensionManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Extensions/UnrealMcpExtensionManager.cpp
@@ -69,6 +69,76 @@ namespace
 		}
 		return true;
 	}
+
+	/**
+	 * The KIND-agnostic prompt/resource rebuild pass (§A.2). The prompt and resource passes were verbatim
+	 * copies differing only in the provider/registry KIND and the kind nouns; this template factors out the
+	 * shared loop — clear the previous contribution, ExtensionId sort (StableSort tie-break = registration
+	 * order), per-provider IsValidExtensionId + duplicate-id + DisabledExtensions gating — and takes the two
+	 * kind-specific operations (remove-by-id, register-one-provider) plus the @p KindNoun for the log lines.
+	 * Called from inside the manager's re-entrancy guard, so each kind's RegisterExtension scope is opened+
+	 * closed here per provider and never nests across passes (a per-registry scope is independent of the others').
+	 */
+	template <typename TProvider>
+	void RebuildProviderKind(
+		const TArray<TProvider*>& Providers,
+		const TSet<FString>& DisabledExtensions,
+		TArray<FString>& RegisteredIds,
+		const TCHAR* KindNoun,
+		TFunctionRef<void(const FString&)> RemoveForExtension,
+		TFunctionRef<void(const FString&, TProvider*)> RegisterForExtension)
+	{
+		// 1. Clear the previous KIND-extension contribution (core entries are untouched: only ids we registered).
+		for (const FString& Id : RegisteredIds)
+			RemoveForExtension(Id);
+		RegisteredIds.Reset();
+
+		// 2. Deterministic ordering by ExtensionId (StableSort keeps registration order as the tie-break).
+		TArray<TProvider*> Sorted;
+		Sorted.Reserve(Providers.Num());
+		for (TProvider* P : Providers)
+		{
+			if (P != nullptr)
+				Sorted.Add(P);
+		}
+		Sorted.StableSort([](const TProvider& A, const TProvider& B)
+		{
+			return A.GetExtensionId() < B.GetExtensionId();
+		});
+
+		// 3. Register each ENABLED + valid + non-duplicate provider's entries.
+		TSet<FString> SeenIds;
+		for (TProvider* Provider : Sorted)
+		{
+			const FString Id = Provider->GetExtensionId();
+
+			// 3a. Validate the id (reuse the SAME helper as the tool pass — never register under "core"/garbage).
+			FString IdError;
+			if (!IsValidExtensionId(Id, IdError))
+			{
+				UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] %s extension rejected: %s — its %ss were skipped."), KindNoun, *IdError, KindNoun);
+				continue;
+			}
+
+			// 3b. Duplicate id (first-sorted wins). The tool pass already records the public Record for this id; the
+			//     KIND pass only needs to avoid double-registration / a clobbered removal key.
+			if (SeenIds.Contains(Id))
+			{
+				UE_LOG(LogUnrealMcp, Warning,
+					TEXT("[Unreal-MCP] duplicate %s extension id '%s' — another provider already registered it; this provider's %ss were skipped."),
+					KindNoun, *Id, KindNoun);
+				continue;
+			}
+			SeenIds.Add(Id);
+
+			// 3c. Gated by the SAME DisabledExtensions set as tools (one toggle disables an extension's tools AND this kind).
+			if (DisabledExtensions.Contains(Id))
+				continue;
+
+			RegisterForExtension(Id, Provider);
+			RegisteredIds.AddUnique(Id);
+		}
+	}
 }
 
 FUnrealMcpExtensionManager::FUnrealMcpExtensionManager(
@@ -295,167 +365,68 @@ void FUnrealMcpExtensionManager::RebuildFromProviders(const TArray<IUnrealMcpToo
 void FUnrealMcpExtensionManager::RebuildPromptProviders()
 {
 	// §A.2 prompt pass — the prompt analog of the tool pass in RebuildFromProviders, sharing the same
-	// DisabledExtensions set, IsValidExtensionId discipline, and ExtensionId sort. Called from inside the
-	// re-entrancy guard, so it never opens a nested registry scope across the two passes (the prompt registry's
-	// own RegisterExtension scope is independent of the tool registry's and is opened+closed here per provider).
+	// DisabledExtensions set, IsValidExtensionId discipline, and ExtensionId sort (the KIND-agnostic loop lives
+	// in RebuildProviderKind). Called from inside the re-entrancy guard, so it never opens a nested registry
+	// scope across passes (the prompt registry's own RegisterExtension scope is independent of the tool registry's).
 	if (PromptRegistry == nullptr)
 		return;
 
-	// 1. Clear the previous prompt-extension contribution (core prompts are untouched: only ids we registered).
-	for (const FString& Id : RegisteredPromptExtensionIds)
-		PromptRegistry->RemovePromptsForExtension(Id);
-	RegisteredPromptExtensionIds.Reset();
-
 	const TArray<IUnrealMcpPromptProvider*> Providers = PromptProviderSource ? PromptProviderSource() : GatherPromptProviders();
-
-	// 2. Deterministic ordering by ExtensionId (StableSort keeps registration order as the tie-break).
-	TArray<IUnrealMcpPromptProvider*> Sorted;
-	Sorted.Reserve(Providers.Num());
-	for (IUnrealMcpPromptProvider* P : Providers)
-	{
-		if (P != nullptr)
-			Sorted.Add(P);
-	}
-	Sorted.StableSort([](const IUnrealMcpPromptProvider& A, const IUnrealMcpPromptProvider& B)
-	{
-		return A.GetExtensionId() < B.GetExtensionId();
-	});
-
-	// 3. Register each ENABLED + valid + non-duplicate provider's prompts.
-	TSet<FString> SeenIds;
-	for (IUnrealMcpPromptProvider* Provider : Sorted)
-	{
-		const FString Id = Provider->GetExtensionId();
-
-		// 3a. Validate the id (reuse the SAME helper as the tool pass — never register under "core"/garbage).
-		FString IdError;
-		if (!IsValidExtensionId(Id, IdError))
+	RebuildProviderKind<IUnrealMcpPromptProvider>(
+		Providers, DisabledExtensions, RegisteredPromptExtensionIds, TEXT("prompt"),
+		[this](const FString& Id) { PromptRegistry->RemovePromptsForExtension(Id); },
+		[this](const FString& Id, IUnrealMcpPromptProvider* Provider)
 		{
-			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] prompt extension rejected: %s — its prompts were skipped."), *IdError);
-			continue;
-		}
-
-		// 3b. Duplicate id (first-sorted wins). The tool pass already records the public Record for this id; the
-		//     prompt pass only needs to avoid double-registration / a clobbered removal key.
-		if (SeenIds.Contains(Id))
-		{
-			UE_LOG(LogUnrealMcp, Warning,
-				TEXT("[Unreal-MCP] duplicate prompt extension id '%s' — another provider already registered it; this provider's prompts were skipped."),
-				*Id);
-			continue;
-		}
-		SeenIds.Add(Id);
-
-		// 3c. Gated by the SAME DisabledExtensions set as tools (one toggle disables an extension's tools AND prompts).
-		if (DisabledExtensions.Contains(Id))
-			continue;
-
-		PromptRegistry->RegisterExtension(Id, [Provider](FUnrealMcpPromptRegistry& Reg) { Provider->RegisterPrompts(Reg); });
-		RegisteredPromptExtensionIds.AddUnique(Id);
-	}
+			PromptRegistry->RegisterExtension(Id, [Provider](FUnrealMcpPromptRegistry& Reg) { Provider->RegisterPrompts(Reg); });
+		});
 }
 
 void FUnrealMcpExtensionManager::RebuildResourceProviders()
 {
-	// §A.2 resource pass — the resource analog of RebuildPromptProviders, sharing the same DisabledExtensions
-	// set, IsValidExtensionId discipline, and ExtensionId sort. Called from inside the re-entrancy guard, so it
-	// never opens a nested registry scope across passes (the resource registry's own RegisterExtension scope is
-	// independent of the tool/prompt registries' and is opened+closed here per provider).
+	// §A.2 resource pass — the resource analog of RebuildPromptProviders (same gating + sort via the shared
+	// RebuildProviderKind). Called from inside the re-entrancy guard, so it never opens a nested registry scope
+	// across passes (the resource registry's own RegisterExtension scope is independent of the tool/prompt ones').
 	if (ResourceRegistry == nullptr)
 		return;
 
-	// 1. Clear the previous resource-extension contribution (core resources are untouched: only ids we registered).
-	for (const FString& Id : RegisteredResourceExtensionIds)
-		ResourceRegistry->RemoveResourcesForExtension(Id);
-	RegisteredResourceExtensionIds.Reset();
-
 	const TArray<IUnrealMcpResourceProvider*> Providers = ResourceProviderSource ? ResourceProviderSource() : GatherResourceProviders();
-
-	// 2. Deterministic ordering by ExtensionId (StableSort keeps registration order as the tie-break).
-	TArray<IUnrealMcpResourceProvider*> Sorted;
-	Sorted.Reserve(Providers.Num());
-	for (IUnrealMcpResourceProvider* P : Providers)
-	{
-		if (P != nullptr)
-			Sorted.Add(P);
-	}
-	Sorted.StableSort([](const IUnrealMcpResourceProvider& A, const IUnrealMcpResourceProvider& B)
-	{
-		return A.GetExtensionId() < B.GetExtensionId();
-	});
-
-	// 3. Register each ENABLED + valid + non-duplicate provider's resources.
-	TSet<FString> SeenIds;
-	for (IUnrealMcpResourceProvider* Provider : Sorted)
-	{
-		const FString Id = Provider->GetExtensionId();
-
-		// 3a. Validate the id (reuse the SAME helper as the tool/prompt passes — never register under "core"/garbage).
-		FString IdError;
-		if (!IsValidExtensionId(Id, IdError))
+	RebuildProviderKind<IUnrealMcpResourceProvider>(
+		Providers, DisabledExtensions, RegisteredResourceExtensionIds, TEXT("resource"),
+		[this](const FString& Id) { ResourceRegistry->RemoveResourcesForExtension(Id); },
+		[this](const FString& Id, IUnrealMcpResourceProvider* Provider)
 		{
-			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] resource extension rejected: %s — its resources were skipped."), *IdError);
-			continue;
-		}
+			ResourceRegistry->RegisterExtension(Id, [Provider](FUnrealMcpResourceRegistry& Reg) { Provider->RegisterResources(Reg); });
+		});
+}
 
-		// 3b. Duplicate id (first-sorted wins). The tool pass already records the public Record for this id; the
-		//     resource pass only needs to avoid double-registration / a clobbered removal key.
-		if (SeenIds.Contains(Id))
-		{
-			UE_LOG(LogUnrealMcp, Warning,
-				TEXT("[Unreal-MCP] duplicate resource extension id '%s' — another provider already registered it; this provider's resources were skipped."),
-				*Id);
-			continue;
-		}
-		SeenIds.Add(Id);
+void FUnrealMcpExtensionManager::HandleFeatureChange(const FName& Type, const TCHAR* Verb)
+{
+	// The single OnModularFeature(Un)Registered subscription receives EVERY feature type; rebuild when the type is
+	// the tool OR (§A.2) the prompt/resource provider feature (gated on the matching registry being wired). A
+	// rebuild runs all wired passes + the single OnChanged.
+	const TCHAR* Kind = nullptr;
+	if (Type == IUnrealMcpToolProvider::GetModularFeatureName())
+		Kind = TEXT("tool");
+	else if (PromptRegistry != nullptr && Type == IUnrealMcpPromptProvider::GetModularFeatureName())
+		Kind = TEXT("prompt");
+	else if (ResourceRegistry != nullptr && Type == IUnrealMcpResourceProvider::GetModularFeatureName())
+		Kind = TEXT("resource");
 
-		// 3c. Gated by the SAME DisabledExtensions set as tools/prompts (one toggle disables an extension's tools AND prompts AND resources).
-		if (DisabledExtensions.Contains(Id))
-			continue;
+	if (Kind == nullptr)
+		return;
 
-		ResourceRegistry->RegisterExtension(Id, [Provider](FUnrealMcpResourceRegistry& Reg) { Provider->RegisterResources(Reg); });
-		RegisteredResourceExtensionIds.AddUnique(Id);
-	}
+	UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] %s provider %s; rebuilding extensions."), Kind, Verb);
+	Rebuild(/*bNotify*/ true);
 }
 
 void FUnrealMcpExtensionManager::OnFeatureRegistered(const FName& Type, IModularFeature* /*Feature*/)
 {
-	// The single OnModularFeatureRegistered subscription receives EVERY feature type; rebuild when the type is
-	// the tool OR (§A.2) the prompt provider feature. A rebuild runs both passes + the single OnChanged.
-	if (Type == IUnrealMcpToolProvider::GetModularFeatureName())
-	{
-		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] tool provider registered; rebuilding extensions."));
-		Rebuild(/*bNotify*/ true);
-	}
-	else if (PromptRegistry != nullptr && Type == IUnrealMcpPromptProvider::GetModularFeatureName())
-	{
-		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] prompt provider registered; rebuilding extensions."));
-		Rebuild(/*bNotify*/ true);
-	}
-	else if (ResourceRegistry != nullptr && Type == IUnrealMcpResourceProvider::GetModularFeatureName())
-	{
-		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] resource provider registered; rebuilding extensions."));
-		Rebuild(/*bNotify*/ true);
-	}
+	HandleFeatureChange(Type, TEXT("registered"));
 }
 
 void FUnrealMcpExtensionManager::OnFeatureUnregistered(const FName& Type, IModularFeature* /*Feature*/)
 {
-	if (Type == IUnrealMcpToolProvider::GetModularFeatureName())
-	{
-		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] tool provider unregistered; rebuilding extensions."));
-		Rebuild(/*bNotify*/ true);
-	}
-	else if (PromptRegistry != nullptr && Type == IUnrealMcpPromptProvider::GetModularFeatureName())
-	{
-		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] prompt provider unregistered; rebuilding extensions."));
-		Rebuild(/*bNotify*/ true);
-	}
-	else if (ResourceRegistry != nullptr && Type == IUnrealMcpResourceProvider::GetModularFeatureName())
-	{
-		UE_LOG(LogUnrealMcp, Verbose, TEXT("[Unreal-MCP] resource provider unregistered; rebuilding extensions."));
-		Rebuild(/*bNotify*/ true);
-	}
+	HandleFeatureChange(Type, TEXT("unregistered"));
 }
 
 void FUnrealMcpExtensionManager::LoadConfig()

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Extensions/UnrealMcpExtensionManager.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Extensions/UnrealMcpExtensionManager.h
@@ -124,6 +124,9 @@ private:
 
 	void OnFeatureRegistered(const FName& Type, IModularFeature* Feature);
 	void OnFeatureUnregistered(const FName& Type, IModularFeature* Feature);
+	/** Shared body of the register/unregister handlers: if @p Type is one of the (wired) provider kinds, log
+	 *  `<kind> provider <Verb>` and rebuild. @p Verb is "registered" / "unregistered". */
+	void HandleFeatureChange(const FName& Type, const TCHAR* Verb);
 
 	void LoadConfig();
 	void SaveConfig() const;

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Prompts/UnrealMcpPromptRegistry.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Prompts/UnrealMcpPromptRegistry.cpp
@@ -3,52 +3,16 @@
 
 #include "UnrealMcpPromptRegistry.h"
 #include "UnrealMcpLog.h"
-#include "Misc/SecureHash.h"
-#include "Serialization/JsonSerializer.h"
-#include "Serialization/JsonWriter.h"
-#include "Policies/CondensedJsonPrintPolicy.h"
+#include "UnrealMcpDescriptorHash.h"
+#include "UnrealMcpSchema.h"
+#include "UnrealMcpValidation.h"
 
 // --- Schema building ------------------------------------------------------------------------------
-// The §3.2 schema generation is VERBATIM identical to the tool registry's. The tool file's anonymous-namespace
-// helpers (MakeTypedSchema / MakeVectorSchema / SerializeStable) cannot be reused across translation units in a
-// unity build without an ODR collision, so the prompt registry gets family-UNIQUE copies (Prompt*-prefixed).
+// The §3.2 scalar + vector schema builders are the shared FUnrealMcpSchema TU (UnrealMcpSchema.h) — the same
+// externally-linked definition the tool registry + editor tool families use (no more Prompt*-prefixed clones).
 
 namespace
 {
-	TSharedPtr<FJsonObject> PromptMakeTypedSchema(const FString& JsonType, const FString& Description)
-	{
-		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
-		Schema->SetStringField(TEXT("type"), JsonType);
-		if (!Description.IsEmpty())
-			Schema->SetStringField(TEXT("description"), Description);
-		return Schema;
-	}
-
-	/** A {x,y,z: number} object schema (the §3.2 FVector mapping). */
-	TSharedPtr<FJsonObject> PromptMakeVectorSchema(const FString& Description)
-	{
-		TSharedPtr<FJsonObject> Props = MakeShared<FJsonObject>();
-		Props->SetObjectField(TEXT("x"), PromptMakeTypedSchema(TEXT("number"), FString()));
-		Props->SetObjectField(TEXT("y"), PromptMakeTypedSchema(TEXT("number"), FString()));
-		Props->SetObjectField(TEXT("z"), PromptMakeTypedSchema(TEXT("number"), FString()));
-
-		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
-		Schema->SetStringField(TEXT("type"), TEXT("object"));
-		if (!Description.IsEmpty())
-			Schema->SetStringField(TEXT("description"), Description);
-		Schema->SetObjectField(TEXT("properties"), Props);
-		return Schema;
-	}
-
-	FString PromptSerializeStable(const TSharedPtr<FJsonObject>& Object)
-	{
-		FString Out;
-		TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =
-			TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&Out);
-		FJsonSerializer::Serialize(Object.ToSharedRef(), Writer);
-		return Out;
-	}
-
 	/** The wire string for an EUnrealMcpPromptRole ("user" | "assistant"). */
 	const TCHAR* PromptRoleToString(EUnrealMcpPromptRole Role)
 	{
@@ -69,7 +33,7 @@ TSharedPtr<FJsonObject> FUnrealMcpRegisteredPrompt::BuildInputSchema() const
 	{
 		TSharedPtr<FJsonObject> ParamSchema = Param.ObjectSchema.IsValid()
 			? Param.ObjectSchema
-			: PromptMakeTypedSchema(Param.JsonType, Param.Description);
+			: FUnrealMcpSchema::TypedSchema(Param.JsonType, Param.Description);
 
 		Properties->SetObjectField(Param.Name, ParamSchema);
 		if (Param.Requirement == EUnrealMcpParamRequirement::Required)
@@ -131,7 +95,7 @@ FUnrealMcpPromptBuilder& FUnrealMcpPromptBuilder::ParamBool(const FString& Name,
 }
 FUnrealMcpPromptBuilder& FUnrealMcpPromptBuilder::ParamVector(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req)
 {
-	FUnrealMcpParamSpec Spec{ Name, TEXT("object"), Desc, Req, PromptMakeVectorSchema(Desc) };
+	FUnrealMcpParamSpec Spec{ Name, TEXT("object"), Desc, Req, FUnrealMcpSchema::VectorSchema(Desc) };
 	Prompt.Params.Add(Spec);
 	return *this;
 }
@@ -157,45 +121,15 @@ FUnrealMcpPromptBuilder FUnrealMcpPromptRegistry::Prompt(const FString& Name)
 
 FString FUnrealMcpPromptRegistry::ComputeSchemaHash(const FUnrealMcpRegisteredPrompt& InPrompt)
 {
-	// Hash the canonicalized descriptor MINUS the enabled flag (mirror the tool registry). Reuse
-	// ToDescriptorJson and drop "enabled" + "schemaHash" so the hash is stable regardless of those fields.
-	FUnrealMcpRegisteredPrompt Copy = InPrompt;
-	Copy.SchemaHash.Empty();
-	TSharedPtr<FJsonObject> Desc = Copy.ToDescriptorJson();
-	Desc->RemoveField(TEXT("enabled"));
-	Desc->RemoveField(TEXT("schemaHash"));
-
-	const FString Canonical = PromptSerializeStable(Desc);
-	FSHA1 Sha;
-	const FTCHARToUTF8 Utf8(*Canonical);
-	Sha.Update(reinterpret_cast<const uint8*>(Utf8.Get()), Utf8.Length());
-	Sha.Final();
-	uint8 Digest[20];
-	Sha.GetHash(Digest);
-	return FString(TEXT("sha1:")) + BytesToHex(Digest, 20).ToLower();
+	// Hash the canonicalized descriptor MINUS the enabled flag (mirror the tool registry): the shared helper
+	// builds the hash off the descriptor JSON directly (it strips enabled/schemaHash itself), no struct copy needed.
+	return UnrealMcpComputeDescriptorHash(InPrompt.ToDescriptorJson());
 }
 
 bool FUnrealMcpPromptRegistry::IsValidPromptName(const FString& Name)
 {
-	// Same kebab rule as the tool registry (no leading/trailing/doubled hyphen; lowercase letters/digits).
-	if (Name.IsEmpty())
-		return false;
-
-	bool bPrevHyphen = false;
-	const int32 Len = Name.Len();
-	for (int32 i = 0; i < Len; ++i)
-	{
-		const TCHAR C = Name[i];
-		const bool bLower = (C >= TEXT('a') && C <= TEXT('z'));
-		const bool bDigit = (C >= TEXT('0') && C <= TEXT('9'));
-		const bool bHyphen = (C == TEXT('-'));
-		if (!bLower && !bDigit && !bHyphen)
-			return false;
-		if (bHyphen && (i == 0 || i == Len - 1 || bPrevHyphen))
-			return false;
-		bPrevHyphen = bHyphen;
-	}
-	return true;
+	// Same shared kebab rule as the tool registry (no leading/trailing/doubled hyphen; lowercase letters/digits).
+	return FUnrealMcpValidation::IsValidKebabName(Name);
 }
 
 bool FUnrealMcpPromptRegistry::ValidatePrompt(const FUnrealMcpRegisteredPrompt& InPrompt, FString& OutError)
@@ -214,45 +148,7 @@ bool FUnrealMcpPromptRegistry::ValidatePrompt(const FUnrealMcpRegisteredPrompt& 
 		return false;
 	}
 
-	static const TCHAR* const KnownTypes[] = { TEXT("string"), TEXT("integer"), TEXT("number"), TEXT("boolean"), TEXT("object"), TEXT("array") };
-	TSet<FString> SeenParams;
-	for (const FUnrealMcpParamSpec& Param : InPrompt.Params)
-	{
-		if (Param.Name.IsEmpty())
-		{
-			OutError = FString::Printf(TEXT("prompt '%s' has a parameter with an empty name (malformed schema)"), *InPrompt.Name);
-			return false;
-		}
-
-		bool bKnown = false;
-		for (const TCHAR* const Known : KnownTypes)
-		{
-			if (Param.JsonType == Known) { bKnown = true; break; }
-		}
-		if (!bKnown)
-		{
-			OutError = FString::Printf(TEXT("prompt '%s' parameter '%s' has unknown JSON type '%s' (malformed schema)"),
-				*InPrompt.Name, *Param.Name, *Param.JsonType);
-			return false;
-		}
-
-		if ((Param.JsonType == TEXT("object") || Param.JsonType == TEXT("array")) && !Param.ObjectSchema.IsValid())
-		{
-			OutError = FString::Printf(TEXT("prompt '%s' %s parameter '%s' has no schema (malformed schema)"),
-				*InPrompt.Name, *Param.JsonType, *Param.Name);
-			return false;
-		}
-
-		bool bAlreadyPresent = false;
-		SeenParams.Add(Param.Name, &bAlreadyPresent);
-		if (bAlreadyPresent)
-		{
-			OutError = FString::Printf(TEXT("prompt '%s' declares duplicate parameter '%s' (malformed schema)"),
-				*InPrompt.Name, *Param.Name);
-			return false;
-		}
-	}
-	return true;
+	return FUnrealMcpValidation::ValidateParamSpecs(InPrompt.Params, TEXT("prompt"), InPrompt.Name, OutError);
 }
 
 void FUnrealMcpPromptRegistry::Commit(FUnrealMcpRegisteredPrompt&& InPrompt)
@@ -353,9 +249,7 @@ TSharedPtr<FJsonObject> FUnrealMcpPromptRegistry::BuildManifestJson() const
 	Manifest->SetNumberField(TEXT("revision"), Revision);
 
 	TArray<TSharedPtr<FJsonValue>> PromptArray;
-	TArray<FString> Names;
-	Prompts.GetKeys(Names);
-	Names.Sort();
+	const TArray<FString> Names = GetPromptNamesSorted();
 	for (const FString& Name : Names)
 	{
 		// A disabled prompt is EXCLUDED from the served manifest entirely (mirror the tool registry).
@@ -402,12 +296,12 @@ bool FUnrealMcpPromptRegistry::SetPromptEnabled(const FString& Name, bool bEnabl
 
 bool FUnrealMcpPromptRegistry::ShouldPromptBeEnabled(const FString& Name) const
 {
-	return PassesEnabledPromptsWhitelist(Name) && !DisabledPromptNames.Contains(Name);
+	return Enablement.ShouldBeEnabled(Name);
 }
 
 bool FUnrealMcpPromptRegistry::PassesEnabledPromptsWhitelist(const FString& Name) const
 {
-	return EnabledPromptsWhitelist.IsEmpty() || EnabledPromptsWhitelist.Contains(Name);
+	return Enablement.PassesWhitelist(Name);
 }
 
 void FUnrealMcpPromptRegistry::RecomputeEnablement()
@@ -428,13 +322,13 @@ void FUnrealMcpPromptRegistry::RecomputeEnablement()
 
 void FUnrealMcpPromptRegistry::SetEnabledPromptsFilter(const TArray<FString>& EnabledPrompts)
 {
-	EnabledPromptsWhitelist = TSet<FString>(EnabledPrompts);
+	Enablement.SetWhitelist(EnabledPrompts);
 	RecomputeEnablement();
 }
 
 void FUnrealMcpPromptRegistry::ApplyDisabledPrompts(const TArray<FString>& DisabledNames)
 {
-	DisabledPromptNames = TSet<FString>(DisabledNames);
+	Enablement.SetBlocklist(DisabledNames);
 	RecomputeEnablement();
 }
 

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Resources/UnrealMcpResourceRegistry.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Resources/UnrealMcpResourceRegistry.cpp
@@ -3,27 +3,7 @@
 
 #include "UnrealMcpResourceRegistry.h"
 #include "UnrealMcpLog.h"
-#include "Misc/SecureHash.h"
-#include "Serialization/JsonSerializer.h"
-#include "Serialization/JsonWriter.h"
-#include "Policies/CondensedJsonPrintPolicy.h"
-
-// --- Stable serialization helper (family-UNIQUE name) ---------------------------------------------
-// The tool/prompt registries each have their own SerializeStable in an anonymous namespace; a unity build
-// concatenates every .cpp into one TU, so an anonymous-namespace helper is NOT file-private. Give the
-// resource copy a family-unique name (Resource*-prefixed) to dodge the §ODR collision (conventions.md).
-
-namespace
-{
-	FString ResourceSerializeStable(const TSharedPtr<FJsonObject>& Object)
-	{
-		FString Out;
-		TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =
-			TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&Out);
-		FJsonSerializer::Serialize(Object.ToSharedRef(), Writer);
-		return Out;
-	}
-}
+#include "UnrealMcpDescriptorHash.h"
 
 TSharedPtr<FJsonObject> FUnrealMcpRegisteredResource::ToDescriptorJson() const
 {
@@ -67,22 +47,9 @@ FUnrealMcpResourceBuilder FUnrealMcpResourceRegistry::Resource(const FString& Ur
 
 FString FUnrealMcpResourceRegistry::ComputeSchemaHash(const FUnrealMcpRegisteredResource& InResource)
 {
-	// Hash the canonicalized descriptor MINUS the enabled flag (mirror the tool/prompt registries). Reuse
-	// ToDescriptorJson and drop "enabled" + "schemaHash" so the hash is stable regardless of those fields.
-	FUnrealMcpRegisteredResource Copy = InResource;
-	Copy.SchemaHash.Empty();
-	TSharedPtr<FJsonObject> Desc = Copy.ToDescriptorJson();
-	Desc->RemoveField(TEXT("enabled"));
-	Desc->RemoveField(TEXT("schemaHash"));
-
-	const FString Canonical = ResourceSerializeStable(Desc);
-	FSHA1 Sha;
-	const FTCHARToUTF8 Utf8(*Canonical);
-	Sha.Update(reinterpret_cast<const uint8*>(Utf8.Get()), Utf8.Length());
-	Sha.Final();
-	uint8 Digest[20];
-	Sha.GetHash(Digest);
-	return FString(TEXT("sha1:")) + BytesToHex(Digest, 20).ToLower();
+	// Hash the canonicalized descriptor MINUS the enabled flag (mirror the tool/prompt registries): the shared
+	// helper builds the hash off the descriptor JSON directly (it strips enabled/schemaHash itself), no copy needed.
+	return UnrealMcpComputeDescriptorHash(InResource.ToDescriptorJson());
 }
 
 bool FUnrealMcpResourceRegistry::IsValidResourceUri(const FString& Uri)
@@ -218,9 +185,7 @@ TSharedPtr<FJsonObject> FUnrealMcpResourceRegistry::BuildManifestJson() const
 	Manifest->SetNumberField(TEXT("revision"), Revision);
 
 	TArray<TSharedPtr<FJsonValue>> ResourceArray;
-	TArray<FString> Uris;
-	Resources.GetKeys(Uris);
-	Uris.Sort();
+	const TArray<FString> Uris = GetResourceUrisSorted();
 	for (const FString& Uri : Uris)
 	{
 		// A disabled resource is EXCLUDED from the served manifest entirely (mirror the tool/prompt registries).
@@ -267,12 +232,12 @@ bool FUnrealMcpResourceRegistry::SetResourceEnabled(const FString& Uri, bool bEn
 
 bool FUnrealMcpResourceRegistry::ShouldResourceBeEnabled(const FString& Uri) const
 {
-	return PassesEnabledResourcesWhitelist(Uri) && !DisabledResourceUris.Contains(Uri);
+	return Enablement.ShouldBeEnabled(Uri);
 }
 
 bool FUnrealMcpResourceRegistry::PassesEnabledResourcesWhitelist(const FString& Uri) const
 {
-	return EnabledResourcesWhitelist.IsEmpty() || EnabledResourcesWhitelist.Contains(Uri);
+	return Enablement.PassesWhitelist(Uri);
 }
 
 void FUnrealMcpResourceRegistry::RecomputeEnablement()
@@ -293,13 +258,13 @@ void FUnrealMcpResourceRegistry::RecomputeEnablement()
 
 void FUnrealMcpResourceRegistry::SetEnabledResourcesFilter(const TArray<FString>& EnabledResources)
 {
-	EnabledResourcesWhitelist = TSet<FString>(EnabledResources);
+	Enablement.SetWhitelist(EnabledResources);
 	RecomputeEnablement();
 }
 
 void FUnrealMcpResourceRegistry::ApplyDisabledResources(const TArray<FString>& DisabledUris)
 {
-	DisabledResourceUris = TSet<FString>(DisabledUris);
+	Enablement.SetBlocklist(DisabledUris);
 	RecomputeEnablement();
 }
 

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Sidecar/UnrealMcpSidecarManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Sidecar/UnrealMcpSidecarManager.cpp
@@ -11,10 +11,8 @@
 
 #include <random>
 
-#if PLATFORM_MAC || PLATFORM_LINUX
-#include <cerrno>
-#endif
 #if PLATFORM_MAC
+#include <cerrno>
 #include <sys/xattr.h>
 #endif
 

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Sidecar/UnrealMcpSidecarManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Sidecar/UnrealMcpSidecarManager.cpp
@@ -3,8 +3,9 @@
 
 #include "UnrealMcpSidecarManager.h"
 #include "UnrealMcpLog.h"
-#include "Async/Async.h"
+#include "UnrealMcpProcessUtil.h"   // shared ResolveDotNetRid + MakeExecutable
 #include "HAL/PlatformProcess.h"
+#include "HAL/PlatformTime.h"       // FPlatformTime::Seconds (WaitForExit) — was transitively via the removed Async/Async.h
 #include "Misc/Paths.h"
 #include "Interfaces/IPluginManager.h"
 
@@ -12,20 +13,12 @@
 
 #if PLATFORM_MAC || PLATFORM_LINUX
 #include <cerrno>
-#include <sys/stat.h>
 #endif
 #if PLATFORM_MAC
 #include <sys/xattr.h>
-#include <sys/sysctl.h>
 #endif
 
-namespace
-{
-	// §1.5 restart backoff schedule (seconds).
-	const int32 BackoffSeconds[] = { 1, 2, 5, 10, 30 };
-	constexpr int32 MaxCrashesPerWindow = 5;
-	constexpr double CrashWindowSeconds = 300.0;
-}
+// The §1.5 backoff schedule + crash-rate constants now live in FUnrealMcpSupervisedProcess.
 
 FUnrealMcpSidecarManager::~FUnrealMcpSidecarManager()
 {
@@ -43,28 +36,9 @@ FString FUnrealMcpSidecarManager::BridgeBinaryBasename()
 
 FString FUnrealMcpSidecarManager::ResolveRid(bool bArm64DirExists)
 {
-#if PLATFORM_WINDOWS
-	(void)bArm64DirExists;
-	return TEXT("win-x64");
-#elif PLATFORM_MAC
-	// §6.2: select from the PHYSICAL host CPU, not the (possibly Rosetta-translated) editor arch — the
-	// bridge is a separate child and should match the hardware. `hw.optional.arm64 == 1` on Apple
-	// Silicon reports the hardware even under a translated process (verified per design R5). Fall back to
-	// osx-x64 (runs under Rosetta 2) when the arm64 slice is absent, so a missing build is never fatal.
-	int32 IsArm64 = 0;
-	size_t Size = sizeof(IsArm64);
-	if (sysctlbyname("hw.optional.arm64", &IsArm64, &Size, nullptr, 0) != 0)
-		IsArm64 = 0; // probe unavailable → treat as Intel
-	if (IsArm64 == 1 && bArm64DirExists)
-		return TEXT("osx-arm64");
-	return TEXT("osx-x64");
-#elif PLATFORM_LINUX
-	(void)bArm64DirExists;
-	return TEXT("linux-x64");
-#else
-	(void)bArm64DirExists;
-	return FString();
-#endif
+	// The RID resolver is shared with FUnrealMcpServerManager — see FUnrealMcpProcessUtil::ResolveDotNetRid
+	// (§6.2). This thin forwarder keeps the tested static-member entry point.
+	return FUnrealMcpProcessUtil::ResolveDotNetRid(bArm64DirExists);
 }
 
 FString FUnrealMcpSidecarManager::ComposeBundledBridgePath(const FString& PluginBaseDir, bool bArm64DirExists)
@@ -175,23 +149,15 @@ bool FUnrealMcpSidecarManager::PrepareBundledBinaryForSpawn(const FString& Path)
 	if (Path.IsEmpty())
 		return false;
 
-#if PLATFORM_MAC || PLATFORM_LINUX
-	// §6.6: ensure the apphost is executable. UE has no portable chmod; call the syscall directly (no
-	// shell, no PATH dependency). 0755 = rwxr-xr-x.
-	const auto Utf8Path = StringCast<ANSICHAR>(*Path);
-	if (chmod(Utf8Path.Get(), 0755) != 0)
-	{
-		UE_LOG(LogUnrealMcp, Warning,
-			TEXT("[Unreal-MCP] could not set +x on the bundled sidecar '%s' (errno=%d); spawn may fail."),
-			*Path, errno);
-		// Not fatal — the bit may already be set by the packager; let the spawn attempt surface a real failure.
-	}
-#endif
+	// §6.6: ensure the apphost is executable (shared +x helper — no-op on Windows). Not fatal on failure.
+	FUnrealMcpProcessUtil::MakeExecutable(Path);
+
 #if PLATFORM_MAC
 	// §6.6 / design R3: strip com.apple.quarantine so Gatekeeper's first-exec check is bypassed even
 	// offline (a binary with no quarantine xattr is not Gatekeeper-checked on exec). Belt-and-suspenders
 	// alongside notarization (T3). ENOATTR (no such attribute) is the expected happy case for an
 	// already-clean or never-quarantined binary — tolerate it.
+	const auto Utf8Path = StringCast<ANSICHAR>(*Path);
 	if (removexattr(Utf8Path.Get(), "com.apple.quarantine", 0) != 0 && errno != ENOATTR)
 	{
 		UE_LOG(LogUnrealMcp, Verbose,
@@ -199,7 +165,6 @@ bool FUnrealMcpSidecarManager::PrepareBundledBinaryForSpawn(const FString& Path)
 			*Path, errno);
 	}
 #endif
-	(void)Path;
 	return true;
 }
 
@@ -226,7 +191,6 @@ bool FUnrealMcpSidecarManager::StartForPort(int32 InIpcPort, const FString& InTo
 {
 	IpcPort = InIpcPort;
 	Token = InToken;
-	bStopRequested = false;
 
 	BridgePath = ResolveBridgeBinaryPath();
 	if (BridgePath.IsEmpty())
@@ -274,9 +238,7 @@ bool FUnrealMcpSidecarManager::StartForPort(int32 InIpcPort, const FString& InTo
 		return false;
 	}
 
-	WindowStartSeconds = FPlatformTime::Seconds();
-	CrashesInWindow = 0;
-	StartWatchdog();
+	StartWatchdog();   // Watchdog.Start() resets the crash window + stop flag for this run.
 	return true;
 }
 
@@ -336,76 +298,28 @@ bool FUnrealMcpSidecarManager::SpawnProcess()
 
 void FUnrealMcpSidecarManager::StartWatchdog()
 {
-	if (WatchdogFuture.IsValid())
-		return;
-
-	WatchdogFuture = Async(EAsyncExecution::Thread, [this]()
-	{
-		int32 BackoffIndex = 0;
-		while (!bStopRequested)
+	// The §1.5 crash-restart loop lives in FUnrealMcpSupervisedProcess; supply the sidecar-specific liveness
+	// probe + respawn. The respawn closes the dead handle and re-spawns (a fresh token rotates each relaunch,
+	// §1.4 — the bridge server reads the new token on the next handshake). No give-up side effect (the bridge
+	// server keeps listening). All run ON the watchdog thread, the manager's single-owner mutation context.
+	Watchdog.Start(
+		/*IsAlive*/ [this]() { return ProcHandle.IsValid() && FPlatformProcess::IsProcRunning(ProcHandle); },
+		/*Respawn*/ [this]() -> bool
 		{
-			FPlatformProcess::Sleep(1.0f);
-			if (bStopRequested)
-				break;
-
-			if (ProcHandle.IsValid() && FPlatformProcess::IsProcRunning(ProcHandle))
-			{
-				BackoffIndex = 0; // healthy
-				continue;
-			}
-
-			// The process died unexpectedly (§1.5 auto-restart).
-			const double Now = FPlatformTime::Seconds();
-			if (Now - WindowStartSeconds > CrashWindowSeconds)
-			{
-				WindowStartSeconds = Now;
-				CrashesInWindow = 0;
-			}
-			if (++CrashesInWindow > MaxCrashesPerWindow)
-			{
-				UE_LOG(LogUnrealMcp, Error,
-					TEXT("[Unreal-MCP] sidecar crashed > %d times in %.0fs; giving up auto-restart."),
-					MaxCrashesPerWindow, CrashWindowSeconds);
-				return;
-			}
-
-			const int32 DelaySeconds = BackoffSeconds[FMath::Min(BackoffIndex, (int32)UE_ARRAY_COUNT(BackoffSeconds) - 1)];
-			++BackoffIndex;
-			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] sidecar exited; restarting in %ds (restart #%d)."),
-				DelaySeconds, RestartCount.GetValue() + 1);
-
-			// Chunk the backoff on a short tick (not one uninterruptible Sleep of up to 30 s): StopWatchdog()
-			// joins this thread on the game thread at editor shutdown, so a single long sleep would stall the
-			// editor's quit for the remainder of the backoff. Poll bStopRequested like the bridge heartbeat.
-			const double BackoffUntil = FPlatformTime::Seconds() + DelaySeconds;
-			while (!bStopRequested && FPlatformTime::Seconds() < BackoffUntil)
-				FPlatformProcess::Sleep(0.5f);
-			if (bStopRequested)
-				break;
-
 			if (ProcHandle.IsValid())
 			{
 				FPlatformProcess::CloseProc(ProcHandle);
 				ProcHandle.Reset();
 			}
-			// Fresh token each relaunch (§1.4 — token rotates every relaunch). The bridge server reads
-			// the new token on the next handshake; the server's Start() token is the authority, so a
-			// relaunched sidecar with a stale token would be rejected. NOTE: rotating the server-side
-			// token on relaunch lands with the full lifecycle wiring; the MVP keeps the launch token.
-			if (SpawnProcess())
-				RestartCount.Increment();
-		}
-	});
+			return SpawnProcess();
+		},
+		/*OnGiveUp*/ nullptr,
+		TEXT("sidecar"));
 }
 
 void FUnrealMcpSidecarManager::StopWatchdog()
 {
-	bStopRequested = true;
-	if (WatchdogFuture.IsValid())
-	{
-		WatchdogFuture.Wait();
-		WatchdogFuture = TFuture<void>();
-	}
+	Watchdog.Stop();
 }
 
 void FUnrealMcpSidecarManager::TerminateProcess()

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Sidecar/UnrealMcpSidecarManager.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Sidecar/UnrealMcpSidecarManager.h
@@ -4,9 +4,8 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "HAL/ThreadSafeBool.h"
 #include "HAL/PlatformProcess.h"   // FProcHandle is a by-value member below; the platform header defines the complete type (the generic header only forward-declares it)
-#include "Async/Future.h"          // TFuture<void> WatchdogFuture member below
+#include "UnrealMcpSupervisedProcess.h"   // the shared §1.5 crash-restart watchdog (FUnrealMcpSupervisedProcess Watchdog member below)
 
 /**
  * Owns the lifecycle of the unreal-mcp-bridge sidecar process (docs/ARCHITECTURE.md §6): resolve the
@@ -57,7 +56,7 @@ public:
 	 * is intentionally unsynchronized — a concurrent call racing a watchdog restart is not a supported use.
 	 */
 	bool IsRunning() const;
-	int32 GetRestartCount() const { return RestartCount.GetValue(); }
+	int32 GetRestartCount() const { return Watchdog.GetRestartCount(); }
 
 	/**
 	 * Resolve the bridge binary path (§6 BUNDLE model): UNREAL_MCP_BRIDGE_PATH dev/CI override first,
@@ -132,11 +131,8 @@ private:
 	FProcHandle ProcHandle;
 	uint32 ProcId = 0;
 
-	FThreadSafeBool bStopRequested = false;
-	FThreadSafeCounter RestartCount;
-	TFuture<void> WatchdogFuture;
-
-	// Crash-rate guard (§1.5): > 5 crashes in 5 minutes → stop restarting.
-	double WindowStartSeconds = 0.0;
-	int32 CrashesInWindow = 0;
+	// The §1.5 crash-restart watchdog (backoff {1,2,5,10,30}s + give-up after 5 crashes / 300s). Shared with
+	// FUnrealMcpServerManager via FUnrealMcpSupervisedProcess; this manager supplies the IsAlive / Respawn
+	// closures in StartWatchdog().
+	FUnrealMcpSupervisedProcess Watchdog;
 };

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Tools/UnrealMcpLogCollector.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Tools/UnrealMcpLogCollector.cpp
@@ -126,17 +126,10 @@ TArray<FUnrealMcpLogEntry> FUnrealMcpLogCollector::Snapshot(ELogVerbosity::Type 
 
 FString FUnrealMcpLogCollector::VerbosityToString(ELogVerbosity::Type Verbosity)
 {
-	switch (Verbosity & ELogVerbosity::VerbosityMask)
-	{
-	case ELogVerbosity::Fatal:       return TEXT("Fatal");
-	case ELogVerbosity::Error:       return TEXT("Error");
-	case ELogVerbosity::Warning:     return TEXT("Warning");
-	case ELogVerbosity::Display:     return TEXT("Display");
-	case ELogVerbosity::Log:         return TEXT("Log");
-	case ELogVerbosity::Verbose:     return TEXT("Verbose");
-	case ELogVerbosity::VeryVerbose: return TEXT("VeryVerbose");
-	default:                         return TEXT("Log");
-	}
+	// Defer to the engine's verbosity→name mapping (Fatal/Error/Warning/Display/Log/Verbose/VeryVerbose), masking
+	// off the flag bits first (the `&` yields an int, so cast back to the enum). A captured GLog entry always
+	// carries one of those real verbosities.
+	return ::ToString(static_cast<ELogVerbosity::Type>(Verbosity & ELogVerbosity::VerbosityMask));
 }
 
 bool FUnrealMcpLogCollector::ParseVerbosity(const FString& Token, ELogVerbosity::Type& OutVerbosity)

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Tools/UnrealMcpObjectRef.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Tools/UnrealMcpObjectRef.cpp
@@ -81,7 +81,11 @@ namespace FUnrealMcpObjectRef
 
 		// Exact (case-SENSITIVE) match on label / name / full path first (deterministic). FString::operator==
 		// is case-INSENSITIVE in UE, so an explicit ESearchCase::CaseSensitive Equals is required to make the
-		// exact-first preference real and keep the case-insensitive fallback below reachable.
+		// exact-first preference real and keep the case-insensitive fallback below reachable. A single sweep:
+		// any exact match returns immediately; otherwise we remember the FIRST case-insensitive label match
+		// (LLM-supplied labels are often loosely cased) and return it after the sweep — same result the old
+		// second pass produced (iteration order is identical), without walking every actor twice.
+		AActor* IgnoreCaseFallback = nullptr;
 		for (TActorIterator<AActor> It(World); It; ++It)
 		{
 			AActor* Actor = *It;
@@ -91,16 +95,11 @@ namespace FUnrealMcpObjectRef
 			{
 				return Actor;
 			}
+			if (IgnoreCaseFallback == nullptr && ObjectRefActorLabel(Actor).Equals(ActorRef, ESearchCase::IgnoreCase))
+				IgnoreCaseFallback = Actor;
 		}
 
-		// Case-insensitive label fallback (LLM-supplied labels are often loosely cased).
-		for (TActorIterator<AActor> It(World); It; ++It)
-		{
-			if (ObjectRefActorLabel(*It).Equals(ActorRef, ESearchCase::IgnoreCase))
-				return *It;
-		}
-
-		return nullptr;
+		return IgnoreCaseFallback;
 	}
 
 	UActorComponent* ResolveComponent(AActor* Actor, const FString& ComponentRef)

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Tools/UnrealMcpToolRegistry.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Tools/UnrealMcpToolRegistry.cpp
@@ -3,10 +3,9 @@
 
 #include "UnrealMcpToolRegistry.h"
 #include "UnrealMcpLog.h"
-#include "Misc/SecureHash.h"
-#include "Serialization/JsonSerializer.h"
-#include "Serialization/JsonWriter.h"
-#include "Policies/CondensedJsonPrintPolicy.h"
+#include "UnrealMcpDescriptorHash.h"
+#include "UnrealMcpSchema.h"
+#include "UnrealMcpValidation.h"
 
 // --- FUnrealMcpToolCall accessors -----------------------------------------------------------------
 
@@ -65,43 +64,8 @@ FRotator FUnrealMcpToolCall::GetRotator(const FString& Key, const FRotator& Defa
 }
 
 // --- Schema building ------------------------------------------------------------------------------
-
-namespace
-{
-	TSharedPtr<FJsonObject> MakeTypedSchema(const FString& JsonType, const FString& Description)
-	{
-		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
-		Schema->SetStringField(TEXT("type"), JsonType);
-		if (!Description.IsEmpty())
-			Schema->SetStringField(TEXT("description"), Description);
-		return Schema;
-	}
-
-	/** A {x,y,z: number} object schema (the §3.2 FVector mapping). */
-	TSharedPtr<FJsonObject> MakeVectorSchema(const FString& Description)
-	{
-		TSharedPtr<FJsonObject> Props = MakeShared<FJsonObject>();
-		Props->SetObjectField(TEXT("x"), MakeTypedSchema(TEXT("number"), FString()));
-		Props->SetObjectField(TEXT("y"), MakeTypedSchema(TEXT("number"), FString()));
-		Props->SetObjectField(TEXT("z"), MakeTypedSchema(TEXT("number"), FString()));
-
-		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
-		Schema->SetStringField(TEXT("type"), TEXT("object"));
-		if (!Description.IsEmpty())
-			Schema->SetStringField(TEXT("description"), Description);
-		Schema->SetObjectField(TEXT("properties"), Props);
-		return Schema;
-	}
-
-	FString SerializeStable(const TSharedPtr<FJsonObject>& Object)
-	{
-		FString Out;
-		TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =
-			TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&Out);
-		FJsonSerializer::Serialize(Object.ToSharedRef(), Writer);
-		return Out;
-	}
-}
+// The §3.2 scalar + vector schema builders now live in the shared FUnrealMcpSchema TU (UnrealMcpSchema.h),
+// externally linked so the prompt registry + the editor tool families reuse the SAME definition.
 
 TSharedPtr<FJsonObject> FUnrealMcpRegisteredTool::BuildInputSchema() const
 {
@@ -117,7 +81,7 @@ TSharedPtr<FJsonObject> FUnrealMcpRegisteredTool::BuildInputSchema() const
 		// the simple scalar types fall back to a {type,description} schema.
 		TSharedPtr<FJsonObject> ParamSchema = Param.ObjectSchema.IsValid()
 			? Param.ObjectSchema
-			: MakeTypedSchema(Param.JsonType, Param.Description);
+			: FUnrealMcpSchema::TypedSchema(Param.JsonType, Param.Description);
 
 		Properties->SetObjectField(Param.Name, ParamSchema);
 		if (Param.Requirement == EUnrealMcpParamRequirement::Required)
@@ -188,7 +152,7 @@ FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::ParamBool(const FString& Name, con
 }
 FUnrealMcpToolBuilder& FUnrealMcpToolBuilder::ParamVector(const FString& Name, const FString& Desc, EUnrealMcpParamRequirement Req)
 {
-	FUnrealMcpParamSpec Spec{ Name, TEXT("object"), Desc, Req, MakeVectorSchema(Desc) };
+	FUnrealMcpParamSpec Spec{ Name, TEXT("object"), Desc, Req, FUnrealMcpSchema::VectorSchema(Desc) };
 	Tool.Params.Add(Spec);
 	return *this;
 }
@@ -218,44 +182,14 @@ FUnrealMcpToolBuilder FUnrealMcpToolRegistry::Tool(const FString& Name)
 
 FString FUnrealMcpToolRegistry::ComputeSchemaHash(const FUnrealMcpRegisteredTool& InTool)
 {
-	// Hash the canonicalized descriptor MINUS the enabled flag (§2.2). Reuse ToDescriptorJson and drop
-	// "enabled" + "schemaHash" so the hash is stable regardless of those mutable fields.
-	FUnrealMcpRegisteredTool Copy = InTool;
-	Copy.SchemaHash.Empty();
-	TSharedPtr<FJsonObject> Desc = Copy.ToDescriptorJson();
-	Desc->RemoveField(TEXT("enabled"));
-	Desc->RemoveField(TEXT("schemaHash"));
-
-	const FString Canonical = SerializeStable(Desc);
-	FSHA1 Sha;
-	const FTCHARToUTF8 Utf8(*Canonical);
-	Sha.Update(reinterpret_cast<const uint8*>(Utf8.Get()), Utf8.Length());
-	Sha.Final();
-	uint8 Digest[20];
-	Sha.GetHash(Digest);
-	return FString(TEXT("sha1:")) + BytesToHex(Digest, 20).ToLower();
+	// Hash the canonicalized descriptor MINUS the enabled flag (§2.2): the shared helper builds the hash off the
+	// descriptor JSON directly (it strips enabled/schemaHash itself), so no struct deep-copy is needed.
+	return UnrealMcpComputeDescriptorHash(InTool.ToDescriptorJson());
 }
 
 bool FUnrealMcpToolRegistry::IsValidToolName(const FString& Name)
 {
-	if (Name.IsEmpty())
-		return false;
-
-	bool bPrevHyphen = false;
-	const int32 Len = Name.Len();
-	for (int32 i = 0; i < Len; ++i)
-	{
-		const TCHAR C = Name[i];
-		const bool bLower = (C >= TEXT('a') && C <= TEXT('z'));
-		const bool bDigit = (C >= TEXT('0') && C <= TEXT('9'));
-		const bool bHyphen = (C == TEXT('-'));
-		if (!bLower && !bDigit && !bHyphen)
-			return false;
-		if (bHyphen && (i == 0 || i == Len - 1 || bPrevHyphen))
-			return false; // no leading, trailing, or doubled hyphen
-		bPrevHyphen = bHyphen;
-	}
-	return true;
+	return FUnrealMcpValidation::IsValidKebabName(Name);
 }
 
 bool FUnrealMcpToolRegistry::ValidateTool(const FUnrealMcpRegisteredTool& InTool, FString& OutError)
@@ -274,45 +208,7 @@ bool FUnrealMcpToolRegistry::ValidateTool(const FUnrealMcpRegisteredTool& InTool
 		return false;
 	}
 
-	static const TCHAR* const KnownTypes[] = { TEXT("string"), TEXT("integer"), TEXT("number"), TEXT("boolean"), TEXT("object"), TEXT("array") };
-	TSet<FString> SeenParams;
-	for (const FUnrealMcpParamSpec& Param : InTool.Params)
-	{
-		if (Param.Name.IsEmpty())
-		{
-			OutError = FString::Printf(TEXT("tool '%s' has a parameter with an empty name (malformed schema)"), *InTool.Name);
-			return false;
-		}
-
-		bool bKnown = false;
-		for (const TCHAR* const Known : KnownTypes)
-		{
-			if (Param.JsonType == Known) { bKnown = true; break; }
-		}
-		if (!bKnown)
-		{
-			OutError = FString::Printf(TEXT("tool '%s' parameter '%s' has unknown JSON type '%s' (malformed schema)"),
-				*InTool.Name, *Param.Name, *Param.JsonType);
-			return false;
-		}
-
-		if ((Param.JsonType == TEXT("object") || Param.JsonType == TEXT("array")) && !Param.ObjectSchema.IsValid())
-		{
-			OutError = FString::Printf(TEXT("tool '%s' %s parameter '%s' has no schema (malformed schema)"),
-				*InTool.Name, *Param.JsonType, *Param.Name);
-			return false;
-		}
-
-		bool bAlreadyPresent = false;
-		SeenParams.Add(Param.Name, &bAlreadyPresent);
-		if (bAlreadyPresent)
-		{
-			OutError = FString::Printf(TEXT("tool '%s' declares duplicate parameter '%s' (malformed schema)"),
-				*InTool.Name, *Param.Name);
-			return false;
-		}
-	}
-	return true;
+	return FUnrealMcpValidation::ValidateParamSpecs(InTool.Params, TEXT("tool"), InTool.Name, OutError);
 }
 
 void FUnrealMcpToolRegistry::Commit(FUnrealMcpRegisteredTool&& InTool)
@@ -422,9 +318,7 @@ TSharedPtr<FJsonObject> FUnrealMcpToolRegistry::BuildManifestJson() const
 
 	TArray<TSharedPtr<FJsonValue>> ToolArray;
 	// Deterministic ordering by name keeps the manifest stable across runs (§5 ordering principle).
-	TArray<FString> Names;
-	Tools.GetKeys(Names);
-	Names.Sort();
+	const TArray<FString> Names = GetToolNamesSorted();
 	for (const FString& Name : Names)
 	{
 		// §7 per-tool enable-map: a disabled tool is EXCLUDED from the served manifest entirely (not merely
@@ -473,15 +367,14 @@ bool FUnrealMcpToolRegistry::SetToolEnabled(const FString& Name, bool bEnabled)
 bool FUnrealMcpToolRegistry::ShouldToolBeEnabled(const FString& Name) const
 {
 	// §8 effective-served rule: served iff (whitelist empty — no filter — OR the name is whitelisted) AND the
-	// name is NOT in the §7 blocklist. Both sets are retained members, so this is the single source of truth
-	// shared by Commit (per-registration) and RecomputeEnablement (per-filter-change) — neither can clobber the
-	// other's intent.
-	return PassesEnabledToolsWhitelist(Name) && !DisabledToolNames.Contains(Name);
+	// name is NOT in the §7 blocklist. The retained filter is the single source of truth shared by Commit
+	// (per-registration) and RecomputeEnablement (per-filter-change) — neither can clobber the other's intent.
+	return Enablement.ShouldBeEnabled(Name);
 }
 
 bool FUnrealMcpToolRegistry::PassesEnabledToolsWhitelist(const FString& Name) const
 {
-	return EnabledToolsWhitelist.IsEmpty() || EnabledToolsWhitelist.Contains(Name);
+	return Enablement.PassesWhitelist(Name);
 }
 
 void FUnrealMcpToolRegistry::RecomputeEnablement()
@@ -502,13 +395,13 @@ void FUnrealMcpToolRegistry::RecomputeEnablement()
 
 void FUnrealMcpToolRegistry::SetEnabledToolsFilter(const TArray<FString>& EnabledTools)
 {
-	EnabledToolsWhitelist = TSet<FString>(EnabledTools);
+	Enablement.SetWhitelist(EnabledTools);
 	RecomputeEnablement();
 }
 
 void FUnrealMcpToolRegistry::ApplyDisabledTools(const TArray<FString>& DisabledNames)
 {
-	DisabledToolNames = TSet<FString>(DisabledNames);
+	Enablement.SetBlocklist(DisabledNames);
 	RecomputeEnablement();
 }
 

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpDescriptorHash.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpDescriptorHash.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpDescriptorHash.h"
+#include "UnrealMcpSchema.h"   // UnrealMcpSerializeCondensed (the one shared condensed serializer)
+#include "Misc/SecureHash.h"
+
+FString UnrealMcpComputeDescriptorHash(const TSharedPtr<FJsonObject>& Descriptor)
+{
+	// Condensed (whitespace-free, stable order) serialization MINUS the mutable enabled/schemaHash fields — the
+	// canonical form every registry hashed. A null descriptor (never happens in practice — call sites always pass
+	// a freshly built ToDescriptorJson()) degrades to hashing the empty string.
+	if (Descriptor.IsValid())
+	{
+		Descriptor->RemoveField(TEXT("enabled"));
+		Descriptor->RemoveField(TEXT("schemaHash"));
+	}
+	const FString Canonical = UnrealMcpSerializeCondensed(Descriptor);
+
+	FSHA1 Sha;
+	const FTCHARToUTF8 Utf8(*Canonical);
+	Sha.Update(reinterpret_cast<const uint8*>(Utf8.Get()), Utf8.Length());
+	Sha.Final();
+	uint8 Digest[20];
+	Sha.GetHash(Digest);
+	return FString(TEXT("sha1:")) + BytesToHex(Digest, 20).ToLower();
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpDescriptorHash.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpDescriptorHash.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+
+/**
+ * Shared stable schema-hash helper for the tool / prompt / resource registries (docs/ARCHITECTURE.md §2.2).
+ *
+ * All three registries compute an identical "stable descriptor hash": serialize the descriptor JSON with the
+ * condensed printer (no whitespace, stable field order) MINUS the mutable `enabled` + `schemaHash` fields, then
+ * SHA-1 the UTF-8 bytes and return `sha1:<lowercase-hex>`. They previously each carried a verbatim copy guarded
+ * only by a family-unique `*SerializeStable` name to dodge the unity-build ODR collision (conventions.md). This
+ * single UNREALMCPRUNTIME_API free function replaces those three copies.
+ *
+ * Pass the descriptor JSON the caller already built via `Entry.ToDescriptorJson()` — the function strips
+ * `enabled` + `schemaHash` from it (mutating the passed object, which is a throwaway built for the hash) before
+ * canonicalizing, so the caller no longer needs the old deep-copy-the-struct-and-clear-SchemaHash dance.
+ */
+UNREALMCPRUNTIME_API FString UnrealMcpComputeDescriptorHash(const TSharedPtr<FJsonObject>& Descriptor);

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpProcessUtil.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpProcessUtil.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpProcessUtil.h"
+#include "UnrealMcpLog.h"
+
+#if PLATFORM_MAC || PLATFORM_LINUX
+#include <cerrno>
+#include <sys/stat.h>
+#endif
+#if PLATFORM_MAC
+#include <sys/sysctl.h>
+#endif
+
+namespace FUnrealMcpProcessUtil
+{
+	FString ResolveDotNetRid(bool bArm64SliceExists)
+	{
+#if PLATFORM_WINDOWS
+		(void)bArm64SliceExists;
+		return TEXT("win-x64");
+#elif PLATFORM_MAC
+		// §6.2: select from the PHYSICAL host CPU, not the (possibly Rosetta-translated) editor arch — the
+		// child should match the hardware. `hw.optional.arm64 == 1` reports Apple Silicon even under a
+		// translated process (design R5). Fall back to osx-x64 (runs under Rosetta 2) when the arm64 slice is
+		// absent, so a missing build is never fatal.
+		int32 IsArm64 = 0;
+		size_t Size = sizeof(IsArm64);
+		if (sysctlbyname("hw.optional.arm64", &IsArm64, &Size, nullptr, 0) != 0)
+			IsArm64 = 0; // probe unavailable → treat as Intel
+		if (IsArm64 == 1 && bArm64SliceExists)
+			return TEXT("osx-arm64");
+		return TEXT("osx-x64");
+#elif PLATFORM_LINUX
+		(void)bArm64SliceExists;
+		return TEXT("linux-x64");
+#else
+		(void)bArm64SliceExists;
+		return FString();
+#endif
+	}
+
+	bool MakeExecutable(const FString& Path)
+	{
+		if (Path.IsEmpty())
+			return false;
+
+#if PLATFORM_MAC || PLATFORM_LINUX
+		// UE has no portable chmod; call the syscall directly (no shell, no PATH dependency). 0755 = rwxr-xr-x.
+		const auto Utf8Path = StringCast<ANSICHAR>(*Path);
+		if (chmod(Utf8Path.Get(), 0755) != 0)
+		{
+			UE_LOG(LogUnrealMcp, Warning,
+				TEXT("[Unreal-MCP] could not set +x on '%s' (errno=%d); spawn may fail."), *Path, errno);
+			// Not fatal — the bit may already be set by the packager; let the spawn attempt surface a real failure.
+			return false;
+		}
+		return true;
+#else
+		return true; // Windows: no POSIX mode bits to set
+#endif
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpProcessUtil.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpProcessUtil.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * Shared external-process helpers for the sidecar / local-server managers (docs/ARCHITECTURE.md §6 / §7).
+ * The .NET RID resolver and the +x helper were verbatim copies in both managers; this single
+ * UNREALMCPRUNTIME_API surface owns one definition of each.
+ */
+namespace FUnrealMcpProcessUtil
+{
+	/**
+	 * Resolve the .NET runtime-identifier directory name the bundled apphost lives under (§6.2 / §12.5):
+	 * win-x64 / linux-x64 / osx-arm64 / osx-x64. On Apple Silicon the PHYSICAL host CPU is probed via
+	 * `sysctlbyname("hw.optional.arm64")` (correct even under a Rosetta-translated editor); osx-arm64 is
+	 * chosen only when @p bArm64SliceExists (so a missing arm64 build falls back to osx-x64 under Rosetta
+	 * rather than failing). Returns empty on a non-desktop platform (console/mobile cannot spawn .NET).
+	 */
+	UNREALMCPRUNTIME_API FString ResolveDotNetRid(bool bArm64SliceExists);
+
+	/**
+	 * Best-effort `chmod 0755` (rwxr-xr-x) on @p Path so a bundled apphost is executable (§6.6). A no-op on
+	 * Windows (no POSIX mode bits). NOT fatal on failure — the bit may already be set by the packager — so it
+	 * logs a warning and returns false rather than aborting the spawn. Returns true when the mode was set (or
+	 * on Windows, where nothing is needed).
+	 */
+	UNREALMCPRUNTIME_API bool MakeExecutable(const FString& Path);
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpSchema.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpSchema.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpSchema.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
+
+namespace FUnrealMcpSchema
+{
+	TSharedPtr<FJsonObject> TypedSchema(const FString& JsonType, const FString& Description)
+	{
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), JsonType);
+		if (!Description.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Description);
+		return Schema;
+	}
+
+	/** Build a `{type:"object", properties:{<axes>:number}}` schema with an optional description. */
+	static TSharedPtr<FJsonObject> AxisObjectSchema(const TArray<FString>& Axes, const FString& Description)
+	{
+		TSharedPtr<FJsonObject> Props = MakeShared<FJsonObject>();
+		for (const FString& Axis : Axes)
+			Props->SetObjectField(Axis, TypedSchema(TEXT("number"), FString()));
+
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), TEXT("object"));
+		if (!Description.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Description);
+		Schema->SetObjectField(TEXT("properties"), Props);
+		return Schema;
+	}
+
+	TSharedPtr<FJsonObject> VectorSchema(const FString& Description)
+	{
+		return AxisObjectSchema({ TEXT("x"), TEXT("y"), TEXT("z") }, Description);
+	}
+
+	TSharedPtr<FJsonObject> Rotator(const FString& Description)
+	{
+		return AxisObjectSchema({ TEXT("pitch"), TEXT("yaw"), TEXT("roll") }, Description);
+	}
+
+	TSharedPtr<FJsonObject> StringArray(const FString& Description)
+	{
+		TSharedPtr<FJsonObject> Items = MakeShared<FJsonObject>();
+		Items->SetStringField(TEXT("type"), TEXT("string"));
+
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), TEXT("array"));
+		if (!Description.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Description);
+		Schema->SetObjectField(TEXT("items"), Items);
+		return Schema;
+	}
+
+	TSharedPtr<FJsonObject> ObjectBag(const FString& Description)
+	{
+		TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+		Schema->SetStringField(TEXT("type"), TEXT("object"));
+		if (!Description.IsEmpty())
+			Schema->SetStringField(TEXT("description"), Description);
+		Schema->SetBoolField(TEXT("additionalProperties"), true);
+		return Schema;
+	}
+}
+
+FString UnrealMcpSerializeCondensed(const TSharedPtr<FJsonObject>& Object)
+{
+	if (!Object.IsValid())
+		return FString();
+
+	FString Out;
+	TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =
+		TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&Out);
+	FJsonSerializer::Serialize(Object.ToSharedRef(), Writer);
+	return Out;
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpSchema.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpSchema.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+
+/**
+ * Shared JSON-Schema builders for tool / prompt parameters (docs/ARCHITECTURE.md §3.2).
+ *
+ * These were ODR-cloned per family — the registries each carried `MakeTypedSchema` / `MakeVectorSchema`
+ * (family-prefixed to dodge the unity-build collision), and the actor/level/editor tool families each carried
+ * their own `Make*StringArraySchema` / property-bag / rotator copy. This single UNREALMCPRUNTIME_API surface
+ * replaces all of them with externally-linked free functions (defined once, declared once), so there is exactly
+ * one definition of each and the unity build cannot collide. The editor module reaches these via the runtime
+ * module's public dependency + private-include path, exactly like the other Tools/ helpers.
+ */
+namespace FUnrealMcpSchema
+{
+	/** `{ type: <JsonType>[, description] }` — the scalar §3.2 schema (string/integer/number/boolean). */
+	UNREALMCPRUNTIME_API TSharedPtr<FJsonObject> TypedSchema(const FString& JsonType, const FString& Description);
+
+	/** `{ type:"object", properties:{x,y,z:number}[, description] }` — the §3.2 FVector mapping. */
+	UNREALMCPRUNTIME_API TSharedPtr<FJsonObject> VectorSchema(const FString& Description);
+
+	/** `{ type:"object", properties:{pitch,yaw,roll:number}[, description] }` — the §3.2 FRotator mapping (degrees). */
+	UNREALMCPRUNTIME_API TSharedPtr<FJsonObject> Rotator(const FString& Description);
+
+	/** `{ type:"array", items:{type:"string"}[, description] }` — the §3.2 scoped-read `paths` filter. */
+	UNREALMCPRUNTIME_API TSharedPtr<FJsonObject> StringArray(const FString& Description);
+
+	/** `{ type:"object", additionalProperties:true[, description] }` — a free-form `{ key: value }` property bag. */
+	UNREALMCPRUNTIME_API TSharedPtr<FJsonObject> ObjectBag(const FString& Description);
+}
+
+/** Serialize a JSON object to a compact (whitespace-free, stable field order) string — the canonical condensed
+ *  form used for the §2.2 stable schema hash and any condensed wire payload. One definition shared across the
+ *  runtime module. */
+UNREALMCPRUNTIME_API FString UnrealMcpSerializeCondensed(const TSharedPtr<FJsonObject>& Object);

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpSupervisedProcess.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpSupervisedProcess.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpSupervisedProcess.h"
+#include "UnrealMcpLog.h"
+#include "Async/Async.h"
+#include "HAL/PlatformProcess.h"
+#include "HAL/PlatformTime.h"        // FPlatformTime::Seconds — explicit (not relying on a transitive editor-PCH include)
+#include "Math/UnrealMathUtility.h"
+
+namespace
+{
+	// §1.5 restart backoff schedule (seconds) + crash-rate circuit-breaker — identical across both managers.
+	const int32 SupervisedBackoffSeconds[] = { 1, 2, 5, 10, 30 };
+	constexpr int32 SupervisedMaxCrashesPerWindow = 5;
+	constexpr double SupervisedCrashWindowSeconds = 300.0;
+}
+
+void FUnrealMcpSupervisedProcess::Start(
+	TFunction<bool()> IsAlive, TFunction<bool()> Respawn, TFunction<void()> OnGiveUp, const TCHAR* Label)
+{
+	if (WatchdogFuture.IsValid())
+		return;
+
+	// Reset the crash window + stop flag for this run (the watchdog thread reads them below).
+	bStopRequested = false;
+	WindowStartSeconds = FPlatformTime::Seconds();
+	CrashesInWindow = 0;
+
+	const FString LabelStr = Label != nullptr ? FString(Label) : FString(TEXT("child process"));
+
+	WatchdogFuture = Async(EAsyncExecution::Thread,
+		[this, IsAlive = MoveTemp(IsAlive), Respawn = MoveTemp(Respawn), OnGiveUp = MoveTemp(OnGiveUp), LabelStr]()
+	{
+		int32 BackoffIndex = 0;
+		while (!bStopRequested)
+		{
+			FPlatformProcess::Sleep(1.0f);
+			if (bStopRequested)
+				break;
+
+			if (IsAlive())
+			{
+				BackoffIndex = 0;
+				continue;
+			}
+
+			// Child died unexpectedly — crash-restart with backoff + a crash-rate guard.
+			const double Now = FPlatformTime::Seconds();
+			if (Now - WindowStartSeconds > SupervisedCrashWindowSeconds)
+			{
+				WindowStartSeconds = Now;
+				CrashesInWindow = 0;
+			}
+			if (++CrashesInWindow > SupervisedMaxCrashesPerWindow)
+			{
+				UE_LOG(LogUnrealMcp, Error,
+					TEXT("[Unreal-MCP] %s crashed > %d times in %.0fs; giving up auto-restart."),
+					*LabelStr, SupervisedMaxCrashesPerWindow, SupervisedCrashWindowSeconds);
+				if (OnGiveUp)
+					OnGiveUp();
+				return;
+			}
+
+			const int32 DelaySeconds = SupervisedBackoffSeconds[FMath::Min(BackoffIndex, (int32)UE_ARRAY_COUNT(SupervisedBackoffSeconds) - 1)];
+			++BackoffIndex;
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] %s exited; restarting in %ds (restart #%d)."),
+				*LabelStr, DelaySeconds, RestartCount.GetValue() + 1);
+
+			// Chunk the backoff so editor shutdown (which joins this thread) is not stalled by one long sleep.
+			const double BackoffUntil = FPlatformTime::Seconds() + DelaySeconds;
+			while (!bStopRequested && FPlatformTime::Seconds() < BackoffUntil)
+				FPlatformProcess::Sleep(0.5f);
+			if (bStopRequested)
+				break;
+
+			if (Respawn())
+				RestartCount.Increment();
+		}
+	});
+}
+
+void FUnrealMcpSupervisedProcess::Stop()
+{
+	bStopRequested = true;
+	if (WatchdogFuture.IsValid())
+	{
+		WatchdogFuture.Wait();
+		WatchdogFuture = TFuture<void>();
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpSupervisedProcess.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpSupervisedProcess.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "HAL/ThreadSafeBool.h"
+#include "HAL/ThreadSafeCounter.h"
+#include "Async/Future.h"
+#include "Templates/Function.h"
+
+/**
+ * A shared crash-restart WATCHDOG for an external child process (docs/ARCHITECTURE.md §1.5 / §6).
+ *
+ * The local-server manager (§7) and the sidecar manager (§6) carried byte-identical watchdog loops — a
+ * background thread that polls liveness every second and, when the child died unexpectedly, relaunches it with
+ * an exponential backoff ({1,2,5,10,30}s) under a crash-rate circuit-breaker (give up after 5 crashes in a
+ * 300s window). This class owns that loop + its state ONCE; each manager supplies three callbacks for the
+ * parts that genuinely differ:
+ *
+ *   - @c IsAlive   — whether the supervised child is currently running (each manager guards its own handle
+ *                    with its own locking model, so the liveness probe is injected, not shared).
+ *   - @c Respawn   — relaunch the child + any per-manager cleanup (kill an orphan on the port, rotate the IPC
+ *                    token, close the dead handle, …). Returns true when the child was relaunched; the watchdog
+ *                    bumps the restart counter on true. Runs only after the backoff elapses.
+ *   - @c OnGiveUp  — runs once if the crash threshold is exceeded (e.g. clear the pid file). May be null.
+ *
+ * Every callback runs ON the watchdog thread. The backoff sleep is chunked on a short tick so Stop() (called
+ * on the game thread at editor shutdown, which joins this thread) is never stalled for the full backoff.
+ */
+class UNREALMCPRUNTIME_API FUnrealMcpSupervisedProcess
+{
+public:
+	~FUnrealMcpSupervisedProcess() { Stop(); }
+
+	/**
+	 * Launch the watchdog thread (no-op if already running). Resets the crash-window counters + the stop flag,
+	 * then polls @p IsAlive every second; on an unexpected death it backs off and calls @p Respawn, or calls
+	 * @p OnGiveUp once and exits when the circuit-breaker trips. @p Label names the child in log lines
+	 * (e.g. "local server" / "sidecar").
+	 */
+	void Start(TFunction<bool()> IsAlive, TFunction<bool()> Respawn, TFunction<void()> OnGiveUp, const TCHAR* Label);
+
+	/** Signal the watchdog to stop and JOIN it (idempotent; safe to call when not running). */
+	void Stop();
+
+	/** True while the watchdog thread is live. */
+	bool IsWatching() const { return WatchdogFuture.IsValid(); }
+
+	/** Number of successful relaunches since construction (the §1.5 restart counter the managers expose). */
+	int32 GetRestartCount() const { return RestartCount.GetValue(); }
+
+	/** Reset the restart counter (the local-server manager zeroes it on a fresh Start). */
+	void ResetRestartCount() { RestartCount.Reset(); }
+
+private:
+	FThreadSafeBool bStopRequested = false;
+	FThreadSafeCounter RestartCount;
+	TFuture<void> WatchdogFuture;
+	double WindowStartSeconds = 0.0;
+	int32 CrashesInWindow = 0;
+};

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpToolArgs.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpToolArgs.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpToolArgs.h"
+#include "UnrealMcpToolRegistry.h"   // FUnrealMcpToolCall (Arguments)
+#include "Dom/JsonValue.h"
+
+namespace FUnrealMcpToolArgs
+{
+	TArray<FString> GetStringArray(const FUnrealMcpToolCall& Call, const FString& Key, FString& OutError)
+	{
+		TArray<FString> Out;
+		const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
+		if (Call.Arguments->TryGetArrayField(Key, Arr) && Arr)
+		{
+			for (const TSharedPtr<FJsonValue>& V : *Arr)
+			{
+				FString S;
+				if (V.IsValid() && V->TryGetString(S))
+				{
+					Out.Add(S);
+				}
+				else
+				{
+					OutError = FString::Printf(TEXT("'%s' must be an array of strings; a non-string entry was provided."), *Key);
+					Out.Reset();
+					return Out;
+				}
+			}
+		}
+		else if (Call.Arguments->HasField(Key))
+		{
+			// Present but not an array (a bare string/object/number): error rather than returning an empty list,
+			// which the caller would read as "select nothing" / "full object" and act on the OPPOSITE of intent.
+			OutError = FString::Printf(TEXT("'%s' must be an array of strings."), *Key);
+		}
+		return Out;
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpToolArgs.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpToolArgs.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+struct FUnrealMcpToolCall;
+
+/**
+ * Shared argument readers for tool / prompt handlers (docs/ARCHITECTURE.md §3.2). The actor / level / editor /
+ * asset families each carried their own `*GetStringArray` copy (family-prefixed to dodge the unity-build ODR
+ * collision); this single UNREALMCPRUNTIME_API surface replaces them with one externally-linked definition.
+ */
+namespace FUnrealMcpToolArgs
+{
+	/**
+	 * Read a string-array argument @p Key off @p Call — the §3.2 scoped-read `paths` / refs filter. Returns empty
+	 * when the field is ABSENT. Two malformed shapes are hard errors (set @p OutError, return an EMPTY array):
+	 * a non-string ENTRY inside the array, and a field that is PRESENT but is not an array (a bare string/number/
+	 * object). Silently accepting either would flip the read to the OPPOSITE extreme of the requested scope
+	 * ("identity only" / "full object" / "select nothing") with no signal to the caller, so every family
+	 * converges on this single strict contract.
+	 */
+	UNREALMCPRUNTIME_API TArray<FString> GetStringArray(const FUnrealMcpToolCall& Call, const FString& Key, FString& OutError);
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpValidation.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpValidation.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UnrealMcpValidation.h"
+#include "UnrealMcpToolRegistry.h"   // FUnrealMcpParamSpec + EUnrealMcpParamRequirement
+
+namespace FUnrealMcpValidation
+{
+	bool IsValidKebabName(const FString& Name)
+	{
+		if (Name.IsEmpty())
+			return false;
+
+		bool bPrevHyphen = false;
+		const int32 Len = Name.Len();
+		for (int32 i = 0; i < Len; ++i)
+		{
+			const TCHAR C = Name[i];
+			const bool bLower = (C >= TEXT('a') && C <= TEXT('z'));
+			const bool bDigit = (C >= TEXT('0') && C <= TEXT('9'));
+			const bool bHyphen = (C == TEXT('-'));
+			if (!bLower && !bDigit && !bHyphen)
+				return false;
+			if (bHyphen && (i == 0 || i == Len - 1 || bPrevHyphen))
+				return false; // no leading, trailing, or doubled hyphen
+			bPrevHyphen = bHyphen;
+		}
+		return true;
+	}
+
+	bool ValidateParamSpecs(
+		const TArray<FUnrealMcpParamSpec>& Params, const TCHAR* Noun, const FString& EntryName, FString& OutError)
+	{
+		static const TCHAR* const KnownTypes[] = { TEXT("string"), TEXT("integer"), TEXT("number"), TEXT("boolean"), TEXT("object"), TEXT("array") };
+		TSet<FString> SeenParams;
+		for (const FUnrealMcpParamSpec& Param : Params)
+		{
+			if (Param.Name.IsEmpty())
+			{
+				OutError = FString::Printf(TEXT("%s '%s' has a parameter with an empty name (malformed schema)"), Noun, *EntryName);
+				return false;
+			}
+
+			bool bKnown = false;
+			for (const TCHAR* const Known : KnownTypes)
+			{
+				if (Param.JsonType == Known) { bKnown = true; break; }
+			}
+			if (!bKnown)
+			{
+				OutError = FString::Printf(TEXT("%s '%s' parameter '%s' has unknown JSON type '%s' (malformed schema)"),
+					Noun, *EntryName, *Param.Name, *Param.JsonType);
+				return false;
+			}
+
+			if ((Param.JsonType == TEXT("object") || Param.JsonType == TEXT("array")) && !Param.ObjectSchema.IsValid())
+			{
+				OutError = FString::Printf(TEXT("%s '%s' %s parameter '%s' has no schema (malformed schema)"),
+					Noun, *EntryName, *Param.JsonType, *Param.Name);
+				return false;
+			}
+
+			bool bAlreadyPresent = false;
+			SeenParams.Add(Param.Name, &bAlreadyPresent);
+			if (bAlreadyPresent)
+			{
+				OutError = FString::Printf(TEXT("%s '%s' declares duplicate parameter '%s' (malformed schema)"),
+					Noun, *EntryName, *Param.Name);
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpValidation.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpValidation.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+struct FUnrealMcpParamSpec;
+
+/**
+ * Shared §5 descriptor-validation helpers for the tool / prompt registries (docs/ARCHITECTURE.md §3.3, §5).
+ * The kebab-id rule and the param-spec well-formedness loop were verbatim copies in both registries; this single
+ * UNREALMCPRUNTIME_API surface owns one definition of each, with the entry-kind noun injected for the messages.
+ */
+namespace FUnrealMcpValidation
+{
+	/**
+	 * True iff @p Name is a valid kebab-case id: non-empty; lowercase letters / digits with single internal
+	 * hyphens (no leading, trailing, or doubled hyphen). The shared rule behind IsValidToolName / IsValidPromptName.
+	 */
+	UNREALMCPRUNTIME_API bool IsValidKebabName(const FString& Name);
+
+	/**
+	 * Validate a declared parameter list for the §5 isolation contract: every param has a non-empty name, a known
+	 * JSON type (string/integer/number/boolean/object/array), a schema present for object/array params, and no
+	 * duplicate names. Returns false + a reason (naming the offending @p EntryName, prefixed by @p Noun, e.g.
+	 * "tool" / "prompt") on the FIRST problem; true when the whole list is well-formed.
+	 */
+	UNREALMCPRUNTIME_API bool ValidateParamSpecs(
+		const TArray<FUnrealMcpParamSpec>& Params, const TCHAR* Noun, const FString& EntryName, FString& OutError);
+}

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpPromptProvider.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpPromptProvider.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Features/IModularFeature.h"
+#include "IUnrealMcpProviderBase.h"
 
 class FUnrealMcpPromptRegistry;
 
@@ -28,7 +28,7 @@ class FUnrealMcpPromptRegistry;
  * handler bound). Invalid entries are dropped and a duplicate prompt name across providers rejects the
  * later registration (first-wins by the ExtensionId sort). Other extensions are never affected.
  */
-class IUnrealMcpPromptProvider : public IModularFeature
+class IUnrealMcpPromptProvider : public IUnrealMcpProviderBase
 {
 public:
 	virtual ~IUnrealMcpPromptProvider() = default;
@@ -39,18 +39,7 @@ public:
 		return FName(TEXT("UnrealMcpPromptProvider"));
 	}
 
-	/**
-	 * Stable, unique extension identifier — reverse-DNS recommended (e.g. "com.foo.niagara-ai"). Used as
-	 * the deterministic sort key and as the manifest's per-prompt extensionId. Two providers with the same
-	 * id is an authoring error (the second's duplicate prompts are rejected).
-	 */
-	virtual FString GetExtensionId() const = 0;
-
-	/** Human-readable name shown in the extensions UI row (§7). */
-	virtual FText GetDisplayName() const = 0;
-
-	/** Free-form version string of the extension (independent of the Unreal-MCP plugin version). */
-	virtual FString GetExtensionVersion() const = 0;
+	// GetExtensionId / GetDisplayName / GetExtensionVersion are inherited from IUnrealMcpProviderBase.
 
 	/**
 	 * Declare the extension's prompts into @p Registry using the fluent FUnrealMcpPromptBuilder

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpProviderBase.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpProviderBase.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Features/IModularFeature.h"
+
+/**
+ * The common identity surface every Unreal-MCP extension provider exposes (docs/ARCHITECTURE.md §5 / §A.2).
+ *
+ * The tool / prompt / resource provider contracts each carried an identical id/name/version trio; this base
+ * factors it out so the three interfaces (IUnrealMcpToolProvider / IUnrealMcpPromptProvider /
+ * IUnrealMcpResourceProvider) declare only their KIND-specific surface — the `GetModularFeatureName()` the
+ * kind registers under and the `Register*` body — and inherit the identity trio from here. A provider that
+ * implements more than one kind (tools + prompts) implements this trio once.
+ *
+ * It is itself an IModularFeature so the manager's KIND-agnostic rebuild can treat any provider uniformly when
+ * it only needs the identity (sort key, manifest extensionId, UI row); the per-kind discovery still keys off the
+ * kind interface's own GetModularFeatureName().
+ */
+class IUnrealMcpProviderBase : public IModularFeature
+{
+public:
+	virtual ~IUnrealMcpProviderBase() = default;
+
+	/**
+	 * Stable, unique extension identifier — reverse-DNS recommended (e.g. "com.foo.niagara-ai"). Used as the
+	 * deterministic sort key and as the manifest's per-entry extensionId. Two providers with the same id is an
+	 * authoring error (the second's duplicate entries are rejected, first-wins by the ExtensionId sort).
+	 */
+	virtual FString GetExtensionId() const = 0;
+
+	/** Human-readable name shown in the extensions UI row (§7). */
+	virtual FText GetDisplayName() const = 0;
+
+	/** Free-form version string of the extension (independent of the Unreal-MCP plugin version). */
+	virtual FString GetExtensionVersion() const = 0;
+};

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpResourceProvider.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpResourceProvider.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Features/IModularFeature.h"
+#include "IUnrealMcpProviderBase.h"
 
 class FUnrealMcpResourceRegistry;
 
@@ -32,7 +32,7 @@ class FUnrealMcpResourceRegistry;
  * present). Invalid entries are dropped and a duplicate resource uri across providers rejects the later
  * registration (first-wins by the ExtensionId sort). Other extensions are never affected.
  */
-class IUnrealMcpResourceProvider : public IModularFeature
+class IUnrealMcpResourceProvider : public IUnrealMcpProviderBase
 {
 public:
 	virtual ~IUnrealMcpResourceProvider() = default;
@@ -43,18 +43,7 @@ public:
 		return FName(TEXT("UnrealMcpResourceProvider"));
 	}
 
-	/**
-	 * Stable, unique extension identifier — reverse-DNS recommended (e.g. "com.foo.niagara-ai"). Used as
-	 * the deterministic sort key and as the manifest's per-resource extensionId. Two providers with the
-	 * same id is an authoring error (the second's duplicate resources are rejected).
-	 */
-	virtual FString GetExtensionId() const = 0;
-
-	/** Human-readable name shown in the extensions UI row (§7). */
-	virtual FText GetDisplayName() const = 0;
-
-	/** Free-form version string of the extension (independent of the Unreal-MCP plugin version). */
-	virtual FString GetExtensionVersion() const = 0;
+	// GetExtensionId / GetDisplayName / GetExtensionVersion are inherited from IUnrealMcpProviderBase.
 
 	/**
 	 * Declare the extension's resources into @p Registry using the fluent FUnrealMcpResourceBuilder

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpToolProvider.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/IUnrealMcpToolProvider.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Features/IModularFeature.h"
+#include "IUnrealMcpProviderBase.h"
 
 class FUnrealMcpToolRegistry;
 
@@ -32,7 +32,7 @@ class FUnrealMcpToolRegistry;
  * (first-wins by the ExtensionId sort). Other extensions are never affected. Crash-level faults
  * inside a tool body are editor crashes regardless of family and are out of isolation scope.
  */
-class IUnrealMcpToolProvider : public IModularFeature
+class IUnrealMcpToolProvider : public IUnrealMcpProviderBase
 {
 public:
 	virtual ~IUnrealMcpToolProvider() = default;
@@ -43,18 +43,7 @@ public:
 		return FName(TEXT("UnrealMcpToolProvider"));
 	}
 
-	/**
-	 * Stable, unique extension identifier — reverse-DNS recommended (e.g. "com.foo.niagara-ai").
-	 * Used as the deterministic sort key and as the manifest's per-tool extensionId. Two providers
-	 * with the same id is an authoring error (the second's duplicate tools are rejected).
-	 */
-	virtual FString GetExtensionId() const = 0;
-
-	/** Human-readable name shown in the extensions UI row (§7). */
-	virtual FText GetDisplayName() const = 0;
-
-	/** Free-form version string of the extension (independent of the Unreal-MCP plugin version). */
-	virtual FString GetExtensionVersion() const = 0;
+	// GetExtensionId / GetDisplayName / GetExtensionVersion are inherited from IUnrealMcpProviderBase.
 
 	/**
 	 * Declare the extension's tools into @p Registry using the fluent FUnrealMcpToolBuilder

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpEnablementFilter.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpEnablementFilter.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * The shared §7/§8 enable-state predicate for the tool / prompt / resource registries
+ * (docs/ARCHITECTURE.md §2.2, §8). Each registry decides whether an entry is "served" from two retained sets:
+ *
+ *   - Whitelist (§8, the env `UNREAL_MCP_TOOLS` / `Config.EnabledTools` dimension): when EMPTY there is no filter
+ *     (the common case — every entry passes the whitelist gate); when non-empty only listed keys pass.
+ *   - Blocklist (§7, the persisted per-entry disable-map the MCP window writes): a listed key is always disabled.
+ *
+ * The combined effective-served rule is `(whitelist empty OR member) AND NOT blocklisted`. All three registries
+ * carried verbatim copies of these two TSet<FString> members plus the `PassesWhitelist` / `ShouldBeEnabled`
+ * predicates; this one small value type replaces the triplication. It is RETAINED on the registry so a later
+ * re-registration (extension hot-reload) and every blocklist re-apply re-evaluate against both sets — a blocklist
+ * re-apply can never clobber the whitelist, and vice versa.
+ *
+ * Pure data + inline predicates — the per-registry `RecomputeEnablement()` (which iterates that registry's own
+ * map and bumps its revision) stays in each registry and calls these after mutating the filter.
+ */
+struct UNREALMCPRUNTIME_API FUnrealMcpEnablementFilter
+{
+	/** §8 env whitelist; EMPTY means "no filter" (every key passes the whitelist gate). */
+	TSet<FString> Whitelist;
+	/** §7 persisted blocklist (the window's `disabled*` map); a member key is always disabled. */
+	TSet<FString> Blocklist;
+
+	/** The STATIC §8 whitelist dimension alone: passes iff the whitelist is empty OR contains @p Key. */
+	bool PassesWhitelist(const FString& Key) const
+	{
+		return Whitelist.IsEmpty() || Whitelist.Contains(Key);
+	}
+
+	/** The combined effective-served predicate: served iff (whitelist empty OR member) AND NOT blocklisted. */
+	bool ShouldBeEnabled(const FString& Key) const
+	{
+		return PassesWhitelist(Key) && !Blocklist.Contains(Key);
+	}
+
+	/** Replace the §8 whitelist from a list (RETAINED). The caller recomputes enablement afterward. */
+	void SetWhitelist(const TArray<FString>& InWhitelist)
+	{
+		Whitelist = TSet<FString>(InWhitelist);
+	}
+
+	/** Replace the §7 blocklist from a list (RETAINED). The caller recomputes enablement afterward. */
+	void SetBlocklist(const TArray<FString>& InBlocklist)
+	{
+		Blocklist = TSet<FString>(InBlocklist);
+	}
+};

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpPromptRegistry.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpPromptRegistry.h
@@ -214,9 +214,9 @@ private:
 	TMap<FString, FUnrealMcpRegisteredPrompt> Prompts;
 	int32 Revision = 0;
 
-	// --- Retained §7/§8 enablement filters (mirror the tool registry exactly). ---
-	TSet<FString> EnabledPromptsWhitelist; // §8 whitelist; empty = no filter
-	TSet<FString> DisabledPromptNames;     // §7 persisted blocklist
+	// --- Retained §7/§8 enablement filter (mirror the tool registry exactly).
+	//     Whitelist = §8 whitelist (empty = no filter); Blocklist = §7 persisted blocklist. ---
+	FUnrealMcpEnablementFilter Enablement;
 
 	/** The combined §8 effective-served predicate: enabled iff (whitelist empty OR member) AND NOT blocklisted. */
 	bool ShouldPromptBeEnabled(const FString& Name) const;

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpResourceRegistry.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpResourceRegistry.h
@@ -226,9 +226,9 @@ private:
 	TMap<FString, FUnrealMcpRegisteredResource> Resources;
 	int32 Revision = 0;
 
-	// --- Retained §7/§8 enablement filters (mirror the tool/prompt registries exactly). ---
-	TSet<FString> EnabledResourcesWhitelist; // §8 whitelist; empty = no filter
-	TSet<FString> DisabledResourceUris;      // §7 persisted blocklist
+	// --- Retained §7/§8 enablement filter (mirror the tool/prompt registries exactly).
+	//     Whitelist = §8 whitelist (empty = no filter); Blocklist = §7 persisted blocklist. ---
+	FUnrealMcpEnablementFilter Enablement;
 
 	/** The combined §8 effective-served predicate: enabled iff (whitelist empty OR member) AND NOT blocklisted. */
 	bool ShouldResourceBeEnabled(const FString& Uri) const;

--- a/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpToolRegistry.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Public/UnrealMcpToolRegistry.h
@@ -7,6 +7,7 @@
 #include "Dom/JsonObject.h"
 #include "HAL/ThreadSafeBool.h"
 #include "Templates/Function.h"
+#include "UnrealMcpEnablementFilter.h"
 
 /**
  * Core tool-registration types for the Unreal-MCP plugin (docs/ARCHITECTURE.md §2, §3.3).
@@ -292,10 +293,10 @@ private:
 	TMap<FString, FUnrealMcpRegisteredTool> Tools;
 	int32 Revision = 0;
 
-	// --- Retained §7/§8 enablement filters. Re-applied on every (re-)registration (Commit) so an extension
-	//     hot-reload cannot resurrect a disabled tool, and a blocklist re-apply never clobbers the whitelist. ---
-	TSet<FString> EnabledToolsWhitelist; // §8 UNREAL_MCP_TOOLS; empty = no filter (every tool passes the whitelist gate)
-	TSet<FString> DisabledToolNames;     // §7 persisted blocklist (the MCP Tools window's `disabledTools`)
+	// --- Retained §7/§8 enablement filter. Re-applied on every (re-)registration (Commit) so an extension
+	//     hot-reload cannot resurrect a disabled tool, and a blocklist re-apply never clobbers the whitelist.
+	//     Whitelist = §8 UNREAL_MCP_TOOLS (empty = no filter); Blocklist = §7 persisted `disabledTools`. ---
+	FUnrealMcpEnablementFilter Enablement;
 
 	/** The combined §8 effective-served predicate: enabled iff (whitelist empty OR member) AND NOT blocklisted. */
 	bool ShouldToolBeEnabled(const FString& Name) const;


### PR DESCRIPTION
## Summary
Behavior-preserving code-quality cleanup of the UE editor plugin (`UnrealMCP/` only — `bridge/` and `cli/` untouched), the STRUCTURAL wave (Tier 1-2) pre-vetted by a 4-agent audit. No behavior change; the registry-template collapse (F2) and scoped-read unify (F7) are a separate Tier-3 run.

Dead code removed (grep-confirmed zero callers): SUnrealMcpAlertPanel, TimelineRail, TemplateFoldoutFirst, 6 unused rich-content factories (F12).

Duplication collapsed into single UNREALMCPRUNTIME_API definitions:
- Shared descriptor-hash (F8), enablement filter (F3), schema/tool-args builders + condensed serializer (F1/F5), kebab-name + param-spec validators — across the 3 registries + editor tool families.
- Bridge teardown + framed-send + manifest-sender dedup (F6).
- Provider-kind rebuild template + shared `IUnrealMcpProviderBase` + folded feature-change handlers (F9).
- Shared `FUnrealMcpSupervisedProcess` watchdog + `FUnrealMcpProcessUtil` (ResolveDotNetRid / MakeExecutable) across the server + sidecar managers (F4/F11).
- Blueprint family converged on `FUnrealMcpObjectRef::ResolveClass` (F10, intentionally broadens resolution).
- Lower-value sweep: VerbosityToString, ParseEnvLine, ResolveActor single-sweep, BuildManifestJson sort reuse, OpenUrlClicked.

Atomic conventional commits grouped by theme (7).

## Test plan
- [x] Suite 1 — UBT editor build (exit 0)
- [x] Suite 1b — RunUAT BuildPlugin Game+Editor (BUILD SUCCESSFUL) — required: the plugin ships a `UnrealMcpRuntime` (Type Runtime) module; this caught + fixed a pre-existing lost transitive include (HAL/PlatformTime.h)
- [x] Suite 2 — headless boot smoke (`[Unreal-MCP] plugin loaded`, clean Engine init)
- [x] Suite 3 — Automation `UnrealMcp.` specs: failed=0, succeeded=314
- Pure-infra refactor → Suite 7 (live e2e) not applicable

Closes #166