### PR TITLE
feat(cli): add Unreal-AI-Niagara to the extensions catalog

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -110,14 +110,15 @@ and (4) compiles it. It is **idempotent** — a re-run that finds the same versi
 enabled writes nothing.
 
 **Catalog / manifest format.** The installable extensions are listed in a shared, **engine-agnostic**
-catalog (`src/utils/extensions-catalog.ts`, the typed mirror of the future
+catalog (`src/utils/extensions-catalog.ts`, the typed mirror of the source-of-truth
 `extensions.catalog.json` — `{ schemaVersion, extensions[] }`, the same shape as Godot's
-`addons/godot_mcp/extensions.catalog.json`). Each `ExtensionDescriptor` carries `extensionId`
-(reverse-DNS resolve key), `name`, `pluginName` (the `Plugins/<pluginName>` folder), `repo` (GitHub
-release source), `version`, **`minCoreVersion`** (the minimum core Unreal-MCP version — surfaced as a
-warning when unmet), `enginePlugins` (gating plugins), and `tools`. The catalog ships **empty** until
-the first extension is published; `--source <dir>` installs an unpublished extension regardless (the
-descriptor is then synthesized from the source `.uplugin`).
+`addons/godot_mcp/extensions.catalog.json`; a parity test keeps the two in lockstep). Each
+`ExtensionDescriptor` carries `extensionId` (reverse-DNS resolve key), `name`, `pluginName` (the
+`Plugins/<pluginName>` folder), `repo` (GitHub release source), `version`, **`minCoreVersion`** (the
+minimum core Unreal-MCP version — surfaced as a warning when unmet), `enginePlugins` (gating plugins),
+and `tools`. The catalog currently lists **Niagara Tools** (`com.ivanmurzak.unreal-ai-niagara`);
+`--source <dir>` installs an unpublished or off-catalog extension regardless (the descriptor is then
+synthesized from the source `.uplugin`).
 
 **Pluggable install source (Fab-ready).** `resolveInstallSource` (`src/utils/extension-source.ts`) is
 the single decision point for *where* the files come from — `--source` (local) or the GitHub release

--- a/cli/extensions.catalog.json
+++ b/cli/extensions.catalog.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "extensions": [
+    {
+      "extensionId": "com.ivanmurzak.unreal-ai-niagara",
+      "name": "Niagara Tools",
+      "description": "AI tools for Unreal's Niagara VFX system (list/inspect systems, spawn components).",
+      "pluginName": "UnrealAINiagara",
+      "repo": "IvanMurzak/Unreal-AI-Niagara",
+      "version": "0.1.0",
+      "minCoreVersion": "0.5.0",
+      "enginePlugins": ["Niagara"],
+      "tools": [
+        { "name": "niagara-list-systems", "description": "List every Niagara system (UNiagaraSystem) asset in the project (read-only), optionally filtered by a content-path prefix." },
+        { "name": "niagara-get-system", "description": "Inspect a single Niagara system asset (read-only) and report its emitters." },
+        { "name": "niagara-spawn-component", "description": "Spawn a Niagara component for a system into the active editor world at a location." }
+      ]
+    }
+  ]
+}

--- a/cli/src/utils/extensions-catalog.ts
+++ b/cli/src/utils/extensions-catalog.ts
@@ -13,16 +13,19 @@
 // by UBT — so the descriptor carries plugin-placement metadata (`pluginName`,
 // `repo`, `enginePlugins`) rather than a package id.
 //
-// CATALOG FORMAT (also the shape of the future shared
-// `engines/unreal/.../extensions.catalog.json`, mirroring Godot's
+// CATALOG FORMAT (the shape of the shared source-of-truth
+// `cli/extensions.catalog.json`, mirroring Godot's
 // `addons/godot_mcp/extensions.catalog.json` `{ schemaVersion, extensions[] }`):
 //
 //   { schemaVersion: 1, extensions: ExtensionDescriptor[] }
 //
 // This module is the CLI's typed mirror so the published npm package stays
-// self-contained (no runtime dependency on a sibling JSON). When the first Unreal
-// extension ships, append its entry here AND to the JSON, and add a parity test
-// (mirroring godot-cli's `extensions-catalog-parity.test.ts`).
+// self-contained (no runtime dependency on a sibling JSON). The JSON is the
+// single source of truth; this constant MUST stay value-equivalent to it. The
+// parity test `cli/tests/extensions-catalog-parity.test.ts` reads the JSON and
+// FAILS the build if this mirror drifts — so adding/changing an extension means
+// editing BOTH the JSON and this array (the test enforces it), exactly the
+// discipline godot-cli's `extensions-catalog-parity.test.ts` uses.
 //
 // No top-level side effects; pure data + pure lookups only.
 
@@ -81,13 +84,40 @@ export interface ExtensionDescriptor {
 
 /**
  * The extension catalog, the typed mirror of the shared
- * `extensions.catalog.json`. Ships EMPTY until the first Unreal-MCP extension
- * plugin is published — `install-extension <id>` then reports "unknown
- * extension" for every catalog id (the `--source <dir>` channel still works for
- * local/CI/offline installs of an unpublished extension). A future parity test
- * keeps this in lockstep with the JSON.
+ * `cli/extensions.catalog.json`. `install-extension <id>` resolves a user-typed
+ * id against this list (by `extensionId`, `name`, or `pluginName`); an id absent
+ * from it reports "unknown extension" but is still installable via the
+ * `--source <dir>` channel. The parity test
+ * `cli/tests/extensions-catalog-parity.test.ts` keeps this in lockstep with the
+ * JSON source of truth.
  */
-export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [] as const;
+export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [
+  {
+    extensionId: 'com.ivanmurzak.unreal-ai-niagara',
+    name: 'Niagara Tools',
+    description: "AI tools for Unreal's Niagara VFX system (list/inspect systems, spawn components).",
+    pluginName: 'UnrealAINiagara',
+    repo: 'IvanMurzak/Unreal-AI-Niagara',
+    version: '0.1.0',
+    minCoreVersion: '0.5.0',
+    enginePlugins: ['Niagara'],
+    tools: [
+      {
+        name: 'niagara-list-systems',
+        description:
+          'List every Niagara system (UNiagaraSystem) asset in the project (read-only), optionally filtered by a content-path prefix.',
+      },
+      {
+        name: 'niagara-get-system',
+        description: 'Inspect a single Niagara system asset (read-only) and report its emitters.',
+      },
+      {
+        name: 'niagara-spawn-component',
+        description: 'Spawn a Niagara component for a system into the active editor world at a location.',
+      },
+    ],
+  },
+] as const;
 
 /** True when a descriptor carries a concrete version pin (drives the up-to-date / update decision). */
 export function hasVersion(descriptor: ExtensionDescriptor): boolean {

--- a/cli/tests/extensions-catalog-parity.test.ts
+++ b/cli/tests/extensions-catalog-parity.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  EXTENSIONS_CATALOG,
+  EXTENSION_CATALOG_SCHEMA_VERSION,
+  type ExtensionDescriptor,
+} from '../src/utils/extensions-catalog.js';
+
+// The CLI's EXTENSIONS_CATALOG mirror MUST stay value-equivalent to the SHARED source of
+// truth `cli/extensions.catalog.json` (the future in-editor extensions panel / app reads the
+// same JSON). If the catalog gains/changes an entry, this test fails until the mirror is
+// updated — the drift tripwire that keeps the CLI + panel + app from diverging. Same
+// discipline as godot-cli's `extensions-catalog-parity.test.ts`.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CATALOG_JSON = path.resolve(__dirname, '..', 'extensions.catalog.json');
+
+interface CatalogJsonTool {
+  name?: string;
+  description?: string;
+}
+
+interface CatalogJsonEntry {
+  extensionId?: string;
+  name?: string;
+  description?: string;
+  pluginName?: string;
+  repo?: string | null;
+  version?: string | null;
+  minCoreVersion?: string | null;
+  enginePlugins?: string[];
+  tools?: CatalogJsonTool[];
+}
+
+/** Trim a string-or-null-or-absent field to a non-empty string, else null (mirrors the descriptor's nullable fields). */
+function trimOrNull(v: string | null | undefined): string | null {
+  if (v === undefined || v === null) return null;
+  const s = String(v).trim();
+  return s === '' ? null : s;
+}
+
+/** Normalize a raw JSON entry to the canonical ExtensionDescriptor shape. */
+function normalizeJsonEntry(e: CatalogJsonEntry): ExtensionDescriptor {
+  return {
+    extensionId: (e.extensionId ?? '').trim(),
+    name: (e.name ?? '').trim(),
+    description: (e.description ?? '').trim(),
+    pluginName: (e.pluginName ?? '').trim(),
+    repo: trimOrNull(e.repo),
+    version: trimOrNull(e.version),
+    minCoreVersion: trimOrNull(e.minCoreVersion),
+    enginePlugins: (e.enginePlugins ?? []).map((p) => p.trim()).filter((p) => p !== ''),
+    tools: (e.tools ?? [])
+      .filter((t) => t.name && t.name.trim() !== '')
+      .map((t) => ({ name: (t.name ?? '').trim(), description: (t.description ?? '').trim() })),
+  };
+}
+
+describe('extensions-catalog parity with cli/extensions.catalog.json', () => {
+  it('the catalog JSON is reachable from the test (relative layout sanity)', () => {
+    expect(fs.existsSync(CATALOG_JSON)).toBe(true);
+  });
+
+  it('the JSON schemaVersion matches the TS mirror constant', () => {
+    const raw = JSON.parse(fs.readFileSync(CATALOG_JSON, 'utf-8')) as { schemaVersion?: number };
+    expect(raw.schemaVersion).toBe(EXTENSION_CATALOG_SCHEMA_VERSION);
+  });
+
+  it('the TS mirror EXTENSIONS_CATALOG matches the JSON source of truth exactly', () => {
+    const raw = JSON.parse(fs.readFileSync(CATALOG_JSON, 'utf-8')) as {
+      extensions?: CatalogJsonEntry[];
+    };
+    const expected = (raw.extensions ?? [])
+      .filter(
+        (e) =>
+          e.extensionId && e.extensionId.trim() !== '' && e.pluginName && e.pluginName.trim() !== '',
+      )
+      .map(normalizeJsonEntry);
+
+    // Compare as plain objects (EXTENSIONS_CATALOG is readonly; spread to mutable for deep-equal).
+    const actual = EXTENSIONS_CATALOG.map((d) => ({
+      extensionId: d.extensionId,
+      name: d.name,
+      description: d.description,
+      pluginName: d.pluginName,
+      repo: d.repo,
+      version: d.version,
+      minCoreVersion: d.minCoreVersion,
+      enginePlugins: [...d.enginePlugins],
+      tools: d.tools.map((t) => ({ name: t.name, description: t.description })),
+    }));
+
+    expect(
+      actual,
+      'cli/src/utils/extensions-catalog.ts drifted from cli/extensions.catalog.json. ' +
+        'Update EXTENSIONS_CATALOG to match the JSON source of truth.',
+    ).toEqual(expected);
+  });
+});

--- a/cli/tests/install-extension.test.ts
+++ b/cli/tests/install-extension.test.ts
@@ -103,8 +103,38 @@ describe('extensions-catalog', () => {
     tools: [{ name: 'niagara-create', description: 'Create a Niagara system.' }],
   };
 
-  it('ships empty by default', () => {
-    expect(EXTENSIONS_CATALOG).toHaveLength(0);
+  it('ships the Unreal-AI-Niagara entry', () => {
+    expect(EXTENSIONS_CATALOG.length).toBeGreaterThanOrEqual(1);
+    const niagara = findExtension('com.ivanmurzak.unreal-ai-niagara');
+    expect(niagara).not.toBeNull();
+    expect(niagara!.pluginName).toBe('UnrealAINiagara');
+    expect(niagara!.repo).toBe('IvanMurzak/Unreal-AI-Niagara');
+    expect(niagara!.version).toBe('0.1.0');
+    expect(niagara!.enginePlugins).toEqual(['Niagara']);
+    expect(niagara!.tools.map((t) => t.name)).toEqual([
+      'niagara-list-systems',
+      'niagara-get-system',
+      'niagara-spawn-component',
+    ]);
+  });
+
+  it('install-extension resolves the Niagara id to the v0.1.0 release zip by id', () => {
+    // Default-channel resolution: a user typing `install-extension <niagara-id>` (no --source,
+    // no --version) resolves to the catalog-pinned v0.1.0 GitHub-release zip.
+    const niagara = findExtension('com.ivanmurzak.unreal-ai-niagara');
+    expect(niagara).not.toBeNull();
+    const source = resolveInstallSource({
+      repo: niagara!.repo,
+      pluginName: niagara!.pluginName,
+      version: niagara!.version,
+    });
+    expect(source.kind).toBe('github-release');
+    if (source.kind === 'github-release') {
+      expect(source.url).toBe(
+        'https://github.com/IvanMurzak/Unreal-AI-Niagara/releases/download/v0.1.0/UnrealAINiagara-0.1.0.zip',
+      );
+      expect(source.version).toBe('0.1.0');
+    }
   });
 
   it('findExtension matches by extensionId, name, or pluginName (case-insensitive)', () => {


### PR DESCRIPTION
## Summary
- Add the **Niagara Tools** descriptor (`com.ivanmurzak.unreal-ai-niagara`, plugin `UnrealAINiagara`, repo `IvanMurzak/Unreal-AI-Niagara`, `v0.1.0`, `enginePlugins: [Niagara]`, 3 tools) to `EXTENSIONS_CATALOG` in `cli/src/utils/extensions-catalog.ts`.
- Add the new shared source-of-truth `cli/extensions.catalog.json` (`{ schemaVersion: 1, extensions[] }`, the same shape as Godot's `addons/godot_mcp/extensions.catalog.json`) and a parity test (`cli/tests/extensions-catalog-parity.test.ts`) that keeps the TS mirror in lockstep with the JSON.
- `unreal-mcp-cli install-extension com.ivanmurzak.unreal-ai-niagara` now resolves the v0.1.0 release zip by id (`.../releases/download/v0.1.0/UnrealAINiagara-0.1.0.zip`); `--source` / `--version` escape hatches unchanged.

## Test plan
- [x] `cli` Suite 6 (`npm run build` + `npm test`) green: **297 passed, 1 skipped** (incl. new parity test + by-id resolution test).

Closes #174