### PR TITLE
feat(plugin): in-editor Extensions Slate panel — native install channel #3

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionCatalog.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionCatalog.cpp
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "Extensions/UnrealMcpExtensionCatalog.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+const int32 FUnrealMcpExtensionCatalog::SupportedSchemaVersion = 1;
+
+FString FUnrealMcpExtensionCatalog::DefaultCatalogUrl()
+{
+	// Raw single-source-of-truth JSON on the repo's default branch. The CLI mirrors this JSON as a typed
+	// constant kept in lockstep by a parity test (cli/tests/extensions-catalog-parity.test.ts); the panel
+	// fetches the JSON directly so it never carries a second drifting copy.
+	return TEXT("https://raw.githubusercontent.com/IvanMurzak/Unreal-MCP/main/cli/extensions.catalog.json");
+}
+
+bool FUnrealMcpExtensionCatalog::ParseEntry(
+	const TSharedPtr<FJsonObject>& Obj, FUnrealMcpCatalogEntry& OutEntry, FString& OutError)
+{
+	if (!Obj.IsValid())
+	{
+		OutError = TEXT("a catalog entry was not a JSON object");
+		return false;
+	}
+
+	// extensionId + pluginName are the required identity fields — an entry missing either cannot be
+	// resolved or placed, so reject the whole parse rather than silently dropping it.
+	if (!Obj->TryGetStringField(TEXT("extensionId"), OutEntry.ExtensionId) || OutEntry.ExtensionId.TrimStartAndEnd().IsEmpty())
+	{
+		OutError = TEXT("a catalog entry is missing the required 'extensionId' field");
+		return false;
+	}
+	if (!Obj->TryGetStringField(TEXT("pluginName"), OutEntry.PluginName) || OutEntry.PluginName.TrimStartAndEnd().IsEmpty())
+	{
+		OutError = FString::Printf(TEXT("catalog entry '%s' is missing the required 'pluginName' field"), *OutEntry.ExtensionId);
+		return false;
+	}
+
+	// Optional descriptive fields — absent is fine (mirrors the descriptor's nullable members).
+	Obj->TryGetStringField(TEXT("name"), OutEntry.Name);
+	Obj->TryGetStringField(TEXT("description"), OutEntry.Description);
+	Obj->TryGetStringField(TEXT("repo"), OutEntry.Repo);
+	Obj->TryGetStringField(TEXT("version"), OutEntry.Version);
+	Obj->TryGetStringField(TEXT("minCoreVersion"), OutEntry.MinCoreVersion);
+	if (OutEntry.Name.IsEmpty())
+		OutEntry.Name = OutEntry.PluginName;
+
+	const TArray<TSharedPtr<FJsonValue>>* EnginePlugins = nullptr;
+	if (Obj->TryGetArrayField(TEXT("enginePlugins"), EnginePlugins) && EnginePlugins)
+	{
+		for (const TSharedPtr<FJsonValue>& Value : *EnginePlugins)
+		{
+			FString Name;
+			if (Value.IsValid() && Value->TryGetString(Name) && !Name.TrimStartAndEnd().IsEmpty())
+				OutEntry.EnginePlugins.Add(Name.TrimStartAndEnd());
+		}
+	}
+
+	const TArray<TSharedPtr<FJsonValue>>* Tools = nullptr;
+	if (Obj->TryGetArrayField(TEXT("tools"), Tools) && Tools)
+	{
+		for (const TSharedPtr<FJsonValue>& Value : *Tools)
+		{
+			const TSharedPtr<FJsonObject>* ToolObj = nullptr;
+			if (Value.IsValid() && Value->TryGetObject(ToolObj) && ToolObj && (*ToolObj).IsValid())
+			{
+				FUnrealMcpCatalogTool Tool;
+				(*ToolObj)->TryGetStringField(TEXT("name"), Tool.Name);
+				(*ToolObj)->TryGetStringField(TEXT("description"), Tool.Description);
+				if (!Tool.Name.IsEmpty())
+					OutEntry.Tools.Add(MoveTemp(Tool));
+			}
+		}
+	}
+
+	return true;
+}
+
+bool FUnrealMcpExtensionCatalog::ParseCatalogJson(
+	const FString& Json, TArray<FUnrealMcpCatalogEntry>& OutEntries, FString& OutError, FString& OutWarning)
+{
+	OutEntries.Reset();
+	OutError.Reset();
+	OutWarning.Reset();
+
+	if (Json.TrimStartAndEnd().IsEmpty())
+	{
+		OutError = TEXT("the catalog JSON was empty");
+		return false;
+	}
+
+	TSharedPtr<FJsonObject> Root;
+	const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
+	if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid())
+	{
+		OutError = TEXT("the catalog JSON is malformed");
+		return false;
+	}
+
+	// schemaVersion is advisory: a NEWER catalog parses best-effort (warn, don't fail) so this client keeps
+	// installing the entries it understands; an absent field is treated as the supported version.
+	int32 SchemaVersion = SupportedSchemaVersion;
+	Root->TryGetNumberField(TEXT("schemaVersion"), SchemaVersion);
+	if (SchemaVersion > SupportedSchemaVersion)
+	{
+		OutWarning = FString::Printf(
+			TEXT("catalog schemaVersion %d is newer than the supported version %d; parsing best-effort — update the plugin for full support."),
+			SchemaVersion, SupportedSchemaVersion);
+	}
+
+	const TArray<TSharedPtr<FJsonValue>>* Extensions = nullptr;
+	if (!Root->TryGetArrayField(TEXT("extensions"), Extensions) || Extensions == nullptr)
+	{
+		OutError = TEXT("the catalog JSON has no 'extensions' array");
+		return false;
+	}
+
+	OutEntries.Reserve(Extensions->Num());
+	for (const TSharedPtr<FJsonValue>& Value : *Extensions)
+	{
+		const TSharedPtr<FJsonObject>* Obj = nullptr;
+		if (!Value.IsValid() || !Value->TryGetObject(Obj) || Obj == nullptr || !(*Obj).IsValid())
+		{
+			OutError = TEXT("a catalog 'extensions' element was not a JSON object");
+			OutEntries.Reset();
+			return false;
+		}
+		FUnrealMcpCatalogEntry Entry;
+		if (!ParseEntry(*Obj, Entry, OutError))
+		{
+			OutEntries.Reset();
+			return false;
+		}
+		OutEntries.Add(MoveTemp(Entry));
+	}
+
+	return true;
+}
+
+const FUnrealMcpCatalogEntry* FUnrealMcpExtensionCatalog::FindEntry(
+	const TArray<FUnrealMcpCatalogEntry>& Entries, const FString& Id)
+{
+	const FString Needle = Id.TrimStartAndEnd().ToLower();
+	if (Needle.IsEmpty())
+		return nullptr;
+
+	// extensionId first (the install identity), then name, then pluginName — the CLI's findExtension order.
+	if (const FUnrealMcpCatalogEntry* ById = Entries.FindByPredicate(
+		[&Needle](const FUnrealMcpCatalogEntry& E) { return E.ExtensionId.ToLower() == Needle; }))
+		return ById;
+	if (const FUnrealMcpCatalogEntry* ByName = Entries.FindByPredicate(
+		[&Needle](const FUnrealMcpCatalogEntry& E) { return E.Name.ToLower() == Needle; }))
+		return ByName;
+	if (const FUnrealMcpCatalogEntry* ByPlugin = Entries.FindByPredicate(
+		[&Needle](const FUnrealMcpCatalogEntry& E) { return E.PluginName.ToLower() == Needle; }))
+		return ByPlugin;
+	return nullptr;
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionCatalog.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionCatalog.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FJsonObject;
+
+/**
+ * One MCP tool an extension contributes — the native mirror of the CLI catalog's `tools[]` entry
+ * (cli/src/utils/extensions-catalog.ts `ExtensionTool`).
+ */
+struct FUnrealMcpCatalogTool
+{
+	FString Name;
+	FString Description;
+};
+
+/**
+ * One installable extension — the native C++ mirror of the SHARED catalog descriptor
+ * (`ExtensionDescriptor` in cli/src/utils/extensions-catalog.ts, source-of-truth JSON
+ * `cli/extensions.catalog.json` `{ schemaVersion, extensions[] }`). The in-editor Extensions panel
+ * (docs/ARCHITECTURE.md §7 item 10, install channel #3) reuses the SAME catalog format + install
+ * contract as the CLI (#172) and the Niagara catalog entry (#174) so all three install channels are
+ * behaviorally identical — this struct is the C++ value-equivalent of the TS descriptor, parsed from
+ * the same JSON shape rather than a second hand-maintained copy.
+ */
+struct FUnrealMcpCatalogEntry
+{
+	/** Stable reverse-DNS id (the provider's `GetExtensionId()`). Primary resolve key. */
+	FString ExtensionId;
+	/** Human-readable display name shown in the Extensions panel. */
+	FString Name;
+	FString Description;
+	/** The UE plugin folder + descriptor basename: installs into `<project>/Plugins/<PluginName>/`. */
+	FString PluginName;
+	/** `owner/repo` the extension zip is released from on GitHub Releases; empty for a source-only entry. */
+	FString Repo;
+	/** Catalog-pinned version, or empty for an unpinned entry. */
+	FString Version;
+	/** Minimum core Unreal-MCP plugin version required (`min-core-version`); empty = no floor. */
+	FString MinCoreVersion;
+	/** Gating engine plugins (e.g. `Niagara`) enabled in the `.uproject` alongside the extension. */
+	TArray<FString> EnginePlugins;
+	/** The MCP tools this extension contributes (advisory; for the panel's detail view). */
+	TArray<FUnrealMcpCatalogTool> Tools;
+
+	/** True when the descriptor carries a concrete version pin (drives the up-to-date / update decision). */
+	bool HasVersion() const { return !Version.TrimStartAndEnd().IsEmpty(); }
+};
+
+/**
+ * Parse + lookup helpers for the shared extension catalog JSON, the native analog of the CLI's
+ * `extensions-catalog.ts` (`findExtension` / `hasVersion`). Pure, no engine-process / no network — the
+ * panel fetches the JSON text over HTTP (or reads a local copy) and hands it here. Keeping the parse +
+ * lookup as pure transforms makes every decision unit-testable in an Automation spec with no live
+ * download (mirrors the FUnrealMcpServerChecksum seam).
+ */
+class FUnrealMcpExtensionCatalog
+{
+public:
+	/** The catalog schema version this parser understands (mirrors EXTENSION_CATALOG_SCHEMA_VERSION = 1). */
+	static UNREALMCPEDITOR_API const int32 SupportedSchemaVersion;
+
+	/**
+	 * The default catalog source URL: the raw `cli/extensions.catalog.json` on the Unreal-MCP repo's
+	 * default branch. This is the SINGLE source of truth shared with the CLI (a parity test keeps the
+	 * TS mirror in lockstep with the JSON), so the panel never carries a second drifting copy.
+	 */
+	static UNREALMCPEDITOR_API FString DefaultCatalogUrl();
+
+	/**
+	 * Parse the shared catalog JSON `{ schemaVersion, extensions[] }` into typed entries. Returns false +
+	 * a human-readable reason on malformed JSON, a missing/!array `extensions`, or an entry missing the
+	 * required `extensionId` / `pluginName`. A schemaVersion newer than @ref SupportedSchemaVersion is a
+	 * WARNING returned via @p OutWarning (still parsed best-effort), not a hard failure — a newer catalog
+	 * should degrade gracefully rather than block installs of the entries this client understands.
+	 */
+	static UNREALMCPEDITOR_API bool ParseCatalogJson(
+		const FString& Json, TArray<FUnrealMcpCatalogEntry>& OutEntries, FString& OutError, FString& OutWarning);
+
+	/**
+	 * Resolve a user-supplied id to a catalog entry, case-insensitively, by `extensionId` first (the
+	 * install identity), then `name`, then `pluginName` — exactly the CLI's `findExtension` precedence.
+	 * Returns nullptr when absent or @p Id is empty.
+	 */
+	static UNREALMCPEDITOR_API const FUnrealMcpCatalogEntry* FindEntry(
+		const TArray<FUnrealMcpCatalogEntry>& Entries, const FString& Id);
+
+private:
+	static bool ParseEntry(const TSharedPtr<FJsonObject>& Obj, FUnrealMcpCatalogEntry& OutEntry, FString& OutError);
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionInstaller.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionInstaller.cpp
@@ -30,6 +30,21 @@ namespace
 	/** The trusted download host — extension zips come ONLY from github.com (mirrors extension-source.ts). */
 	const TCHAR* ExtInstTrustedDownloadHost = TEXT("github.com");
 
+	/**
+	 * Shared state for a bounded, synchronous HTTP wait. Heap-held via a thread-safe shared ref and captured
+	 * BY VALUE in the completion lambda, so a cancelled request whose completion delegate fires on a LATER
+	 * HttpManager tick (after the calling frame returned on the timeout path) writes into live memory rather
+	 * than dangling stack references (use-after-return).
+	 */
+	struct FExtInstHttpWait
+	{
+		bool bDone = false;
+		bool bOk = false;
+		int32 ResponseCode = -1;
+		TArray<uint8> Bytes; // DownloadAndExtract payload
+		FString Body;        // FetchCatalogSync payload
+	};
+
 	/** Plugin-source subtrees never copied into the target project (mirrors install-extension.ts EXCLUDED_DIRS). */
 	bool ExtInstIsExcludedSegment(const FString& Segment)
 	{
@@ -121,9 +136,9 @@ FString FUnrealMcpExtensionInstaller::ExtensionAssetName(const FString& PluginNa
 
 FString FUnrealMcpExtensionInstaller::ExtensionDownloadUrl(const FString& Repo, const FString& PluginName, const FString& Version)
 {
-	const FString Bare = StripLeadingV(Version);
+	// ExtensionAssetName strips the leading v internally, so pass Version through directly.
 	return FString::Printf(TEXT("https://%s/%s/releases/download/%s/%s"),
-		ExtInstTrustedDownloadHost, *Repo, *ReleaseTag(Version), *ExtensionAssetName(PluginName, Bare));
+		ExtInstTrustedDownloadHost, *Repo, *ReleaseTag(Version), *ExtensionAssetName(PluginName, Version));
 }
 
 bool FUnrealMcpExtensionInstaller::IsTrustedDownloadUrl(const FString& Url)
@@ -353,32 +368,32 @@ bool FUnrealMcpExtensionInstaller::CopyPluginTreeFiltered(const FString& SourceR
 
 	bool bOk = true;
 	FString FailReason;
-	PF.IterateDirectoryRecursively(*SourceFull, [&](const TCHAR* Path, bool bIsDir) -> bool
+	// Recursive walk that PRUNES build-cache / VCS subtrees at the directory level (never descends into
+	// them), rather than descending everywhere and discarding each excluded file after the fact.
+	TFunction<void(const FString&, const FString&)> Walk = [&](const FString& SrcDir, const FString& DstDir)
 	{
-		if (bIsDir)
+		PF.IterateDirectory(*SrcDir, [&](const TCHAR* Path, bool bIsDir) -> bool
+		{
+			const FString Full = Path;
+			const FString Leaf = FPaths::GetCleanFilename(Full);
+			if (bIsDir)
+			{
+				if (!ExtInstIsExcludedSegment(Leaf))
+					Walk(Full, DstDir / Leaf);
+				return bOk; // stop the walk once a copy has failed
+			}
+			const FString DestFile = DstDir / Leaf;
+			PF.CreateDirectoryTree(*DstDir);
+			if (!PF.CopyFile(*DestFile, Path))
+			{
+				bOk = false;
+				FailReason = FString::Printf(TEXT("failed to copy '%s' → '%s'"), Path, *DestFile);
+				return false; // stop iterating this directory
+			}
 			return true;
-		FString Rel = Path;
-		FPaths::MakePathRelativeTo(Rel, *(SourceFull / TEXT("")));
-		Rel.ReplaceInline(TEXT("\\"), TEXT("/"));
-
-		TArray<FString> Segments;
-		Rel.ParseIntoArray(Segments, TEXT("/"));
-		for (const FString& Seg : Segments)
-		{
-			if (ExtInstIsExcludedSegment(Seg))
-				return true; // skip build-cache / VCS subtree file
-		}
-
-		const FString DestFile = DestFull / Rel;
-		PF.CreateDirectoryTree(*FPaths::GetPath(DestFile));
-		if (!PF.CopyFile(*DestFile, Path))
-		{
-			bOk = false;
-			FailReason = FString::Printf(TEXT("failed to copy '%s' → '%s'"), Path, *DestFile);
-			return false; // stop iterating
-		}
-		return true;
-	});
+		});
+	};
+	Walk(SourceFull, DestFull);
 
 	if (!bOk)
 		OutError = FailReason;
@@ -397,7 +412,8 @@ bool FUnrealMcpExtensionInstaller::PlacePluginDir(const FString& SourcePluginRoo
 	PF.DeleteDirectoryRecursively(*Staging);
 	ON_SCOPE_EXIT { PF.DeleteDirectoryRecursively(*Staging); };
 
-	// 1. Filtered copy into a sibling staging dir (a mid-copy failure never touches an existing install).
+	// 1. Filtered copy into a sibling staging dir first, so the swap below only ever copies a validated
+	//    tree (a mid-copy failure HERE leaves the existing install untouched — the staging dir is separate).
 	if (!CopyPluginTreeFiltered(SourcePluginRoot, Staging, OutError))
 		return false;
 	if (FindUPluginFile(Staging).IsEmpty())
@@ -406,11 +422,30 @@ bool FUnrealMcpExtensionInstaller::PlacePluginDir(const FString& SourcePluginRoo
 		return false;
 	}
 
-	// 2. Swap: drop the existing install, then move the validated staging tree into place
-	//    (CopyDirectoryTree lives on IPlatformFile, not IFileManager).
+	// 2. Swap with rollback. Preserve the prior install (move it aside to a sibling backup) BEFORE
+	//    dropping it, so that if the final copy-into-place fails the project is restored to its previous
+	//    working install rather than left half-written with nothing. (CopyDirectoryTree is on IPlatformFile.)
+	const FString Backup = PluginsDir / FString::Printf(TEXT(".unreal-mcp-ext-backup-%u-%llx"),
+		FPlatformProcess::GetCurrentProcessId(), (uint64)FPlatformTime::Cycles64());
+	PF.DeleteDirectoryRecursively(*Backup);
+	ON_SCOPE_EXIT { PF.DeleteDirectoryRecursively(*Backup); };
+
+	const bool bHadExisting = PF.DirectoryExists(*InstallReal);
+	if (bHadExisting && !PF.CopyDirectoryTree(*Backup, *InstallReal, /*bOverwriteAllExisting*/ true))
+	{
+		OutError = FString::Printf(TEXT("failed to back up the existing install at '%s' before replacing it"), *InstallReal);
+		return false;
+	}
+
 	PF.DeleteDirectoryRecursively(*InstallReal);
 	if (!PF.CopyDirectoryTree(*InstallReal, *Staging, /*bOverwriteAllExisting*/ true))
 	{
+		// Restore the prior install so a failed swap can't leave the project with no working install.
+		if (bHadExisting)
+		{
+			PF.DeleteDirectoryRecursively(*InstallReal);
+			PF.CopyDirectoryTree(*InstallReal, *Backup, /*bOverwriteAllExisting*/ true);
+		}
 		OutError = FString::Printf(TEXT("failed to move staged plugin into '%s'"), *InstallReal);
 		return false;
 	}
@@ -435,7 +470,7 @@ FString FUnrealMcpExtensionInstaller::ResolveLocalPluginRoot(const FString& Sour
 	return FPaths::GetPath(Uplugin);
 }
 
-bool FUnrealMcpExtensionInstaller::DownloadAndExtract(const FString& Url, double TimeoutSeconds, FString& OutPluginRoot, FString& OutError)
+bool FUnrealMcpExtensionInstaller::DownloadAndExtract(const FString& Url, double TimeoutSeconds, FString& OutPluginRoot, FString& OutExtractDir, FString& OutError)
 {
 	if (!IsTrustedDownloadUrl(Url))
 	{
@@ -446,25 +481,23 @@ bool FUnrealMcpExtensionInstaller::DownloadAndExtract(const FString& Url, double
 	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] downloading extension zip from %s"), *Url);
 
 	// Bounded synchronous HTTP GET on the game thread (the user explicitly clicked Install) — mirrors the
-	// local-server download's bounded wait (FUnrealMcpServerManager::DownloadBinaryIfNeeded).
+	// local-server download's bounded wait (FUnrealMcpServerManager::DownloadBinaryIfNeeded). The wait state
+	// is heap-held + captured by value so a late completion after a timeout cancel can't write dangling refs.
 	FHttpModule& Http = FHttpModule::Get();
 	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> Request = Http.CreateRequest();
 	Request->SetURL(Url);
 	Request->SetVerb(TEXT("GET"));
 
-	bool bDone = false;
-	bool bOk = false;
-	int32 ResponseCode = -1;
-	TArray<uint8> ZipBytes;
+	TSharedRef<FExtInstHttpWait, ESPMode::ThreadSafe> State = MakeShared<FExtInstHttpWait, ESPMode::ThreadSafe>();
 	Request->OnProcessRequestComplete().BindLambda(
-		[&bDone, &bOk, &ResponseCode, &ZipBytes](FHttpRequestPtr, FHttpResponsePtr Resp, bool bConnectedOk)
+		[State](FHttpRequestPtr, FHttpResponsePtr Resp, bool bConnectedOk)
 		{
-			bDone = true;
-			ResponseCode = Resp.IsValid() ? Resp->GetResponseCode() : -1;
-			if (bConnectedOk && Resp.IsValid() && ResponseCode == 200)
+			State->bDone = true;
+			State->ResponseCode = Resp.IsValid() ? Resp->GetResponseCode() : -1;
+			if (bConnectedOk && Resp.IsValid() && State->ResponseCode == 200)
 			{
-				ZipBytes = Resp->GetContent();
-				bOk = true;
+				State->Bytes = Resp->GetContent();
+				State->bOk = true;
 			}
 		});
 
@@ -475,21 +508,21 @@ bool FUnrealMcpExtensionInstaller::DownloadAndExtract(const FString& Url, double
 	}
 
 	const double Deadline = FPlatformTime::Seconds() + TimeoutSeconds;
-	while (!bDone && FPlatformTime::Seconds() < Deadline)
+	while (!State->bDone && FPlatformTime::Seconds() < Deadline)
 	{
 		Http.GetHttpManager().Tick(0.1f);
 		FPlatformProcess::Sleep(0.05f);
 	}
-	if (!bDone)
+	if (!State->bDone)
 	{
 		Request->CancelRequest();
 		OutError = TEXT("the extension download timed out");
 		return false;
 	}
-	if (!bOk || ZipBytes.Num() == 0)
+	if (!State->bOk || State->Bytes.Num() == 0)
 	{
 		OutError = FString::Printf(TEXT("extension download failed (HTTP %d) from %s. Verify the release exists, or install from a local source."),
-			ResponseCode, *Url);
+			State->ResponseCode, *Url);
 		return false;
 	}
 
@@ -499,7 +532,7 @@ bool FUnrealMcpExtensionInstaller::DownloadAndExtract(const FString& Url, double
 	IFileManager& FM = IFileManager::Get();
 	const FString TempZip = FPaths::ConvertRelativePathToFull(
 		FPaths::CreateTempFilename(*FPaths::ProjectIntermediateDir(), TEXT("unreal-mcp-ext-"), TEXT(".zip")));
-	if (!FFileHelper::SaveArrayToFile(ZipBytes, *TempZip))
+	if (!FFileHelper::SaveArrayToFile(State->Bytes, *TempZip))
 	{
 		OutError = TEXT("could not stage the downloaded extension zip");
 		return false;
@@ -523,6 +556,9 @@ bool FUnrealMcpExtensionInstaller::DownloadAndExtract(const FString& Url, double
 		FPaths::CreateTempFilename(*FPaths::ProjectIntermediateDir(), TEXT("unreal-mcp-ext-extract-"), TEXT("")));
 	const FString ExtractReal = ExtractDir; // already absolute
 	FM.MakeDirectory(*ExtractReal, /*Tree*/ true);
+	// Surface the temp extract dir so the caller deletes it once PlacePluginDir has consumed the plugin
+	// root inside it — the returned OutPluginRoot points INTO this dir, so it cannot be cleaned here.
+	OutExtractDir = ExtractReal;
 
 	const TArray<FString> Names = Reader.GetFileNames();
 	for (const FString& Name : Names)
@@ -575,19 +611,16 @@ bool FUnrealMcpExtensionInstaller::FetchCatalogSync(
 	Request->SetURL(Trimmed);
 	Request->SetVerb(TEXT("GET"));
 
-	bool bDone = false;
-	bool bOk = false;
-	int32 ResponseCode = -1;
-	FString Body;
+	TSharedRef<FExtInstHttpWait, ESPMode::ThreadSafe> State = MakeShared<FExtInstHttpWait, ESPMode::ThreadSafe>();
 	Request->OnProcessRequestComplete().BindLambda(
-		[&bDone, &bOk, &ResponseCode, &Body](FHttpRequestPtr, FHttpResponsePtr Resp, bool bConnectedOk)
+		[State](FHttpRequestPtr, FHttpResponsePtr Resp, bool bConnectedOk)
 		{
-			bDone = true;
-			ResponseCode = Resp.IsValid() ? Resp->GetResponseCode() : -1;
-			if (bConnectedOk && Resp.IsValid() && ResponseCode == 200)
+			State->bDone = true;
+			State->ResponseCode = Resp.IsValid() ? Resp->GetResponseCode() : -1;
+			if (bConnectedOk && Resp.IsValid() && State->ResponseCode == 200)
 			{
-				Body = Resp->GetContentAsString();
-				bOk = true;
+				State->Body = Resp->GetContentAsString();
+				State->bOk = true;
 			}
 		});
 
@@ -597,25 +630,25 @@ bool FUnrealMcpExtensionInstaller::FetchCatalogSync(
 		return false;
 	}
 	const double Deadline = FPlatformTime::Seconds() + TimeoutSeconds;
-	while (!bDone && FPlatformTime::Seconds() < Deadline)
+	while (!State->bDone && FPlatformTime::Seconds() < Deadline)
 	{
 		Http.GetHttpManager().Tick(0.1f);
 		FPlatformProcess::Sleep(0.05f);
 	}
-	if (!bDone)
+	if (!State->bDone)
 	{
 		Request->CancelRequest();
 		OutError = TEXT("the catalog fetch timed out");
 		return false;
 	}
-	if (!bOk)
+	if (!State->bOk)
 	{
-		OutError = FString::Printf(TEXT("could not fetch the catalog (HTTP %d) from %s"), ResponseCode, *Trimmed);
+		OutError = FString::Printf(TEXT("could not fetch the catalog (HTTP %d) from %s"), State->ResponseCode, *Trimmed);
 		return false;
 	}
 
 	FString Warning;
-	if (!FUnrealMcpExtensionCatalog::ParseCatalogJson(Body, OutEntries, OutError, Warning))
+	if (!FUnrealMcpExtensionCatalog::ParseCatalogJson(State->Body, OutEntries, OutError, Warning))
 		return false;
 	if (!Warning.IsEmpty())
 		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] %s"), *Warning);
@@ -671,6 +704,14 @@ FUnrealMcpInstallResult FUnrealMcpExtensionInstaller::Install(const FUnrealMcpIn
 	{
 		FString PluginRoot;
 		FString Err;
+		// The github-release path extracts into a temp dir whose lifetime must outlast DownloadAndExtract
+		// (PluginRoot points inside it) but end after PlacePluginDir consumes it — clean it on block exit.
+		FString ExtractDirToClean;
+		ON_SCOPE_EXIT
+		{
+			if (!ExtractDirToClean.IsEmpty())
+				IFileManager::Get().DeleteDirectory(*ExtractDirToClean, /*RequireExists*/ false, /*Tree*/ true);
+		};
 		if (!Options.SourceDir.TrimStartAndEnd().IsEmpty())
 		{
 			PluginRoot = ResolveLocalPluginRoot(Options.SourceDir, Err);
@@ -684,7 +725,7 @@ FUnrealMcpInstallResult FUnrealMcpExtensionInstaller::Install(const FUnrealMcpIn
 		{
 			const FString Url = ExtensionDownloadUrl(Options.Descriptor.Repo, PluginName, ToVersion);
 			FString ExtractedRoot;
-			if (!DownloadAndExtract(Url, Options.DownloadTimeoutSeconds, ExtractedRoot, Err))
+			if (!DownloadAndExtract(Url, Options.DownloadTimeoutSeconds, ExtractedRoot, ExtractDirToClean, Err))
 			{
 				Result.Error = Err;
 				return Result;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionInstaller.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionInstaller.cpp
@@ -554,20 +554,19 @@ bool FUnrealMcpExtensionInstaller::DownloadAndExtract(const FString& Url, double
 
 	const FString ExtractDir = FPaths::ConvertRelativePathToFull(
 		FPaths::CreateTempFilename(*FPaths::ProjectIntermediateDir(), TEXT("unreal-mcp-ext-extract-"), TEXT("")));
-	const FString ExtractReal = ExtractDir; // already absolute
-	FM.MakeDirectory(*ExtractReal, /*Tree*/ true);
+	FM.MakeDirectory(*ExtractDir, /*Tree*/ true);
 	// Surface the temp extract dir so the caller deletes it once PlacePluginDir has consumed the plugin
 	// root inside it — the returned OutPluginRoot points INTO this dir, so it cannot be cleaned here.
-	OutExtractDir = ExtractReal;
+	OutExtractDir = ExtractDir;
 
 	const TArray<FString> Names = Reader.GetFileNames();
 	for (const FString& Name : Names)
 	{
 		if (Name.EndsWith(TEXT("/")))
 			continue; // directory entry
-		// Zip-slip guard: the resolved path must stay under ExtractReal (mirrors the CLI's extractZip).
-		const FString Target = FPaths::ConvertRelativePathToFull(ExtractReal / Name);
-		if (Target != ExtractReal && !Target.StartsWith(ExtractReal + TEXT("/")) && !Target.StartsWith(ExtractReal + TEXT("\\")))
+		// Zip-slip guard: the resolved path must stay under ExtractDir (mirrors the CLI's extractZip).
+		const FString Target = FPaths::ConvertRelativePathToFull(ExtractDir / Name);
+		if (Target != ExtractDir && !Target.StartsWith(ExtractDir + TEXT("/")) && !Target.StartsWith(ExtractDir + TEXT("\\")))
 		{
 			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] skipped suspicious zip entry escaping the extract dir: %s"), *Name);
 			continue;
@@ -586,7 +585,7 @@ bool FUnrealMcpExtensionInstaller::DownloadAndExtract(const FString& Url, double
 		}
 	}
 
-	const FString Uplugin = FindUPluginFile(ExtractReal);
+	const FString Uplugin = FindUPluginFile(ExtractDir);
 	if (Uplugin.IsEmpty())
 	{
 		OutError = FString::Printf(TEXT("downloaded zip did not contain a .uplugin (%s is not a valid extension release)"), *Url);

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionInstaller.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionInstaller.cpp
@@ -1,0 +1,794 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "Extensions/UnrealMcpExtensionInstaller.h"
+#include "Extensions/UnrealMcpUProjectPlugins.h"
+#include "Extensions/UnrealMcpExtensionManager.h" // FUnrealMcpExtensionRecord (runtime module, reached via PrivateIncludePaths)
+#include "UnrealMcpLog.h"
+
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Misc/ScopeExit.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformFileManager.h"
+#include "GenericPlatform/GenericPlatformFile.h"
+#include "HAL/PlatformProcess.h"
+#include "HAL/PlatformTime.h"
+
+#include "HttpModule.h"
+#include "HttpManager.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+
+#include "FileUtilities/ZipArchiveReader.h"
+
+namespace
+{
+	/** The trusted download host — extension zips come ONLY from github.com (mirrors extension-source.ts). */
+	const TCHAR* ExtInstTrustedDownloadHost = TEXT("github.com");
+
+	/** Plugin-source subtrees never copied into the target project (mirrors install-extension.ts EXCLUDED_DIRS). */
+	bool ExtInstIsExcludedSegment(const FString& Segment)
+	{
+		return Segment == TEXT("Intermediate") || Segment == TEXT("Binaries") || Segment == TEXT("Saved")
+			|| Segment == TEXT("DerivedDataCache") || Segment == TEXT(".git") || Segment == TEXT(".vs")
+			|| Segment == TEXT("node_modules");
+	}
+
+	/** Parse a file's JSON into an FJsonObject (or null on failure). */
+	TSharedPtr<FJsonObject> ExtInstLoadJsonObject(const FString& FilePath)
+	{
+		FString Text;
+		if (!FFileHelper::LoadFileToString(Text, *FilePath))
+			return nullptr;
+		TSharedPtr<FJsonObject> Root;
+		const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Text);
+		if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid())
+			return nullptr;
+		return Root;
+	}
+
+	/** Numeric dotted-version compare (`1.2.0` vs `1.10.0`). Returns -1 / 0 / 1; non-numeric parts compare as 0. */
+	int32 ExtInstCompareSemver(const FString& A, const FString& B)
+	{
+		TArray<FString> PartsA, PartsB;
+		A.ParseIntoArray(PartsA, TEXT("."));
+		B.ParseIntoArray(PartsB, TEXT("."));
+		const int32 Len = FMath::Max(PartsA.Num(), PartsB.Num());
+		for (int32 i = 0; i < Len; ++i)
+		{
+			const int32 Da = PartsA.IsValidIndex(i) ? FCString::Atoi(*PartsA[i]) : 0;
+			const int32 Db = PartsB.IsValidIndex(i) ? FCString::Atoi(*PartsB[i]) : 0;
+			if (Da != Db)
+				return Da < Db ? -1 : 1;
+		}
+		return 0;
+	}
+
+	/** Find the first top-level `*.uproject` in @p ProjectDir, or empty. */
+	FString ExtInstFindUProjectFile(const FString& ProjectDir)
+	{
+		TArray<FString> Found;
+		IFileManager::Get().FindFiles(Found, *(ProjectDir / TEXT("*.uproject")), /*Files*/ true, /*Dirs*/ false);
+		return Found.Num() > 0 ? (ProjectDir / Found[0]) : FString();
+	}
+
+	/** De-dupe strings case-insensitively, preserving first-seen order. */
+	TArray<FString> ExtInstUniqueCaseless(const TArray<FString>& Values)
+	{
+		TArray<FString> Out;
+		TSet<FString> Seen;
+		for (const FString& V : Values)
+		{
+			const FString Key = V.ToLower();
+			if (!Seen.Contains(Key))
+			{
+				Seen.Add(Key);
+				Out.Add(V);
+			}
+		}
+		return Out;
+	}
+}
+
+// ---------------------------------------------------------------------------------------------------
+// Pure helpers — extension-source.ts parity
+// ---------------------------------------------------------------------------------------------------
+
+FString FUnrealMcpExtensionInstaller::StripLeadingV(const FString& Version)
+{
+	const FString V = Version.TrimStartAndEnd();
+	if (V.Len() > 0 && (V[0] == TEXT('v') || V[0] == TEXT('V')))
+		return V.RightChop(1);
+	return V;
+}
+
+FString FUnrealMcpExtensionInstaller::ReleaseTag(const FString& Version)
+{
+	const FString V = Version.TrimStartAndEnd();
+	if (V.Len() > 0 && (V[0] == TEXT('v') || V[0] == TEXT('V')))
+		return V;
+	return FString::Printf(TEXT("v%s"), *V);
+}
+
+FString FUnrealMcpExtensionInstaller::ExtensionAssetName(const FString& PluginName, const FString& Version)
+{
+	return FString::Printf(TEXT("%s-%s.zip"), *PluginName, *StripLeadingV(Version));
+}
+
+FString FUnrealMcpExtensionInstaller::ExtensionDownloadUrl(const FString& Repo, const FString& PluginName, const FString& Version)
+{
+	const FString Bare = StripLeadingV(Version);
+	return FString::Printf(TEXT("https://%s/%s/releases/download/%s/%s"),
+		ExtInstTrustedDownloadHost, *Repo, *ReleaseTag(Version), *ExtensionAssetName(PluginName, Bare));
+}
+
+bool FUnrealMcpExtensionInstaller::IsTrustedDownloadUrl(const FString& Url)
+{
+	const FString Trimmed = Url.TrimStartAndEnd();
+	if (!Trimmed.StartsWith(TEXT("https://"), ESearchCase::IgnoreCase))
+		return false;
+	FString Authority = Trimmed.RightChop(8); // drop "https://"
+	int32 SlashIdx;
+	if (Authority.FindChar(TEXT('/'), SlashIdx))
+		Authority.LeftInline(SlashIdx);
+	// Reject embedded userinfo ("user@github.com.evil") outright.
+	if (Authority.Contains(TEXT("@")))
+		return false;
+	// Strip an optional :port and compare the host EXACTLY (no subdomains).
+	FString Host = Authority;
+	int32 ColonIdx;
+	if (Host.FindChar(TEXT(':'), ColonIdx))
+		Host.LeftInline(ColonIdx);
+	return Host.ToLower() == FString(ExtInstTrustedDownloadHost);
+}
+
+// ---------------------------------------------------------------------------------------------------
+// Pure helpers — install-extension.ts decisions
+// ---------------------------------------------------------------------------------------------------
+
+bool FUnrealMcpExtensionInstaller::IsMaterializeNeeded(
+	bool bForce, bool bInstalledPresent, const FString& FromVersion, const FString& ToVersion)
+{
+	if (bForce || !bInstalledPresent)
+		return true;
+	const FString To = ToVersion.TrimStartAndEnd();
+	if (To.IsEmpty())
+		return false; // no target version known and already present → nothing to do
+	return StripLeadingV(FromVersion) != StripLeadingV(To);
+}
+
+EUnrealMcpInstallOutcome FUnrealMcpExtensionInstaller::ComputeOutcome(
+	bool bChanged, bool bMaterializeNeeded, bool bHadPrevVersion)
+{
+	if (!bChanged)
+		return EUnrealMcpInstallOutcome::AlreadyUpToDate;
+	if (!bMaterializeNeeded)
+		return EUnrealMcpInstallOutcome::Enabled; // only the .uproject enable entry was (re)written
+	return bHadPrevVersion ? EUnrealMcpInstallOutcome::Updated : EUnrealMcpInstallOutcome::Added;
+}
+
+FString FUnrealMcpExtensionInstaller::BuildOutcomeMessage(
+	EUnrealMcpInstallOutcome Outcome, const FString& PluginName, const FString& FromVersion,
+	const FString& ToVersion, bool bRebuildRequired, const TArray<FString>& GatingPlugins)
+{
+	const FString Gating = GatingPlugins.Num() > 0
+		? FString::Printf(TEXT(" (also enabled: %s)"), *FString::Join(GatingPlugins, TEXT(", ")))
+		: FString();
+	const FString Compile = bRebuildRequired
+		? TEXT(" Rebuild required — restart the editor (or trigger Live Coding) to finish compiling.")
+		: FString();
+	const FString ToSuffix = ToVersion.IsEmpty() ? FString() : FString::Printf(TEXT(" %s"), *ToVersion);
+	const FString FromSuffix = FromVersion.IsEmpty() ? FString() : FString::Printf(TEXT(" %s"), *FromVersion);
+
+	switch (Outcome)
+	{
+	case EUnrealMcpInstallOutcome::Added:
+		return FString::Printf(TEXT("Installed extension %s%s and enabled it%s.%s"), *PluginName, *ToSuffix, *Gating, *Compile);
+	case EUnrealMcpInstallOutcome::Updated:
+		return FString::Printf(TEXT("Updated extension %s%s → %s%s.%s"),
+			*PluginName, *FromSuffix, ToVersion.IsEmpty() ? TEXT("(unpinned)") : *ToVersion, *Gating, *Compile);
+	case EUnrealMcpInstallOutcome::Enabled:
+		return FString::Printf(TEXT("Enabled existing extension %s%s in the project%s.%s"), *PluginName, *FromSuffix, *Gating, *Compile);
+	case EUnrealMcpInstallOutcome::AlreadyUpToDate:
+	default:
+		return FString::Printf(TEXT("Extension %s%s is already installed and enabled."), *PluginName, *ToSuffix);
+	}
+}
+
+// ---------------------------------------------------------------------------------------------------
+// The catalog ∪ loaded ∪ disk row-merge (pure)
+// ---------------------------------------------------------------------------------------------------
+
+TArray<FUnrealMcpExtensionRow> FUnrealMcpExtensionInstaller::BuildRows(
+	const TArray<FUnrealMcpCatalogEntry>& Catalog,
+	const TArray<FUnrealMcpExtensionRecord>& LoadedRecords,
+	const TArray<FUnrealMcpInstalledOnDisk>& InstalledOnDisk)
+{
+	TArray<FUnrealMcpExtensionRow> Rows;
+	TSet<FString> CatalogExtensionIds; // lowercased, to detect loaded-but-not-cataloged extras
+
+	for (const FUnrealMcpCatalogEntry& Entry : Catalog)
+	{
+		FUnrealMcpExtensionRow Row;
+		Row.ExtensionId = Entry.ExtensionId;
+		Row.DisplayName = Entry.Name;
+		Row.Description = Entry.Description;
+		Row.PluginName = Entry.PluginName;
+		Row.Repo = Entry.Repo;
+		Row.CatalogVersion = Entry.Version;
+		Row.bInCatalog = true;
+		CatalogExtensionIds.Add(Entry.ExtensionId.ToLower());
+
+		// On-disk match by plugin folder name (case-insensitive — UE plugin names are case-insensitive).
+		FString InstalledVersion;
+		for (const FUnrealMcpInstalledOnDisk& Disk : InstalledOnDisk)
+		{
+			if (Disk.PluginName.ToLower() == Entry.PluginName.ToLower())
+			{
+				Row.bInstalled = true;
+				InstalledVersion = Disk.Version;
+				break;
+			}
+		}
+
+		// Loaded-provider match by extension id (compiled + registered via IModularFeatures).
+		for (const FUnrealMcpExtensionRecord& Rec : LoadedRecords)
+		{
+			if (Rec.Id.ToLower() == Entry.ExtensionId.ToLower())
+			{
+				Row.bLoaded = true;
+				Row.bInstalled = true; // loaded implies present
+				Row.bEnabled = Rec.bEnabled;
+				Row.bHasError = Rec.HasError();
+				Row.Error = Rec.Error;
+				Row.ToolCount = Rec.ToolCount;
+				if (!Rec.Version.IsEmpty())
+					InstalledVersion = Rec.Version;
+				break;
+			}
+		}
+
+		Row.Version = !InstalledVersion.IsEmpty() ? InstalledVersion : Entry.Version;
+		// An update is offered when installed at a version that differs from the (newer) catalog pin.
+		if (Row.bInstalled && Entry.HasVersion() && !InstalledVersion.IsEmpty()
+			&& StripLeadingV(InstalledVersion) != StripLeadingV(Entry.Version))
+		{
+			Row.bUpdateAvailable = true;
+		}
+		Rows.Add(MoveTemp(Row));
+	}
+
+	// Loaded providers NOT in the catalog (e.g. a local --source dev install) — surface them too.
+	for (const FUnrealMcpExtensionRecord& Rec : LoadedRecords)
+	{
+		if (CatalogExtensionIds.Contains(Rec.Id.ToLower()))
+			continue;
+		FUnrealMcpExtensionRow Row;
+		Row.ExtensionId = Rec.Id;
+		Row.DisplayName = Rec.DisplayName.IsEmpty() ? Rec.Id : Rec.DisplayName.ToString();
+		Row.PluginName = Rec.Id;
+		Row.Version = Rec.Version;
+		Row.bInCatalog = false;
+		Row.bInstalled = true;
+		Row.bLoaded = true;
+		Row.bEnabled = Rec.bEnabled;
+		Row.bHasError = Rec.HasError();
+		Row.Error = Rec.Error;
+		Row.ToolCount = Rec.ToolCount;
+		Rows.Add(MoveTemp(Row));
+	}
+
+	return Rows;
+}
+
+// ---------------------------------------------------------------------------------------------------
+// Filesystem helpers
+// ---------------------------------------------------------------------------------------------------
+
+FString FUnrealMcpExtensionInstaller::FindUPluginFile(const FString& Dir)
+{
+	IPlatformFile& PF = FPlatformFileManager::Get().GetPlatformFile();
+	FString Best;
+	int32 BestDepth = MAX_int32;
+
+	TFunction<void(const FString&, int32)> Walk = [&](const FString& Current, int32 Depth)
+	{
+		if (Depth >= BestDepth)
+			return;
+		PF.IterateDirectory(*Current, [&](const TCHAR* Path, bool bIsDir) -> bool
+		{
+			const FString Full = Path;
+			const FString Leaf = FPaths::GetCleanFilename(Full);
+			if (bIsDir)
+			{
+				if (!ExtInstIsExcludedSegment(Leaf))
+					Walk(Full, Depth + 1);
+			}
+			else if (Leaf.EndsWith(TEXT(".uplugin"), ESearchCase::IgnoreCase) && Depth < BestDepth)
+			{
+				Best = Full;
+				BestDepth = Depth;
+			}
+			return true; // keep iterating
+		});
+	};
+	Walk(Dir, 0);
+	return Best;
+}
+
+TArray<FUnrealMcpInstalledOnDisk> FUnrealMcpExtensionInstaller::ScanInstalledPlugins(const FString& ProjectDir)
+{
+	TArray<FUnrealMcpInstalledOnDisk> Out;
+	const FString PluginsDir = ProjectDir / TEXT("Plugins");
+	IFileManager& FM = IFileManager::Get();
+	if (!FM.DirectoryExists(*PluginsDir))
+		return Out;
+
+	TArray<FString> Dirs;
+	FM.FindFiles(Dirs, *(PluginsDir / TEXT("*")), /*Files*/ false, /*Dirs*/ true);
+	for (const FString& DirName : Dirs)
+	{
+		const FString PluginDir = PluginsDir / DirName;
+		const FString Uplugin = FindUPluginFile(PluginDir);
+		if (Uplugin.IsEmpty())
+			continue;
+		FUnrealMcpInstalledOnDisk Entry;
+		Entry.PluginName = FPaths::GetBaseFilename(Uplugin); // UE requires folder == .uplugin basename
+		Entry.Version = FUnrealMcpUProjectPlugins::ReadUPluginVersionName(ExtInstLoadJsonObject(Uplugin));
+		Out.Add(MoveTemp(Entry));
+	}
+	return Out;
+}
+
+bool FUnrealMcpExtensionInstaller::CopyPluginTreeFiltered(const FString& SourceRoot, const FString& DestRoot, FString& OutError)
+{
+	IPlatformFile& PF = FPlatformFileManager::Get().GetPlatformFile();
+	const FString SourceFull = FPaths::ConvertRelativePathToFull(SourceRoot);
+	const FString DestFull = FPaths::ConvertRelativePathToFull(DestRoot);
+	PF.CreateDirectoryTree(*DestFull);
+
+	bool bOk = true;
+	FString FailReason;
+	PF.IterateDirectoryRecursively(*SourceFull, [&](const TCHAR* Path, bool bIsDir) -> bool
+	{
+		if (bIsDir)
+			return true;
+		FString Rel = Path;
+		FPaths::MakePathRelativeTo(Rel, *(SourceFull / TEXT("")));
+		Rel.ReplaceInline(TEXT("\\"), TEXT("/"));
+
+		TArray<FString> Segments;
+		Rel.ParseIntoArray(Segments, TEXT("/"));
+		for (const FString& Seg : Segments)
+		{
+			if (ExtInstIsExcludedSegment(Seg))
+				return true; // skip build-cache / VCS subtree file
+		}
+
+		const FString DestFile = DestFull / Rel;
+		PF.CreateDirectoryTree(*FPaths::GetPath(DestFile));
+		if (!PF.CopyFile(*DestFile, Path))
+		{
+			bOk = false;
+			FailReason = FString::Printf(TEXT("failed to copy '%s' → '%s'"), Path, *DestFile);
+			return false; // stop iterating
+		}
+		return true;
+	});
+
+	if (!bOk)
+		OutError = FailReason;
+	return bOk;
+}
+
+bool FUnrealMcpExtensionInstaller::PlacePluginDir(const FString& SourcePluginRoot, const FString& InstalledPath, FString& OutError)
+{
+	IPlatformFile& PF = FPlatformFileManager::Get().GetPlatformFile();
+	const FString InstallReal = FPaths::ConvertRelativePathToFull(InstalledPath);
+	const FString PluginsDir = FPaths::GetPath(InstallReal);
+	PF.CreateDirectoryTree(*PluginsDir);
+
+	const FString Staging = PluginsDir / FString::Printf(TEXT(".unreal-mcp-ext-staging-%u-%llx"),
+		FPlatformProcess::GetCurrentProcessId(), (uint64)FPlatformTime::Cycles64());
+	PF.DeleteDirectoryRecursively(*Staging);
+	ON_SCOPE_EXIT { PF.DeleteDirectoryRecursively(*Staging); };
+
+	// 1. Filtered copy into a sibling staging dir (a mid-copy failure never touches an existing install).
+	if (!CopyPluginTreeFiltered(SourcePluginRoot, Staging, OutError))
+		return false;
+	if (FindUPluginFile(Staging).IsEmpty())
+	{
+		OutError = FString::Printf(TEXT("copy from '%s' produced no .uplugin"), *SourcePluginRoot);
+		return false;
+	}
+
+	// 2. Swap: drop the existing install, then move the validated staging tree into place
+	//    (CopyDirectoryTree lives on IPlatformFile, not IFileManager).
+	PF.DeleteDirectoryRecursively(*InstallReal);
+	if (!PF.CopyDirectoryTree(*InstallReal, *Staging, /*bOverwriteAllExisting*/ true))
+	{
+		OutError = FString::Printf(TEXT("failed to move staged plugin into '%s'"), *InstallReal);
+		return false;
+	}
+	return true;
+}
+
+FString FUnrealMcpExtensionInstaller::ResolveLocalPluginRoot(const FString& SourceDir, FString& OutError)
+{
+	const FString Resolved = FPaths::ConvertRelativePathToFull(SourceDir);
+	if (!IFileManager::Get().DirectoryExists(*Resolved))
+	{
+		OutError = FString::Printf(TEXT("--source directory does not exist: %s"), *Resolved);
+		return FString();
+	}
+	// A dir directly holding a .uplugin is the plugin root; otherwise the parent of the shallowest one.
+	const FString Uplugin = FindUPluginFile(Resolved);
+	if (Uplugin.IsEmpty())
+	{
+		OutError = FString::Printf(TEXT("source %s does not contain a .uplugin"), *Resolved);
+		return FString();
+	}
+	return FPaths::GetPath(Uplugin);
+}
+
+bool FUnrealMcpExtensionInstaller::DownloadAndExtract(const FString& Url, double TimeoutSeconds, FString& OutPluginRoot, FString& OutError)
+{
+	if (!IsTrustedDownloadUrl(Url))
+	{
+		OutError = FString::Printf(TEXT("refusing to download from untrusted URL '%s' (only https://github.com is trusted)"), *Url);
+		return false;
+	}
+
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] downloading extension zip from %s"), *Url);
+
+	// Bounded synchronous HTTP GET on the game thread (the user explicitly clicked Install) — mirrors the
+	// local-server download's bounded wait (FUnrealMcpServerManager::DownloadBinaryIfNeeded).
+	FHttpModule& Http = FHttpModule::Get();
+	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> Request = Http.CreateRequest();
+	Request->SetURL(Url);
+	Request->SetVerb(TEXT("GET"));
+
+	bool bDone = false;
+	bool bOk = false;
+	int32 ResponseCode = -1;
+	TArray<uint8> ZipBytes;
+	Request->OnProcessRequestComplete().BindLambda(
+		[&bDone, &bOk, &ResponseCode, &ZipBytes](FHttpRequestPtr, FHttpResponsePtr Resp, bool bConnectedOk)
+		{
+			bDone = true;
+			ResponseCode = Resp.IsValid() ? Resp->GetResponseCode() : -1;
+			if (bConnectedOk && Resp.IsValid() && ResponseCode == 200)
+			{
+				ZipBytes = Resp->GetContent();
+				bOk = true;
+			}
+		});
+
+	if (!Request->ProcessRequest())
+	{
+		OutError = TEXT("could not start the extension download request");
+		return false;
+	}
+
+	const double Deadline = FPlatformTime::Seconds() + TimeoutSeconds;
+	while (!bDone && FPlatformTime::Seconds() < Deadline)
+	{
+		Http.GetHttpManager().Tick(0.1f);
+		FPlatformProcess::Sleep(0.05f);
+	}
+	if (!bDone)
+	{
+		Request->CancelRequest();
+		OutError = TEXT("the extension download timed out");
+		return false;
+	}
+	if (!bOk || ZipBytes.Num() == 0)
+	{
+		OutError = FString::Printf(TEXT("extension download failed (HTTP %d) from %s. Verify the release exists, or install from a local source."),
+			ResponseCode, *Url);
+		return false;
+	}
+
+	// Stage the bytes to a temp file and open with FZipArchiveReader (libzip-backed), exactly as the server
+	// manager does. Extract every entry into a fresh dir, zip-slip-guarded, then return the dir holding the
+	// shallowest .uplugin as the plugin root for PlacePluginDir.
+	IFileManager& FM = IFileManager::Get();
+	const FString TempZip = FPaths::ConvertRelativePathToFull(
+		FPaths::CreateTempFilename(*FPaths::ProjectIntermediateDir(), TEXT("unreal-mcp-ext-"), TEXT(".zip")));
+	if (!FFileHelper::SaveArrayToFile(ZipBytes, *TempZip))
+	{
+		OutError = TEXT("could not stage the downloaded extension zip");
+		return false;
+	}
+	ON_SCOPE_EXIT { FM.Delete(*TempZip, /*RequireExists*/ false, /*EvenReadOnly*/ true, /*Quiet*/ true); };
+
+	IFileHandle* ZipHandle = FPlatformFileManager::Get().GetPlatformFile().OpenRead(*TempZip);
+	if (ZipHandle == nullptr)
+	{
+		OutError = TEXT("could not reopen the staged extension zip");
+		return false;
+	}
+	FZipArchiveReader Reader(ZipHandle); // takes ownership of the handle
+	if (!Reader.IsValid())
+	{
+		OutError = TEXT("the downloaded extension zip is malformed / unreadable");
+		return false;
+	}
+
+	const FString ExtractDir = FPaths::ConvertRelativePathToFull(
+		FPaths::CreateTempFilename(*FPaths::ProjectIntermediateDir(), TEXT("unreal-mcp-ext-extract-"), TEXT("")));
+	const FString ExtractReal = ExtractDir; // already absolute
+	FM.MakeDirectory(*ExtractReal, /*Tree*/ true);
+
+	const TArray<FString> Names = Reader.GetFileNames();
+	for (const FString& Name : Names)
+	{
+		if (Name.EndsWith(TEXT("/")))
+			continue; // directory entry
+		// Zip-slip guard: the resolved path must stay under ExtractReal (mirrors the CLI's extractZip).
+		const FString Target = FPaths::ConvertRelativePathToFull(ExtractReal / Name);
+		if (Target != ExtractReal && !Target.StartsWith(ExtractReal + TEXT("/")) && !Target.StartsWith(ExtractReal + TEXT("\\")))
+		{
+			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] skipped suspicious zip entry escaping the extract dir: %s"), *Name);
+			continue;
+		}
+		TArray<uint8> FileData;
+		if (!Reader.TryReadFile(Name, FileData))
+		{
+			OutError = FString::Printf(TEXT("failed to extract '%s' from the extension zip"), *Name);
+			return false;
+		}
+		FM.MakeDirectory(*FPaths::GetPath(Target), /*Tree*/ true);
+		if (!FFileHelper::SaveArrayToFile(FileData, *Target))
+		{
+			OutError = FString::Printf(TEXT("failed to write extracted file '%s'"), *Target);
+			return false;
+		}
+	}
+
+	const FString Uplugin = FindUPluginFile(ExtractReal);
+	if (Uplugin.IsEmpty())
+	{
+		OutError = FString::Printf(TEXT("downloaded zip did not contain a .uplugin (%s is not a valid extension release)"), *Url);
+		return false;
+	}
+	OutPluginRoot = FPaths::GetPath(Uplugin);
+	return true;
+}
+
+bool FUnrealMcpExtensionInstaller::FetchCatalogSync(
+	const FString& Url, double TimeoutSeconds, TArray<FUnrealMcpCatalogEntry>& OutEntries, FString& OutError)
+{
+	const FString Trimmed = Url.TrimStartAndEnd();
+	if (!Trimmed.StartsWith(TEXT("https://"), ESearchCase::IgnoreCase))
+	{
+		OutError = TEXT("the catalog URL must be https");
+		return false;
+	}
+
+	FHttpModule& Http = FHttpModule::Get();
+	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> Request = Http.CreateRequest();
+	Request->SetURL(Trimmed);
+	Request->SetVerb(TEXT("GET"));
+
+	bool bDone = false;
+	bool bOk = false;
+	int32 ResponseCode = -1;
+	FString Body;
+	Request->OnProcessRequestComplete().BindLambda(
+		[&bDone, &bOk, &ResponseCode, &Body](FHttpRequestPtr, FHttpResponsePtr Resp, bool bConnectedOk)
+		{
+			bDone = true;
+			ResponseCode = Resp.IsValid() ? Resp->GetResponseCode() : -1;
+			if (bConnectedOk && Resp.IsValid() && ResponseCode == 200)
+			{
+				Body = Resp->GetContentAsString();
+				bOk = true;
+			}
+		});
+
+	if (!Request->ProcessRequest())
+	{
+		OutError = TEXT("could not start the catalog fetch request");
+		return false;
+	}
+	const double Deadline = FPlatformTime::Seconds() + TimeoutSeconds;
+	while (!bDone && FPlatformTime::Seconds() < Deadline)
+	{
+		Http.GetHttpManager().Tick(0.1f);
+		FPlatformProcess::Sleep(0.05f);
+	}
+	if (!bDone)
+	{
+		Request->CancelRequest();
+		OutError = TEXT("the catalog fetch timed out");
+		return false;
+	}
+	if (!bOk)
+	{
+		OutError = FString::Printf(TEXT("could not fetch the catalog (HTTP %d) from %s"), ResponseCode, *Trimmed);
+		return false;
+	}
+
+	FString Warning;
+	if (!FUnrealMcpExtensionCatalog::ParseCatalogJson(Body, OutEntries, OutError, Warning))
+		return false;
+	if (!Warning.IsEmpty())
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] %s"), *Warning);
+	return true;
+}
+
+// ---------------------------------------------------------------------------------------------------
+// Install entry point
+// ---------------------------------------------------------------------------------------------------
+
+FUnrealMcpInstallResult FUnrealMcpExtensionInstaller::Install(const FUnrealMcpInstallOptions& Options)
+{
+	FUnrealMcpInstallResult Result;
+	Result.ExtensionId = Options.Descriptor.ExtensionId;
+	Result.PluginName = Options.Descriptor.PluginName;
+
+	const FString ProjectDir = Options.ProjectDir.TrimStartAndEnd();
+	if (ProjectDir.IsEmpty() || !IFileManager::Get().DirectoryExists(*ProjectDir))
+	{
+		Result.Error = FString::Printf(TEXT("project directory does not exist: %s"), *ProjectDir);
+		return Result;
+	}
+	const FString PluginName = Options.Descriptor.PluginName.TrimStartAndEnd();
+	if (PluginName.IsEmpty())
+	{
+		Result.Error = TEXT("the catalog descriptor has no pluginName");
+		return Result;
+	}
+
+	const FString UprojectPath = ExtInstFindUProjectFile(ProjectDir);
+	if (UprojectPath.IsEmpty())
+	{
+		Result.Error = FString::Printf(TEXT("no .uproject found in %s — run install inside an Unreal project directory"), *ProjectDir);
+		return Result;
+	}
+	Result.UprojectPath = UprojectPath;
+
+	const FString ToVersion = Options.Descriptor.HasVersion() ? Options.Descriptor.Version.TrimStartAndEnd() : FString();
+	Result.ToVersion = ToVersion;
+	const FString InstalledPath = ProjectDir / TEXT("Plugins") / PluginName;
+	Result.InstalledPath = InstalledPath;
+
+	const FString InstalledUplugin = FindUPluginFile(InstalledPath);
+	const FString FromVersion = InstalledUplugin.IsEmpty()
+		? FString()
+		: FUnrealMcpUProjectPlugins::ReadUPluginVersionName(ExtInstLoadJsonObject(InstalledUplugin));
+	Result.FromVersion = FromVersion;
+	const bool bInstalledPresent = !InstalledUplugin.IsEmpty();
+	const bool bMaterializeNeeded = IsMaterializeNeeded(Options.bForce, bInstalledPresent, FromVersion, ToVersion);
+
+	// 1. Materialize the plugin files when needed (local source, else github release).
+	if (bMaterializeNeeded)
+	{
+		FString PluginRoot;
+		FString Err;
+		if (!Options.SourceDir.TrimStartAndEnd().IsEmpty())
+		{
+			PluginRoot = ResolveLocalPluginRoot(Options.SourceDir, Err);
+			if (PluginRoot.IsEmpty())
+			{
+				Result.Error = Err;
+				return Result;
+			}
+		}
+		else if (!Options.Descriptor.Repo.TrimStartAndEnd().IsEmpty() && !ToVersion.IsEmpty())
+		{
+			const FString Url = ExtensionDownloadUrl(Options.Descriptor.Repo, PluginName, ToVersion);
+			FString ExtractedRoot;
+			if (!DownloadAndExtract(Url, Options.DownloadTimeoutSeconds, ExtractedRoot, Err))
+			{
+				Result.Error = Err;
+				return Result;
+			}
+			PluginRoot = ExtractedRoot;
+		}
+		else if (Options.Descriptor.Repo.TrimStartAndEnd().IsEmpty())
+		{
+			Result.Error = FString::Printf(
+				TEXT("no download source for '%s': the catalog entry has no release repo. Install from a local source instead."), *PluginName);
+			return Result;
+		}
+		else
+		{
+			Result.Error = FString::Printf(
+				TEXT("no version to download for '%s'. Set a catalog pin, or install from a local source."), *PluginName);
+			return Result;
+		}
+
+		if (!PlacePluginDir(PluginRoot, InstalledPath, Err))
+		{
+			Result.Error = Err;
+			return Result;
+		}
+
+		// The placed descriptor basename MUST equal the plugin name or UE will not load it.
+		const FString Placed = FindUPluginFile(InstalledPath);
+		if (Placed.IsEmpty())
+		{
+			Result.Error = FString::Printf(TEXT("no .uplugin found after materializing %s into %s"), *PluginName, *InstalledPath);
+			return Result;
+		}
+		const FString PlacedName = FPaths::GetBaseFilename(Placed);
+		if (PlacedName.ToLower() != PluginName.ToLower())
+		{
+			Result.Error = FString::Printf(
+				TEXT("materialized descriptor '%s.uplugin' does not match the expected plugin name '%s' (UE requires the folder and .uplugin share a name)"),
+				*PlacedName, *PluginName);
+			return Result;
+		}
+	}
+
+	// 2. Enable the extension + its gating engine plugins in the .uproject (idempotent).
+	const FString EffectiveUplugin = FindUPluginFile(InstalledPath);
+	const TArray<FString> DeclaredDeps = EffectiveUplugin.IsEmpty()
+		? TArray<FString>()
+		: FUnrealMcpUProjectPlugins::ParseUPluginDependencies(ExtInstLoadJsonObject(EffectiveUplugin));
+	TArray<FString> Gating = DeclaredDeps;
+	Gating.Append(Options.Descriptor.EnginePlugins);
+	Gating = ExtInstUniqueCaseless(Gating);
+
+	TArray<FString> ToEnable;
+	ToEnable.Add(PluginName);
+	ToEnable.Append(Gating);
+
+	FString UprojectText;
+	if (!FFileHelper::LoadFileToString(UprojectText, *UprojectPath))
+	{
+		Result.Error = FString::Printf(TEXT("could not read the .uproject at %s"), *UprojectPath);
+		return Result;
+	}
+	FUnrealMcpEnablePluginsResult Enable;
+	FString EnableErr;
+	if (!FUnrealMcpUProjectPlugins::EnablePluginsInUProject(UprojectText, ToEnable, Enable, EnableErr))
+	{
+		Result.Error = EnableErr;
+		return Result;
+	}
+	if (Enable.bChanged && !FFileHelper::SaveStringToFile(Enable.Text, *UprojectPath))
+	{
+		Result.Error = FString::Printf(TEXT("could not write the updated .uproject at %s"), *UprojectPath);
+		return Result;
+	}
+	Result.EnabledPlugins = Enable.AddedOrFlipped;
+
+	const bool bChanged = bMaterializeNeeded || Enable.bChanged;
+	Result.bChanged = bChanged;
+
+	// minCoreVersion advisory (warn-only, never blocks the install — mirrors the CLI).
+	const FString MinCore = Options.Descriptor.MinCoreVersion.TrimStartAndEnd();
+	if (!MinCore.IsEmpty())
+	{
+		const FString CoreUplugin = ProjectDir / TEXT("Plugins") / TEXT("UnrealMCP") / TEXT("UnrealMCP.uplugin");
+		if (!FPaths::FileExists(CoreUplugin))
+		{
+			Result.Warnings.Add(FString::Printf(
+				TEXT("extension requires core Unreal-MCP >= %s, but no UnrealMCP plugin was found at %s."), *MinCore, *CoreUplugin));
+		}
+		else
+		{
+			const FString CoreVersion = FUnrealMcpUProjectPlugins::ReadUPluginVersionName(ExtInstLoadJsonObject(CoreUplugin));
+			if (!CoreVersion.IsEmpty() && ExtInstCompareSemver(CoreVersion, MinCore) < 0)
+			{
+				Result.Warnings.Add(FString::Printf(
+					TEXT("extension requires core Unreal-MCP >= %s, but the installed core plugin is %s. Update it."), *MinCore, *CoreVersion));
+			}
+		}
+	}
+
+	// 3. The extension ships as SOURCE: the editor recompiles on next open (no eager UBT in-editor here —
+	//    the panel offers a Live Coding trigger). rebuildRequired iff something changed and was not compiled.
+	Result.bRebuildRequired = bChanged;
+	Result.Outcome = ComputeOutcome(bChanged, bMaterializeNeeded, !FromVersion.IsEmpty());
+	Result.Message = BuildOutcomeMessage(Result.Outcome, PluginName, FromVersion, ToVersion, Result.bRebuildRequired, Gating);
+	Result.bSuccess = true;
+	return Result;
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionInstaller.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionInstaller.cpp
@@ -444,7 +444,15 @@ bool FUnrealMcpExtensionInstaller::PlacePluginDir(const FString& SourcePluginRoo
 		if (bHadExisting)
 		{
 			PF.DeleteDirectoryRecursively(*InstallReal);
-			PF.CopyDirectoryTree(*InstallReal, *Backup, /*bOverwriteAllExisting*/ true);
+			if (!PF.CopyDirectoryTree(*InstallReal, *Backup, /*bOverwriteAllExisting*/ true))
+			{
+				// Both the swap AND the rollback failed: the prior install is gone and the plugin dir is now
+				// empty — say so, so the user knows manual repair is needed rather than a simple retry.
+				OutError = FString::Printf(
+					TEXT("failed to move staged plugin into '%s', and restoring the prior install from backup also failed — '%s' is now empty and needs manual repair"),
+					*InstallReal, *InstallReal);
+				return false;
+			}
 		}
 		OutError = FString::Printf(TEXT("failed to move staged plugin into '%s'"), *InstallReal);
 		return false;
@@ -566,7 +574,7 @@ bool FUnrealMcpExtensionInstaller::DownloadAndExtract(const FString& Url, double
 			continue; // directory entry
 		// Zip-slip guard: the resolved path must stay under ExtractDir (mirrors the CLI's extractZip).
 		const FString Target = FPaths::ConvertRelativePathToFull(ExtractDir / Name);
-		if (Target != ExtractDir && !Target.StartsWith(ExtractDir + TEXT("/")) && !Target.StartsWith(ExtractDir + TEXT("\\")))
+		if (Target != ExtractDir && !Target.StartsWith(ExtractDir + TEXT("/")))
 		{
 			UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] skipped suspicious zip entry escaping the extract dir: %s"), *Name);
 			continue;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionInstaller.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionInstaller.h
@@ -171,8 +171,13 @@ public:
 private:
 	/** Resolve a `--source` arg to the plugin root (dir directly holding a `.uplugin`, else its parent). */
 	static FString ResolveLocalPluginRoot(const FString& SourceDir, FString& OutError);
-	/** Bounded sync HTTP GET of the github-release zip → extract to a fresh staging dir → return its plugin root. */
-	static bool DownloadAndExtract(const FString& Url, double TimeoutSeconds, FString& OutPluginRoot, FString& OutError);
+	/**
+	 * Bounded sync HTTP GET of the github-release zip → extract to a fresh temp dir → return its plugin root
+	 * (@p OutPluginRoot, which points INSIDE @p OutExtractDir). The caller owns @p OutExtractDir and must
+	 * delete it once the plugin root has been consumed (it is set as soon as the temp dir is created, so a
+	 * post-creation extract failure still hands back a dir to clean).
+	 */
+	static bool DownloadAndExtract(const FString& Url, double TimeoutSeconds, FString& OutPluginRoot, FString& OutExtractDir, FString& OutError);
 	/** Recursively copy @p SourceRoot → @p DestRoot, skipping build-cache / VCS subtrees. */
 	static bool CopyPluginTreeFiltered(const FString& SourceRoot, const FString& DestRoot, FString& OutError);
 };

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionInstaller.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionInstaller.h
@@ -45,7 +45,11 @@ struct FUnrealMcpInstallResult
 	FString InstalledPath;
 	FString FromVersion;
 	FString ToVersion;
-	/** The gating engine plugins enabled alongside the extension (e.g. Niagara). */
+	/**
+	 * Plugins this install newly enabled in the .uproject — the extension's own plugin plus any
+	 * gating engine plugins (e.g. Niagara) it appended or flipped from disabled. Plugins already
+	 * enabled before the run are NOT listed. Mirrors the CLI's InstallExtensionResult.enabledPlugins.
+	 */
 	TArray<FString> EnabledPlugins;
 	FString UprojectPath;
 	FString Message;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionInstaller.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpExtensionInstaller.h
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Extensions/UnrealMcpExtensionCatalog.h"
+
+struct FUnrealMcpExtensionRecord; // runtime module (Extensions/UnrealMcpExtensionManager.h)
+
+/** The terminal outcome of an install (native mirror of the CLI's ExtensionInstallOutcome). */
+enum class EUnrealMcpInstallOutcome : uint8
+{
+	Added,            // freshly installed (no prior version on disk)
+	Updated,          // materialized a different version over an existing install
+	Enabled,          // files already at target version; only the .uproject enable entry was (re)written
+	AlreadyUpToDate,  // present at the target version and already enabled — nothing written
+};
+
+/** Options for an in-editor extension install. */
+struct FUnrealMcpInstallOptions
+{
+	/** The UE project directory containing the `.uproject` to enable the extension in. */
+	FString ProjectDir;
+	/** The resolved catalog descriptor (plugin name, repo, version, gating engine plugins). */
+	FUnrealMcpCatalogEntry Descriptor;
+	/** Local source override: when non-empty, materialize from this directory instead of the GitHub release. */
+	FString SourceDir;
+	/** Force re-materialization even when the installed version already matches. */
+	bool bForce = false;
+	/** Bounded ceiling for the GitHub-release zip download (game-thread sync wait), seconds. */
+	double DownloadTimeoutSeconds = 120.0;
+};
+
+/** The structured result of an install (mirrors the CLI's InstallExtensionResult, UE types). */
+struct FUnrealMcpInstallResult
+{
+	bool bSuccess = false;
+	EUnrealMcpInstallOutcome Outcome = EUnrealMcpInstallOutcome::AlreadyUpToDate;
+	bool bChanged = false;
+	/** True when the extension's C++ must be (re)compiled to load — the compile-on-install reality (§5). */
+	bool bRebuildRequired = false;
+	FString ExtensionId;
+	FString PluginName;
+	FString InstalledPath;
+	FString FromVersion;
+	FString ToVersion;
+	/** The gating engine plugins enabled alongside the extension (e.g. Niagara). */
+	TArray<FString> EnabledPlugins;
+	FString UprojectPath;
+	FString Message;
+	TArray<FString> Warnings;
+	/** Non-empty on failure (bSuccess == false). */
+	FString Error;
+};
+
+/** One catalog ∪ installed row the panel renders (a merge of the catalog, loaded providers, and disk). */
+struct FUnrealMcpExtensionRow
+{
+	FString ExtensionId;
+	FString DisplayName;
+	FString Description;
+	FString PluginName;
+	FString Repo;
+	/** The version shown for this row (installed version if present, else catalog pin). */
+	FString Version;
+	/** The catalog-pinned version (empty when not in the catalog / unpinned). */
+	FString CatalogVersion;
+	bool bInCatalog = false;
+	/** Present on disk under Plugins/<PluginName>/ (compiled or not). */
+	bool bInstalled = false;
+	/** A live IModularFeatures provider is registered (compiled + loaded) for this extension. */
+	bool bLoaded = false;
+	/** Enabled state (from the loaded provider's record); meaningful only when bLoaded. */
+	bool bEnabled = true;
+	bool bHasError = false;
+	FString Error;
+	int32 ToolCount = 0;
+	/** Installed on disk at a version that differs from the catalog pin → an update is offered. */
+	bool bUpdateAvailable = false;
+};
+
+/** A minimal on-disk install fact (plugin folder name + its `.uplugin` VersionName) the row-merge consumes. */
+struct FUnrealMcpInstalledOnDisk
+{
+	FString PluginName;
+	FString Version;
+};
+
+/**
+ * The in-editor extension install SERVICE — the native C++ implementation of the SAME install contract
+ * the CLI's `install-extension` (#172) implements in TypeScript, so install channel #3 (the in-editor
+ * "Extensions" Slate panel, docs/ARCHITECTURE.md §7 item 10) is behaviorally identical to the CLI + app
+ * channels. It reuses the plugin's existing Http/FileUtilities/Json deps:
+ *
+ *   1. resolve the catalog descriptor (caller supplies it);
+ *   2. resolve the install source — local `SourceDir` (offline/dev/CI) or the extension's
+ *      github.com-only release zip (fail-closed host trust, mirrors extension-source.ts);
+ *   3. materialize into `<project>/Plugins/<PluginName>/` (stage-then-swap, build-cache filtered);
+ *   4. enable the extension + its gating engine plugins in the `.uproject` Plugins[] (idempotent);
+ *   5. the extension ships as SOURCE → the editor recompiles it on next open (rebuildRequired) — the
+ *      panel surfaces the compile-on-install messaging + a Live Coding affordance (§5 key UX risk).
+ *
+ * The pure helpers (URL build, host trust, outcome/materialize decision, the catalog ∪ loaded ∪ disk
+ * row-merge) carry no engine-process / no network, so every decision is unit-testable in an Automation
+ * spec; the live HTTP download + real zip extract are exercised via the local `SourceDir` channel in
+ * tests and operator-verified for the network channel.
+ */
+class FUnrealMcpExtensionInstaller
+{
+public:
+	// --- Pure helpers (mirror extension-source.ts) ----------------------------------------------------
+
+	/** Drop a single leading `v`/`V` from a version string. Pure. */
+	static UNREALMCPEDITOR_API FString StripLeadingV(const FString& Version);
+	/** The git release TAG for a version (`1.0.0` → `v1.0.0`); an already-`v` input passes through. Pure. */
+	static UNREALMCPEDITOR_API FString ReleaseTag(const FString& Version);
+	/** The release-asset name `<PluginName>-<version>.zip` (bare version, no leading `v`). Pure. */
+	static UNREALMCPEDITOR_API FString ExtensionAssetName(const FString& PluginName, const FString& Version);
+	/** The github.com release-zip download URL for an extension version. Pure string build. */
+	static UNREALMCPEDITOR_API FString ExtensionDownloadUrl(const FString& Repo, const FString& PluginName, const FString& Version);
+	/** Fail-closed host trust: true iff @p Url is https AND host is EXACTLY github.com. Pure. */
+	static UNREALMCPEDITOR_API bool IsTrustedDownloadUrl(const FString& Url);
+
+	// --- Pure helpers (mirror install-extension.ts decisions) -----------------------------------------
+
+	/** True when files must be (re)materialized: force, or absent, or a known target version differs. Pure. */
+	static UNREALMCPEDITOR_API bool IsMaterializeNeeded(
+		bool bForce, bool bInstalledPresent, const FString& FromVersion, const FString& ToVersion);
+	/** Map (changed, materialized, hadPrevVersion) → the terminal outcome. Pure. */
+	static UNREALMCPEDITOR_API EUnrealMcpInstallOutcome ComputeOutcome(
+		bool bChanged, bool bMaterializeNeeded, bool bHadPrevVersion);
+	/** A short printable status line for an outcome (mirrors the CLI's buildMessage). Pure. */
+	static UNREALMCPEDITOR_API FString BuildOutcomeMessage(
+		EUnrealMcpInstallOutcome Outcome, const FString& PluginName, const FString& FromVersion,
+		const FString& ToVersion, bool bRebuildRequired, const TArray<FString>& GatingPlugins);
+
+	/** The catalog ∪ loaded-providers ∪ on-disk row-merge the panel renders. Pure. */
+	static UNREALMCPEDITOR_API TArray<FUnrealMcpExtensionRow> BuildRows(
+		const TArray<FUnrealMcpCatalogEntry>& Catalog,
+		const TArray<FUnrealMcpExtensionRecord>& LoadedRecords,
+		const TArray<FUnrealMcpInstalledOnDisk>& InstalledOnDisk);
+
+	// --- Filesystem helpers (no network; project Saved/Intermediate scratch — spec-testable) ----------
+
+	/** The shallowest `*.uplugin` file under @p Dir (build-cache subtrees skipped), or empty. */
+	static UNREALMCPEDITOR_API FString FindUPluginFile(const FString& Dir);
+	/** Scan `<ProjectDir>/Plugins/*` for installed extension plugins (folder name + `.uplugin` VersionName). */
+	static UNREALMCPEDITOR_API TArray<FUnrealMcpInstalledOnDisk> ScanInstalledPlugins(const FString& ProjectDir);
+	/** Copy a plugin source root into @p InstalledPath via stage-then-swap, filtering build-cache subtrees. */
+	static UNREALMCPEDITOR_API bool PlacePluginDir(const FString& SourcePluginRoot, const FString& InstalledPath, FString& OutError);
+
+	// --- The install entry point ----------------------------------------------------------------------
+
+	/**
+	 * Bounded synchronous HTTP GET of the shared catalog JSON → parsed entries (game-thread, user-initiated
+	 * via the panel's Refresh). Returns false + a reason on a non-200 / timeout / malformed-JSON. The catalog
+	 * URL must be https; defaults to FUnrealMcpExtensionCatalog::DefaultCatalogUrl().
+	 */
+	static UNREALMCPEDITOR_API bool FetchCatalogSync(
+		const FString& Url, double TimeoutSeconds, TArray<FUnrealMcpCatalogEntry>& OutEntries, FString& OutError);
+
+	/**
+	 * Install (or update / enable) the extension. The local `SourceDir` channel runs fully headless; the
+	 * github-release channel performs a bounded synchronous HTTP download + zip extract on the GAME thread
+	 * (the user explicitly clicked Install, mirroring the local-server download's bounded wait). Returns a
+	 * structured result; never throws.
+	 */
+	static UNREALMCPEDITOR_API FUnrealMcpInstallResult Install(const FUnrealMcpInstallOptions& Options);
+
+private:
+	/** Resolve a `--source` arg to the plugin root (dir directly holding a `.uplugin`, else its parent). */
+	static FString ResolveLocalPluginRoot(const FString& SourceDir, FString& OutError);
+	/** Bounded sync HTTP GET of the github-release zip → extract to a fresh staging dir → return its plugin root. */
+	static bool DownloadAndExtract(const FString& Url, double TimeoutSeconds, FString& OutPluginRoot, FString& OutError);
+	/** Recursively copy @p SourceRoot → @p DestRoot, skipping build-cache / VCS subtrees. */
+	static bool CopyPluginTreeFiltered(const FString& SourceRoot, const FString& DestRoot, FString& OutError);
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpUProjectPlugins.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpUProjectPlugins.cpp
@@ -111,7 +111,8 @@ bool FUnrealMcpUProjectPlugins::EnablePluginsInUProject(
 		else
 		{
 			const TSharedPtr<FJsonObject>* Obj = nullptr;
-			Plugins[Idx]->TryGetObject(Obj);
+			if (!Plugins[Idx]->TryGetObject(Obj) || !Obj || !(*Obj).IsValid())
+				continue; // defensive: FindPluginIndex validated this entry, but never deref a null object
 			bool bEnabled = true;
 			(*Obj)->TryGetBoolField(TEXT("Enabled"), bEnabled);
 			if (!bEnabled)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpUProjectPlugins.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpUProjectPlugins.cpp
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "Extensions/UnrealMcpUProjectPlugins.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Policies/PrettyJsonPrintPolicy.h"
+
+TArray<FString> FUnrealMcpUProjectPlugins::ParseUPluginDependencies(const TSharedPtr<FJsonObject>& UpluginJson)
+{
+	TArray<FString> Names;
+	if (!UpluginJson.IsValid())
+		return Names;
+
+	const TArray<TSharedPtr<FJsonValue>>* Plugins = nullptr;
+	if (!UpluginJson->TryGetArrayField(TEXT("Plugins"), Plugins) || Plugins == nullptr)
+		return Names;
+
+	for (const TSharedPtr<FJsonValue>& Value : *Plugins)
+	{
+		const TSharedPtr<FJsonObject>* Obj = nullptr;
+		if (!Value.IsValid() || !Value->TryGetObject(Obj) || Obj == nullptr || !(*Obj).IsValid())
+			continue;
+		FString Name;
+		if (!(*Obj)->TryGetStringField(TEXT("Name"), Name) || Name.TrimStartAndEnd().IsEmpty())
+			continue;
+		// Enabled defaults true: only an explicit `Enabled: false` excludes the dependency.
+		bool bEnabled = true;
+		(*Obj)->TryGetBoolField(TEXT("Enabled"), bEnabled);
+		if (bEnabled)
+			Names.Add(Name.TrimStartAndEnd());
+	}
+	return Names;
+}
+
+FString FUnrealMcpUProjectPlugins::ReadUPluginVersionName(const TSharedPtr<FJsonObject>& UpluginJson)
+{
+	if (!UpluginJson.IsValid())
+		return FString();
+	FString Version;
+	if (UpluginJson->TryGetStringField(TEXT("VersionName"), Version) && !Version.TrimStartAndEnd().IsEmpty())
+		return Version.TrimStartAndEnd();
+	return FString();
+}
+
+bool FUnrealMcpUProjectPlugins::EnablePluginsInUProject(
+	const FString& UprojectText, const TArray<FString>& PluginNames,
+	FUnrealMcpEnablePluginsResult& OutResult, FString& OutError)
+{
+	OutResult = FUnrealMcpEnablePluginsResult();
+	OutResult.Text = UprojectText;
+	OutError.Reset();
+
+	TSharedPtr<FJsonObject> Root;
+	const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(UprojectText);
+	if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid())
+	{
+		OutError = TEXT("the .uproject JSON is malformed");
+		return false;
+	}
+
+	// Existing Plugins[] (may be absent → start empty).
+	TArray<TSharedPtr<FJsonValue>> Plugins;
+	const TArray<TSharedPtr<FJsonValue>>* Existing = nullptr;
+	if (Root->TryGetArrayField(TEXT("Plugins"), Existing) && Existing)
+		Plugins = *Existing;
+
+	// De-dupe requested names case-insensitively, preserving first-seen order.
+	TArray<FString> Wanted;
+	TSet<FString> Seen;
+	for (const FString& Raw : PluginNames)
+	{
+		const FString Name = Raw.TrimStartAndEnd();
+		if (Name.IsEmpty())
+			continue;
+		const FString Key = Name.ToLower();
+		if (Seen.Contains(Key))
+			continue;
+		Seen.Add(Key);
+		Wanted.Add(Name);
+	}
+
+	auto FindPluginIndex = [&Plugins](const FString& Name) -> int32
+	{
+		for (int32 i = 0; i < Plugins.Num(); ++i)
+		{
+			const TSharedPtr<FJsonObject>* Obj = nullptr;
+			FString ExistingName;
+			if (Plugins[i].IsValid() && Plugins[i]->TryGetObject(Obj) && Obj && (*Obj).IsValid()
+				&& (*Obj)->TryGetStringField(TEXT("Name"), ExistingName)
+				&& ExistingName.ToLower() == Name.ToLower())
+				return i;
+		}
+		return INDEX_NONE;
+	};
+
+	for (const FString& Name : Wanted)
+	{
+		const int32 Idx = FindPluginIndex(Name);
+		if (Idx == INDEX_NONE)
+		{
+			TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+			Entry->SetStringField(TEXT("Name"), Name);
+			Entry->SetBoolField(TEXT("Enabled"), true);
+			Plugins.Add(MakeShared<FJsonValueObject>(Entry));
+			OutResult.AddedOrFlipped.Add(Name);
+		}
+		else
+		{
+			const TSharedPtr<FJsonObject>* Obj = nullptr;
+			Plugins[Idx]->TryGetObject(Obj);
+			bool bEnabled = true;
+			(*Obj)->TryGetBoolField(TEXT("Enabled"), bEnabled);
+			if (!bEnabled)
+			{
+				(*Obj)->SetBoolField(TEXT("Enabled"), true);
+				OutResult.AddedOrFlipped.Add(Name);
+			}
+		}
+	}
+
+	// Compute the full enabled set after the operation.
+	for (const TSharedPtr<FJsonValue>& Value : Plugins)
+	{
+		const TSharedPtr<FJsonObject>* Obj = nullptr;
+		FString Name;
+		if (Value.IsValid() && Value->TryGetObject(Obj) && Obj && (*Obj).IsValid()
+			&& (*Obj)->TryGetStringField(TEXT("Name"), Name) && !Name.IsEmpty())
+		{
+			bool bEnabled = true;
+			(*Obj)->TryGetBoolField(TEXT("Enabled"), bEnabled);
+			if (bEnabled)
+				OutResult.EnabledPlugins.Add(Name);
+		}
+	}
+
+	if (OutResult.AddedOrFlipped.Num() == 0)
+	{
+		// Idempotent no-op: nothing appended or flipped → return the input text verbatim (no reserialize churn).
+		OutResult.bChanged = false;
+		OutResult.Text = UprojectText;
+		return true;
+	}
+
+	Root->SetArrayField(TEXT("Plugins"), Plugins);
+
+	FString Out;
+	const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> Writer =
+		TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Out);
+	if (!FJsonSerializer::Serialize(Root.ToSharedRef(), Writer))
+	{
+		OutError = TEXT("failed to re-serialize the .uproject JSON");
+		return false;
+	}
+
+	// Preserve a trailing newline iff the input had one (UE descriptors conventionally end with one).
+	if (UprojectText.EndsWith(TEXT("\n")) && !Out.EndsWith(TEXT("\n")))
+		Out += TEXT("\n");
+
+	OutResult.bChanged = true;
+	OutResult.Text = Out;
+	return true;
+}

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpUProjectPlugins.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Extensions/UnrealMcpUProjectPlugins.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FJsonObject;
+
+/** Result of enabling plugins in a `.uproject`'s JSON text (native mirror of the CLI's EnablePluginsResult). */
+struct FUnrealMcpEnablePluginsResult
+{
+	/** True when the `.uproject` text was modified. */
+	bool bChanged = false;
+	/** The resulting `.uproject` text (unchanged when bChanged == false). */
+	FString Text;
+	/** The names enabled in the project after the operation (full enabled set). */
+	TArray<FString> EnabledPlugins;
+	/** The subset this call actually switched on — appended, or flipped from Enabled:false to true. */
+	TArray<FString> AddedOrFlipped;
+};
+
+/**
+ * Pure helpers for the two UE descriptor files the in-editor install touches — the native C++ port of
+ * the CLI's `cli/src/utils/uproject-plugins.ts`, so the in-editor install channel (#3) edits the
+ * `.uproject` Plugins[] array with behavioral parity to the CLI (#172):
+ *
+ *  - a plugin's `.uplugin` — its declared `Plugins[]` dependencies (the gating engine plugins, e.g.
+ *    Niagara) and its `VersionName`.
+ *  - the project's `.uproject` — ENABLE the extension + its gating plugins in `Plugins[]`, idempotently.
+ *
+ * No I/O here (callers read/write the files); these are pure JSON transforms so they are exhaustively
+ * unit-testable in an Automation spec without a UE project on disk.
+ *
+ * NOTE (deliberate deviation from the TS): UE's FJsonObject does not preserve source key order, so the
+ * re-serialized `.uproject` may reorder top-level keys vs the input. This is harmless — UE reads
+ * `.uproject` keys order-independently — and the enable semantics (append / flip / idempotent no-op)
+ * match the CLI exactly. The output uses tab indentation + preserves a trailing newline, matching the
+ * UE descriptor convention.
+ */
+class FUnrealMcpUProjectPlugins
+{
+public:
+	/**
+	 * Extract the names of the plugin dependencies a `.uplugin` JSON declares as enabled (`Plugins[]`
+	 * entries whose `Enabled` is not false) — the gating plugins that must also be enabled in the
+	 * consuming `.uproject`. Tolerant of a missing/!array `Plugins` field (→ empty). Pure.
+	 */
+	static UNREALMCPEDITOR_API TArray<FString> ParseUPluginDependencies(const TSharedPtr<FJsonObject>& UpluginJson);
+
+	/** Read a `.uplugin` JSON's `VersionName`, or empty when absent / not a non-empty string. Pure. */
+	static UNREALMCPEDITOR_API FString ReadUPluginVersionName(const TSharedPtr<FJsonObject>& UpluginJson);
+
+	/**
+	 * Enable each plugin in @p PluginNames in a `.uproject`'s JSON text:
+	 *  - a plugin already present and enabled is left untouched (idempotent);
+	 *  - a plugin present but `Enabled: false` is flipped to true;
+	 *  - a plugin absent is appended as `{ "Name": <n>, "Enabled": true }`.
+	 * Names are de-duplicated case-insensitively (UE plugin names are case-insensitive). Returns false +
+	 * @p OutError on malformed JSON (the caller turns it into a structured failure). Pure transform.
+	 */
+	static UNREALMCPEDITOR_API bool EnablePluginsInUProject(
+		const FString& UprojectText, const TArray<FString>& PluginNames,
+		FUnrealMcpEnablePluginsResult& OutResult, FString& OutError);
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpExtensionsWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpExtensionsWindow.cpp
@@ -1,0 +1,310 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#include "UI/SUnrealMcpExtensionsWindow.h"
+#include "Extensions/UnrealMcpExtensionManager.h" // FUnrealMcpExtensionRecord (runtime module)
+#include "UnrealMcpLog.h"
+
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SScrollBox.h"
+#include "Widgets/Layout/SSeparator.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SCheckBox.h"
+#include "Styling/AppStyle.h"
+
+#define LOCTEXT_NAMESPACE "UnrealMcp"
+
+void SUnrealMcpExtensionsWindow::Construct(const FArguments& InArgs)
+{
+	ProjectDir = InArgs._ProjectDir;
+	Catalog = InArgs._InitialCatalog;
+	InstalledProvider = InArgs._InstalledProvider;
+	CatalogFetcher = InArgs._CatalogFetcher;
+	OnSetEnabled = InArgs._OnSetEnabled;
+	OnInstall = InArgs._OnInstall;
+	OnTriggerLiveCompile = InArgs._OnTriggerLiveCompile;
+
+	StatusMessage = Catalog.Num() > 0
+		? LOCTEXT("ExtReadyCatalog", "Showing installed extensions and the catalog.").ToString()
+		: LOCTEXT("ExtReadyNoCatalog", "Showing installed extensions. Click Refresh to load the available-extensions catalog.").ToString();
+
+	ListContainer = SNew(SVerticalBox);
+
+	ChildSlot
+	[
+		SNew(SVerticalBox)
+		// Header: title + Refresh.
+		+ SVerticalBox::Slot().AutoHeight().Padding(8, 8, 8, 4)
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("ExtHeading", "Extensions"))
+				.Font(FCoreStyle::GetDefaultFontStyle("Bold", 13))
+			]
+			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center)
+			[
+				SNew(SButton)
+				.Text(LOCTEXT("ExtRefresh", "Refresh catalog"))
+				.ToolTipText(LOCTEXT("ExtRefreshTip", "Fetch the latest available-extensions catalog over HTTP."))
+				.OnClicked(this, &SUnrealMcpExtensionsWindow::OnRefreshClicked)
+			]
+		]
+		// Status line.
+		+ SVerticalBox::Slot().AutoHeight().Padding(8, 0, 8, 4)
+		[
+			SNew(STextBlock)
+			.Text(this, &SUnrealMcpExtensionsWindow::GetStatusText)
+			.AutoWrapText(true)
+			.ColorAndOpacity(FSlateColor::UseSubduedForeground())
+		]
+		// Compile-on-install hint (the §5 key UX risk): visible only after an install that needs a rebuild.
+		+ SVerticalBox::Slot().AutoHeight().Padding(8, 0, 8, 4)
+		[
+			SNew(SBorder)
+			.Visibility(this, &SUnrealMcpExtensionsWindow::GetRestartHintVisibility)
+			.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+			.Padding(8.0f)
+			[
+				SNew(SHorizontalBox)
+				+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
+				[
+					SNew(STextBlock)
+					.Text(LOCTEXT("ExtRebuildHint",
+						"An installed extension ships as C++ source — restart the editor to finish compiling, or trigger Live Coding now."))
+					.AutoWrapText(true)
+				]
+				+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(8, 0, 0, 0)
+				[
+					SNew(SButton)
+					.Text(LOCTEXT("ExtCompile", "Compile (Live Coding)"))
+					.OnClicked(this, &SUnrealMcpExtensionsWindow::OnCompileClicked)
+				]
+			]
+		]
+		+ SVerticalBox::Slot().AutoHeight()[ SNew(SSeparator) ]
+		+ SVerticalBox::Slot().FillHeight(1.0f)
+		[
+			SNew(SScrollBox)
+			+ SScrollBox::Slot().Padding(8.0f)[ ListContainer.ToSharedRef() ]
+		]
+	];
+
+	RebuildList();
+}
+
+void SUnrealMcpExtensionsWindow::RebuildList()
+{
+	if (!ListContainer.IsValid())
+		return;
+	ListContainer->ClearChildren();
+
+	TArray<FUnrealMcpExtensionRecord> Loaded;
+	if (InstalledProvider)
+		Loaded = InstalledProvider();
+	const TArray<FUnrealMcpInstalledOnDisk> OnDisk = FUnrealMcpExtensionInstaller::ScanInstalledPlugins(ProjectDir);
+
+	const TArray<FUnrealMcpExtensionRow> Rows = FUnrealMcpExtensionInstaller::BuildRows(Catalog, Loaded, OnDisk);
+	if (Rows.Num() == 0)
+	{
+		ListContainer->AddSlot().AutoHeight().Padding(4.0f)
+		[
+			SNew(STextBlock).Text(LOCTEXT("ExtEmpty",
+				"No extensions installed and no catalog loaded. Click Refresh to load the available-extensions catalog."))
+			.AutoWrapText(true)
+		];
+		return;
+	}
+
+	for (const FUnrealMcpExtensionRow& Row : Rows)
+		ListContainer->AddSlot().AutoHeight().Padding(0, 0, 0, 6)[ BuildRow(Row) ];
+}
+
+TSharedRef<SWidget> SUnrealMcpExtensionsWindow::BuildRow(const FUnrealMcpExtensionRow& Row)
+{
+	// State badge text + the action affordance depend on the install/loaded state.
+	FText StateBadge;
+	if (Row.bLoaded)
+		StateBadge = Row.bEnabled ? LOCTEXT("ExtStateEnabled", "Installed · enabled")
+								  : LOCTEXT("ExtStateDisabled", "Installed · disabled");
+	else if (Row.bInstalled)
+		StateBadge = LOCTEXT("ExtStateNeedsCompile", "Installed · needs editor restart to compile");
+	else
+		StateBadge = LOCTEXT("ExtStateAvailable", "Available");
+
+	const FString ExtensionId = Row.ExtensionId;
+	const FText Title = Row.DisplayName.IsEmpty()
+		? FText::FromString(Row.PluginName)
+		: FText::FromString(Row.DisplayName);
+	const FString VersionLabel = Row.Version.IsEmpty() ? FString() : FString::Printf(TEXT("v%s"), *FUnrealMcpExtensionInstaller::StripLeadingV(Row.Version));
+
+	TSharedRef<SHorizontalBox> ActionRow = SNew(SHorizontalBox);
+
+	// Enable/disable checkbox — only meaningful for a loaded provider (the §5 hot-load toggle).
+	if (Row.bLoaded && OnSetEnabled)
+	{
+		ActionRow->AddSlot().AutoWidth().VAlign(VAlign_Center).Padding(0, 0, 8, 0)
+		[
+			SNew(SCheckBox)
+			.IsChecked(Row.bEnabled ? ECheckBoxState::Checked : ECheckBoxState::Unchecked)
+			.ToolTipText(LOCTEXT("ExtToggleTip", "Enable or disable this extension's tools live (no editor restart)."))
+			.OnCheckStateChanged_Lambda([this, ExtensionId](ECheckBoxState NewState)
+			{
+				OnEnabledChanged(ExtensionId, NewState == ECheckBoxState::Checked);
+			})
+		];
+	}
+
+	// Install / Update button — for catalog rows that are installable (have a repo or are available).
+	if (Row.bInCatalog && OnInstall)
+	{
+		if (!Row.bInstalled)
+		{
+			ActionRow->AddSlot().AutoWidth().VAlign(VAlign_Center).Padding(0, 0, 4, 0)
+			[
+				SNew(SButton)
+				.Text(LOCTEXT("ExtInstall", "Install"))
+				.OnClicked(this, &SUnrealMcpExtensionsWindow::OnInstallClicked, ExtensionId, false)
+			];
+		}
+		else if (Row.bUpdateAvailable)
+		{
+			ActionRow->AddSlot().AutoWidth().VAlign(VAlign_Center).Padding(0, 0, 4, 0)
+			[
+				SNew(SButton)
+				.Text(LOCTEXT("ExtUpdate", "Update"))
+				.OnClicked(this, &SUnrealMcpExtensionsWindow::OnInstallClicked, ExtensionId, true)
+			];
+		}
+	}
+
+	TSharedRef<SVerticalBox> TextCol = SNew(SVerticalBox)
+		+ SVerticalBox::Slot().AutoHeight()
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center)
+			[
+				SNew(STextBlock).Text(Title).Font(FCoreStyle::GetDefaultFontStyle("Bold", 11))
+			]
+			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(8, 0, 0, 0)
+			[
+				SNew(STextBlock).Text(FText::FromString(VersionLabel)).ColorAndOpacity(FSlateColor::UseSubduedForeground())
+			]
+			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(8, 0, 0, 0)
+			[
+				SNew(STextBlock).Text(StateBadge).ColorAndOpacity(FSlateColor::UseSubduedForeground())
+			]
+		]
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 2, 0, 0)
+		[
+			SNew(STextBlock)
+			.Text(FText::FromString(Row.Description))
+			.AutoWrapText(true)
+			.ColorAndOpacity(FSlateColor::UseSubduedForeground())
+		];
+
+	// Per-extension error badge — the registry surfaces invalid/duplicate-id / per-tool validation failures.
+	if (Row.bHasError)
+	{
+		TextCol->AddSlot().AutoHeight().Padding(0, 2, 0, 0)
+		[
+			SNew(STextBlock)
+			.Text(FText::Format(LOCTEXT("ExtError", "Error: {0}"), FText::FromString(Row.Error)))
+			.AutoWrapText(true)
+			.ColorAndOpacity(FLinearColor(0.9f, 0.4f, 0.4f))
+		];
+	}
+
+	return SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+		.Padding(8.0f)
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot().FillWidth(1.0f)[ TextCol ]
+			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(8, 0, 0, 0)[ ActionRow ]
+		];
+}
+
+FReply SUnrealMcpExtensionsWindow::OnRefreshClicked()
+{
+	if (!CatalogFetcher)
+	{
+		StatusMessage = LOCTEXT("ExtNoFetcher", "Catalog refresh is unavailable in this build.").ToString();
+		return FReply::Handled();
+	}
+	TArray<FUnrealMcpCatalogEntry> Fetched;
+	FString Error;
+	if (CatalogFetcher(Fetched, Error))
+	{
+		Catalog = MoveTemp(Fetched);
+		StatusMessage = FString::Printf(TEXT("Loaded %d available extension(s) from the catalog."), Catalog.Num());
+	}
+	else
+	{
+		StatusMessage = FString::Printf(TEXT("Could not load the catalog: %s"), *Error);
+	}
+	RebuildList();
+	return FReply::Handled();
+}
+
+FReply SUnrealMcpExtensionsWindow::OnInstallClicked(FString ExtensionId, bool bForce)
+{
+	if (!OnInstall)
+		return FReply::Handled();
+	const FUnrealMcpCatalogEntry* Entry = FUnrealMcpExtensionCatalog::FindEntry(Catalog, ExtensionId);
+	if (Entry == nullptr)
+	{
+		StatusMessage = FString::Printf(TEXT("Extension '%s' is no longer in the catalog — Refresh and try again."), *ExtensionId);
+		return FReply::Handled();
+	}
+
+	const FUnrealMcpInstallResult Result = OnInstall(*Entry, bForce);
+	StatusMessage = Result.bSuccess ? Result.Message : FString::Printf(TEXT("Install failed: %s"), *Result.Error);
+	for (const FString& Warning : Result.Warnings)
+		StatusMessage += FString::Printf(TEXT("\nWarning: %s"), *Warning);
+	bRestartHintVisible = Result.bSuccess && Result.bRebuildRequired;
+
+	if (Result.bSuccess)
+	{
+		UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] extension install: %s"), *Result.Message);
+	}
+	else
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] extension install failed: %s"), *Result.Error);
+	}
+
+	RebuildList();
+	return FReply::Handled();
+}
+
+FReply SUnrealMcpExtensionsWindow::OnCompileClicked()
+{
+	if (OnTriggerLiveCompile)
+		StatusMessage = OnTriggerLiveCompile();
+	else
+		StatusMessage = LOCTEXT("ExtNoLiveCoding", "Live Coding is unavailable — restart the editor to finish compiling.").ToString();
+	return FReply::Handled();
+}
+
+void SUnrealMcpExtensionsWindow::OnEnabledChanged(FString ExtensionId, bool bEnabled)
+{
+	if (OnSetEnabled)
+		OnSetEnabled(ExtensionId, bEnabled);
+	StatusMessage = FString::Printf(TEXT("Extension '%s' %s."), *ExtensionId, bEnabled ? TEXT("enabled") : TEXT("disabled"));
+	RebuildList();
+}
+
+FText SUnrealMcpExtensionsWindow::GetStatusText() const
+{
+	return FText::FromString(StatusMessage);
+}
+
+EVisibility SUnrealMcpExtensionsWindow::GetRestartHintVisibility() const
+{
+	return bRestartHintVisible ? EVisibility::Visible : EVisibility::Collapsed;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpExtensionsWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpExtensionsWindow.cpp
@@ -240,11 +240,15 @@ FReply SUnrealMcpExtensionsWindow::OnRefreshClicked()
 	if (CatalogFetcher(Fetched, Error))
 	{
 		Catalog = MoveTemp(Fetched);
-		StatusMessage = FString::Printf(TEXT("Loaded %d available extension(s) from the catalog."), Catalog.Num());
+		StatusMessage = FText::Format(
+			LOCTEXT("ExtLoadedCount", "Loaded {0} available extension(s) from the catalog."),
+			FText::AsNumber(Catalog.Num())).ToString();
 	}
 	else
 	{
-		StatusMessage = FString::Printf(TEXT("Could not load the catalog: %s"), *Error);
+		StatusMessage = FText::Format(
+			LOCTEXT("ExtCatalogLoadFailed", "Could not load the catalog: {0}"),
+			FText::FromString(Error)).ToString();
 	}
 	RebuildList();
 	return FReply::Handled();
@@ -257,14 +261,18 @@ FReply SUnrealMcpExtensionsWindow::OnInstallClicked(FString ExtensionId, bool bF
 	const FUnrealMcpCatalogEntry* Entry = FUnrealMcpExtensionCatalog::FindEntry(Catalog, ExtensionId);
 	if (Entry == nullptr)
 	{
-		StatusMessage = FString::Printf(TEXT("Extension '%s' is no longer in the catalog — Refresh and try again."), *ExtensionId);
+		StatusMessage = FText::Format(
+			LOCTEXT("ExtNotInCatalog", "Extension '{0}' is no longer in the catalog — Refresh and try again."),
+			FText::FromString(ExtensionId)).ToString();
 		return FReply::Handled();
 	}
 
 	const FUnrealMcpInstallResult Result = OnInstall(*Entry, bForce);
-	StatusMessage = Result.bSuccess ? Result.Message : FString::Printf(TEXT("Install failed: %s"), *Result.Error);
+	StatusMessage = Result.bSuccess
+		? Result.Message
+		: FText::Format(LOCTEXT("ExtInstallFailed", "Install failed: {0}"), FText::FromString(Result.Error)).ToString();
 	for (const FString& Warning : Result.Warnings)
-		StatusMessage += FString::Printf(TEXT("\nWarning: %s"), *Warning);
+		StatusMessage += FText::Format(LOCTEXT("ExtInstallWarning", "\nWarning: {0}"), FText::FromString(Warning)).ToString();
 	bRestartHintVisible = Result.bSuccess && Result.bRebuildRequired;
 
 	if (Result.bSuccess)
@@ -293,7 +301,10 @@ void SUnrealMcpExtensionsWindow::OnEnabledChanged(FString ExtensionId, bool bEna
 {
 	if (OnSetEnabled)
 		OnSetEnabled(ExtensionId, bEnabled);
-	StatusMessage = FString::Printf(TEXT("Extension '%s' %s."), *ExtensionId, bEnabled ? TEXT("enabled") : TEXT("disabled"));
+	StatusMessage = FText::Format(
+		LOCTEXT("ExtToggleStatus", "Extension '{0}' {1}."),
+		FText::FromString(ExtensionId),
+		bEnabled ? LOCTEXT("ExtEnabledWord", "enabled") : LOCTEXT("ExtDisabledWord", "disabled")).ToString();
 	RebuildList();
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpExtensionsWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpExtensionsWindow.h
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Templates/Function.h"
+#include "Extensions/UnrealMcpExtensionCatalog.h"
+#include "Extensions/UnrealMcpExtensionInstaller.h"
+
+struct FUnrealMcpExtensionRecord; // runtime module
+class SVerticalBox;
+
+/**
+ * The "Extensions" window (docs/ARCHITECTURE.md §7 item 10) — install channel #3 of three, the most
+ * NATIVE no-terminal path. A pure-Slate compound widget (NO UMG) that lists AVAILABLE (catalog) +
+ * INSTALLED extensions with state and offers install / update / enable / disable from inside the editor,
+ * reusing the SAME catalog format + install contract as the CLI (#172) and the app GUI so all three
+ * channels are behaviorally identical (FUnrealMcpExtensionInstaller).
+ *
+ * The list is the pure catalog ∪ loaded-providers ∪ on-disk merge (FUnrealMcpExtensionInstaller::BuildRows):
+ *  - INSTALLED + LOADED rows carry a live enable/disable toggle routed to the §5 hot-load path
+ *    (FUnrealMcpExtensionManager::SetExtensionEnabled → manifest revision bump → bridge re-proxies), plus
+ *    the per-extension error badge the registry exposes.
+ *  - AVAILABLE (catalog-only) rows carry an Install button; an installed-but-outdated row carries Update.
+ *  - After any install/update the row surfaces the compile-on-install reality (§5 key UX risk): a
+ *    "needs editor restart to finish compiling" hint + a best-effort "Compile (Live Coding)" affordance.
+ *
+ * Catalog fetch is on-demand (a Refresh button), never on construct — so the headless boot smoke / Automation
+ * runs never block on the network. The window renders the INSTALLED/LOADED set immediately from the supplied
+ * providers and merges the catalog in once fetched.
+ */
+class SUnrealMcpExtensionsWindow : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SUnrealMcpExtensionsWindow) {}
+		/** The UE project directory (scanned for installed plugins + the install target). */
+		SLATE_ARGUMENT(FString, ProjectDir)
+		/** An initial catalog (usually empty at boot — fetched on Refresh to avoid a boot-time network call). */
+		SLATE_ARGUMENT(TArray<FUnrealMcpCatalogEntry>, InitialCatalog)
+		/** Snapshots the live loaded-provider records (id / display name / version / tool count / enabled / error). */
+		SLATE_ARGUMENT(TFunction<TArray<FUnrealMcpExtensionRecord>()>, InstalledProvider)
+		/** Fetch the shared catalog over HTTP; returns false + an error message on failure. Optional. */
+		SLATE_ARGUMENT(TFunction<bool(TArray<FUnrealMcpCatalogEntry>&, FString&)>, CatalogFetcher)
+		/** Enable/disable a loaded extension (the §5 hot-load toggle). Optional. */
+		SLATE_ARGUMENT(TFunction<void(const FString&, bool)>, OnSetEnabled)
+		/** Install/update an extension from its catalog descriptor (force re-materialize when @p bForce). Optional. */
+		SLATE_ARGUMENT(TFunction<FUnrealMcpInstallResult(const FUnrealMcpCatalogEntry&, bool)>, OnInstall)
+		/** Best-effort Live Coding trigger; returns a human-readable status. Optional. */
+		SLATE_ARGUMENT(TFunction<FString()>, OnTriggerLiveCompile)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	FString ProjectDir;
+	TArray<FUnrealMcpCatalogEntry> Catalog;
+	TFunction<TArray<FUnrealMcpExtensionRecord>()> InstalledProvider;
+	TFunction<bool(TArray<FUnrealMcpCatalogEntry>&, FString&)> CatalogFetcher;
+	TFunction<void(const FString&, bool)> OnSetEnabled;
+	TFunction<FUnrealMcpInstallResult(const FUnrealMcpCatalogEntry&, bool)> OnInstall;
+	TFunction<FString()> OnTriggerLiveCompile;
+
+	TSharedPtr<SVerticalBox> ListContainer;
+	FString StatusMessage;
+	bool bRestartHintVisible = false;
+
+	/** Recompute the merged rows and refill the list container. */
+	void RebuildList();
+	TSharedRef<SWidget> BuildRow(const FUnrealMcpExtensionRow& Row);
+
+	FReply OnRefreshClicked();
+	FReply OnInstallClicked(FString ExtensionId, bool bForce);
+	FReply OnCompileClicked();
+	void OnEnabledChanged(FString ExtensionId, bool bEnabled);
+
+	FText GetStatusText() const;
+	EVisibility GetRestartHintVisibility() const;
+};

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.cpp
@@ -21,17 +21,20 @@ const FName FUnrealMcpAuxWindows::ToolsTabId(TEXT("UnrealMcpToolsWindow"));
 const FName FUnrealMcpAuxWindows::PromptsTabId(TEXT("UnrealMcpPromptsWindow"));
 const FName FUnrealMcpAuxWindows::ResourcesTabId(TEXT("UnrealMcpResourcesWindow"));
 const FName FUnrealMcpAuxWindows::SerializationCheckTabId(TEXT("UnrealMcpSerializationCheckWindow"));
+const FName FUnrealMcpAuxWindows::ExtensionsTabId(TEXT("UnrealMcpExtensionsWindow"));
 
 void FUnrealMcpAuxWindows::Register(
 	const TSharedRef<FUnrealMcpEditorViewModel>& InViewModel,
 	TFunction<TArray<FUnrealMcpToolListEntry>()> InToolListProvider,
 	TFunction<TArray<FUnrealMcpFeatureEntry>()> InPromptProvider,
-	TFunction<TArray<FUnrealMcpFeatureEntry>()> InResourceProvider)
+	TFunction<TArray<FUnrealMcpFeatureEntry>()> InResourceProvider,
+	FUnrealMcpExtensionsPanelWiring InExtensionsWiring)
 {
 	if (bRegistered)
 		return;
 
 	ViewModel = InViewModel;
+	ExtensionsWiring = MoveTemp(InExtensionsWiring);
 
 	// The Tools provider closes over the runtime-owned registry (raw, non-owning). A widget can outlive
 	// Unregister() — a deferred RequestCloseTab still queued when the runtime frees those subsystems — and
@@ -47,6 +50,19 @@ void FUnrealMcpAuxWindows::Register(
 	};
 	PromptProvider = MoveTemp(InPromptProvider);
 	ResourceProvider = MoveTemp(InResourceProvider);
+
+	// Guard the Extensions panel's loaded-provider snapshot with the SAME teardown alive-flag: a deferred
+	// widget paint after Unregister() (which frees the runtime extension manager) must short-circuit to an
+	// empty result rather than dereference freed memory. The enable/install delegates are click-driven on a
+	// live editor, but guard the read-each-paint InstalledProvider exactly like the Tools provider.
+	if (ExtensionsWiring.InstalledProvider)
+	{
+		ExtensionsWiring.InstalledProvider =
+			[Alive, Inner = MoveTemp(ExtensionsWiring.InstalledProvider)]() -> TArray<FUnrealMcpExtensionRecord>
+			{
+				return (Alive.IsValid() && *Alive && Inner) ? Inner() : TArray<FUnrealMcpExtensionRecord>();
+			};
+	}
 
 	// Slate may be unavailable in a commandlet / -nullrhi headless run; guard so the Automation/smoke runs
 	// (which load the module) never crash on tab registration (mirrors the main-window tab).
@@ -90,6 +106,13 @@ void FUnrealMcpAuxWindows::Register(
 		.SetGroup(Group)
 		.SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "Icons.Adjust"));
 
+	// §7 item 10 Extensions panel — install channel #3 (browse/install/enable/disable/update extensions in-editor).
+	TabManager.RegisterNomadTabSpawner(ExtensionsTabId, FOnSpawnTab::CreateRaw(this, &FUnrealMcpAuxWindows::SpawnExtensionsTab))
+		.SetDisplayName(LOCTEXT("ExtensionsTabTitle", "Extensions"))
+		.SetTooltipText(LOCTEXT("ExtensionsTabTooltip", "Browse, install, enable/disable, and update Unreal-MCP extensions without leaving the editor."))
+		.SetGroup(Group)
+		.SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "Icons.Plus"));
+
 	// Connection settings live entirely in the single "AI Game Developer" main window (issue #107, Unity-MCP
 	// parity). The separate "AI Game Developer Settings" nomad tab and the "Project → Plugins → AI Game Developer"
 	// ISettingsModule section that both rendered SUnrealMcpSettingsWindow were removed — the main window's
@@ -116,7 +139,7 @@ void FUnrealMcpAuxWindows::Unregister()
 		FGlobalTabmanager& TabManager = *FGlobalTabmanager::Get();
 		// Close any live tab first so its hosted widget (a strong view-model ref) is torn down before the runtime
 		// frees the view-model — same use-after-free guard as the main-window tab.
-		for (const FName& TabId : { ToolsTabId, PromptsTabId, ResourcesTabId, SerializationCheckTabId })
+		for (const FName& TabId : { ToolsTabId, PromptsTabId, ResourcesTabId, SerializationCheckTabId, ExtensionsTabId })
 		{
 			if (TSharedPtr<SDockTab> LiveTab = TabManager.FindExistingLiveTab(TabId))
 				LiveTab->RequestCloseTab();
@@ -172,6 +195,24 @@ TSharedRef<SDockTab> FUnrealMcpAuxWindows::SpawnSerializationCheckTab(const FSpa
 	// guard here (unlike the registry-backed Tools window).
 	TSharedRef<SDockTab> Tab = SNew(SDockTab).TabRole(ETabRole::NomadTab);
 	Tab->SetContent(SNew(SUnrealMcpSerializationCheckWindow));
+	return Tab;
+}
+
+TSharedRef<SDockTab> FUnrealMcpAuxWindows::SpawnExtensionsTab(const FSpawnTabArgs& Args)
+{
+	// The §7 Extensions panel (install channel #3). The InstalledProvider was alive-flag-guarded in Register so a
+	// deferred paint after teardown returns empty rather than dereferencing the freed runtime extension manager;
+	// the catalog fetch + install + enable delegates are click-driven on a live editor.
+	TSharedRef<SDockTab> Tab = SNew(SDockTab).TabRole(ETabRole::NomadTab);
+	Tab->SetContent(
+		SNew(SUnrealMcpExtensionsWindow)
+		.ProjectDir(ExtensionsWiring.ProjectDir)
+		.InitialCatalog(ExtensionsWiring.InitialCatalog)
+		.InstalledProvider(ExtensionsWiring.InstalledProvider)
+		.CatalogFetcher(ExtensionsWiring.CatalogFetcher)
+		.OnSetEnabled(ExtensionsWiring.OnSetEnabled)
+		.OnInstall(ExtensionsWiring.OnInstall)
+		.OnTriggerLiveCompile(ExtensionsWiring.OnTriggerLiveCompile));
 	return Tab;
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.h
@@ -6,10 +6,30 @@
 #include "CoreMinimal.h"
 #include "UI/SUnrealMcpToolsWindow.h"
 #include "UI/SUnrealMcpFeatureListWindow.h"
+#include "UI/SUnrealMcpExtensionsWindow.h"
+#include "Extensions/UnrealMcpExtensionManager.h" // FUnrealMcpExtensionRecord (by value in the installed-provider signature)
 
 class FUnrealMcpEditorViewModel;
 class SDockTab;
 class FSpawnTabArgs;
+
+/**
+ * Wiring for the §7 Extensions panel (docs/ARCHITECTURE.md §7 item 10 — install channel #3). Bundled so
+ * the aux-windows Register() signature stays readable. The providers/delegates are owned by the editor
+ * coordinator (catalog fetch + installer in the editor module; the enable toggle routes to the runtime
+ * extension manager's §5 hot-load path). The InstalledProvider is guarded by the same teardown alive-flag
+ * as the Tools provider.
+ */
+struct FUnrealMcpExtensionsPanelWiring
+{
+	FString ProjectDir;
+	TArray<FUnrealMcpCatalogEntry> InitialCatalog;
+	TFunction<TArray<FUnrealMcpExtensionRecord>()> InstalledProvider;
+	TFunction<bool(TArray<FUnrealMcpCatalogEntry>&, FString&)> CatalogFetcher;
+	TFunction<void(const FString&, bool)> OnSetEnabled;
+	TFunction<FUnrealMcpInstallResult(const FUnrealMcpCatalogEntry&, bool)> OnInstall;
+	TFunction<FString()> OnTriggerLiveCompile;
+};
 
 /**
  * Registers the §7 auxiliary windows (docs/ARCHITECTURE.md §7) as nomad dockable tabs under the same
@@ -39,6 +59,7 @@ public:
 	static const FName PromptsTabId;
 	static const FName ResourcesTabId;
 	static const FName SerializationCheckTabId;
+	static const FName ExtensionsTabId;
 
 	/**
 	 * Open (or focus, if already open) the Serialization Check tab. Static so the footer "Check" button and the
@@ -58,7 +79,8 @@ public:
 		const TSharedRef<FUnrealMcpEditorViewModel>& InViewModel,
 		TFunction<TArray<FUnrealMcpToolListEntry>()> InToolListProvider,
 		TFunction<TArray<FUnrealMcpFeatureEntry>()> InPromptProvider,
-		TFunction<TArray<FUnrealMcpFeatureEntry>()> InResourceProvider);
+		TFunction<TArray<FUnrealMcpFeatureEntry>()> InResourceProvider,
+		FUnrealMcpExtensionsPanelWiring InExtensionsWiring = FUnrealMcpExtensionsPanelWiring());
 
 	/** Unregister the tab spawners (Shutdown). Idempotent. Neutralizes the providers first. */
 	void Unregister();
@@ -76,11 +98,14 @@ private:
 	TSharedRef<SDockTab> SpawnPromptsTab(const FSpawnTabArgs& Args);
 	TSharedRef<SDockTab> SpawnResourcesTab(const FSpawnTabArgs& Args);
 	TSharedRef<SDockTab> SpawnSerializationCheckTab(const FSpawnTabArgs& Args);
+	TSharedRef<SDockTab> SpawnExtensionsTab(const FSpawnTabArgs& Args);
 
 	TSharedPtr<FUnrealMcpEditorViewModel> ViewModel;
 	TFunction<TArray<FUnrealMcpToolListEntry>()> ToolListProvider;
 	TFunction<TArray<FUnrealMcpFeatureEntry>()> PromptProvider;
 	TFunction<TArray<FUnrealMcpFeatureEntry>()> ResourceProvider;
+	// §7 Extensions panel (install channel #3) wiring; InstalledProvider is alive-flag-guarded like the Tools provider.
+	FUnrealMcpExtensionsPanelWiring ExtensionsWiring;
 	// Shared with every widget-held copy of the registry-touching provider; NeutralizeProviders() flips it
 	// false during teardown so a surviving widget's next paint returns empty rather than dereferencing freed memory.
 	TSharedPtr<bool> ProvidersAlive;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
@@ -407,12 +407,15 @@ void FUnrealMcpEditorCoordinator::Startup()
 			ILiveCodingModule* LiveCoding = FModuleManager::GetModulePtr<ILiveCodingModule>(FName(LIVE_CODING_MODULE_NAME));
 			if (LiveCoding && LiveCoding->IsEnabledForSession() && LiveCoding->HasStarted() && !LiveCoding->IsCompiling())
 			{
-				ELiveCodingCompileResult Result = ELiveCodingCompileResult::NotStarted;
-				LiveCoding->Compile(ELiveCodingCompileFlags::WaitForCompletion, &Result);
-				if (Result == ELiveCodingCompileResult::Success || Result == ELiveCodingCompileResult::NoChanges)
-					return TEXT("Live Coding compile finished. A newly added extension module may still need an editor restart to load.");
-				return TEXT("Live Coding compile did not complete cleanly — restart the editor to finish compiling.");
+				// Fire-and-forget: OnCompileClicked() calls this synchronously on the game thread, so a
+				// WaitForCompletion compile (20-60s) would freeze the editor — and this very panel — looking
+				// like a hang. Kick it off like UE's own Compile button does and point the user at the Live
+				// Coding panel for progress.
+				LiveCoding->Compile(ELiveCodingCompileFlags::None, nullptr);
+				return TEXT("Live Coding compilation started — watch the Live Coding panel for progress. A newly added extension module may still need an editor restart to load.");
 			}
+			if (LiveCoding && LiveCoding->IsEnabledForSession() && LiveCoding->HasStarted())
+				return TEXT("Live Coding is already compiling — wait for it to finish, then restart the editor if the new extension module still isn't loaded.");
 			return TEXT("Live Coding is not enabled/started — restart the editor to finish compiling the installed extension(s).");
 		}
 		return TEXT("Live Coding is unavailable in this session — restart the editor to finish compiling.");

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
@@ -16,6 +16,7 @@
 #include "Sidecar/UnrealMcpSidecarManager.h"
 #include "Server/UnrealMcpServerManager.h"
 #include "Extensions/UnrealMcpExtensionManager.h"
+#include "Extensions/UnrealMcpExtensionInstaller.h" // §7 install channel #3 (catalog fetch + installer)
 #include "UI/UnrealMcpEditorViewModel.h"
 #include "UI/UnrealMcpMainWindowTab.h"
 #include "UI/UnrealMcpAuxWindows.h"
@@ -26,12 +27,18 @@
 #include "DevControl/UnrealMcpDevControlServer.h"
 
 #include "Editor.h"
+#include "Misc/App.h"
 #include "Misc/CoreDelegates.h"
 #include "Misc/Paths.h"
 #include "Misc/EngineVersion.h"
 #include "Async/Async.h"
 #include "HAL/PlatformProcess.h"
+#include "Modules/ModuleManager.h"
 #include "Interfaces/IPluginManager.h"
+
+#if WITH_UNREAL_MCP_LIVE_CODING
+#include "ILiveCodingModule.h"
+#endif
 
 // Defined here (where every subsystem type is complete) so the TUniquePtr member deleters instantiate
 // correctly regardless of unity-build grouping. See the header comment.
@@ -359,6 +366,61 @@ void FUnrealMcpEditorCoordinator::Startup()
 	// owns those features, §2) — their providers return empty and the windows render an honest empty state rather
 	// than a fabricated registry. Connection settings (incl. the read-only IPC-bridge-port line) live in the
 	// single "AI Game Developer" main window, not an aux window (issue #107, Unity-MCP parity).
+	// §7 item 10 Extensions panel (install channel #3): wire the catalog fetch (HTTP, on-demand), the install
+	// service (FUnrealMcpExtensionInstaller — fetch → place in Plugins/ → edit .uproject → compile-on-open), and
+	// the §5 hot-load enable toggle (ExtensionManager::SetExtensionEnabled → manifest revision bump → bridge
+	// re-proxies). The InstalledProvider snapshots the runtime extension manager's live records; the aux-windows
+	// guards it with the teardown alive-flag. No catalog fetch happens at boot (empty InitialCatalog) so the
+	// headless smoke / Automation runs never block on the network.
+	FUnrealMcpExtensionManager* ExtMgrPtr = ExtensionManager.Get();
+	const FString ExtProjectDir = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
+	FUnrealMcpExtensionsPanelWiring ExtWiring;
+	ExtWiring.ProjectDir = ExtProjectDir;
+	ExtWiring.InstalledProvider = [ExtMgrPtr]() -> TArray<FUnrealMcpExtensionRecord>
+	{
+		return ExtMgrPtr ? ExtMgrPtr->GetExtensions() : TArray<FUnrealMcpExtensionRecord>();
+	};
+	ExtWiring.CatalogFetcher = [](TArray<FUnrealMcpCatalogEntry>& Out, FString& Err) -> bool
+	{
+		return FUnrealMcpExtensionInstaller::FetchCatalogSync(FUnrealMcpExtensionCatalog::DefaultCatalogUrl(), 30.0, Out, Err);
+	};
+	ExtWiring.OnSetEnabled = [ExtMgrPtr](const FString& Id, bool bEnabled)
+	{
+		if (ExtMgrPtr)
+			ExtMgrPtr->SetExtensionEnabled(Id, bEnabled); // §5 hot-load: rebuild + re-push the manifest(s)
+	};
+	ExtWiring.OnInstall = [ExtProjectDir](const FUnrealMcpCatalogEntry& Entry, bool bForce) -> FUnrealMcpInstallResult
+	{
+		FUnrealMcpInstallOptions Opts;
+		Opts.ProjectDir = ExtProjectDir;
+		Opts.Descriptor = Entry;
+		Opts.bForce = bForce;
+		return FUnrealMcpExtensionInstaller::Install(Opts);
+	};
+	ExtWiring.OnTriggerLiveCompile = []() -> FString
+	{
+#if WITH_UNREAL_MCP_LIVE_CODING
+		// Best-effort: Live Coding patches already-loaded modules. A freshly installed extension's brand-new
+		// module may still require a full editor restart to load — so the messaging stays honest either way.
+		if (!FApp::IsUnattended())
+		{
+			ILiveCodingModule* LiveCoding = FModuleManager::GetModulePtr<ILiveCodingModule>(FName(LIVE_CODING_MODULE_NAME));
+			if (LiveCoding && LiveCoding->IsEnabledForSession() && LiveCoding->HasStarted() && !LiveCoding->IsCompiling())
+			{
+				ELiveCodingCompileResult Result = ELiveCodingCompileResult::NotStarted;
+				LiveCoding->Compile(ELiveCodingCompileFlags::WaitForCompletion, &Result);
+				if (Result == ELiveCodingCompileResult::Success || Result == ELiveCodingCompileResult::NoChanges)
+					return TEXT("Live Coding compile finished. A newly added extension module may still need an editor restart to load.");
+				return TEXT("Live Coding compile did not complete cleanly — restart the editor to finish compiling.");
+			}
+			return TEXT("Live Coding is not enabled/started — restart the editor to finish compiling the installed extension(s).");
+		}
+		return TEXT("Live Coding is unavailable in this session — restart the editor to finish compiling.");
+#else
+		return TEXT("Live Coding is unavailable on this platform — restart the editor to finish compiling.");
+#endif
+	};
+
 	AuxWindows = MakeUnique<FUnrealMcpAuxWindows>();
 	AuxWindows->Register(
 		ViewModel.ToSharedRef(),
@@ -377,7 +439,8 @@ void FUnrealMcpEditorCoordinator::Startup()
 			return Entries;
 		},
 		[]() -> TArray<FUnrealMcpFeatureEntry> { return {}; },  // prompts (none surfaced to the plugin yet)
-		[]() -> TArray<FUnrealMcpFeatureEntry> { return {}; }); // resources (none surfaced to the plugin yet)
+		[]() -> TArray<FUnrealMcpFeatureEntry> { return {}; },  // resources (none surfaced to the plugin yet)
+		MoveTemp(ExtWiring));
 
 	// DEV-ONLY inject/control HTTP bridge (docs/ARCHITECTURE.md §7). Started ONLY when the editor process env
 	// UNREAL_MCP_DEV_CONTROL == "1" — OFF by default, so a shipped plugin never opens a port. The port comes

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpExtensionCatalogSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpExtensionCatalogSpec.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Extensions/UnrealMcpExtensionCatalog.h"
+#include "Extensions/UnrealMcpUProjectPlugins.h"
+
+/**
+ * Extensions panel — catalog + .uproject helper specs (docs/ARCHITECTURE.md §7 item 10, issue #176). The
+ * in-editor install channel (#3) reuses the SAME catalog format + install contract as the CLI (#172); these
+ * specs prove the native C++ catalog parser / lookup and the `.uproject`/`.uplugin` edit helpers behave with
+ * parity to the TS (`extensions-catalog.ts` / `uproject-plugins.ts`) — all pure, no live download / no editor
+ * world. The Slate panel itself is operator-verified (windowed).
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpExtensionCatalogSpec, "UnrealMcp.ExtensionCatalog",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	// The real shared catalog JSON shape (mirrors cli/extensions.catalog.json) — one Niagara entry.
+	static FString CatalogSpecSampleJson()
+	{
+		return TEXT(R"({
+			"schemaVersion": 1,
+			"extensions": [
+				{
+					"extensionId": "com.ivanmurzak.unreal-ai-niagara",
+					"name": "Niagara Tools",
+					"description": "AI tools for Unreal's Niagara VFX system.",
+					"pluginName": "UnrealAINiagara",
+					"repo": "IvanMurzak/Unreal-AI-Niagara",
+					"version": "0.1.0",
+					"minCoreVersion": "0.5.0",
+					"enginePlugins": ["Niagara"],
+					"tools": [
+						{ "name": "niagara-list-systems", "description": "List Niagara systems." }
+					]
+				}
+			]
+		})");
+	}
+
+	// Parse a JSON text into an FJsonObject (helper for the .uplugin/.uproject specs).
+	static TSharedPtr<FJsonObject> CatalogSpecParseObject(const FString& Json)
+	{
+		TSharedPtr<FJsonObject> Root;
+		const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
+		FJsonSerializer::Deserialize(Reader, Root);
+		return Root;
+	}
+
+END_DEFINE_SPEC(FUnrealMcpExtensionCatalogSpec)
+
+void FUnrealMcpExtensionCatalogSpec::Define()
+{
+	Describe("ParseCatalogJson", [this]()
+	{
+		It("parses the shared catalog shape into typed entries", [this]()
+		{
+			TArray<FUnrealMcpCatalogEntry> Entries;
+			FString Error, Warning;
+			TestTrue("parse succeeds", FUnrealMcpExtensionCatalog::ParseCatalogJson(CatalogSpecSampleJson(), Entries, Error, Warning));
+			TestEqual("one entry", Entries.Num(), 1);
+			TestTrue("no warning on supported schema", Warning.IsEmpty());
+
+			const FUnrealMcpCatalogEntry& E = Entries[0];
+			TestEqual("extensionId", E.ExtensionId, FString(TEXT("com.ivanmurzak.unreal-ai-niagara")));
+			TestEqual("pluginName", E.PluginName, FString(TEXT("UnrealAINiagara")));
+			TestEqual("repo", E.Repo, FString(TEXT("IvanMurzak/Unreal-AI-Niagara")));
+			TestEqual("version", E.Version, FString(TEXT("0.1.0")));
+			TestEqual("minCoreVersion", E.MinCoreVersion, FString(TEXT("0.5.0")));
+			TestTrue("has version", E.HasVersion());
+			TestEqual("one gating engine plugin", E.EnginePlugins.Num(), 1);
+			TestEqual("gating plugin is Niagara", E.EnginePlugins[0], FString(TEXT("Niagara")));
+			TestEqual("one tool", E.Tools.Num(), 1);
+			TestEqual("tool name", E.Tools[0].Name, FString(TEXT("niagara-list-systems")));
+		});
+
+		It("rejects malformed JSON, a missing extensions array, and an entry missing required identity", [this]()
+		{
+			TArray<FUnrealMcpCatalogEntry> Entries;
+			FString Error, Warning;
+			TestFalse("malformed JSON fails", FUnrealMcpExtensionCatalog::ParseCatalogJson(TEXT("{ not json"), Entries, Error, Warning));
+			TestFalse("no extensions array fails", FUnrealMcpExtensionCatalog::ParseCatalogJson(TEXT("{ \"schemaVersion\": 1 }"), Entries, Error, Warning));
+
+			const FString NoId = TEXT("{ \"extensions\": [ { \"pluginName\": \"X\" } ] }");
+			TestFalse("missing extensionId fails", FUnrealMcpExtensionCatalog::ParseCatalogJson(NoId, Entries, Error, Warning));
+			const FString NoPlugin = TEXT("{ \"extensions\": [ { \"extensionId\": \"a.b\" } ] }");
+			TestFalse("missing pluginName fails", FUnrealMcpExtensionCatalog::ParseCatalogJson(NoPlugin, Entries, Error, Warning));
+		});
+
+		It("warns (but still parses) when the schemaVersion is newer than supported", [this]()
+		{
+			const FString Newer = TEXT("{ \"schemaVersion\": 99, \"extensions\": [ { \"extensionId\": \"a.b\", \"pluginName\": \"AB\" } ] }");
+			TArray<FUnrealMcpCatalogEntry> Entries;
+			FString Error, Warning;
+			TestTrue("still parses best-effort", FUnrealMcpExtensionCatalog::ParseCatalogJson(Newer, Entries, Error, Warning));
+			TestEqual("one entry parsed", Entries.Num(), 1);
+			TestFalse("a warning is surfaced", Warning.IsEmpty());
+		});
+	});
+
+	Describe("FindEntry", [this]()
+	{
+		It("resolves by extensionId, name, and pluginName, case-insensitively", [this]()
+		{
+			TArray<FUnrealMcpCatalogEntry> Entries;
+			FString Error, Warning;
+			FUnrealMcpExtensionCatalog::ParseCatalogJson(CatalogSpecSampleJson(), Entries, Error, Warning);
+
+			TestNotNull("by extensionId", FUnrealMcpExtensionCatalog::FindEntry(Entries, TEXT("com.ivanmurzak.unreal-ai-niagara")));
+			TestNotNull("by name (caseless)", FUnrealMcpExtensionCatalog::FindEntry(Entries, TEXT("niagara tools")));
+			TestNotNull("by pluginName (caseless)", FUnrealMcpExtensionCatalog::FindEntry(Entries, TEXT("unrealainiagara")));
+			TestNull("unknown id", FUnrealMcpExtensionCatalog::FindEntry(Entries, TEXT("does.not.exist")));
+			TestNull("empty id", FUnrealMcpExtensionCatalog::FindEntry(Entries, TEXT("")));
+		});
+	});
+
+	Describe("UProject/.uplugin helpers", [this]()
+	{
+		It("reads a .uplugin's enabled dependencies and VersionName", [this]()
+		{
+			const FString Uplugin = TEXT(R"({
+				"VersionName": "1.2.3",
+				"Plugins": [
+					{ "Name": "Niagara", "Enabled": true },
+					{ "Name": "Disabled", "Enabled": false },
+					{ "Name": "DefaultEnabled" }
+				]
+			})");
+			const TSharedPtr<FJsonObject> Obj = CatalogSpecParseObject(Uplugin);
+			const TArray<FString> Deps = FUnrealMcpUProjectPlugins::ParseUPluginDependencies(Obj);
+			TestTrue("Niagara is a dep", Deps.Contains(TEXT("Niagara")));
+			TestTrue("default-enabled (no Enabled field) is a dep", Deps.Contains(TEXT("DefaultEnabled")));
+			TestFalse("explicitly disabled is excluded", Deps.Contains(TEXT("Disabled")));
+			TestEqual("VersionName", FUnrealMcpUProjectPlugins::ReadUPluginVersionName(Obj), FString(TEXT("1.2.3")));
+		});
+
+		It("enables absent plugins, flips disabled ones, and is idempotent", [this]()
+		{
+			const FString Before = TEXT("{\n\t\"FileVersion\": 3,\n\t\"Plugins\": [\n\t\t{ \"Name\": \"Off\", \"Enabled\": false }\n\t]\n}\n");
+
+			FUnrealMcpEnablePluginsResult Result;
+			FString Error;
+			TestTrue("enable succeeds", FUnrealMcpUProjectPlugins::EnablePluginsInUProject(Before, { TEXT("UnrealAINiagara"), TEXT("Niagara"), TEXT("Off") }, Result, Error));
+			TestTrue("text changed", Result.bChanged);
+			TestTrue("appended UnrealAINiagara", Result.AddedOrFlipped.Contains(TEXT("UnrealAINiagara")));
+			TestTrue("appended Niagara", Result.AddedOrFlipped.Contains(TEXT("Niagara")));
+			TestTrue("flipped Off on", Result.AddedOrFlipped.Contains(TEXT("Off")));
+
+			// Re-parse the output and assert the enabled set (key order is not asserted — UE reorders).
+			const TSharedPtr<FJsonObject> After = CatalogSpecParseObject(Result.Text);
+			const TArray<FString> Enabled = FUnrealMcpUProjectPlugins::ParseUPluginDependencies(After);
+			TestTrue("UnrealAINiagara enabled", Enabled.Contains(TEXT("UnrealAINiagara")));
+			TestTrue("Niagara enabled", Enabled.Contains(TEXT("Niagara")));
+			TestTrue("Off now enabled", Enabled.Contains(TEXT("Off")));
+
+			// Idempotent: re-running with the same set is a no-op (nothing added/flipped, text unchanged).
+			FUnrealMcpEnablePluginsResult Again;
+			TestTrue("second run succeeds", FUnrealMcpUProjectPlugins::EnablePluginsInUProject(Result.Text, { TEXT("UnrealAINiagara"), TEXT("Niagara"), TEXT("Off") }, Again, Error));
+			TestFalse("no change on the idempotent re-run", Again.bChanged);
+			TestEqual("nothing added/flipped on the re-run", Again.AddedOrFlipped.Num(), 0);
+		});
+
+		It("returns the input verbatim on a pure no-op (already enabled)", [this]()
+		{
+			const FString Before = TEXT("{\n\t\"Plugins\": [\n\t\t{ \"Name\": \"Niagara\", \"Enabled\": true }\n\t]\n}\n");
+			FUnrealMcpEnablePluginsResult Result;
+			FString Error;
+			TestTrue("succeeds", FUnrealMcpUProjectPlugins::EnablePluginsInUProject(Before, { TEXT("Niagara") }, Result, Error));
+			TestFalse("no change", Result.bChanged);
+			TestEqual("text returned verbatim", Result.Text, Before);
+		});
+
+		It("fails cleanly on malformed .uproject JSON", [this]()
+		{
+			FUnrealMcpEnablePluginsResult Result;
+			FString Error;
+			TestFalse("malformed fails", FUnrealMcpUProjectPlugins::EnablePluginsInUProject(TEXT("{ not json"), { TEXT("X") }, Result, Error));
+			TestFalse("error is set", Error.IsEmpty());
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpExtensionInstallerSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpExtensionInstallerSpec.cpp
@@ -34,7 +34,9 @@ BEGIN_DEFINE_SPEC(FUnrealMcpExtensionInstallerSpec, "UnrealMcp.ExtensionInstalle
 	static void InstallerSpecWrite(const FString& Path, const FString& Contents)
 	{
 		IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), /*Tree*/ true);
-		FFileHelper::SaveStringToFile(Contents, *Path);
+		// Surface a failed scratch write here (fatal in a dev/automation build) instead of letting it turn
+		// into an opaque "file not found" / "install failed" further down the spec.
+		verifyf(FFileHelper::SaveStringToFile(Contents, *Path), TEXT("InstallerSpecWrite: failed to write '%s'"), *Path);
 	}
 
 	static FUnrealMcpExtensionRecord InstallerSpecRecord(const FString& Id, const FString& Version, bool bEnabled, int32 Tools, const FString& Error)

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpExtensionInstallerSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpExtensionInstallerSpec.cpp
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 Ivan Murzak. Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the repository root for more information.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/Paths.h"
+#include "Misc/Guid.h"
+#include "Misc/FileHelper.h"
+#include "Misc/ScopeExit.h"
+#include "HAL/FileManager.h"
+#include "Extensions/UnrealMcpExtensionInstaller.h"
+#include "Extensions/UnrealMcpExtensionManager.h" // FUnrealMcpExtensionRecord
+
+/**
+ * Extensions panel — install-service specs (docs/ARCHITECTURE.md §7 item 10, issue #176). The in-editor
+ * install channel (#3) is the native C++ implementation of the SAME contract the CLI's install-extension
+ * (#172) implements; these specs prove the pure decisions (download-URL build, github-only host trust,
+ * materialize/outcome/message), the catalog ∪ loaded ∪ disk row-merge the panel renders, and a full
+ * LOCAL-SOURCE install round-trip (place in Plugins/ with build-cache filtering + enable in the .uproject +
+ * idempotent re-run) — all headless. The live github-release download + the Slate window are
+ * operator/network-verified (the local-source channel exercises the same post-materialization path here).
+ */
+BEGIN_DEFINE_SPEC(FUnrealMcpExtensionInstallerSpec, "UnrealMcp.ExtensionInstaller",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+	static FString InstallerSpecScratchRoot()
+	{
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectIntermediateDir(),
+			TEXT("UnrealMcpInstallerSpec"), FGuid::NewGuid().ToString(EGuidFormats::Digits)));
+	}
+
+	static void InstallerSpecWrite(const FString& Path, const FString& Contents)
+	{
+		IFileManager::Get().MakeDirectory(*FPaths::GetPath(Path), /*Tree*/ true);
+		FFileHelper::SaveStringToFile(Contents, *Path);
+	}
+
+	static FUnrealMcpExtensionRecord InstallerSpecRecord(const FString& Id, const FString& Version, bool bEnabled, int32 Tools, const FString& Error)
+	{
+		FUnrealMcpExtensionRecord R;
+		R.Id = Id;
+		R.DisplayName = FText::FromString(Id);
+		R.Version = Version;
+		R.bEnabled = bEnabled;
+		R.ToolCount = Tools;
+		R.Error = Error;
+		return R;
+	}
+
+	static FUnrealMcpCatalogEntry InstallerSpecCatalogEntry(const FString& Id, const FString& PluginName, const FString& Version)
+	{
+		FUnrealMcpCatalogEntry E;
+		E.ExtensionId = Id;
+		E.Name = PluginName;
+		E.PluginName = PluginName;
+		E.Version = Version;
+		E.Repo = TEXT("IvanMurzak/Some-Ext");
+		return E;
+	}
+
+END_DEFINE_SPEC(FUnrealMcpExtensionInstallerSpec)
+
+void FUnrealMcpExtensionInstallerSpec::Define()
+{
+	Describe("download-source helpers", [this]()
+	{
+		It("builds the github-release zip URL with parity to the CLI", [this]()
+		{
+			TestEqual("strip leading v", FUnrealMcpExtensionInstaller::StripLeadingV(TEXT("v1.2.3")), FString(TEXT("1.2.3")));
+			TestEqual("release tag adds v", FUnrealMcpExtensionInstaller::ReleaseTag(TEXT("1.2.3")), FString(TEXT("v1.2.3")));
+			TestEqual("release tag no double-v", FUnrealMcpExtensionInstaller::ReleaseTag(TEXT("v1.2.3")), FString(TEXT("v1.2.3")));
+			TestEqual("asset name", FUnrealMcpExtensionInstaller::ExtensionAssetName(TEXT("UnrealAINiagara"), TEXT("v0.1.0")), FString(TEXT("UnrealAINiagara-0.1.0.zip")));
+			TestEqual("download url",
+				FUnrealMcpExtensionInstaller::ExtensionDownloadUrl(TEXT("IvanMurzak/Unreal-AI-Niagara"), TEXT("UnrealAINiagara"), TEXT("0.1.0")),
+				FString(TEXT("https://github.com/IvanMurzak/Unreal-AI-Niagara/releases/download/v0.1.0/UnrealAINiagara-0.1.0.zip")));
+		});
+
+		It("fail-closes host trust to github.com over https only", [this]()
+		{
+			TestTrue("github https ok", FUnrealMcpExtensionInstaller::IsTrustedDownloadUrl(TEXT("https://github.com/a/b/releases/download/v1/x.zip")));
+			TestFalse("http rejected", FUnrealMcpExtensionInstaller::IsTrustedDownloadUrl(TEXT("http://github.com/a/b.zip")));
+			TestFalse("subdomain rejected", FUnrealMcpExtensionInstaller::IsTrustedDownloadUrl(TEXT("https://raw.github.com/a/b.zip")));
+			TestFalse("look-alike host rejected", FUnrealMcpExtensionInstaller::IsTrustedDownloadUrl(TEXT("https://github.com.evil.test/a/b.zip")));
+			TestFalse("userinfo trick rejected", FUnrealMcpExtensionInstaller::IsTrustedDownloadUrl(TEXT("https://github.com@evil.test/a/b.zip")));
+		});
+	});
+
+	Describe("materialize + outcome decisions", [this]()
+	{
+		It("decides when files must be (re)materialized", [this]()
+		{
+			TestTrue("force always materializes", FUnrealMcpExtensionInstaller::IsMaterializeNeeded(true, true, TEXT("1.0.0"), TEXT("1.0.0")));
+			TestTrue("absent materializes", FUnrealMcpExtensionInstaller::IsMaterializeNeeded(false, false, TEXT(""), TEXT("1.0.0")));
+			TestTrue("version mismatch materializes", FUnrealMcpExtensionInstaller::IsMaterializeNeeded(false, true, TEXT("1.0.0"), TEXT("2.0.0")));
+			TestFalse("present + same version skips", FUnrealMcpExtensionInstaller::IsMaterializeNeeded(false, true, TEXT("v1.0.0"), TEXT("1.0.0")));
+			TestFalse("present + no target version skips", FUnrealMcpExtensionInstaller::IsMaterializeNeeded(false, true, TEXT("1.0.0"), TEXT("")));
+		});
+
+		It("maps changed/materialized/hadPrev to the terminal outcome", [this]()
+		{
+			TestTrue("nothing changed", FUnrealMcpExtensionInstaller::ComputeOutcome(false, false, false) == EUnrealMcpInstallOutcome::AlreadyUpToDate);
+			TestTrue("enabled only", FUnrealMcpExtensionInstaller::ComputeOutcome(true, false, true) == EUnrealMcpInstallOutcome::Enabled);
+			TestTrue("added (no prev)", FUnrealMcpExtensionInstaller::ComputeOutcome(true, true, false) == EUnrealMcpInstallOutcome::Added);
+			TestTrue("updated (had prev)", FUnrealMcpExtensionInstaller::ComputeOutcome(true, true, true) == EUnrealMcpInstallOutcome::Updated);
+		});
+
+		It("builds a human message carrying the compile-on-install hint + gating list", [this]()
+		{
+			const FString Msg = FUnrealMcpExtensionInstaller::BuildOutcomeMessage(
+				EUnrealMcpInstallOutcome::Added, TEXT("UnrealAINiagara"), TEXT(""), TEXT("0.1.0"), /*rebuild*/ true, { TEXT("Niagara") });
+			TestTrue("names the plugin", Msg.Contains(TEXT("UnrealAINiagara")));
+			TestTrue("lists gating Niagara", Msg.Contains(TEXT("Niagara")));
+			TestTrue("surfaces the rebuild hint", Msg.Contains(TEXT("Rebuild required")));
+		});
+	});
+
+	Describe("BuildRows merge (catalog ∪ loaded ∪ disk)", [this]()
+	{
+		It("renders an available catalog-only extension", [this]()
+		{
+			const TArray<FUnrealMcpCatalogEntry> Catalog = { InstallerSpecCatalogEntry(TEXT("com.x.a"), TEXT("PluginA"), TEXT("1.0.0")) };
+			const TArray<FUnrealMcpExtensionRow> Rows = FUnrealMcpExtensionInstaller::BuildRows(Catalog, {}, {});
+			TestEqual("one row", Rows.Num(), 1);
+			TestTrue("in catalog", Rows[0].bInCatalog);
+			TestFalse("not installed", Rows[0].bInstalled);
+			TestFalse("not loaded", Rows[0].bLoaded);
+			TestEqual("shows catalog version", Rows[0].Version, FString(TEXT("1.0.0")));
+		});
+
+		It("marks installed-on-disk-but-not-loaded and computes update-available", [this]()
+		{
+			const TArray<FUnrealMcpCatalogEntry> Catalog = { InstallerSpecCatalogEntry(TEXT("com.x.a"), TEXT("PluginA"), TEXT("2.0.0")) };
+			TArray<FUnrealMcpInstalledOnDisk> OnDisk;
+			OnDisk.Add({ TEXT("PluginA"), TEXT("1.0.0") }); // older than the catalog pin
+			const TArray<FUnrealMcpExtensionRow> Rows = FUnrealMcpExtensionInstaller::BuildRows(Catalog, {}, OnDisk);
+			TestTrue("installed on disk", Rows[0].bInstalled);
+			TestFalse("not loaded (needs compile)", Rows[0].bLoaded);
+			TestTrue("update available (1.0.0 < 2.0.0)", Rows[0].bUpdateAvailable);
+			TestEqual("shows the INSTALLED version", Rows[0].Version, FString(TEXT("1.0.0")));
+		});
+
+		It("reflects a loaded provider's enable state, tool count, and error badge", [this]()
+		{
+			const TArray<FUnrealMcpCatalogEntry> Catalog = { InstallerSpecCatalogEntry(TEXT("com.x.a"), TEXT("PluginA"), TEXT("1.0.0")) };
+			TArray<FUnrealMcpExtensionRecord> Loaded;
+			Loaded.Add(InstallerSpecRecord(TEXT("com.x.a"), TEXT("1.0.0"), /*enabled*/ false, /*tools*/ 4, TEXT("bad tool id")));
+			const TArray<FUnrealMcpExtensionRow> Rows = FUnrealMcpExtensionInstaller::BuildRows(Catalog, Loaded, {});
+			TestTrue("loaded", Rows[0].bLoaded);
+			TestFalse("disabled", Rows[0].bEnabled);
+			TestEqual("tool count", Rows[0].ToolCount, 4);
+			TestTrue("has error", Rows[0].bHasError);
+			TestFalse("no update at same version", Rows[0].bUpdateAvailable);
+		});
+
+		It("appends a loaded provider that is not in the catalog (e.g. a local dev install)", [this]()
+		{
+			TArray<FUnrealMcpExtensionRecord> Loaded;
+			Loaded.Add(InstallerSpecRecord(TEXT("com.dev.local"), TEXT("0.0.1"), /*enabled*/ true, /*tools*/ 1, TEXT("")));
+			const TArray<FUnrealMcpExtensionRow> Rows = FUnrealMcpExtensionInstaller::BuildRows({}, Loaded, {});
+			TestEqual("one extra row", Rows.Num(), 1);
+			TestFalse("not in catalog", Rows[0].bInCatalog);
+			TestTrue("loaded + installed", Rows[0].bLoaded && Rows[0].bInstalled);
+		});
+	});
+
+	Describe("local-source install round-trip", [this]()
+	{
+		It("places the plugin (build-cache filtered), enables it + its gating plugin, and is idempotent", [this]()
+		{
+			const FString Root = InstallerSpecScratchRoot();
+			const FString ProjectDir = Root / TEXT("Project");
+			const FString SourceDir = Root / TEXT("Source") / TEXT("UnrealAINiagara");
+			ON_SCOPE_EXIT { IFileManager::Get().DeleteDirectory(*Root, /*RequireExists*/ false, /*Tree*/ true); };
+
+			// A minimal target project + a source plugin (with a gating dep + a build-cache dir that MUST be filtered).
+			InstallerSpecWrite(ProjectDir / TEXT("MyProj.uproject"),
+				TEXT("{\n\t\"FileVersion\": 3,\n\t\"EngineAssociation\": \"5.7\",\n\t\"Plugins\": []\n}\n"));
+			InstallerSpecWrite(SourceDir / TEXT("UnrealAINiagara.uplugin"),
+				TEXT("{\n\t\"VersionName\": \"0.1.0\",\n\t\"Plugins\": [ { \"Name\": \"Niagara\", \"Enabled\": true } ]\n}\n"));
+			InstallerSpecWrite(SourceDir / TEXT("Source") / TEXT("Keep.txt"), TEXT("keep me"));
+			InstallerSpecWrite(SourceDir / TEXT("Binaries") / TEXT("Drop.txt"), TEXT("stale build cache"));
+
+			FUnrealMcpInstallOptions Opts;
+			Opts.ProjectDir = ProjectDir;
+			Opts.SourceDir = SourceDir;
+			Opts.Descriptor.ExtensionId = TEXT("com.ivanmurzak.unreal-ai-niagara");
+			Opts.Descriptor.PluginName = TEXT("UnrealAINiagara");
+			Opts.Descriptor.Version = TEXT("0.1.0");
+			Opts.Descriptor.EnginePlugins = { TEXT("Niagara") };
+
+			const FUnrealMcpInstallResult Result = FUnrealMcpExtensionInstaller::Install(Opts);
+			TestTrue("install succeeded", Result.bSuccess);
+			TestTrue("outcome is Added", Result.Outcome == EUnrealMcpInstallOutcome::Added);
+			TestTrue("rebuild required (source extension)", Result.bRebuildRequired);
+
+			const FString InstalledUplugin = ProjectDir / TEXT("Plugins") / TEXT("UnrealAINiagara") / TEXT("UnrealAINiagara.uplugin");
+			TestTrue("placed the .uplugin", FPaths::FileExists(InstalledUplugin));
+			TestTrue("copied a Source file", FPaths::FileExists(ProjectDir / TEXT("Plugins") / TEXT("UnrealAINiagara") / TEXT("Source") / TEXT("Keep.txt")));
+			TestFalse("filtered out Binaries", FPaths::FileExists(ProjectDir / TEXT("Plugins") / TEXT("UnrealAINiagara") / TEXT("Binaries") / TEXT("Drop.txt")));
+
+			// The .uproject now enables the extension + its gating Niagara plugin.
+			FString UprojectText;
+			FFileHelper::LoadFileToString(UprojectText, *(ProjectDir / TEXT("MyProj.uproject")));
+			TestTrue("uproject enables the extension", UprojectText.Contains(TEXT("UnrealAINiagara")));
+			TestTrue("uproject enables Niagara", UprojectText.Contains(TEXT("Niagara")));
+			TestTrue("result lists Niagara enabled", Result.EnabledPlugins.Contains(TEXT("Niagara")));
+
+			// Idempotent: a second install of the same version + already enabled writes nothing new.
+			const FUnrealMcpInstallResult Again = FUnrealMcpExtensionInstaller::Install(Opts);
+			TestTrue("second install succeeded", Again.bSuccess);
+			TestTrue("idempotent → already-up-to-date", Again.Outcome == EUnrealMcpInstallOutcome::AlreadyUpToDate);
+			TestFalse("no rebuild needed the second time", Again.bRebuildRequired);
+		});
+
+		It("fails clearly when no .uproject is present in the project dir", [this]()
+		{
+			const FString Root = InstallerSpecScratchRoot();
+			ON_SCOPE_EXIT { IFileManager::Get().DeleteDirectory(*Root, /*RequireExists*/ false, /*Tree*/ true); };
+			IFileManager::Get().MakeDirectory(*Root, /*Tree*/ true);
+
+			FUnrealMcpInstallOptions Opts;
+			Opts.ProjectDir = Root; // exists, but holds no .uproject
+			Opts.Descriptor.ExtensionId = TEXT("com.x.a");
+			Opts.Descriptor.PluginName = TEXT("PluginA");
+			Opts.SourceDir = Root; // irrelevant — the .uproject check fails first
+
+			const FUnrealMcpInstallResult Result = FUnrealMcpExtensionInstaller::Install(Opts);
+			TestFalse("install fails", Result.bSuccess);
+			TestTrue("error mentions .uproject", Result.Error.Contains(TEXT(".uproject")));
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS


### PR DESCRIPTION
## Summary
- Native C++ **Extensions** Slate panel inside the Unreal-MCP plugin — install channel #3 of three (CLI + app-GUI are the others; all three behaviorally identical). Browse, install, enable/disable, and update extensions without leaving the editor.
- Reuses the CLI's catalog format + install contract: a native `FUnrealMcpExtensionCatalog` parser for the shared `extensions.catalog.json` (`ExtensionDescriptor`), a native port of `uproject-plugins.ts`, and `FUnrealMcpExtensionInstaller` (github.com-only release-zip download via `Http` + `FZipArchiveReader` extract, OR local `--source`; stage-then-swap into `Plugins/<Name>/`; idempotent `.uproject` enable of the extension + its gating engine plugins; outcome/rebuild-required computation).
- `SUnrealMcpExtensionsWindow` lists AVAILABLE (catalog) + INSTALLED extensions with state via the pure catalog ∪ loaded ∪ on-disk row-merge; install/update/enable/disable actions; compile-on-install UX (restart hint + best-effort Live Coding) and the per-extension error badge the registry exposes.
- Registered as the **Extensions** nomad tab via `FUnrealMcpAuxWindows`; the editor coordinator wires the catalog fetch, the installer, and the §5 hot-load enable toggle (`ExtensionManager::SetExtensionEnabled` → manifest revision bump → bridge re-proxies). All new code stays in the editor module (no runtime-module change).

## Test plan
- [x] Target-specific local tests passed (profile `test.md`): plugin gate Suites **1/2/3** green — UBT editor build (exit 0), headless boot smoke (`[Unreal-MCP] plugin loaded`), Automation specs (failed=0, succeeded=333). New specs `UnrealMcp.ExtensionCatalog` + `UnrealMcp.ExtensionInstaller` cover catalog parse/lookup, the `.uproject`/`.uplugin` edit helpers, download-URL/host-trust/outcome decisions, the row-merge, and a full local-source install round-trip.
- [ ] Windowed Slate behavior (panel open/dock, install button flows) is operator-verified — not reachable headless.

Closes #176