### PR TITLE
feat(cli): install-extension — library function + CLI command (engine-agnostic)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -127,7 +127,9 @@ there plus a materializer branch, **without touching callers**.
 **Compile-on-install strategy (chosen + documented).** Extensions ship as **source** and are compiled
 by **UnrealBuildTool**. The default is **source-ship + compile-on-next-editor-open** (the install
 reports `rebuildRequired: true`); `--build` opts into an **eager** UBT compile against the resolved
-engine. Source-ship is chosen over shipping precompiled-per-UE-version binaries because UE plugin
+engine (**Windows-only** — it invokes `UnrealBuildTool.exe` for the `Win64` target; on macOS/Linux omit
+`--build` and let the editor recompile on next open). Source-ship is chosen over shipping
+precompiled-per-UE-version binaries because UE plugin
 binaries are version/config/platform-specific and ABI-unstable across engine minors — exactly why the
 core `install-plugin` also ships source and excludes the stale build cache.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -44,6 +44,7 @@ Requires Node `^20.19.0 || >=22.12.0`. See the
 | `close [path]` | Terminate the editor process running a project |
 | `install-plugin [path]` | Copy (or `--junction`) the UnrealMCP plugin into `<project>/Plugins` |
 | `remove-plugin [path]` | Remove the installed plugin |
+| `install-extension <id> [path]` | Install a third-party Unreal-MCP **extension** plugin into `<project>/Plugins/<name>`, enable it + its gating engine plugins (e.g. `Niagara`) in the `.uproject`, and (re)compile (on next editor open, or now with `--build`). `--source <dir>` installs from a local copy (offline/CI); `--version <x.y.z>` overrides the catalog pin. Idempotent. See [Extensions](#extensions) |
 | `configure` | Write `UNREAL_MCP_*` into `<project>/.env` and gitignore `.env` (§8) |
 | `setup-mcp <agent>` | Write an MCP client config snippet (claude-code, cursor, vscode). With `--transport stdio` it also downloads the pinned shared [`gamedev-mcp-server`](https://github.com/IvanMurzak/GameDev-MCP-Server) release into `<project>/Intermediate/UnrealMCP/server/<rid>/` (skipped when `UNREAL_MCP_SERVER_PATH` points at a local build) |
 | `login` | OAuth device-code auth against ai-game.dev |
@@ -84,6 +85,56 @@ import { configure, openProject, runTool, detectInstalledEngines } from 'unreal-
 `dist/lib.js` exposes the command logic as a side-effect-free library: no argv parsing, no stdout,
 no process exit. Every function returns a `{ kind: 'success' | 'failure' }` discriminated union and
 never throws past the boundary — the same contract as the Unity/Godot CLIs.
+
+## Extensions
+
+An **extension** is a third-party UE C++ Editor (or Runtime) plugin that implements
+`IUnrealMcpToolProvider` (see [`docs/EXTENSIONS.md`](../docs/EXTENSIONS.md)) and contributes MCP tools
+to the core Unreal-MCP plugin. `install-extension` is the install channel for them:
+
+```bash
+# From the extension's GitHub release (the default channel):
+unreal-mcp-cli install-extension com.acme.niagara ./MyGame --version 1.2.0
+
+# From a local copy (offline / CI / dev — mirrors godot-cli install-plugin --source):
+unreal-mcp-cli install-extension com.acme.niagara ./MyGame --source ../Unreal-AI-Niagara/MyNiagaraExt
+
+# Compile immediately instead of on next editor open:
+unreal-mcp-cli install-extension com.acme.niagara ./MyGame --source <dir> --build
+```
+
+It (1) resolves `<id>` against the **shared extension catalog**, (2) places the plugin into
+`<project>/Plugins/<pluginName>/`, (3) enables the extension **and its gating engine plugins** (e.g.
+`Niagara`, read from the extension's own `.uplugin` `Plugins[]` ∪ the catalog hint) in the `.uproject`,
+and (4) compiles it. It is **idempotent** — a re-run that finds the same version already installed and
+enabled writes nothing.
+
+**Catalog / manifest format.** The installable extensions are listed in a shared, **engine-agnostic**
+catalog (`src/utils/extensions-catalog.ts`, the typed mirror of the future
+`extensions.catalog.json` — `{ schemaVersion, extensions[] }`, the same shape as Godot's
+`addons/godot_mcp/extensions.catalog.json`). Each `ExtensionDescriptor` carries `extensionId`
+(reverse-DNS resolve key), `name`, `pluginName` (the `Plugins/<pluginName>` folder), `repo` (GitHub
+release source), `version`, **`minCoreVersion`** (the minimum core Unreal-MCP version — surfaced as a
+warning when unmet), `enginePlugins` (gating plugins), and `tools`. The catalog ships **empty** until
+the first extension is published; `--source <dir>` installs an unpublished extension regardless (the
+descriptor is then synthesized from the source `.uplugin`).
+
+**Pluggable install source (Fab-ready).** `resolveInstallSource` (`src/utils/extension-source.ts`) is
+the single decision point for *where* the files come from — `--source` (local) or the GitHub release
+(github.com-only, fail-closed). A future **Fab** (Epic marketplace) channel is added as one new `kind`
+there plus a materializer branch, **without touching callers**.
+
+**Compile-on-install strategy (chosen + documented).** Extensions ship as **source** and are compiled
+by **UnrealBuildTool**. The default is **source-ship + compile-on-next-editor-open** (the install
+reports `rebuildRequired: true`); `--build` opts into an **eager** UBT compile against the resolved
+engine. Source-ship is chosen over shipping precompiled-per-UE-version binaries because UE plugin
+binaries are version/config/platform-specific and ABI-unstable across engine minors — exactly why the
+core `install-plugin` also ships source and excludes the stale build cache.
+
+**Engine-agnostic API.** `installExtension(opts)` and its `ExtensionDescriptor` / `InstallExtensionResult`
+shapes are deliberately engine-neutral (no Unreal-only types in the signature) so `unity-mcp-cli` /
+`godot-cli` can adopt the identical surface — the Unreal-specific bits (plugin placement, `.uproject`
+enable, UBT) live behind it.
 
 ## Develop
 

--- a/cli/src/commands/install-extension.ts
+++ b/cli/src/commands/install-extension.ts
@@ -1,0 +1,47 @@
+import { Command } from 'commander';
+import * as path from 'path';
+import { installExtension } from '../lib/install-extension.js';
+import * as ui from '../utils/ui.js';
+
+export const installExtensionCommand = new Command('install-extension')
+  .description('Install an Unreal-MCP extension plugin into a project: place it under Plugins/, enable it + its gating engine plugins in the .uproject, then compile (on next editor open, or now with --build). Idempotent.')
+  .argument('<id>', 'Extension id to install (the catalog extensionId / name / pluginName)')
+  .argument('[path]', 'Unreal project directory (defaults to cwd)')
+  .option('--source <dir>', 'Install from a local plugin directory (offline / CI / dev) instead of downloading')
+  .option('--version <x.y.z>', 'Override the catalog-pinned version to install (also the GitHub release version)')
+  .option('--build', 'Compile the project via UnrealBuildTool now (default: recompile on next editor open)')
+  .option('--engine-root <dir>', 'Engine root for --build (default: resolved from the project EngineAssociation)')
+  .option('--force', 'Re-materialize + re-enable even when already up to date')
+  .action(
+    async (
+      id: string,
+      pathArg: string | undefined,
+      opts: { source?: string; version?: string; build?: boolean; engineRoot?: string; force?: boolean },
+    ) => {
+      const projectDir = path.resolve(pathArg ?? process.cwd());
+
+      const result = await installExtension({
+        projectDir,
+        extensionId: id,
+        source: opts.source,
+        version: opts.version,
+        build: opts.build,
+        engineRoot: opts.engineRoot,
+        force: opts.force,
+      });
+
+      ui.printWarnings(result.warnings);
+      if (result.kind === 'failure') {
+        ui.error(result.error.message);
+        process.exitCode = 1;
+        return;
+      }
+
+      ui.success(result.message);
+      ui.label('Installed at', result.installedPath);
+      ui.label('Enabled plugins', result.enabledPlugins.join(', '));
+      if (result.rebuildRequired) {
+        ui.label('Next step', 'Open the project (or re-run with --build) to compile the extension.');
+      }
+    },
+  );

--- a/cli/src/commands/install-extension.ts
+++ b/cli/src/commands/install-extension.ts
@@ -9,7 +9,7 @@ export const installExtensionCommand = new Command('install-extension')
   .argument('[path]', 'Unreal project directory (defaults to cwd)')
   .option('--source <dir>', 'Install from a local plugin directory (offline / CI / dev) instead of downloading')
   .option('--version <x.y.z>', 'Override the catalog-pinned version to install (also the GitHub release version)')
-  .option('--build', 'Compile the project via UnrealBuildTool now (default: recompile on next editor open)')
+  .option('--build', 'Compile the project via UnrealBuildTool now (Windows-only; default: recompile on next editor open)')
   .option('--engine-root <dir>', 'Engine root for --build (default: resolved from the project EngineAssociation)')
   .option('--force', 'Re-materialize + re-enable even when already up to date')
   .action(
@@ -39,7 +39,9 @@ export const installExtensionCommand = new Command('install-extension')
 
       ui.success(result.message);
       ui.label('Installed at', result.installedPath);
-      ui.label('Enabled plugins', result.enabledPlugins.join(', '));
+      if (result.enabledPlugins.length > 0) {
+        ui.label('Enabled plugins', result.enabledPlugins.join(', '));
+      }
       if (result.rebuildRequired) {
         ui.label('Next step', 'Open the project (or re-run with --build) to compile the extension.');
       }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,6 +6,7 @@ import { closeCommand } from './commands/close.js';
 import { configureCommand } from './commands/configure.js';
 import { createProjectCommand } from './commands/create-project.js';
 import { installEngineCommand } from './commands/install-engine.js';
+import { installExtensionCommand } from './commands/install-extension.js';
 import { installPluginCommand } from './commands/install-plugin.js';
 import { loginCommand } from './commands/login.js';
 import { openCommand } from './commands/open.js';
@@ -26,13 +27,14 @@ program
   .version(PACKAGE_VERSION)
   .option('-v, --verbose', 'Enable verbose diagnostic output');
 
-// The full 16-command surface (docs/ARCHITECTURE.md §9.1).
+// The full 17-command surface (docs/ARCHITECTURE.md §9.1).
 const subcommands = [
   createProjectCommand,
   openCommand,
   closeCommand,
   installPluginCommand,
   removePluginCommand,
+  installExtensionCommand,
   configureCommand,
   setupMcpCommand,
   loginCommand,

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -16,6 +16,28 @@ export { openProject, buildOpenEnv } from './lib/open.js';
 export { close, selectEditorProcesses } from './lib/close.js';
 export { createProject, renderProjectTemplate, validateModuleName } from './lib/create-project.js';
 export { installPlugin, removePlugin } from './lib/install-plugin.js';
+export { installExtension } from './lib/install-extension.js';
+export {
+  EXTENSIONS_CATALOG,
+  EXTENSION_CATALOG_SCHEMA_VERSION,
+  findExtension,
+  hasVersion,
+  unknownExtensionMessage,
+} from './utils/extensions-catalog.js';
+export {
+  resolveInstallSource,
+  extensionDownloadUrl,
+  extensionAssetName,
+  assertTrustedDownloadUrl,
+  releaseTag as extensionReleaseTag,
+  stripLeadingV as stripExtensionLeadingV,
+  TRUSTED_DOWNLOAD_HOST as EXTENSION_TRUSTED_DOWNLOAD_HOST,
+} from './utils/extension-source.js';
+export {
+  parseUPluginDependencies,
+  readUPluginVersionName,
+  enablePluginsInUProject,
+} from './utils/uproject-plugins.js';
 export { runTool, runSystemTool } from './lib/run-tool.js';
 export { setupMcp, listAgentIds, buildServerEntry } from './lib/setup-mcp.js';
 export {
@@ -127,6 +149,13 @@ export type {
   RemovePluginResult,
   RemovePluginSuccess,
   RemovePluginFailure,
+  InstallExtensionOptions,
+  InstallExtensionResult,
+  InstallExtensionSuccess,
+  InstallExtensionFailure,
+  ExtensionInstallOutcome,
+  ExtensionBuildStep,
+  InstallSourceKind,
   RunToolOptions,
   RunToolResult,
   RunToolSuccess,
@@ -187,3 +216,6 @@ export type {
 } from './lib/clean-plugin.js';
 export type { SetupSkillsOptions, SetupSkillsResult } from './lib/setup-skills.js';
 export type { CloseOptions, CloseResult, RunningProcess } from './lib/close.js';
+export type { ExtensionDescriptor, ExtensionTool } from './utils/extensions-catalog.js';
+export type { InstallSource } from './utils/extension-source.js';
+export type { EnablePluginsResult } from './utils/uproject-plugins.js';

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -24,20 +24,6 @@ export {
   hasVersion,
   unknownExtensionMessage,
 } from './utils/extensions-catalog.js';
-export {
-  resolveInstallSource,
-  extensionDownloadUrl,
-  extensionAssetName,
-  assertTrustedDownloadUrl,
-  releaseTag as extensionReleaseTag,
-  stripLeadingV as stripExtensionLeadingV,
-  TRUSTED_DOWNLOAD_HOST as EXTENSION_TRUSTED_DOWNLOAD_HOST,
-} from './utils/extension-source.js';
-export {
-  parseUPluginDependencies,
-  readUPluginVersionName,
-  enablePluginsInUProject,
-} from './utils/uproject-plugins.js';
 export { runTool, runSystemTool } from './lib/run-tool.js';
 export { setupMcp, listAgentIds, buildServerEntry } from './lib/setup-mcp.js';
 export {
@@ -218,4 +204,3 @@ export type { SetupSkillsOptions, SetupSkillsResult } from './lib/setup-skills.j
 export type { CloseOptions, CloseResult, RunningProcess } from './lib/close.js';
 export type { ExtensionDescriptor, ExtensionTool } from './utils/extensions-catalog.js';
 export type { InstallSource } from './utils/extension-source.js';
-export type { EnablePluginsResult } from './utils/uproject-plugins.js';

--- a/cli/src/lib/install-extension.ts
+++ b/cli/src/lib/install-extension.ts
@@ -40,7 +40,7 @@ import {
   unknownExtensionMessage,
   type ExtensionDescriptor,
 } from '../utils/extensions-catalog.js';
-import { resolveInstallSource, type InstallSource } from '../utils/extension-source.js';
+import { resolveInstallSource, stripLeadingV, type InstallSource } from '../utils/extension-source.js';
 import {
   parseUPluginDependencies,
   readUPluginVersionName,
@@ -129,7 +129,9 @@ export async function installExtension(
     const materializeNeeded =
       opts.force === true ||
       !installedPresent ||
-      (toVersion !== null && fromVersion !== toVersion);
+      // Normalize a possible leading `v` on either side so `v1.0.0` (a .uplugin
+      // VersionName) and `1.0.0` (a catalog/--version pin) are not seen as a diff.
+      (toVersion !== null && stripLeadingV(fromVersion ?? '') !== stripLeadingV(toVersion));
 
     if (materializeNeeded) {
       emitProgress(opts.onProgress, {
@@ -440,6 +442,9 @@ async function runUbtBuild(
     );
     return false;
   }
+  // Eager `--build` is Windows-only: the host binary (`UnrealBuildTool.exe`) and
+  // the `Win64` target platform below are hardcoded. On macOS/Linux, omit `--build`
+  // and let the editor recompile the extension on next open (the default path).
   const ubtPath = path.join(
     engineRoot,
     'Engine',
@@ -476,14 +481,26 @@ function resolveEngineRoot(engineAssociation: string, opts: InstallExtensionOpti
   return r.kind === 'resolved' ? r.engineRoot : null;
 }
 
-/** Default UBT runner: spawn UnrealBuildTool, resolve on exit 0, reject otherwise. */
+/**
+ * Default UBT runner: spawn UnrealBuildTool, resolve on exit 0, reject otherwise.
+ * stdout stays silenced (the library is stdout-quiet), but stderr is captured so a
+ * non-zero exit surfaces the actual compile error — the last ~2KB — through the
+ * rejection (and thus the structured `UBT build failed: ...` warning) instead of a
+ * bare exit code. The buffer is bounded to its tail so a chatty build can't grow it.
+ */
 function defaultBuildImpl(step: ExtensionBuildStep): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    const child = spawn(step.ubtPath, step.args, { stdio: 'ignore' });
+    const child = spawn(step.ubtPath, step.args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString();
+      if (stderr.length > 4096) stderr = stderr.slice(-4096);
+    });
     child.on('error', reject);
     child.on('close', (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`UnrealBuildTool exited with code ${code}`));
+      if (code === 0) return resolve();
+      const tail = stderr.trim().slice(-2048);
+      reject(new Error(`UnrealBuildTool exited with code ${code}${tail ? `:\n${tail}` : ''}`));
     });
   });
 }

--- a/cli/src/lib/install-extension.ts
+++ b/cli/src/lib/install-extension.ts
@@ -49,6 +49,7 @@ import {
 import { emitProgress } from './progress.js';
 import type {
   ExtensionBuildStep,
+  ExtensionInstallOutcome,
   InstallExtensionOptions,
   InstallExtensionResult,
 } from './types.js';
@@ -179,7 +180,16 @@ export async function installExtension(
     }
     const rebuildRequired = changed && !built;
 
-    const outcome = !changed ? 'already-up-to-date' : fromVersion === null ? 'added' : 'updated';
+    // !materializeNeeded with changed === true means the files were already at
+    // the target version and only the .uproject enable entry was (re)written —
+    // an "enabled" outcome, distinct from a real version "updated".
+    const outcome: ExtensionInstallOutcome = !changed
+      ? 'already-up-to-date'
+      : !materializeNeeded
+        ? 'enabled'
+        : fromVersion === null
+          ? 'added'
+          : 'updated';
     const message = buildMessage(outcome, pluginName, fromVersion, toVersion, built, rebuildRequired, gatingPlugins);
 
     emitProgress(opts.onProgress, { phase: 'done', message });
@@ -196,7 +206,7 @@ export async function installExtension(
       sourceKind: source.kind,
       fromVersion,
       toVersion,
-      enabledPlugins: enable.enabledPlugins,
+      enabledPlugins: enable.addedOrFlipped,
       uprojectPath: uproject.uprojectPath,
       built,
       message,
@@ -286,7 +296,9 @@ async function materialize(
     message: `Downloading extension ${pluginName} ${source.version} from ${source.url}`,
   });
   const fetchImpl = opts.fetchImpl ?? fetch;
-  const response = await fetchImpl(source.url);
+  const response = await fetchImpl(source.url, {
+    signal: AbortSignal.timeout(opts.downloadTimeoutMs ?? 60_000),
+  });
   if (!response.ok) {
     throw new Error(
       `Failed to download extension ${pluginName} ${source.version}: HTTP ${response.status} ${response.statusText} ` +
@@ -545,7 +557,7 @@ function compareSemver(a: string, b: string): number {
 
 /** A short, printable status line for the result. */
 function buildMessage(
-  outcome: 'added' | 'updated' | 'already-up-to-date',
+  outcome: ExtensionInstallOutcome,
   pluginName: string,
   fromVersion: string | null,
   toVersion: string | null,
@@ -564,6 +576,8 @@ function buildMessage(
       return `Installed extension ${pluginName}${toVersion ? ` ${toVersion}` : ''} and enabled it${gating}.${compile}`;
     case 'updated':
       return `Updated extension ${pluginName}${fromVersion ? ` ${fromVersion}` : ''} → ${toVersion ?? '(unpinned)'}${gating}.${compile}`;
+    case 'enabled':
+      return `Enabled existing extension ${pluginName}${fromVersion ? ` ${fromVersion}` : ''} in the project${gating}.${compile}`;
     case 'already-up-to-date':
       return `Extension ${pluginName}${toVersion ? ` ${toVersion}` : ''} is already installed and enabled.`;
   }

--- a/cli/src/lib/install-extension.ts
+++ b/cli/src/lib/install-extension.ts
@@ -317,7 +317,7 @@ async function materialize(
 function resolveLocalPluginRoot(source: string): string {
   const resolved = path.resolve(source);
   if (!fs.existsSync(resolved)) throw new Error(`--source directory does not exist: ${resolved}`);
-  const direct = fs.existsSync(resolved) && hasUPluginDirectlyIn(resolved);
+  const direct = hasUPluginDirectlyIn(resolved);
   if (direct) return resolved;
   const found = findUPluginFile(resolved);
   if (found) return path.dirname(found);
@@ -485,6 +485,7 @@ function findUPluginFile(dir: string): string | null {
   let best: string | null = null;
   let bestDepth = Number.MAX_SAFE_INTEGER;
   const walk = (d: string, depth: number): void => {
+    if (depth >= bestDepth) return;
     let entries: fs.Dirent[];
     try {
       entries = fs.readdirSync(d, { withFileTypes: true });

--- a/cli/src/lib/install-extension.ts
+++ b/cli/src/lib/install-extension.ts
@@ -1,0 +1,569 @@
+// `install-extension` — install an Unreal-MCP extension (a UE C++ Editor/Runtime
+// plugin implementing `IUnrealMcpToolProvider`) into a user's Unreal project.
+// Library-safe (the exported `installExtension`, parity with `installPlugin`):
+// no stdout noise, no `process.exit`, no throws past the public boundary — every
+// result is a `{ kind: 'success' | 'failure' }` discriminated union.
+//
+// The flow, mirroring godot-cli's `installExtension` shape but with UE placement:
+//
+//   1. RESOLVE the `<id>` to a descriptor in the shared catalog
+//      (`extensions-catalog.ts`); or, when the id is unknown but `--source <dir>`
+//      is given, SYNTHESIZE a descriptor from that dir's `.uplugin`.
+//   2. RESOLVE the install source via the pluggable resolver
+//      (`extension-source.ts`): `--source <dir>` (local/CI/offline) or the
+//      extension's GitHub-release zip (github.com-only, fail-closed). A future
+//      Fab channel slots in there without touching this file's callers.
+//   3. PLACE the plugin into `<project>/Plugins/<pluginName>/` (stage-then-swap,
+//      zip-slip-guarded, build-cache filtered) — idempotent.
+//   4. ENABLE the extension AND its gating engine plugins (e.g. Niagara, read
+//      from the extension's own `.uplugin` `Plugins[]` ∪ the catalog hint) in the
+//      `.uproject` `Plugins[]` array.
+//   5. COMPILE: the extension ships as SOURCE; by default UE recompiles it on the
+//      next editor open (`rebuildRequired: true`). `--build` opts into an eager
+//      UBT compile against the resolved engine.
+//
+// Idempotent: a re-run that finds the plugin present at the same version and the
+// `.uproject` already enabled reports `already-up-to-date` and writes nothing.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawn } from 'child_process';
+import { unzipSync } from 'fflate';
+import { asError } from '../utils/error.js';
+import { readUProject } from '../utils/project.js';
+import { discoverEngine } from './engine.js';
+import {
+  EXTENSIONS_CATALOG,
+  findExtension,
+  hasVersion,
+  unknownExtensionMessage,
+  type ExtensionDescriptor,
+} from '../utils/extensions-catalog.js';
+import { resolveInstallSource, type InstallSource } from '../utils/extension-source.js';
+import {
+  parseUPluginDependencies,
+  readUPluginVersionName,
+  enablePluginsInUProject,
+} from '../utils/uproject-plugins.js';
+import { emitProgress } from './progress.js';
+import type {
+  ExtensionBuildStep,
+  InstallExtensionOptions,
+  InstallExtensionResult,
+} from './types.js';
+
+/** Plugin-source subtrees never copied into the target project (stale build cache / VCS noise). */
+const EXCLUDED_DIRS = new Set([
+  'Intermediate',
+  'Binaries',
+  'Saved',
+  'DerivedDataCache',
+  '.git',
+  '.vs',
+  'node_modules',
+]);
+
+export async function installExtension(
+  opts: InstallExtensionOptions,
+): Promise<InstallExtensionResult> {
+  const warnings: string[] = [];
+  try {
+    if (!opts?.projectDir) throw new Error('projectDir is required.');
+    if (!opts?.extensionId || opts.extensionId.trim() === '') throw new Error('extensionId is required.');
+
+    const projectDir = path.resolve(opts.projectDir);
+    if (!fs.existsSync(projectDir)) throw new Error(`Project directory does not exist: ${projectDir}`);
+
+    // An extension install MUST target a real UE project — we enable plugins in
+    // its `.uproject`. (install-plugin only WARNS, but it has no .uproject edit.)
+    const uproject = readUProject(projectDir);
+    if (uproject === null) {
+      throw new Error(
+        `No .uproject found in ${projectDir} — run install-extension inside an Unreal project directory.`,
+      );
+    }
+
+    // 1. Resolve the descriptor (catalog, or synthesized from --source).
+    const catalog = opts.catalog ?? EXTENSIONS_CATALOG;
+    const sourceArg = (opts.source ?? '').trim();
+    const versionOverride = (opts.version ?? '').trim();
+
+    let descriptor: ExtensionDescriptor;
+    const fromCatalog = findExtension(opts.extensionId, catalog);
+    if (fromCatalog) {
+      descriptor = applyVersionOverride(fromCatalog, versionOverride, warnings);
+    } else if (sourceArg !== '') {
+      descriptor = synthesizeDescriptorFromSource(opts.extensionId, sourceArg, versionOverride, warnings);
+    } else {
+      return {
+        kind: 'failure',
+        success: false,
+        warnings,
+        error: new Error(unknownExtensionMessage(opts.extensionId, catalog)),
+      };
+    }
+
+    const pluginName = descriptor.pluginName;
+    const installedPath = path.join(projectDir, 'Plugins', pluginName);
+    const toVersion = hasVersion(descriptor) ? (descriptor.version as string) : null;
+
+    // What is already on disk? (drives idempotency + add-vs-update.)
+    const installedUplugin = findUPluginFile(installedPath);
+    const fromVersion = installedUplugin
+      ? readUPluginVersionName(safeReadJson(installedUplugin))
+      : null;
+    const installedPresent = installedUplugin !== null;
+
+    // 2. Resolve the install source (the pluggable channel seam).
+    const source = resolveInstallSource({
+      source: sourceArg,
+      repo: descriptor.repo,
+      pluginName,
+      version: toVersion,
+    });
+
+    // 3. Materialize the plugin files — only when needed (force, not present, or a
+    //    version mismatch when a target version is known).
+    const materializeNeeded =
+      opts.force === true ||
+      !installedPresent ||
+      (toVersion !== null && fromVersion !== toVersion);
+
+    if (materializeNeeded) {
+      emitProgress(opts.onProgress, {
+        phase: 'start',
+        message: `Installing extension ${pluginName}${toVersion ? ` ${toVersion}` : ''} into ${installedPath}`,
+      });
+      await materialize(source, pluginName, installedPath, opts, warnings);
+      // The folder name MUST match the descriptor basename or UE will not load it.
+      const placed = findUPluginFile(installedPath);
+      if (placed === null) {
+        throw new Error(`No .uplugin found after materializing ${pluginName} into ${installedPath}.`);
+      }
+      const placedName = path.basename(placed, '.uplugin');
+      if (placedName.toLowerCase() !== pluginName.toLowerCase()) {
+        throw new Error(
+          `Materialized descriptor "${placedName}.uplugin" does not match the expected plugin name "${pluginName}". ` +
+            'Unreal requires the plugin folder and its .uplugin to share a name.',
+        );
+      }
+    }
+
+    // 4. Enable the extension + its gating engine plugins in the .uproject.
+    const effectiveUplugin = findUPluginFile(installedPath);
+    const declaredDeps = effectiveUplugin ? parseUPluginDependencies(safeReadJson(effectiveUplugin)) : [];
+    const gatingPlugins = unique([...declaredDeps, ...descriptor.enginePlugins]);
+    const toEnable = [pluginName, ...gatingPlugins];
+
+    const beforeText = fs.readFileSync(uproject.uprojectPath, 'utf-8');
+    const enable = enablePluginsInUProject(beforeText, toEnable);
+    if (enable.changed) {
+      fs.writeFileSync(uproject.uprojectPath, enable.text);
+      emitProgress(opts.onProgress, {
+        phase: 'file-written',
+        message: `Enabled ${toEnable.join(', ')} in ${uproject.uprojectPath}`,
+        filePath: uproject.uprojectPath,
+      });
+    }
+
+    const changed = materializeNeeded || enable.changed;
+
+    // minCoreVersion advisory (warn-only — never block an install on it).
+    warnOnCoreVersionFloor(projectDir, descriptor, warnings);
+
+    // 5. Compile. Default: rely on UE's compile-on-next-open. `--build` runs UBT now.
+    let built = false;
+    if (opts.build === true) {
+      built = await runUbtBuild(uproject.uprojectPath, uproject.projectName, uproject.engineAssociation, opts, warnings);
+    }
+    const rebuildRequired = changed && !built;
+
+    const outcome = !changed ? 'already-up-to-date' : fromVersion === null ? 'added' : 'updated';
+    const message = buildMessage(outcome, pluginName, fromVersion, toVersion, built, rebuildRequired, gatingPlugins);
+
+    emitProgress(opts.onProgress, { phase: 'done', message });
+
+    return {
+      kind: 'success',
+      success: true,
+      outcome,
+      changed,
+      rebuildRequired,
+      extensionId: opts.extensionId,
+      pluginName,
+      installedPath,
+      sourceKind: source.kind,
+      fromVersion,
+      toVersion,
+      enabledPlugins: enable.enabledPlugins,
+      uprojectPath: uproject.uprojectPath,
+      built,
+      message,
+      warnings,
+    };
+  } catch (err: unknown) {
+    return { kind: 'failure', success: false, warnings, error: asError(err) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Descriptor resolution
+// ---------------------------------------------------------------------------
+
+/** Apply the `--version` override to a catalog descriptor (empty override is ignored). */
+function applyVersionOverride(
+  descriptor: ExtensionDescriptor,
+  version: string,
+  warnings: string[],
+): ExtensionDescriptor {
+  if (version === '') return descriptor;
+  if (descriptor.version !== null && descriptor.version !== version) {
+    warnings.push(
+      `--version ${version} overrides the catalog pin ${descriptor.pluginName}@${descriptor.version} for this install.`,
+    );
+  }
+  return { ...descriptor, version };
+}
+
+/**
+ * Build a descriptor for an extension NOT in the catalog, from a local `--source`
+ * dir's `.uplugin`. This is the unpublished / dev / CI install path: the plugin
+ * name and gating deps come straight from the descriptor file on disk.
+ */
+function synthesizeDescriptorFromSource(
+  extensionId: string,
+  sourceArg: string,
+  versionOverride: string,
+  warnings: string[],
+): ExtensionDescriptor {
+  const pluginRoot = resolveLocalPluginRoot(sourceArg);
+  const upluginFile = findUPluginFile(pluginRoot);
+  if (upluginFile === null) {
+    throw new Error(`--source ${sourceArg} does not contain a .uplugin (resolved to ${pluginRoot}).`);
+  }
+  const json = safeReadJson(upluginFile);
+  const pluginName = path.basename(upluginFile, '.uplugin');
+  const sourceVersion = versionOverride !== '' ? versionOverride : readUPluginVersionName(json);
+  const enginePlugins = parseUPluginDependencies(json);
+  warnings.push(
+    `Extension "${extensionId}" is not in the catalog — installing from --source as plugin "${pluginName}".`,
+  );
+  return {
+    extensionId,
+    name: pluginName,
+    description: `Local extension installed from ${sourceArg}.`,
+    pluginName,
+    repo: null,
+    version: sourceVersion,
+    minCoreVersion: null,
+    enginePlugins,
+    tools: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Materialization (local copy / GitHub-release download)
+// ---------------------------------------------------------------------------
+
+async function materialize(
+  source: InstallSource,
+  pluginName: string,
+  installedPath: string,
+  opts: InstallExtensionOptions,
+  warnings: string[],
+): Promise<void> {
+  if (source.kind === 'local') {
+    const pluginRoot = resolveLocalPluginRoot(source.dir);
+    emitProgress(opts.onProgress, { phase: 'info', message: `Copying extension from ${pluginRoot}` });
+    placePlugin(pluginRoot, installedPath);
+    return;
+  }
+
+  // github-release
+  emitProgress(opts.onProgress, {
+    phase: 'info',
+    message: `Downloading extension ${pluginName} ${source.version} from ${source.url}`,
+  });
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const response = await fetchImpl(source.url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download extension ${pluginName} ${source.version}: HTTP ${response.status} ${response.statusText} ` +
+        `from ${source.url}. Verify the release exists, or use --source <dir> for an offline/dev install.`,
+    );
+  }
+  const zipBytes = new Uint8Array(await response.arrayBuffer());
+  const staging = fs.mkdtempSync(path.join(os.tmpdir(), `unreal-mcp-ext-extract-`));
+  try {
+    extractZip(zipBytes, staging, warnings);
+    const upluginFile = findUPluginFile(staging);
+    if (upluginFile === null) {
+      throw new Error(
+        `Downloaded zip did not contain a .uplugin — ${source.url} is not a valid extension plugin release.`,
+      );
+    }
+    placePlugin(path.dirname(upluginFile), installedPath);
+  } finally {
+    fs.rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Resolve a `--source` argument to the plugin root: a dir that directly contains
+ * a `.uplugin`, else the parent of the shallowest `.uplugin` beneath it. Throws
+ * when neither exists.
+ */
+function resolveLocalPluginRoot(source: string): string {
+  const resolved = path.resolve(source);
+  if (!fs.existsSync(resolved)) throw new Error(`--source directory does not exist: ${resolved}`);
+  const direct = fs.existsSync(resolved) && hasUPluginDirectlyIn(resolved);
+  if (direct) return resolved;
+  const found = findUPluginFile(resolved);
+  if (found) return path.dirname(found);
+  throw new Error(`--source ${resolved} does not contain a .uplugin.`);
+}
+
+/** True when `dir` directly holds a `*.uplugin` (no descent). */
+function hasUPluginDirectlyIn(dir: string): boolean {
+  try {
+    return fs.readdirSync(dir).some((n) => n.toLowerCase().endsWith('.uplugin'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Copy a plugin source root into `<project>/Plugins/<pluginName>/` via a
+ * stage-then-swap (a sibling staging dir, swapped in only after a fully
+ * successful filtered copy) so a mid-copy failure leaves any existing install
+ * untouched. Build-cache / VCS subtrees are excluded (`EXCLUDED_DIRS`).
+ */
+function placePlugin(sourcePluginRoot: string, installedPath: string): void {
+  const installReal = path.resolve(installedPath);
+  const pluginsDir = path.dirname(installReal);
+  fs.mkdirSync(pluginsDir, { recursive: true });
+  const staging = path.join(pluginsDir, `.unreal-mcp-ext-staging-${process.pid}-${Date.now()}`);
+  fs.rmSync(staging, { recursive: true, force: true });
+  try {
+    fs.cpSync(sourcePluginRoot, staging, {
+      recursive: true,
+      filter: (src) => copyFilter(src, sourcePluginRoot),
+    });
+    if (findUPluginFile(staging) === null) {
+      throw new Error(`Copy from ${sourcePluginRoot} produced no .uplugin.`);
+    }
+    fs.rmSync(installReal, { recursive: true, force: true });
+    fs.renameSync(staging, installReal);
+  } finally {
+    fs.rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+/** Keep everything except the excluded build-cache / VCS subtrees. */
+function copyFilter(srcAbs: string, root: string): boolean {
+  const rel = path.relative(root, srcAbs);
+  if (rel === '' || rel === '.') return true;
+  const top = rel.split(path.sep)[0];
+  return !EXCLUDED_DIRS.has(top);
+}
+
+/** Extract a zip into `destDir` (fflate), guarding against zip-slip traversal. */
+function extractZip(zipBytes: Uint8Array, destDir: string, warnings: string[]): void {
+  const entries = unzipSync(zipBytes);
+  const destReal = path.resolve(destDir);
+  for (const [entryName, data] of Object.entries(entries)) {
+    if (entryName.endsWith('/')) continue; // directory entry
+    const target = path.resolve(destReal, entryName);
+    if (target !== destReal && !target.startsWith(destReal + path.sep)) {
+      warnings.push(`Skipped suspicious zip entry escaping the extract dir: ${entryName}`);
+      continue;
+    }
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, data);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// minCoreVersion + UBT build
+// ---------------------------------------------------------------------------
+
+/** Warn (never fail) when the installed core Unreal-MCP plugin is below `minCoreVersion`. */
+function warnOnCoreVersionFloor(
+  projectDir: string,
+  descriptor: ExtensionDescriptor,
+  warnings: string[],
+): void {
+  const min = (descriptor.minCoreVersion ?? '').trim();
+  if (min === '') return;
+  const coreUplugin = path.join(projectDir, 'Plugins', 'UnrealMCP', 'UnrealMCP.uplugin');
+  if (!fs.existsSync(coreUplugin)) {
+    warnings.push(
+      `Extension requires core Unreal-MCP >= ${min}, but no UnrealMCP plugin was found at ${coreUplugin}. ` +
+        'Install the core plugin (unreal-mcp-cli install-plugin) first.',
+    );
+    return;
+  }
+  const coreVersion = readUPluginVersionName(safeReadJson(coreUplugin));
+  if (coreVersion && compareSemver(coreVersion, min) < 0) {
+    warnings.push(
+      `Extension requires core Unreal-MCP >= ${min}, but the installed core plugin is ${coreVersion}. Update it.`,
+    );
+  }
+}
+
+/** Run UBT to compile the project's editor target. Returns true on success; warns + returns false otherwise. */
+async function runUbtBuild(
+  uprojectPath: string,
+  projectName: string,
+  engineAssociation: string,
+  opts: InstallExtensionOptions,
+  warnings: string[],
+): Promise<boolean> {
+  const engineRoot = (opts.engineRoot ?? '').trim() || resolveEngineRoot(engineAssociation, opts);
+  if (!engineRoot) {
+    warnings.push(
+      `--build requested but no engine root could be resolved for "${engineAssociation}". ` +
+        'Skipping compile — the editor will recompile the extension on next open. Pass --engine-root <dir> to build now.',
+    );
+    return false;
+  }
+  const ubtPath = path.join(
+    engineRoot,
+    'Engine',
+    'Binaries',
+    'DotNET',
+    'UnrealBuildTool',
+    'UnrealBuildTool.exe',
+  );
+  const editorTarget = `${projectName}Editor`;
+  const step: ExtensionBuildStep = {
+    ubtPath,
+    editorTarget,
+    uprojectPath,
+    args: [editorTarget, 'Win64', 'Development', `-project=${uprojectPath}`, '-WaitMutex'],
+  };
+  emitProgress(opts.onProgress, { phase: 'start', message: `Compiling ${editorTarget} via UBT` });
+  const buildImpl = opts.buildImpl ?? defaultBuildImpl;
+  try {
+    await buildImpl(step);
+    emitProgress(opts.onProgress, { phase: 'done', message: 'UBT build succeeded.' });
+    return true;
+  } catch (err: unknown) {
+    warnings.push(
+      `UBT build failed: ${asError(err).message}. The editor will recompile the extension on next open.`,
+    );
+    return false;
+  }
+}
+
+/** Resolve an engine root from the project's EngineAssociation via the discovery chain. */
+function resolveEngineRoot(engineAssociation: string, opts: InstallExtensionOptions): string | null {
+  if (opts.resolveEngineRootImpl) return opts.resolveEngineRootImpl(engineAssociation);
+  const r = discoverEngine({ engineAssociation, noCache: true });
+  return r.kind === 'resolved' ? r.engineRoot : null;
+}
+
+/** Default UBT runner: spawn UnrealBuildTool, resolve on exit 0, reject otherwise. */
+function defaultBuildImpl(step: ExtensionBuildStep): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(step.ubtPath, step.args, { stdio: 'ignore' });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`UnrealBuildTool exited with code ${code}`));
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Small pure helpers
+// ---------------------------------------------------------------------------
+
+/** Shallowest `*.uplugin` under `dir` (the plugin descriptor), or `null`. */
+function findUPluginFile(dir: string): string | null {
+  let best: string | null = null;
+  let bestDepth = Number.MAX_SAFE_INTEGER;
+  const walk = (d: string, depth: number): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) {
+        if (!EXCLUDED_DIRS.has(entry.name)) walk(full, depth + 1);
+      } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.uplugin') && depth < bestDepth) {
+        best = full;
+        bestDepth = depth;
+      }
+    }
+  };
+  walk(dir, 0);
+  return best;
+}
+
+/** Read + JSON.parse a file; throws a clear error on malformed JSON. */
+function safeReadJson(file: string): unknown {
+  const text = fs.readFileSync(file, 'utf-8');
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`Malformed JSON in ${file}.`);
+  }
+}
+
+/** De-dupe strings case-insensitively, preserving first-seen order. */
+function unique(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    const key = v.toLowerCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(v);
+    }
+  }
+  return out;
+}
+
+/** Numeric dotted-version compare (`1.2.0` vs `1.10.0`). Returns -1 / 0 / 1. Non-numeric parts compare as 0. */
+function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map((x) => parseInt(x, 10) || 0);
+  const pb = b.split('.').map((x) => parseInt(x, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const da = pa[i] ?? 0;
+    const db = pb[i] ?? 0;
+    if (da !== db) return da < db ? -1 : 1;
+  }
+  return 0;
+}
+
+/** A short, printable status line for the result. */
+function buildMessage(
+  outcome: 'added' | 'updated' | 'already-up-to-date',
+  pluginName: string,
+  fromVersion: string | null,
+  toVersion: string | null,
+  built: boolean,
+  rebuildRequired: boolean,
+  gatingPlugins: string[],
+): string {
+  const gating = gatingPlugins.length > 0 ? ` (also enabled: ${gatingPlugins.join(', ')})` : '';
+  const compile = built
+    ? ' Compiled via UBT.'
+    : rebuildRequired
+      ? ' Rebuild required — open the project (or pass --build) to compile.'
+      : '';
+  switch (outcome) {
+    case 'added':
+      return `Installed extension ${pluginName}${toVersion ? ` ${toVersion}` : ''} and enabled it${gating}.${compile}`;
+    case 'updated':
+      return `Updated extension ${pluginName}${fromVersion ? ` ${fromVersion}` : ''} → ${toVersion ?? '(unpinned)'}${gating}.${compile}`;
+    case 'already-up-to-date':
+      return `Extension ${pluginName}${toVersion ? ` ${toVersion}` : ''} is already installed and enabled.`;
+  }
+}

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -13,6 +13,9 @@
 //
 // No top-level side effects; no runtime deps beyond TypeScript types.
 
+import type { ExtensionDescriptor } from '../utils/extensions-catalog.js';
+import type { InstallSourceKind } from '../utils/extension-source.js';
+
 export type ResultKind = 'success' | 'failure';
 
 // ---------------------------------------------------------------------------
@@ -624,3 +627,115 @@ export interface BootstrapLocalFailure {
 }
 
 export type BootstrapLocalResult = BootstrapLocalSuccess | BootstrapLocalFailure;
+
+// ---------------------------------------------------------------------------
+// install-extension
+// ---------------------------------------------------------------------------
+
+/** How an `install-extension` run ended (a `kind: 'success'` classification). */
+export type ExtensionInstallOutcome = 'added' | 'updated' | 'already-up-to-date';
+
+/** Re-export of the install-source channel discriminant for the public result. */
+export type { InstallSourceKind };
+
+/**
+ * A single UBT compile invocation `install-extension --build` runs. Exposed so a
+ * test can inject `buildImpl` and assert the build was requested without a real
+ * UnrealBuildTool / engine on the machine.
+ */
+export interface ExtensionBuildStep {
+  /** Absolute path to `UnrealBuildTool.exe`. */
+  ubtPath: string;
+  /** Editor target name, e.g. `MyProjectEditor`. */
+  editorTarget: string;
+  /** Absolute path to the `.uproject`. */
+  uprojectPath: string;
+  /** The full UBT argument vector (target, platform, config, `-project=...`, `-WaitMutex`). */
+  args: string[];
+}
+
+export interface InstallExtensionOptions {
+  /** Target Unreal project root (holds the `.uproject` + `Plugins/`). */
+  projectDir: string;
+  /**
+   * The extension `<id>` to install — matched against the catalog by
+   * `extensionId`, then `name`, then `pluginName` (case-insensitive). When the id
+   * is NOT in the catalog, `source` is required and the descriptor is synthesized
+   * from the `--source` dir's `.uplugin`.
+   */
+  extensionId: string;
+  /**
+   * Local source dir (offline / CI / dev): a UE plugin directory containing
+   * `<pluginName>.uplugin`, or a directory that contains one. Wins over the
+   * GitHub-release download channel. Mirrors godot-cli `install-plugin --source`.
+   */
+  source?: string;
+  /** Override the catalog-pinned version (also the version requested from the GitHub release). Ignored when empty. */
+  version?: string;
+  /**
+   * Compile the project via UBT after install. Default `false` — the extension
+   * ships as SOURCE and UE recompiles it on the next editor open (the documented
+   * compile-on-install strategy); `--build` opts into eager compilation.
+   */
+  build?: boolean;
+  /** Engine root for the `--build` UBT invocation. Defaults to discovery from the project's `EngineAssociation`. */
+  engineRoot?: string;
+  /** Re-materialize + re-enable even when already up to date. Default `false`. */
+  force?: boolean;
+  /**
+   * Catalog to resolve `extensionId` against. Defaults to the bundled
+   * `EXTENSIONS_CATALOG`. Injectable for tests.
+   */
+  catalog?: readonly ExtensionDescriptor[];
+  /** Inject the HTTP client (defaults to global `fetch`). Test injection. */
+  fetchImpl?: typeof fetch;
+  /**
+   * Inject the UBT build runner (defaults to spawning UnrealBuildTool). Test
+   * injection — a fake records the `ExtensionBuildStep` without a real engine.
+   */
+  buildImpl?: (step: ExtensionBuildStep) => Promise<void>;
+  /** Inject engine-root resolution for `--build` (defaults to the engine-discovery chain). Test injection. */
+  resolveEngineRootImpl?: (engineAssociation: string) => string | null;
+  onProgress?: ProgressCallback;
+}
+
+export interface InstallExtensionSuccess {
+  kind: 'success';
+  success: true;
+  /** Classified outcome (added / updated / already-up-to-date). */
+  outcome: ExtensionInstallOutcome;
+  /** True when files were materialized and/or the `.uproject` was written. */
+  changed: boolean;
+  /** True when the project must be (re)compiled — i.e. files changed and `--build` did NOT run. */
+  rebuildRequired: boolean;
+  /** The user-supplied id that resolved to the descriptor. */
+  extensionId: string;
+  /** Resolved plugin folder/descriptor name (`Plugins/<pluginName>`). */
+  pluginName: string;
+  /** Absolute path the extension was installed to (`<project>/Plugins/<pluginName>`). */
+  installedPath: string;
+  /** Which channel the files came from. */
+  sourceKind: InstallSourceKind;
+  /** Version installed before this run: `null` when not previously installed. */
+  fromVersion: string | null;
+  /** Version this install targeted: catalog pin / `--version` / the source `.uplugin`'s `VersionName`, or `null`. */
+  toVersion: string | null;
+  /** Plugins enabled in the `.uproject` after the run (extension + gating engine plugins). */
+  enabledPlugins: string[];
+  /** Absolute path to the `.uproject` touched. */
+  uprojectPath: string;
+  /** True when UBT compiled the project this run (`--build`). */
+  built: boolean;
+  /** A short human-readable status line, safe to print. */
+  message: string;
+  warnings: string[];
+}
+
+export interface InstallExtensionFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  error: Error;
+}
+
+export type InstallExtensionResult = InstallExtensionSuccess | InstallExtensionFailure;

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -633,7 +633,7 @@ export type BootstrapLocalResult = BootstrapLocalSuccess | BootstrapLocalFailure
 // ---------------------------------------------------------------------------
 
 /** How an `install-extension` run ended (a `kind: 'success'` classification). */
-export type ExtensionInstallOutcome = 'added' | 'updated' | 'already-up-to-date';
+export type ExtensionInstallOutcome = 'added' | 'updated' | 'enabled' | 'already-up-to-date';
 
 /** Re-export of the install-source channel discriminant for the public result. */
 export type { InstallSourceKind };
@@ -690,6 +690,12 @@ export interface InstallExtensionOptions {
   /** Inject the HTTP client (defaults to global `fetch`). Test injection. */
   fetchImpl?: typeof fetch;
   /**
+   * Abort the GitHub-release download if no response arrives within this many
+   * milliseconds, so a stalled/slow server cannot hang the CLI indefinitely.
+   * Default 60000. Ignored for `--source` (local) installs.
+   */
+  downloadTimeoutMs?: number;
+  /**
    * Inject the UBT build runner (defaults to spawning UnrealBuildTool). Test
    * injection — a fake records the `ExtensionBuildStep` without a real engine.
    */
@@ -702,7 +708,7 @@ export interface InstallExtensionOptions {
 export interface InstallExtensionSuccess {
   kind: 'success';
   success: true;
-  /** Classified outcome (added / updated / already-up-to-date). */
+  /** Classified outcome (added / updated / enabled / already-up-to-date). */
   outcome: ExtensionInstallOutcome;
   /** True when files were materialized and/or the `.uproject` was written. */
   changed: boolean;
@@ -720,7 +726,11 @@ export interface InstallExtensionSuccess {
   fromVersion: string | null;
   /** Version this install targeted: catalog pin / `--version` / the source `.uplugin`'s `VersionName`, or `null`. */
   toVersion: string | null;
-  /** Plugins enabled in the `.uproject` after the run (extension + gating engine plugins). */
+  /**
+   * Plugins this run newly enabled in the `.uproject` — the extension and any
+   * gating engine plugins it appended or flipped from disabled. Plugins that
+   * were already enabled before the run are NOT listed.
+   */
   enabledPlugins: string[];
   /** Absolute path to the `.uproject` touched. */
   uprojectPath: string;

--- a/cli/src/utils/extension-source.ts
+++ b/cli/src/utils/extension-source.ts
@@ -1,0 +1,145 @@
+// Pure helpers that resolve WHERE an extension's plugin files come from when
+// `install-extension` materializes them. This is the PLUGGABLE INSTALL-SOURCE
+// RESOLVER seam the task requires: callers ask `resolveInstallSource(...)` for a
+// discriminated `InstallSource` and never branch on the channel themselves, so a
+// future Fab (Epic marketplace) channel slots in as a new `kind` here + a new
+// materializer branch in `install-extension.ts` — WITHOUT touching the command or
+// the library's public signature.
+//
+// Mirrors godot-cli's `addon-source.ts` trusted-source pattern (github.com only,
+// `releases/download/v<version>/<asset>`). No side effects; unit-testable.
+
+/** GitHub-release host extension zips are downloaded from. NOTHING else is trusted. */
+export const TRUSTED_DOWNLOAD_HOST = 'github.com';
+
+/**
+ * Where an extension's plugin files are materialized from. A discriminated union
+ * so the installer's `switch (source.kind)` stays exhaustive and a new channel is
+ * a compile-checked addition.
+ *
+ * - `local` — a directory on disk (the `--source <dir>` offline / CI / dev path).
+ * - `github-release` — the extension's plugin zip from its GitHub release.
+ * - (reserved) `fab` — the Epic Fab marketplace channel; add it here + a
+ *   materializer branch when it exists, no caller change needed.
+ */
+export type InstallSource =
+  | { readonly kind: 'local'; readonly dir: string }
+  | { readonly kind: 'github-release'; readonly url: string; readonly version: string; readonly repo: string };
+
+/** The channel discriminant, exported for the public result type. */
+export type InstallSourceKind = InstallSource['kind'];
+
+/** Drop a single leading `v`/`V` from a version string. Pure. */
+export function stripLeadingV(version: string): string {
+  const v = (version ?? '').trim();
+  return /^v/i.test(v) ? v.slice(1) : v;
+}
+
+/**
+ * The git release TAG for a version: the version with a leading `v` (`1.0.0` →
+ * `v1.0.0`). An already-`v`-prefixed input passes through unchanged so a caller
+ * cannot double-prefix. Pure.
+ */
+export function releaseTag(version: string): string {
+  const v = (version ?? '').trim();
+  return v.startsWith('v') ? v : `v${v}`;
+}
+
+/**
+ * The release-asset name for an extension plugin: `<pluginName>-<version>.zip`
+ * (bare version, no leading `v` — the `v` only appears in the tag). Mirrors the
+ * Godot `godot-mcp-addon-<version>.zip` convention, parameterized by plugin name
+ * so each extension repo names its own asset. Pure.
+ */
+export function extensionAssetName(pluginName: string, version: string): string {
+  return `${pluginName}-${stripLeadingV(version)}.zip`;
+}
+
+/**
+ * The download URL for an extension version's plugin zip:
+ * `https://github.com/<repo>/releases/download/v<version>/<pluginName>-<version>.zip`.
+ * The host is always `github.com` by construction; `assertTrustedDownloadUrl`
+ * re-checks any caller-supplied URL before a network call. Pure string build.
+ */
+export function extensionDownloadUrl(repo: string, pluginName: string, version: string): string {
+  const bare = stripLeadingV(version);
+  return `https://${TRUSTED_DOWNLOAD_HOST}/${repo}/releases/download/${releaseTag(version)}/${extensionAssetName(pluginName, bare)}`;
+}
+
+/**
+ * Fail-closed host-trust check: throw unless `url` is an HTTPS URL whose host is
+ * EXACTLY `github.com` (no subdomains, no `github.com.evil.test`, no http). The
+ * security boundary the task requires. Returns the parsed URL on success; the
+ * caller turns the throw into a structured failure so nothing escapes the public
+ * boundary.
+ */
+export function assertTrustedDownloadUrl(url: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Refusing to download extension: malformed URL "${url}".`);
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(
+      `Refusing to download extension: only https is allowed, got "${parsed.protocol}" (${url}).`,
+    );
+  }
+  if (parsed.hostname.toLowerCase() !== TRUSTED_DOWNLOAD_HOST) {
+    throw new Error(
+      `Refusing to download extension from untrusted host "${parsed.hostname}". Only ${TRUSTED_DOWNLOAD_HOST} is trusted.`,
+    );
+  }
+  return parsed;
+}
+
+/** Inputs the resolver needs to pick + build an `InstallSource`. */
+export interface ResolveInstallSourceInput {
+  /** An explicit local `--source <dir>` (wins over every download channel when non-empty). */
+  readonly source?: string;
+  /** `owner/repo` for the GitHub-release channel (from the catalog descriptor). */
+  readonly repo: string | null;
+  /** The plugin name (asset basename). */
+  readonly pluginName: string;
+  /** The version to download (catalog pin or `--version` override). */
+  readonly version: string | null;
+}
+
+/**
+ * Resolve the install source for an extension. This is the single decision point
+ * for the install channel:
+ *
+ *  1. An explicit `--source <dir>` always wins → `{ kind: 'local' }`.
+ *  2. Otherwise, when a `repo` + `version` are known → `{ kind: 'github-release' }`
+ *     with a github.com-only URL (re-checked by `assertTrustedDownloadUrl` before
+ *     the fetch).
+ *  3. Otherwise throw a clear error explaining what is missing.
+ *
+ * A future Fab channel becomes a third branch here; callers are unaffected. Pure
+ * (throws on the unhappy path; the library converts it to a structured failure).
+ */
+export function resolveInstallSource(input: ResolveInstallSourceInput): InstallSource {
+  const source = (input.source ?? '').trim();
+  if (source !== '') {
+    return { kind: 'local', dir: source };
+  }
+
+  const version = (input.version ?? '').trim();
+  if (input.repo && version !== '') {
+    const url = extensionDownloadUrl(input.repo, input.pluginName, version);
+    assertTrustedDownloadUrl(url); // fail-closed: github.com + https only.
+    return { kind: 'github-release', url, version, repo: input.repo };
+  }
+
+  // Neither a local dir nor a resolvable release.
+  if (!input.repo) {
+    throw new Error(
+      `No download source for "${input.pluginName}": the catalog entry has no release repo. ` +
+        'Pass --source <dir> to install from a local copy.',
+    );
+  }
+  throw new Error(
+    `No version to download for "${input.pluginName}". Pass --version <x.y.z> ` +
+      '(or set a catalog pin), or --source <dir> for a local install.',
+  );
+}

--- a/cli/src/utils/extension-source.ts
+++ b/cli/src/utils/extension-source.ts
@@ -42,7 +42,7 @@ export function stripLeadingV(version: string): string {
  */
 export function releaseTag(version: string): string {
   const v = (version ?? '').trim();
-  return v.startsWith('v') ? v : `v${v}`;
+  return /^v/i.test(v) ? v : `v${v}`;
 }
 
 /**

--- a/cli/src/utils/extensions-catalog.ts
+++ b/cli/src/utils/extensions-catalog.ts
@@ -1,0 +1,133 @@
+// The SHARED, ENGINE-AGNOSTIC extension catalog — the typed list of installable
+// Unreal-MCP extensions consumed by `install-extension` (this CLI) and, later, by
+// the in-editor extensions panel and the desktop app. It is the Unreal analog of
+// godot-cli's `extensions-catalog.ts`, deliberately given the SAME public shape
+// (`ExtensionDescriptor` + `findExtension` + `hasVersion`) so unity-mcp-cli /
+// godot-cli can converge on one catalog contract.
+//
+// What is an Unreal-MCP extension? A third-party UE **C++ Editor (or Runtime)
+// plugin** that implements `IUnrealMcpToolProvider` (see `docs/EXTENSIONS.md`) and
+// contributes MCP tools to the core Unreal-MCP plugin. Unlike a Godot extension
+// (a NuGet `<PackageReference>`), it is installed as a **plugin folder** dropped
+// into `<project>/Plugins/<pluginName>/`, enabled in the `.uproject`, and compiled
+// by UBT — so the descriptor carries plugin-placement metadata (`pluginName`,
+// `repo`, `enginePlugins`) rather than a package id.
+//
+// CATALOG FORMAT (also the shape of the future shared
+// `engines/unreal/.../extensions.catalog.json`, mirroring Godot's
+// `addons/godot_mcp/extensions.catalog.json` `{ schemaVersion, extensions[] }`):
+//
+//   { schemaVersion: 1, extensions: ExtensionDescriptor[] }
+//
+// This module is the CLI's typed mirror so the published npm package stays
+// self-contained (no runtime dependency on a sibling JSON). When the first Unreal
+// extension ships, append its entry here AND to the JSON, and add a parity test
+// (mirroring godot-cli's `extensions-catalog-parity.test.ts`).
+//
+// No top-level side effects; pure data + pure lookups only.
+
+/** Catalog schema version — bump on a breaking shape change. */
+export const EXTENSION_CATALOG_SCHEMA_VERSION = 1;
+
+/** One MCP tool an extension contributes — mirrors the JSON `tools[]` entry. */
+export interface ExtensionTool {
+  readonly name: string;
+  readonly description: string;
+}
+
+/**
+ * One installable extension — the engine-agnostic descriptor.
+ *
+ * `extensionId` is the INSTALL IDENTITY: the stable, reverse-DNS string an
+ * extension returns from `IUnrealMcpToolProvider::GetExtensionId()` (e.g.
+ * `"com.ivanmurzak.unreal.niagara"`). It is the primary resolve key.
+ */
+export interface ExtensionDescriptor {
+  /** Stable, unique reverse-DNS id (the provider's `GetExtensionId()`). Primary resolve key. */
+  readonly extensionId: string;
+  /** Human-readable display name (shown in the extensions UI). */
+  readonly name: string;
+  readonly description: string;
+  /**
+   * The UE plugin folder + descriptor basename: the extension installs into
+   * `<project>/Plugins/<pluginName>/` and its descriptor is `<pluginName>.uplugin`.
+   * Also the name enabled in the `.uproject` `Plugins[]` array.
+   */
+  readonly pluginName: string;
+  /**
+   * `owner/repo` the extension's plugin zip is released from on GitHub Releases
+   * (the default download channel). `null` for a source-only / Fab-only entry —
+   * such an extension can still be installed via `--source <dir>`.
+   */
+  readonly repo: string | null;
+  /** Catalog-pinned version, or `null` for an unpinned (floating) entry. */
+  readonly version: string | null;
+  /**
+   * Minimum core Unreal-MCP plugin version this extension requires
+   * (`min-core-version`). `null` = no declared floor. Surfaced as a warning when
+   * the installed core plugin is older.
+   */
+  readonly minCoreVersion: string | null;
+  /**
+   * Gating engine plugins this extension needs (e.g. `["Niagara"]`) — enabled in
+   * the `.uproject` alongside the extension. This is the catalog-declared hint
+   * (so the UI can show requirements BEFORE download); the authoritative gating
+   * set is unioned at install time with the extension's own materialized
+   * `.uplugin` `Plugins[]`.
+   */
+  readonly enginePlugins: readonly string[];
+  readonly tools: readonly ExtensionTool[];
+}
+
+/**
+ * The extension catalog, the typed mirror of the shared
+ * `extensions.catalog.json`. Ships EMPTY until the first Unreal-MCP extension
+ * plugin is published — `install-extension <id>` then reports "unknown
+ * extension" for every catalog id (the `--source <dir>` channel still works for
+ * local/CI/offline installs of an unpublished extension). A future parity test
+ * keeps this in lockstep with the JSON.
+ */
+export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [] as const;
+
+/** True when a descriptor carries a concrete version pin (drives the up-to-date / update decision). */
+export function hasVersion(descriptor: ExtensionDescriptor): boolean {
+  return descriptor.version !== null && descriptor.version.trim() !== '';
+}
+
+/**
+ * Resolve a user-supplied `<id>` to a catalog descriptor. Matches (all
+ * case-insensitive) by `extensionId` first (the install identity), then by
+ * `name`, then by `pluginName`, for convenience. Returns `null` when absent or
+ * `id` is empty.
+ */
+export function findExtension(
+  id: string | undefined | null,
+  catalog: readonly ExtensionDescriptor[] = EXTENSIONS_CATALOG,
+): ExtensionDescriptor | null {
+  if (id === undefined || id === null) return null;
+  const needle = id.trim().toLowerCase();
+  if (needle === '') return null;
+
+  return (
+    catalog.find((d) => d.extensionId.toLowerCase() === needle) ??
+    catalog.find((d) => d.name.toLowerCase() === needle) ??
+    catalog.find((d) => d.pluginName.toLowerCase() === needle) ??
+    null
+  );
+}
+
+/** A clear "unknown extension" message listing what IS installable (or that the catalog is empty). */
+export function unknownExtensionMessage(
+  id: string,
+  catalog: readonly ExtensionDescriptor[] = EXTENSIONS_CATALOG,
+): string {
+  if (catalog.length === 0) {
+    return (
+      `Unknown extension "${id}". The Unreal-MCP extension catalog is currently empty ` +
+      '(no extension plugins have been published yet), so there is nothing to install by id. ' +
+      'Pass --source <dir> to install an extension plugin from a local directory.'
+    );
+  }
+  const available = catalog.map((d) => d.extensionId).join(', ');
+  return `Unknown extension "${id}". Available extensions: ${available}. (Or pass --source <dir> for a local install.)`;
+}

--- a/cli/src/utils/uproject-plugins.ts
+++ b/cli/src/utils/uproject-plugins.ts
@@ -1,0 +1,123 @@
+// Pure helpers for the two UE descriptor files `install-extension` touches:
+//
+//  - a plugin's `*.uplugin` — to learn its declared `Plugins[]` dependencies
+//    (the gating engine plugins, e.g. Niagara) and its `VersionName`.
+//  - the project's `*.uproject` — to ENABLE the extension + its gating plugins in
+//    the `Plugins[]` array, idempotently (a `read-modify-write` of the JSON).
+//
+// Both files are tab-indented JSON; writes round-trip through
+// `JSON.stringify(obj, null, '\t')` and preserve a trailing newline. No I/O here
+// (callers read/write); these are pure transforms so they are exhaustively
+// unit-testable without a UE install.
+
+/** One entry of a UE descriptor `Plugins[]` array. */
+interface UPluginRef {
+  Name?: string;
+  Enabled?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * Extract the names of the plugin dependencies a `.uplugin` declares as enabled
+ * (`Plugins[]` entries whose `Enabled` is not `false`). These are the gating
+ * plugins (e.g. `Niagara`) that must also be enabled in the consuming
+ * `.uproject`. Tolerant of a missing/!object/!array `Plugins` field (→ `[]`).
+ * Pure.
+ */
+export function parseUPluginDependencies(upluginJson: unknown): string[] {
+  if (!upluginJson || typeof upluginJson !== 'object') return [];
+  const plugins = (upluginJson as Record<string, unknown>)['Plugins'];
+  if (!Array.isArray(plugins)) return [];
+  const names: string[] = [];
+  for (const entry of plugins) {
+    if (entry && typeof entry === 'object') {
+      const ref = entry as UPluginRef;
+      if (typeof ref.Name === 'string' && ref.Name.trim() !== '' && ref.Enabled !== false) {
+        names.push(ref.Name.trim());
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * Read a `.uplugin`'s `VersionName` (the extension's own version string), or
+ * `null` when absent / not a string. Pure.
+ */
+export function readUPluginVersionName(upluginJson: unknown): string | null {
+  if (upluginJson && typeof upluginJson === 'object') {
+    const v = (upluginJson as Record<string, unknown>)['VersionName'];
+    if (typeof v === 'string' && v.trim() !== '') return v.trim();
+  }
+  return null;
+}
+
+/** Result of enabling plugins in a `.uproject`'s text. */
+export interface EnablePluginsResult {
+  /** True when the `.uproject` text was modified. */
+  changed: boolean;
+  /** The resulting `.uproject` text (unchanged when `changed === false`). */
+  text: string;
+  /** The names enabled in the project after the operation (full `Plugins[]` enabled set). */
+  enabledPlugins: string[];
+}
+
+/**
+ * Enable each plugin in `pluginNames` in a `.uproject`'s JSON text:
+ *
+ *  - a plugin already present and enabled is left untouched (idempotent);
+ *  - a plugin present but `Enabled: false` is flipped to `true`;
+ *  - a plugin absent is appended as `{ "Name": <n>, "Enabled": true }`.
+ *
+ * Names are de-duplicated case-insensitively (UE plugin names are
+ * case-insensitive). The write preserves the file's tab indentation and a
+ * trailing newline if the input had one. Throws on malformed JSON (the caller
+ * converts it to a structured failure). Pure transform.
+ */
+export function enablePluginsInUProject(uprojectText: string, pluginNames: readonly string[]): EnablePluginsResult {
+  const parsed = JSON.parse(uprojectText) as Record<string, unknown>;
+
+  const existing: UPluginRef[] = Array.isArray(parsed['Plugins'])
+    ? (parsed['Plugins'] as UPluginRef[])
+    : [];
+
+  // De-dupe the requested names case-insensitively, preserving first-seen order.
+  const wanted: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of pluginNames) {
+    const name = (raw ?? '').trim();
+    if (name === '') continue;
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    wanted.push(name);
+  }
+
+  let changed = false;
+  const plugins = existing.slice();
+  for (const name of wanted) {
+    const idx = plugins.findIndex(
+      (p) => typeof p.Name === 'string' && p.Name.toLowerCase() === name.toLowerCase(),
+    );
+    if (idx === -1) {
+      plugins.push({ Name: name, Enabled: true });
+      changed = true;
+    } else if (plugins[idx].Enabled !== true) {
+      plugins[idx] = { ...plugins[idx], Enabled: true };
+      changed = true;
+    }
+  }
+
+  const enabledPlugins = plugins
+    .filter((p) => typeof p.Name === 'string' && p.Enabled !== false)
+    .map((p) => p.Name as string);
+
+  if (!changed) {
+    return { changed: false, text: uprojectText, enabledPlugins };
+  }
+
+  parsed['Plugins'] = plugins;
+  const trailingNewline = uprojectText.endsWith('\n') ? '\n' : '';
+  const text = JSON.stringify(parsed, null, '\t') + trailingNewline;
+  return { changed: true, text, enabledPlugins };
+}

--- a/cli/src/utils/uproject-plugins.ts
+++ b/cli/src/utils/uproject-plugins.ts
@@ -60,6 +60,13 @@ export interface EnablePluginsResult {
   text: string;
   /** The names enabled in the project after the operation (full `Plugins[]` enabled set). */
   enabledPlugins: string[];
+  /**
+   * The subset of names this call actually switched on — appended as new
+   * entries, or flipped from `Enabled: false` to `true`. Plugins already enabled
+   * before the call are excluded (they are still listed in `enabledPlugins`).
+   * Equals `enabledPlugins` only when nothing was pre-enabled.
+   */
+  addedOrFlipped: string[];
 }
 
 /**
@@ -93,7 +100,7 @@ export function enablePluginsInUProject(uprojectText: string, pluginNames: reado
     wanted.push(name);
   }
 
-  let changed = false;
+  const addedOrFlipped: string[] = [];
   const plugins = existing.slice();
   for (const name of wanted) {
     const idx = plugins.findIndex(
@@ -101,10 +108,10 @@ export function enablePluginsInUProject(uprojectText: string, pluginNames: reado
     );
     if (idx === -1) {
       plugins.push({ Name: name, Enabled: true });
-      changed = true;
+      addedOrFlipped.push(name);
     } else if (plugins[idx].Enabled !== true) {
       plugins[idx] = { ...plugins[idx], Enabled: true };
-      changed = true;
+      addedOrFlipped.push(name);
     }
   }
 
@@ -112,12 +119,13 @@ export function enablePluginsInUProject(uprojectText: string, pluginNames: reado
     .filter((p) => typeof p.Name === 'string' && p.Enabled !== false)
     .map((p) => p.Name as string);
 
-  if (!changed) {
-    return { changed: false, text: uprojectText, enabledPlugins };
+  // The text changed iff at least one name was appended or flipped on.
+  if (addedOrFlipped.length === 0) {
+    return { changed: false, text: uprojectText, enabledPlugins, addedOrFlipped };
   }
 
   parsed['Plugins'] = plugins;
   const trailingNewline = uprojectText.endsWith('\n') ? '\n' : '';
   const text = JSON.stringify(parsed, null, '\t') + trailingNewline;
-  return { changed: true, text, enabledPlugins };
+  return { changed: true, text, enabledPlugins, addedOrFlipped };
 }

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -22,6 +22,7 @@ const ALL_COMMANDS = [
   'close',
   'install-plugin',
   'remove-plugin',
+  'install-extension',
   'configure',
   'setup-mcp',
   'login',
@@ -36,7 +37,7 @@ const ALL_COMMANDS = [
 ];
 
 describe('CLI integration', () => {
-  it('--help lists every one of the 16 commands', () => {
+  it('--help lists every one of the 17 commands', () => {
     const { stdout, exitCode } = runCli(['--help']);
     expect(exitCode).toBe(0);
     expect(stdout).toContain('unreal-mcp-cli');

--- a/cli/tests/install-extension.test.ts
+++ b/cli/tests/install-extension.test.ts
@@ -1,0 +1,510 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { zipSync } from 'fflate';
+import { installExtension } from '../src/lib/install-extension.js';
+import {
+  EXTENSIONS_CATALOG,
+  findExtension,
+  hasVersion,
+  unknownExtensionMessage,
+  type ExtensionDescriptor,
+} from '../src/utils/extensions-catalog.js';
+import {
+  resolveInstallSource,
+  extensionDownloadUrl,
+  extensionAssetName,
+  releaseTag,
+  stripLeadingV,
+  assertTrustedDownloadUrl,
+} from '../src/utils/extension-source.js';
+import {
+  parseUPluginDependencies,
+  readUPluginVersionName,
+  enablePluginsInUProject,
+} from '../src/utils/uproject-plugins.js';
+import { makeTempDir, rmTempDir, writeUProject } from './helpers.js';
+import type { ExtensionBuildStep } from '../src/lib/types.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+/** Build a local extension plugin source dir: `<dir>/<name>/<name>.uplugin` + a Source marker. */
+function makeExtensionSource(
+  name: string,
+  opts: { version?: string; plugins?: string[]; intermediate?: boolean } = {},
+): string {
+  const root = tmp();
+  const pluginDir = path.join(root, name);
+  fs.mkdirSync(path.join(pluginDir, 'Source', name), { recursive: true });
+  const uplugin: Record<string, unknown> = {
+    FileVersion: 3,
+    VersionName: opts.version ?? '1.0.0',
+    FriendlyName: name,
+    Modules: [{ Name: name, Type: 'Editor', LoadingPhase: 'Default' }],
+  };
+  if (opts.plugins && opts.plugins.length > 0) {
+    uplugin.Plugins = opts.plugins.map((p) => ({ Name: p, Enabled: true }));
+  }
+  fs.writeFileSync(path.join(pluginDir, `${name}.uplugin`), JSON.stringify(uplugin, null, '\t'), 'utf-8');
+  fs.writeFileSync(path.join(pluginDir, 'Source', name, `${name}.cpp`), '// marker', 'utf-8');
+  if (opts.intermediate) {
+    fs.mkdirSync(path.join(pluginDir, 'Intermediate', 'Build'), { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, 'Intermediate', 'Build', 'x.obj'), 'OBJ', 'utf-8');
+    fs.mkdirSync(path.join(pluginDir, 'Binaries', 'Win64'), { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, 'Binaries', 'Win64', 'stale.dll'), 'DLL', 'utf-8');
+  }
+  return pluginDir;
+}
+
+/** A minimal UE project dir with a `.uproject`. */
+function makeProject(name = 'MyGame'): string {
+  const dir = tmp();
+  writeUProject(dir, name, '5.7');
+  return dir;
+}
+
+/** A `Response`-like stub whose body is a zip of `files`. */
+function zipResponse(files: Record<string, Uint8Array>): Response {
+  const bytes = zipSync(files);
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  } as unknown as Response;
+}
+
+function enc(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+// ===========================================================================
+// catalog
+// ===========================================================================
+
+describe('extensions-catalog', () => {
+  const sample: ExtensionDescriptor = {
+    extensionId: 'com.foo.niagara',
+    name: 'Niagara Tools',
+    description: 'AI tools for Niagara.',
+    pluginName: 'FooNiagara',
+    repo: 'foo/Unreal-AI-Niagara',
+    version: '1.2.0',
+    minCoreVersion: '0.5.0',
+    enginePlugins: ['Niagara'],
+    tools: [{ name: 'niagara-create', description: 'Create a Niagara system.' }],
+  };
+
+  it('ships empty by default', () => {
+    expect(EXTENSIONS_CATALOG).toHaveLength(0);
+  });
+
+  it('findExtension matches by extensionId, name, or pluginName (case-insensitive)', () => {
+    const cat = [sample];
+    expect(findExtension('com.foo.niagara', cat)).toBe(sample);
+    expect(findExtension('NIAGARA TOOLS', cat)).toBe(sample);
+    expect(findExtension('fooniagara', cat)).toBe(sample);
+    expect(findExtension('nope', cat)).toBeNull();
+    expect(findExtension('', cat)).toBeNull();
+    expect(findExtension(undefined, cat)).toBeNull();
+  });
+
+  it('hasVersion reflects the pin', () => {
+    expect(hasVersion(sample)).toBe(true);
+    expect(hasVersion({ ...sample, version: null })).toBe(false);
+    expect(hasVersion({ ...sample, version: '  ' })).toBe(false);
+  });
+
+  it('unknownExtensionMessage explains the empty catalog + the --source escape hatch', () => {
+    const msg = unknownExtensionMessage('com.x.y', []);
+    expect(msg).toContain('currently empty');
+    expect(msg).toContain('--source');
+  });
+});
+
+// ===========================================================================
+// extension-source resolver (the pluggable channel seam)
+// ===========================================================================
+
+describe('extension-source', () => {
+  it('builds a github.com release URL', () => {
+    expect(stripLeadingV('v1.2.0')).toBe('1.2.0');
+    expect(releaseTag('1.2.0')).toBe('v1.2.0');
+    expect(extensionAssetName('FooNiagara', 'v1.2.0')).toBe('FooNiagara-1.2.0.zip');
+    expect(extensionDownloadUrl('foo/Unreal-AI-Niagara', 'FooNiagara', '1.2.0')).toBe(
+      'https://github.com/foo/Unreal-AI-Niagara/releases/download/v1.2.0/FooNiagara-1.2.0.zip',
+    );
+  });
+
+  it('assertTrustedDownloadUrl accepts github https and rejects everything else', () => {
+    expect(() => assertTrustedDownloadUrl('https://github.com/a/b/releases/download/v1/x.zip')).not.toThrow();
+    expect(() => assertTrustedDownloadUrl('http://github.com/a/b')).toThrow(/only https/);
+    expect(() => assertTrustedDownloadUrl('https://evil.test/a/b')).toThrow(/untrusted host/);
+    expect(() => assertTrustedDownloadUrl('https://github.com.evil.test/a')).toThrow(/untrusted host/);
+    expect(() => assertTrustedDownloadUrl('not a url')).toThrow(/malformed/);
+  });
+
+  it('resolveInstallSource prefers --source (local) over a release', () => {
+    const s = resolveInstallSource({ source: '/some/dir', repo: 'a/b', pluginName: 'P', version: '1.0.0' });
+    expect(s).toEqual({ kind: 'local', dir: '/some/dir' });
+  });
+
+  it('resolveInstallSource falls back to github-release when repo + version known', () => {
+    const s = resolveInstallSource({ repo: 'a/b', pluginName: 'P', version: '1.0.0' });
+    expect(s.kind).toBe('github-release');
+    if (s.kind === 'github-release') {
+      expect(s.url).toBe('https://github.com/a/b/releases/download/v1.0.0/P-1.0.0.zip');
+      expect(s.version).toBe('1.0.0');
+    }
+  });
+
+  it('resolveInstallSource throws clearly when neither a source nor a resolvable release exists', () => {
+    expect(() => resolveInstallSource({ repo: null, pluginName: 'P', version: '1.0.0' })).toThrow(/no release repo/);
+    expect(() => resolveInstallSource({ repo: 'a/b', pluginName: 'P', version: null })).toThrow(/No version/);
+  });
+});
+
+// ===========================================================================
+// uproject-plugins pure transforms
+// ===========================================================================
+
+describe('uproject-plugins', () => {
+  it('parses declared (enabled) plugin deps and the version name', () => {
+    const json = {
+      VersionName: '2.3.4',
+      Plugins: [
+        { Name: 'Niagara', Enabled: true },
+        { Name: 'Disabled', Enabled: false },
+        { Name: 'NoFlag' },
+        { Bad: 1 },
+      ],
+    };
+    expect(parseUPluginDependencies(json)).toEqual(['Niagara', 'NoFlag']);
+    expect(readUPluginVersionName(json)).toBe('2.3.4');
+    expect(parseUPluginDependencies({})).toEqual([]);
+    expect(readUPluginVersionName({})).toBeNull();
+  });
+
+  it('enables plugins (add + flip), is idempotent, dedupes, and preserves a trailing newline', () => {
+    const base = JSON.stringify({ FileVersion: 3, Plugins: [{ Name: 'Existing', Enabled: false }] }, null, '\t') + '\n';
+    const r1 = enablePluginsInUProject(base, ['MyExt', 'Existing', 'myext']);
+    expect(r1.changed).toBe(true);
+    expect(r1.text.endsWith('\n')).toBe(true);
+    expect(r1.enabledPlugins.sort()).toEqual(['Existing', 'MyExt']);
+    const parsed = JSON.parse(r1.text) as { Plugins: { Name: string; Enabled: boolean }[] };
+    expect(parsed.Plugins.find((p) => p.Name === 'Existing')!.Enabled).toBe(true);
+
+    // Idempotent: re-running makes no change.
+    const r2 = enablePluginsInUProject(r1.text, ['MyExt', 'Existing']);
+    expect(r2.changed).toBe(false);
+    expect(r2.text).toBe(r1.text);
+  });
+
+  it('creates a Plugins array when absent', () => {
+    const base = JSON.stringify({ FileVersion: 3 }, null, '\t');
+    const r = enablePluginsInUProject(base, ['MyExt']);
+    expect(r.changed).toBe(true);
+    expect(JSON.parse(r.text).Plugins).toEqual([{ Name: 'MyExt', Enabled: true }]);
+  });
+});
+
+// ===========================================================================
+// installExtension — local --source path
+// ===========================================================================
+
+describe('installExtension (local --source)', () => {
+  it('places the plugin, enables it + the gating plugin, reports added + rebuildRequired', async () => {
+    const project = makeProject();
+    const source = makeExtensionSource('FooNiagara', { version: '1.0.0', plugins: ['Niagara'], intermediate: true });
+
+    const r = await installExtension({ projectDir: project, extensionId: 'com.foo.niagara', source });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+
+    expect(r.outcome).toBe('added');
+    expect(r.changed).toBe(true);
+    expect(r.rebuildRequired).toBe(true);
+    expect(r.built).toBe(false);
+    expect(r.sourceKind).toBe('local');
+    expect(r.toVersion).toBe('1.0.0');
+    expect(r.fromVersion).toBeNull();
+
+    // Files placed, build cache excluded.
+    const installed = path.join(project, 'Plugins', 'FooNiagara');
+    expect(fs.existsSync(path.join(installed, 'FooNiagara.uplugin'))).toBe(true);
+    expect(fs.existsSync(path.join(installed, 'Source', 'FooNiagara', 'FooNiagara.cpp'))).toBe(true);
+    expect(fs.existsSync(path.join(installed, 'Intermediate'))).toBe(false);
+    expect(fs.existsSync(path.join(installed, 'Binaries'))).toBe(false);
+
+    // .uproject enabled the extension + the gating plugin.
+    const upj = JSON.parse(fs.readFileSync(r.uprojectPath, 'utf-8')) as { Plugins: { Name: string; Enabled: boolean }[] };
+    const enabled = upj.Plugins.filter((p) => p.Enabled).map((p) => p.Name);
+    expect(enabled).toContain('FooNiagara');
+    expect(enabled).toContain('Niagara');
+    expect(r.enabledPlugins).toContain('Niagara');
+  });
+
+  it('is idempotent — a second identical install is a no-op already-up-to-date', async () => {
+    const project = makeProject();
+    const source = makeExtensionSource('FooNiagara', { version: '1.0.0', plugins: ['Niagara'] });
+    await installExtension({ projectDir: project, extensionId: 'com.foo.niagara', source });
+
+    const uprojectPath = path.join(project, 'MyGame.uproject');
+    const before = fs.readFileSync(uprojectPath, 'utf-8');
+    const r = await installExtension({ projectDir: project, extensionId: 'com.foo.niagara', source });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.outcome).toBe('already-up-to-date');
+    expect(r.changed).toBe(false);
+    expect(r.rebuildRequired).toBe(false);
+    // No write to the .uproject.
+    expect(fs.readFileSync(uprojectPath, 'utf-8')).toBe(before);
+  });
+
+  it('updates when the source version is newer (fromVersion → toVersion)', async () => {
+    const project = makeProject();
+    await installExtension({
+      projectDir: project,
+      extensionId: 'com.foo.niagara',
+      source: makeExtensionSource('FooNiagara', { version: '1.0.0' }),
+    });
+    const r = await installExtension({
+      projectDir: project,
+      extensionId: 'com.foo.niagara',
+      source: makeExtensionSource('FooNiagara', { version: '2.0.0' }),
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.outcome).toBe('updated');
+    expect(r.fromVersion).toBe('1.0.0');
+    expect(r.toVersion).toBe('2.0.0');
+  });
+
+  it('--force re-materializes even when already up to date', async () => {
+    const project = makeProject();
+    const source = makeExtensionSource('FooNiagara', { version: '1.0.0' });
+    await installExtension({ projectDir: project, extensionId: 'com.foo.niagara', source });
+    const r = await installExtension({ projectDir: project, extensionId: 'com.foo.niagara', source, force: true });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.changed).toBe(true);
+  });
+
+  it('uses a catalog descriptor (pluginName + enginePlugins) when the id resolves, with --source for files', async () => {
+    const project = makeProject();
+    const catalog: ExtensionDescriptor[] = [
+      {
+        extensionId: 'com.foo.niagara',
+        name: 'Niagara Tools',
+        description: 'x',
+        pluginName: 'FooNiagara',
+        repo: 'foo/Unreal-AI-Niagara',
+        version: '1.0.0',
+        minCoreVersion: null,
+        enginePlugins: ['Niagara', 'PluginBrowser'],
+        tools: [],
+      },
+    ];
+    // The source .uplugin only declares Niagara; the catalog adds PluginBrowser.
+    const source = makeExtensionSource('FooNiagara', { version: '1.0.0', plugins: ['Niagara'] });
+    const r = await installExtension({ projectDir: project, extensionId: 'com.foo.niagara', source, catalog });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.enabledPlugins).toEqual(expect.arrayContaining(['FooNiagara', 'Niagara', 'PluginBrowser']));
+  });
+});
+
+// ===========================================================================
+// installExtension — download path + failures
+// ===========================================================================
+
+describe('installExtension (download + failures)', () => {
+  const catalog: ExtensionDescriptor[] = [
+    {
+      extensionId: 'com.foo.niagara',
+      name: 'Niagara Tools',
+      description: 'x',
+      pluginName: 'FooNiagara',
+      repo: 'foo/Unreal-AI-Niagara',
+      version: '1.0.0',
+      minCoreVersion: null,
+      enginePlugins: [],
+      tools: [],
+    },
+  ];
+
+  it('downloads + extracts the plugin zip from the (injected) GitHub release', async () => {
+    const project = makeProject();
+    const upluginJson = JSON.stringify({ FileVersion: 3, VersionName: '1.0.0', Plugins: [{ Name: 'Niagara', Enabled: true }] });
+    const fetchImpl = (async (url: string) => {
+      expect(url).toBe('https://github.com/foo/Unreal-AI-Niagara/releases/download/v1.0.0/FooNiagara-1.0.0.zip');
+      return zipResponse({
+        'FooNiagara/FooNiagara.uplugin': enc(upluginJson),
+        'FooNiagara/Source/FooNiagara/FooNiagara.cpp': enc('// marker'),
+      });
+    }) as unknown as typeof fetch;
+
+    const r = await installExtension({ projectDir: project, extensionId: 'com.foo.niagara', catalog, fetchImpl });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.outcome).toBe('added');
+    expect(r.sourceKind).toBe('github-release');
+    const installed = path.join(project, 'Plugins', 'FooNiagara');
+    expect(fs.existsSync(path.join(installed, 'FooNiagara.uplugin'))).toBe(true);
+    expect(r.enabledPlugins).toContain('Niagara');
+  });
+
+  it('fails (no throw) on an HTTP error from the release', async () => {
+    const project = makeProject();
+    const fetchImpl = (async () => ({ ok: false, status: 404, statusText: 'Not Found' }) as unknown as Response) as unknown as typeof fetch;
+    const r = await installExtension({ projectDir: project, extensionId: 'com.foo.niagara', catalog, fetchImpl });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.error.message).toMatch(/HTTP 404/);
+  });
+
+  it('fails (no throw) for an unknown extension with no --source', async () => {
+    const project = makeProject();
+    const r = await installExtension({ projectDir: project, extensionId: 'com.unknown.ext' });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.error.message).toMatch(/Unknown extension/);
+  });
+
+  it('fails (no throw) when the directory is not an Unreal project', async () => {
+    const notProject = tmp();
+    const source = makeExtensionSource('FooNiagara');
+    const r = await installExtension({ projectDir: notProject, extensionId: 'com.foo.niagara', source });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.error.message).toMatch(/No .uproject/);
+  });
+});
+
+// ===========================================================================
+// installExtension — --build (UBT) path
+// ===========================================================================
+
+describe('installExtension (--build)', () => {
+  it('invokes the injected build runner and reports built + no rebuildRequired', async () => {
+    const project = makeProject('MyGame');
+    const source = makeExtensionSource('FooNiagara', { version: '1.0.0' });
+    const steps: ExtensionBuildStep[] = [];
+    const r = await installExtension({
+      projectDir: project,
+      extensionId: 'com.foo.niagara',
+      source,
+      build: true,
+      engineRoot: 'C:/Engine',
+      buildImpl: async (step) => {
+        steps.push(step);
+      },
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.built).toBe(true);
+    expect(r.rebuildRequired).toBe(false);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].editorTarget).toBe('MyGameEditor');
+    expect(steps[0].args).toContain('-WaitMutex');
+    expect(steps[0].ubtPath.replace(/\\/g, '/')).toContain('C:/Engine/Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.exe');
+  });
+
+  it('warns + falls back to rebuild-on-next-open when no engine root resolves', async () => {
+    const project = makeProject();
+    const source = makeExtensionSource('FooNiagara', { version: '1.0.0' });
+    const r = await installExtension({
+      projectDir: project,
+      extensionId: 'com.foo.niagara',
+      source,
+      build: true,
+      resolveEngineRootImpl: () => null,
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.built).toBe(false);
+    expect(r.rebuildRequired).toBe(true);
+    expect(r.warnings.join(' ')).toMatch(/no engine root/i);
+  });
+
+  it('a failing build does not throw — it warns and leaves rebuildRequired true', async () => {
+    const project = makeProject();
+    const source = makeExtensionSource('FooNiagara', { version: '1.0.0' });
+    const r = await installExtension({
+      projectDir: project,
+      extensionId: 'com.foo.niagara',
+      source,
+      build: true,
+      engineRoot: 'C:/Engine',
+      buildImpl: async () => {
+        throw new Error('compile error');
+      },
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.built).toBe(false);
+    expect(r.rebuildRequired).toBe(true);
+    expect(r.warnings.join(' ')).toMatch(/UBT build failed/);
+  });
+});
+
+// ===========================================================================
+// installExtension — minCoreVersion advisory
+// ===========================================================================
+
+describe('installExtension (minCoreVersion advisory)', () => {
+  function catalogWithMin(min: string): ExtensionDescriptor[] {
+    return [
+      {
+        extensionId: 'com.foo.niagara',
+        name: 'Niagara Tools',
+        description: 'x',
+        pluginName: 'FooNiagara',
+        repo: null,
+        version: '1.0.0',
+        minCoreVersion: min,
+        enginePlugins: [],
+        tools: [],
+      },
+    ];
+  }
+
+  it('warns when the core UnrealMCP plugin is missing', async () => {
+    const project = makeProject();
+    const source = makeExtensionSource('FooNiagara', { version: '1.0.0' });
+    const r = await installExtension({ projectDir: project, extensionId: 'com.foo.niagara', source, catalog: catalogWithMin('0.5.0') });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.warnings.join(' ')).toMatch(/requires core Unreal-MCP >= 0.5.0/);
+  });
+
+  it('warns when the installed core plugin is older than min', async () => {
+    const project = makeProject();
+    // Install a fake core plugin at 0.4.0.
+    const coreDir = path.join(project, 'Plugins', 'UnrealMCP');
+    fs.mkdirSync(coreDir, { recursive: true });
+    fs.writeFileSync(path.join(coreDir, 'UnrealMCP.uplugin'), JSON.stringify({ VersionName: '0.4.0' }), 'utf-8');
+    const source = makeExtensionSource('FooNiagara', { version: '1.0.0' });
+    const r = await installExtension({ projectDir: project, extensionId: 'com.foo.niagara', source, catalog: catalogWithMin('0.10.0') });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.warnings.join(' ')).toMatch(/installed core plugin is 0.4.0/);
+  });
+
+  it('does NOT warn when the installed core plugin satisfies min', async () => {
+    const project = makeProject();
+    const coreDir = path.join(project, 'Plugins', 'UnrealMCP');
+    fs.mkdirSync(coreDir, { recursive: true });
+    fs.writeFileSync(path.join(coreDir, 'UnrealMCP.uplugin'), JSON.stringify({ VersionName: '1.0.0' }), 'utf-8');
+    const source = makeExtensionSource('FooNiagara', { version: '1.0.0' });
+    const r = await installExtension({ projectDir: project, extensionId: 'com.foo.niagara', source, catalog: catalogWithMin('0.5.0') });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.warnings.join(' ')).not.toMatch(/requires core Unreal-MCP/);
+  });
+});

--- a/cli/tests/install-extension.test.ts
+++ b/cli/tests/install-extension.test.ts
@@ -199,6 +199,8 @@ describe('uproject-plugins', () => {
     expect(r1.changed).toBe(true);
     expect(r1.text.endsWith('\n')).toBe(true);
     expect(r1.enabledPlugins.sort()).toEqual(['Existing', 'MyExt']);
+    // addedOrFlipped lists exactly what this call switched on (MyExt appended, Existing flipped).
+    expect(r1.addedOrFlipped.sort()).toEqual(['Existing', 'MyExt']);
     const parsed = JSON.parse(r1.text) as { Plugins: { Name: string; Enabled: boolean }[] };
     expect(parsed.Plugins.find((p) => p.Name === 'Existing')!.Enabled).toBe(true);
 
@@ -206,6 +208,17 @@ describe('uproject-plugins', () => {
     const r2 = enablePluginsInUProject(r1.text, ['MyExt', 'Existing']);
     expect(r2.changed).toBe(false);
     expect(r2.text).toBe(r1.text);
+    expect(r2.addedOrFlipped).toEqual([]);
+  });
+
+  it('addedOrFlipped excludes plugins already enabled before the call', () => {
+    const base = JSON.stringify({ FileVersion: 3, Plugins: [{ Name: 'AlreadyOn', Enabled: true }] }, null, '\t');
+    const r = enablePluginsInUProject(base, ['AlreadyOn', 'NewExt']);
+    expect(r.changed).toBe(true);
+    // The full enabled set still includes the pre-existing plugin ...
+    expect(r.enabledPlugins.sort()).toEqual(['AlreadyOn', 'NewExt']);
+    // ... but addedOrFlipped reports only the newly switched-on extension.
+    expect(r.addedOrFlipped).toEqual(['NewExt']);
   });
 
   it('creates a Plugins array when absent', () => {
@@ -267,6 +280,31 @@ describe('installExtension (local --source)', () => {
     expect(r.rebuildRequired).toBe(false);
     // No write to the .uproject.
     expect(fs.readFileSync(uprojectPath, 'utf-8')).toBe(before);
+  });
+
+  it("reports 'enabled' (not 'updated') when files are current but the .uproject lost the enable entry", async () => {
+    const project = makeProject();
+    const source = makeExtensionSource('FooNiagara', { version: '1.0.0', plugins: ['Niagara'] });
+    await installExtension({ projectDir: project, extensionId: 'com.foo.niagara', source });
+
+    // Drop the extension's enable entry while the materialized files stay at the
+    // same version on disk → re-install should re-enable, not "update".
+    const uprojectPath = path.join(project, 'MyGame.uproject');
+    const upj = JSON.parse(fs.readFileSync(uprojectPath, 'utf-8')) as { Plugins: { Name: string; Enabled: boolean }[] };
+    upj.Plugins = upj.Plugins.filter((p) => p.Name !== 'FooNiagara');
+    fs.writeFileSync(uprojectPath, JSON.stringify(upj, null, '\t'));
+
+    const r = await installExtension({ projectDir: project, extensionId: 'com.foo.niagara', source });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.outcome).toBe('enabled');
+    expect(r.changed).toBe(true);
+    expect(r.fromVersion).toBe('1.0.0');
+    expect(r.toVersion).toBe('1.0.0');
+    expect(r.message).toMatch(/Enabled existing extension FooNiagara 1\.0\.0/);
+    // Only the re-enabled extension is reported, not the pre-existing Niagara.
+    expect(r.enabledPlugins).toContain('FooNiagara');
+    expect(r.enabledPlugins).not.toContain('Niagara');
   });
 
   it('updates when the source version is newer (fromVersion → toVersion)', async () => {
@@ -360,6 +398,20 @@ describe('installExtension (download + failures)', () => {
     const installed = path.join(project, 'Plugins', 'FooNiagara');
     expect(fs.existsSync(path.join(installed, 'FooNiagara.uplugin'))).toBe(true);
     expect(r.enabledPlugins).toContain('Niagara');
+  });
+
+  it('passes an abort signal (download timeout) to the release fetch', async () => {
+    const project = makeProject();
+    const upluginJson = JSON.stringify({ FileVersion: 3, VersionName: '1.0.0' });
+    let seenSignal: unknown;
+    const fetchImpl = (async (_url: string, init?: { signal?: AbortSignal }) => {
+      seenSignal = init?.signal;
+      return zipResponse({ 'FooNiagara/FooNiagara.uplugin': enc(upluginJson) });
+    }) as unknown as typeof fetch;
+
+    const r = await installExtension({ projectDir: project, extensionId: 'com.foo.niagara', catalog, fetchImpl });
+    expect(r.kind).toBe('success');
+    expect(seenSignal).toBeInstanceOf(AbortSignal);
   });
 
   it('fails (no throw) on an HTTP error from the release', async () => {

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -450,7 +450,9 @@ What it does, and why:
    itself, in the project's `.uproject` `Plugins[]` array.
 4. **Compile.** A Unreal-MCP extension is shipped as **C++ source** and compiled by UnrealBuildTool. The
    default strategy is **source-ship + compile-on-next-editor-open** (`install-extension` reports
-   `rebuildRequired: true`); `--build` opts into an eager UBT compile against the resolved engine. We
+   `rebuildRequired: true`); `--build` opts into an eager UBT compile against the resolved engine
+   (**Windows-only** — it invokes `UnrealBuildTool.exe` for the `Win64` target; on macOS/Linux omit
+   `--build` and rely on compile-on-next-editor-open). We
    ship source rather than precompiled-per-UE-version binaries because UE plugin binaries are tied to an
    exact engine version + build config + platform and are ABI-unstable across engine minors — the same
    reason the core `install-plugin` ships source and excludes the stale `Intermediate/`/`Binaries/` cache.

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -415,3 +415,47 @@ than one contract (tools + prompts + resources) and be registered under each.
 - [`samples/UnrealAIRuntimeSample/`](../samples/UnrealAIRuntimeSample) — the **runtime (in-game)** extension
   sample: a `Type=Runtime` plugin whose `game-time-dilation` tool reads/sets the live `UWorld`'s
   `AWorldSettings::TimeDilation`, callable in a running game over a runtime MCP connection (§12.9).
+
+---
+
+## Installing an extension into a project
+
+The supported way to install a published (or local) extension into a user's Unreal project is the
+`unreal-mcp-cli install-extension` command (and the matching exported library function
+`installExtension`, parity with `installPlugin`):
+
+```bash
+# From the extension's GitHub release (the default channel):
+unreal-mcp-cli install-extension <extensionId> <project> --version <x.y.z>
+
+# From a local copy — offline / CI / dev (mirrors godot-cli install-plugin --source):
+unreal-mcp-cli install-extension <extensionId> <project> --source <plugin-dir>
+
+# Compile now instead of on next editor open:
+unreal-mcp-cli install-extension <extensionId> <project> --source <plugin-dir> --build
+```
+
+What it does, and why:
+
+1. **Resolve** `<extensionId>` against the shared, engine-agnostic **extension catalog** (the typed
+   `cli/src/utils/extensions-catalog.ts`, mirror of the future `extensions.catalog.json` —
+   `{ schemaVersion, extensions[] }`; each descriptor carries `extensionId`, `pluginName`, `repo`,
+   `version`, `minCoreVersion`, `enginePlugins`, `tools`). An unpublished extension installs anyway via
+   `--source` (the descriptor is synthesized from the source `.uplugin`).
+2. **Place** the plugin into `<project>/Plugins/<pluginName>/` (build-cache / VCS subtrees excluded;
+   staged-then-swapped so a failed install never corrupts an existing one).
+3. **Enable** the extension **and its gating engine plugins** — e.g. an extension that uses Niagara
+   declares `"Plugins": [ { "Name": "Niagara", "Enabled": true } ]` in its own `.uplugin`; the installer
+   reads that set (∪ the catalog `enginePlugins` hint) and enables every entry, plus the extension
+   itself, in the project's `.uproject` `Plugins[]` array.
+4. **Compile.** A Unreal-MCP extension is shipped as **C++ source** and compiled by UnrealBuildTool. The
+   default strategy is **source-ship + compile-on-next-editor-open** (`install-extension` reports
+   `rebuildRequired: true`); `--build` opts into an eager UBT compile against the resolved engine. We
+   ship source rather than precompiled-per-UE-version binaries because UE plugin binaries are tied to an
+   exact engine version + build config + platform and are ABI-unstable across engine minors — the same
+   reason the core `install-plugin` ships source and excludes the stale `Intermediate/`/`Binaries/` cache.
+
+The install is **idempotent** (a re-run at the same version that is already enabled writes nothing) and
+the install-source resolver is **pluggable** — a future **Fab** (Epic marketplace) channel slots in as a
+new source `kind` without changing the command or library API. See
+[`cli/README.md` § Extensions](../cli/README.md#extensions) for the full option list.


### PR DESCRIPTION
## Summary
- Add an `install-extension` capability to `unreal-mcp-cli`: an exported library function `installExtension` (parity with `installPlugin`) **and** a CLI subcommand that installs a third-party Unreal-MCP extension (a UE C++ plugin implementing `IUnrealMcpToolProvider`) into a user's UE project. Foundation for all three extension install channels (CLI, app GUI, in-editor panel).
- **Pluggable install-source resolver** (`extension-source.ts`): `--source <dir>` (local/CI/offline) or a github.com-only, fail-closed GitHub-release download; a future **Fab** channel is a new source `kind` with no caller change.
- **Shared, engine-agnostic extension catalog** (`extensions-catalog.ts`): typed `{ schemaVersion, extensions[] }` mirror with `extensionId` / `pluginName` / `repo` / `version` / `minCoreVersion` / `enginePlugins` / `tools`. Ships empty until the first extension publishes (`--source` installs unpublished extensions).
- Places the plugin into `Plugins/<name>/` (staged-then-swapped, zip-slip-guarded, build-cache filtered) and **enables the extension + its gating engine plugins** (e.g. Niagara — read from the extension `.uplugin` ∪ catalog hint) in the `.uproject` `Plugins[]`. **Idempotent.**
- **Compile-on-install strategy:** source-ship + compile-on-next-editor-open by default (`rebuildRequired`), opt-in eager UBT compile via `--build`. Documented in `cli/README.md` § Extensions + `docs/EXTENSIONS.md`.
- Engine-agnostic public API (no Unreal-only types in the signature) so `unity-mcp-cli` / `godot-cli` can adopt the identical shape later.

Scope: `cli/` only — no app code, no version bump, no publish (CI-owned).

## Test plan
- [x] Target-specific local tests passed (see profile test.md, Suite 6 — `cli` npm): `npm run build` (tsc, 0 errors) + `npm test` (vitest) green — **290 passed, 1 skipped** (32 new tests: catalog, source resolver, `.uproject`/`.uplugin` transforms, local-`--source` + GitHub-release-download + `--build` + minCoreVersion paths, idempotency, failure paths).
- [x] End-to-end CLI smoke: `unreal-mcp-cli install-extension <id> <project> --source <dir>` places the plugin, excludes `Intermediate/`/`Binaries/`, enables the extension + gating `Niagara` in the `.uproject`, and a re-run reports already-up-to-date (idempotent).

Closes #172