### PR TITLE
feat(ui): surface the extensions Install/Update list inside the AI Game Developer window (Unity-parity)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpExtensionsWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpExtensionsWindow.cpp
@@ -18,6 +18,7 @@
 
 void SUnrealMcpExtensionsWindow::Construct(const FArguments& InArgs)
 {
+	bEmbedded = InArgs._bEmbedded;
 	ProjectDir = InArgs._ProjectDir;
 	Catalog = InArgs._InitialCatalog;
 	InstalledProvider = InArgs._InstalledProvider;
@@ -32,29 +33,37 @@ void SUnrealMcpExtensionsWindow::Construct(const FArguments& InArgs)
 
 	ListContainer = SNew(SVerticalBox);
 
-	ChildSlot
-	[
-		SNew(SVerticalBox)
-		// Header: title + Refresh.
-		+ SVerticalBox::Slot().AutoHeight().Padding(8, 8, 8, 4)
+	// The Refresh button is identical in both modes. In embedded mode it is the only header element (the host
+	// main window's section header already says "Extensions"); standalone, it sits to the right of the bold title.
+	const TSharedRef<SWidget> RefreshButton =
+		SNew(SButton)
+		.Text(LOCTEXT("ExtRefresh", "Refresh catalog"))
+		.ToolTipText(LOCTEXT("ExtRefreshTip", "Fetch the latest available-extensions catalog over HTTP."))
+		.OnClicked(this, &SUnrealMcpExtensionsWindow::OnRefreshClicked);
+
+	// Embedded: the host section header already says "Extensions", so the header row is just the Refresh button,
+	// right-aligned at the slot level. Standalone: a FillWidth bold title pushes Refresh to the right.
+	TSharedRef<SHorizontalBox> HeaderRow = SNew(SHorizontalBox);
+	if (!bEmbedded)
+	{
+		HeaderRow->AddSlot().FillWidth(1.0f).VAlign(VAlign_Center)
 		[
-			SNew(SHorizontalBox)
-			+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
-			[
-				SNew(STextBlock)
-				.Text(LOCTEXT("ExtHeading", "Extensions"))
-				.Font(FCoreStyle::GetDefaultFontStyle("Bold", 13))
-			]
-			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center)
-			[
-				SNew(SButton)
-				.Text(LOCTEXT("ExtRefresh", "Refresh catalog"))
-				.ToolTipText(LOCTEXT("ExtRefreshTip", "Fetch the latest available-extensions catalog over HTTP."))
-				.OnClicked(this, &SUnrealMcpExtensionsWindow::OnRefreshClicked)
-			]
-		]
+			SNew(STextBlock)
+			.Text(LOCTEXT("ExtHeading", "Extensions"))
+			.Font(FCoreStyle::GetDefaultFontStyle("Bold", 13))
+		];
+	}
+	HeaderRow->AddSlot().AutoWidth().VAlign(VAlign_Center)[ RefreshButton ];
+
+	// Embedded composes into the host's padded scroll area, so it carries no outer padding of its own.
+	const FMargin HeaderPad = bEmbedded ? FMargin(0, 0, 0, 4) : FMargin(8, 8, 8, 4);
+	const FMargin LinePad   = bEmbedded ? FMargin(0, 0, 0, 4) : FMargin(8, 0, 8, 4);
+
+	TSharedRef<SVerticalBox> Body = SNew(SVerticalBox)
+		// Header: (embedded) Refresh only, right-aligned · (standalone) bold title + Refresh.
+		+ SVerticalBox::Slot().AutoHeight().HAlign(bEmbedded ? HAlign_Right : HAlign_Fill).Padding(HeaderPad)[ HeaderRow ]
 		// Status line.
-		+ SVerticalBox::Slot().AutoHeight().Padding(8, 0, 8, 4)
+		+ SVerticalBox::Slot().AutoHeight().Padding(LinePad)
 		[
 			SNew(STextBlock)
 			.Text(this, &SUnrealMcpExtensionsWindow::GetStatusText)
@@ -62,7 +71,7 @@ void SUnrealMcpExtensionsWindow::Construct(const FArguments& InArgs)
 			.ColorAndOpacity(FSlateColor::UseSubduedForeground())
 		]
 		// Compile-on-install hint (the §5 key UX risk): visible only after an install that needs a rebuild.
-		+ SVerticalBox::Slot().AutoHeight().Padding(8, 0, 8, 4)
+		+ SVerticalBox::Slot().AutoHeight().Padding(LinePad)
 		[
 			SNew(SBorder)
 			.Visibility(this, &SUnrealMcpExtensionsWindow::GetRestartHintVisibility)
@@ -84,14 +93,25 @@ void SUnrealMcpExtensionsWindow::Construct(const FArguments& InArgs)
 					.OnClicked(this, &SUnrealMcpExtensionsWindow::OnCompileClicked)
 				]
 			]
-		]
-		+ SVerticalBox::Slot().AutoHeight()[ SNew(SSeparator) ]
-		+ SVerticalBox::Slot().FillHeight(1.0f)
+		];
+
+	if (bEmbedded)
+	{
+		// The host main window already wraps everything in an SScrollBox, so the list is an AutoHeight block —
+		// a nested FillHeight scroll box here would collapse to zero height inside the host's AutoHeight slot.
+		Body->AddSlot().AutoHeight().Padding(0, 4, 0, 0)[ ListContainer.ToSharedRef() ];
+	}
+	else
+	{
+		Body->AddSlot().AutoHeight()[ SNew(SSeparator) ];
+		Body->AddSlot().FillHeight(1.0f)
 		[
 			SNew(SScrollBox)
 			+ SScrollBox::Slot().Padding(8.0f)[ ListContainer.ToSharedRef() ]
-		]
-	];
+		];
+	}
+
+	ChildSlot[ Body ];
 
 	RebuildList();
 }

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpExtensionsWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpExtensionsWindow.h
@@ -9,9 +9,32 @@
 #include "Templates/Function.h"
 #include "Extensions/UnrealMcpExtensionCatalog.h"
 #include "Extensions/UnrealMcpExtensionInstaller.h"
+#include "Extensions/UnrealMcpExtensionManager.h" // FUnrealMcpExtensionRecord (runtime module; by value in the wiring's installed-provider signature)
 
-struct FUnrealMcpExtensionRecord; // runtime module
 class SVerticalBox;
+
+/**
+ * Wiring for the §7 Extensions panel (docs/ARCHITECTURE.md §7 item 10 — install channel #3). Bundled so the
+ * hosts that construct the panel (the "AI Game Developer" main window's Extensions section, via
+ * FUnrealMcpMainWindowTab) keep a readable construction call. The providers/delegates are owned by the editor
+ * coordinator (catalog fetch + installer in the editor module; the enable toggle routes to the runtime
+ * extension manager's §5 hot-load path). The coordinator guards the InstalledProvider with a teardown
+ * alive-flag so a deferred widget paint after the runtime extension manager is freed returns empty rather than
+ * dereferencing freed memory.
+ */
+struct FUnrealMcpExtensionsPanelWiring
+{
+	FString ProjectDir;
+	TArray<FUnrealMcpCatalogEntry> InitialCatalog;
+	TFunction<TArray<FUnrealMcpExtensionRecord>()> InstalledProvider;
+	TFunction<bool(TArray<FUnrealMcpCatalogEntry>&, FString&)> CatalogFetcher;
+	TFunction<void(const FString&, bool)> OnSetEnabled;
+	TFunction<FUnrealMcpInstallResult(const FUnrealMcpCatalogEntry&, bool)> OnInstall;
+	TFunction<FString()> OnTriggerLiveCompile;
+
+	/** True once the coordinator has wired the live providers (false for a default-constructed placeholder). */
+	bool IsWired() const { return static_cast<bool>(InstalledProvider) || static_cast<bool>(OnInstall) || static_cast<bool>(CatalogFetcher); }
+};
 
 /**
  * The "Extensions" window (docs/ARCHITECTURE.md §7 item 10) — install channel #3 of three, the most
@@ -31,13 +54,28 @@ class SVerticalBox;
  * Catalog fetch is on-demand (a Refresh button), never on construct — so the headless boot smoke / Automation
  * runs never block on the network. The window renders the INSTALLED/LOADED set immediately from the supplied
  * providers and merges the catalog in once fetched.
+ *
+ * Embedded mode (issue #179): this same widget is the Extensions SECTION of the "AI Game Developer" main window
+ * (Unity-parity — Unity surfaces the list inline in its main window, not a separate one). Pass `bEmbedded(true)`
+ * and the widget drops its own bold "Extensions" title (the host section supplies it) and its inner FillHeight
+ * SScrollBox (the host main window already scrolls — a nested FillHeight inside the host's AutoHeight slot would
+ * collapse to zero), rendering the rows as an AutoHeight list instead. Every other affordance — Refresh, the
+ * per-row Install / Update / enable-disable, the compile-on-install hint + Live Coding button, the error badge —
+ * is byte-identical between the two modes, so there is ONE row-builder and ONE install path (no duplicated logic).
  */
 class SUnrealMcpExtensionsWindow : public SCompoundWidget
 {
 public:
-	SLATE_BEGIN_ARGS(SUnrealMcpExtensionsWindow) {}
+	SLATE_BEGIN_ARGS(SUnrealMcpExtensionsWindow)
+		: _bEmbedded(false)
+	{}
 		/** The UE project directory (scanned for installed plugins + the install target). */
 		SLATE_ARGUMENT(FString, ProjectDir)
+		/**
+		 * Embedded-in-the-main-window mode (issue #179): drop the standalone title header + the inner FillHeight
+		 * scroll box so the panel composes into the host main window's own scroll area as an AutoHeight section.
+		 */
+		SLATE_ARGUMENT(bool, bEmbedded)
 		/** An initial catalog (usually empty at boot — fetched on Refresh to avoid a boot-time network call). */
 		SLATE_ARGUMENT(TArray<FUnrealMcpCatalogEntry>, InitialCatalog)
 		/** Snapshots the live loaded-provider records (id / display name / version / tool count / enabled / error). */
@@ -55,6 +93,8 @@ public:
 	void Construct(const FArguments& InArgs);
 
 private:
+	// When true, render as a section of the host main window (no own title, AutoHeight list) — see the class note.
+	bool bEmbedded = false;
 	FString ProjectDir;
 	TArray<FUnrealMcpCatalogEntry> Catalog;
 	TFunction<TArray<FUnrealMcpExtensionRecord>()> InstalledProvider;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -72,6 +72,7 @@ void SUnrealMcpMainWindow::Construct(const FArguments& InArgs)
 	BridgeStatusProvider = InArgs._BridgeStatusProvider;
 	ConnectionInfoProvider = InArgs._ConnectionInfoProvider;
 	SendAgentConfigRequest = InArgs._SendAgentConfigRequest;
+	ExtensionsWiring = InArgs._ExtensionsWiring;
 
 	// The AI-cube logo brush comes from the style set (registered at module startup; lazily-inited fallback).
 	LogoBrush = FUnrealMcpStyle::Get().GetBrush("UnrealMcp.Logo");
@@ -891,38 +892,61 @@ void SUnrealMcpMainWindow::DeliverAgentConfigResult(const TSharedPtr<FJsonObject
 
 TSharedRef<SWidget> SUnrealMcpMainWindow::BuildExtensionsSection()
 {
-	// The Extensions section (issue #78): a styled header + a placeholder row. NOT carded (issue #80 item 6) — Unity
-	// renders the Extensions list flat under its header, with each row a bold name + Install button + description below.
-	return SNew(SVerticalBox)
-		+ SVerticalBox::Slot().AutoHeight()[ UnrealMcpStyleWidgets::SectionHeader(LOCTEXT("ExtHeader", "Extensions")) ]
-		+ SVerticalBox::Slot().AutoHeight().Padding(0, 8, 0, 0)
+	// The Extensions section (issue #78 styled header). Issue #179 (Unity-parity): host the REAL per-extension
+	// Install / Update / Installed list inside this window — the same SUnrealMcpExtensionsWindow widget T5 built
+	// (#177), now in embedded mode (no own title, AutoHeight list) so it composes under this section's header
+	// and reuses T5's catalog + FUnrealMcpExtensionInstaller install path verbatim (no duplicated install logic).
+	// When the coordinator has not wired the live providers (e.g. a bare/test construct), fall back to the static
+	// placeholder so this section never renders an unusable empty panel.
+	TSharedRef<SVerticalBox> Section = SNew(SVerticalBox)
+		+ SVerticalBox::Slot().AutoHeight()[ UnrealMcpStyleWidgets::SectionHeader(LOCTEXT("ExtHeader", "Extensions")) ];
+
+	if (ExtensionsWiring.IsWired())
+	{
+		Section->AddSlot().AutoHeight().Padding(0, 8, 0, 0)
 		[
-			// One placeholder row in the populated-row shape (bold name + Install + description below).
-			SNew(SVerticalBox)
-			+ SVerticalBox::Slot().AutoHeight()
-			[
-				SNew(SHorizontalBox)
-				+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
-				[
-					SNew(STextBlock)
-					.Font(FUnrealMcpStyle::SectionTitleFont())
-					.Text(LOCTEXT("ExtPlaceholderName", "No extensions available"))
-				]
-				+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center)
-				[
-					SNew(SBox).IsEnabled(false)
-					[
-						UnrealMcpStyleWidgets::StyledTextButton("UnrealMcp.Button.Secondary", LOCTEXT("Install", "Install"),
-							FOnClicked::CreateLambda([]() { return FReply::Handled(); }))
-					]
-				]
-			]
-			+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
-			[
-				UnrealMcpStyleWidgets::Description(
-					LOCTEXT("ExtPlaceholderDesc", "Engine extensions will appear here when a registry is available. Each lists a name, a short description, and an Install action."))
-			]
+			SNew(SUnrealMcpExtensionsWindow)
+			.bEmbedded(true)
+			.ProjectDir(ExtensionsWiring.ProjectDir)
+			.InitialCatalog(ExtensionsWiring.InitialCatalog)
+			.InstalledProvider(ExtensionsWiring.InstalledProvider)
+			.CatalogFetcher(ExtensionsWiring.CatalogFetcher)
+			.OnSetEnabled(ExtensionsWiring.OnSetEnabled)
+			.OnInstall(ExtensionsWiring.OnInstall)
+			.OnTriggerLiveCompile(ExtensionsWiring.OnTriggerLiveCompile)
 		];
+		return Section;
+	}
+
+	// Unwired fallback: one placeholder row in the populated-row shape (bold name + disabled Install + description).
+	Section->AddSlot().AutoHeight().Padding(0, 8, 0, 0)
+	[
+		SNew(SVerticalBox)
+		+ SVerticalBox::Slot().AutoHeight()
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)
+			[
+				SNew(STextBlock)
+				.Font(FUnrealMcpStyle::SectionTitleFont())
+				.Text(LOCTEXT("ExtPlaceholderName", "No extensions available"))
+			]
+			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center)
+			[
+				SNew(SBox).IsEnabled(false)
+				[
+					UnrealMcpStyleWidgets::StyledTextButton("UnrealMcp.Button.Secondary", LOCTEXT("Install", "Install"),
+						FOnClicked::CreateLambda([]() { return FReply::Handled(); }))
+				]
+			]
+		]
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 4, 0, 0)
+		[
+			UnrealMcpStyleWidgets::Description(
+				LOCTEXT("ExtPlaceholderDesc", "Engine extensions will appear here when a registry is available. Each lists a name, a short description, and an Install action."))
+		]
+	];
+	return Section;
 }
 
 TSharedRef<SWidget> SUnrealMcpMainWindow::BuildFooterSection()

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.h
@@ -8,6 +8,7 @@
 #include "Widgets/DeclarativeSyntaxSupport.h"
 #include "UI/UnrealMcpEditorViewModel.h"
 #include "UI/UnrealMcpAgentConfigModels.h"
+#include "UI/SUnrealMcpExtensionsWindow.h" // FUnrealMcpExtensionsPanelWiring + the embedded Extensions panel (issue #179)
 
 class FJsonObject;
 class SUnrealMcpAgentConfigurators;
@@ -42,6 +43,13 @@ public:
 		 * the SUnrealMcpAgentConfigurators panel; wired by the runtime to FUnrealMcpBridgeServer::SendAgentConfigMessage.
 		 */
 		SLATE_ARGUMENT(TFunction<bool(const TSharedPtr<FJsonObject>&)>, SendAgentConfigRequest)
+		/**
+		 * Optional: wiring for the embedded Extensions section (§7 item 10, issue #179 — Unity-parity). When the
+		 * coordinator supplies live providers (catalog fetch + the FUnrealMcpExtensionInstaller install path + the
+		 * §5 hot-load enable toggle), BuildExtensionsSection() hosts the real SUnrealMcpExtensionsWindow panel in
+		 * embedded mode; left default (unwired) it falls back to the static placeholder.
+		 */
+		SLATE_ARGUMENT(FUnrealMcpExtensionsPanelWiring, ExtensionsWiring)
 	SLATE_END_ARGS()
 
 	void Construct(const FArguments& InArgs);
@@ -59,6 +67,9 @@ private:
 	TFunction<FString()> BridgeStatusProvider;
 	TFunction<FAiAgentConnectionInfo()> ConnectionInfoProvider;
 	TFunction<bool(const TSharedPtr<FJsonObject>&)> SendAgentConfigRequest;
+	// §7 item 10 (issue #179): wiring for the embedded Extensions section. Held so BuildExtensionsSection() can
+	// construct the SUnrealMcpExtensionsWindow panel in embedded mode against the coordinator's install providers.
+	FUnrealMcpExtensionsPanelWiring ExtensionsWiring;
 	// The AI Agent Configurators panel — held so the runtime's `agent-config-result` feed can reach it.
 	TSharedPtr<SUnrealMcpAgentConfigurators> AgentConfiguratorsPanel;
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.cpp
@@ -21,20 +21,17 @@ const FName FUnrealMcpAuxWindows::ToolsTabId(TEXT("UnrealMcpToolsWindow"));
 const FName FUnrealMcpAuxWindows::PromptsTabId(TEXT("UnrealMcpPromptsWindow"));
 const FName FUnrealMcpAuxWindows::ResourcesTabId(TEXT("UnrealMcpResourcesWindow"));
 const FName FUnrealMcpAuxWindows::SerializationCheckTabId(TEXT("UnrealMcpSerializationCheckWindow"));
-const FName FUnrealMcpAuxWindows::ExtensionsTabId(TEXT("UnrealMcpExtensionsWindow"));
 
 void FUnrealMcpAuxWindows::Register(
 	const TSharedRef<FUnrealMcpEditorViewModel>& InViewModel,
 	TFunction<TArray<FUnrealMcpToolListEntry>()> InToolListProvider,
 	TFunction<TArray<FUnrealMcpFeatureEntry>()> InPromptProvider,
-	TFunction<TArray<FUnrealMcpFeatureEntry>()> InResourceProvider,
-	FUnrealMcpExtensionsPanelWiring InExtensionsWiring)
+	TFunction<TArray<FUnrealMcpFeatureEntry>()> InResourceProvider)
 {
 	if (bRegistered)
 		return;
 
 	ViewModel = InViewModel;
-	ExtensionsWiring = MoveTemp(InExtensionsWiring);
 
 	// The Tools provider closes over the runtime-owned registry (raw, non-owning). A widget can outlive
 	// Unregister() — a deferred RequestCloseTab still queued when the runtime frees those subsystems — and
@@ -50,19 +47,6 @@ void FUnrealMcpAuxWindows::Register(
 	};
 	PromptProvider = MoveTemp(InPromptProvider);
 	ResourceProvider = MoveTemp(InResourceProvider);
-
-	// Guard the Extensions panel's loaded-provider snapshot with the SAME teardown alive-flag: a deferred
-	// widget paint after Unregister() (which frees the runtime extension manager) must short-circuit to an
-	// empty result rather than dereference freed memory. The enable/install delegates are click-driven on a
-	// live editor, but guard the read-each-paint InstalledProvider exactly like the Tools provider.
-	if (ExtensionsWiring.InstalledProvider)
-	{
-		ExtensionsWiring.InstalledProvider =
-			[Alive, Inner = MoveTemp(ExtensionsWiring.InstalledProvider)]() -> TArray<FUnrealMcpExtensionRecord>
-			{
-				return (Alive.IsValid() && *Alive && Inner) ? Inner() : TArray<FUnrealMcpExtensionRecord>();
-			};
-	}
 
 	// Slate may be unavailable in a commandlet / -nullrhi headless run; guard so the Automation/smoke runs
 	// (which load the module) never crash on tab registration (mirrors the main-window tab).
@@ -106,12 +90,10 @@ void FUnrealMcpAuxWindows::Register(
 		.SetGroup(Group)
 		.SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "Icons.Adjust"));
 
-	// §7 item 10 Extensions panel — install channel #3 (browse/install/enable/disable/update extensions in-editor).
-	TabManager.RegisterNomadTabSpawner(ExtensionsTabId, FOnSpawnTab::CreateRaw(this, &FUnrealMcpAuxWindows::SpawnExtensionsTab))
-		.SetDisplayName(LOCTEXT("ExtensionsTabTitle", "Extensions"))
-		.SetTooltipText(LOCTEXT("ExtensionsTabTooltip", "Browse, install, enable/disable, and update Unreal-MCP extensions without leaving the editor."))
-		.SetGroup(Group)
-		.SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "Icons.Plus"));
+	// The §7 item 10 Extensions panel (install channel #3) is NO LONGER a standalone nomad tab (issue #179): the
+	// per-extension Install / Update / Installed list now lives inside the "AI Game Developer" main window's
+	// Extensions section (Unity-parity), wired by the coordinator straight to FUnrealMcpMainWindowTab. The same
+	// SUnrealMcpExtensionsWindow widget is reused there in embedded mode — no duplicate window for the user to find.
 
 	// Connection settings live entirely in the single "AI Game Developer" main window (issue #107, Unity-MCP
 	// parity). The separate "AI Game Developer Settings" nomad tab and the "Project → Plugins → AI Game Developer"
@@ -139,7 +121,7 @@ void FUnrealMcpAuxWindows::Unregister()
 		FGlobalTabmanager& TabManager = *FGlobalTabmanager::Get();
 		// Close any live tab first so its hosted widget (a strong view-model ref) is torn down before the runtime
 		// frees the view-model — same use-after-free guard as the main-window tab.
-		for (const FName& TabId : { ToolsTabId, PromptsTabId, ResourcesTabId, SerializationCheckTabId, ExtensionsTabId })
+		for (const FName& TabId : { ToolsTabId, PromptsTabId, ResourcesTabId, SerializationCheckTabId })
 		{
 			if (TSharedPtr<SDockTab> LiveTab = TabManager.FindExistingLiveTab(TabId))
 				LiveTab->RequestCloseTab();
@@ -195,24 +177,6 @@ TSharedRef<SDockTab> FUnrealMcpAuxWindows::SpawnSerializationCheckTab(const FSpa
 	// guard here (unlike the registry-backed Tools window).
 	TSharedRef<SDockTab> Tab = SNew(SDockTab).TabRole(ETabRole::NomadTab);
 	Tab->SetContent(SNew(SUnrealMcpSerializationCheckWindow));
-	return Tab;
-}
-
-TSharedRef<SDockTab> FUnrealMcpAuxWindows::SpawnExtensionsTab(const FSpawnTabArgs& Args)
-{
-	// The §7 Extensions panel (install channel #3). The InstalledProvider was alive-flag-guarded in Register so a
-	// deferred paint after teardown returns empty rather than dereferencing the freed runtime extension manager;
-	// the catalog fetch + install + enable delegates are click-driven on a live editor.
-	TSharedRef<SDockTab> Tab = SNew(SDockTab).TabRole(ETabRole::NomadTab);
-	Tab->SetContent(
-		SNew(SUnrealMcpExtensionsWindow)
-		.ProjectDir(ExtensionsWiring.ProjectDir)
-		.InitialCatalog(ExtensionsWiring.InitialCatalog)
-		.InstalledProvider(ExtensionsWiring.InstalledProvider)
-		.CatalogFetcher(ExtensionsWiring.CatalogFetcher)
-		.OnSetEnabled(ExtensionsWiring.OnSetEnabled)
-		.OnInstall(ExtensionsWiring.OnInstall)
-		.OnTriggerLiveCompile(ExtensionsWiring.OnTriggerLiveCompile));
 	return Tab;
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAuxWindows.h
@@ -6,30 +6,10 @@
 #include "CoreMinimal.h"
 #include "UI/SUnrealMcpToolsWindow.h"
 #include "UI/SUnrealMcpFeatureListWindow.h"
-#include "UI/SUnrealMcpExtensionsWindow.h"
-#include "Extensions/UnrealMcpExtensionManager.h" // FUnrealMcpExtensionRecord (by value in the installed-provider signature)
 
 class FUnrealMcpEditorViewModel;
 class SDockTab;
 class FSpawnTabArgs;
-
-/**
- * Wiring for the §7 Extensions panel (docs/ARCHITECTURE.md §7 item 10 — install channel #3). Bundled so
- * the aux-windows Register() signature stays readable. The providers/delegates are owned by the editor
- * coordinator (catalog fetch + installer in the editor module; the enable toggle routes to the runtime
- * extension manager's §5 hot-load path). The InstalledProvider is guarded by the same teardown alive-flag
- * as the Tools provider.
- */
-struct FUnrealMcpExtensionsPanelWiring
-{
-	FString ProjectDir;
-	TArray<FUnrealMcpCatalogEntry> InitialCatalog;
-	TFunction<TArray<FUnrealMcpExtensionRecord>()> InstalledProvider;
-	TFunction<bool(TArray<FUnrealMcpCatalogEntry>&, FString&)> CatalogFetcher;
-	TFunction<void(const FString&, bool)> OnSetEnabled;
-	TFunction<FUnrealMcpInstallResult(const FUnrealMcpCatalogEntry&, bool)> OnInstall;
-	TFunction<FString()> OnTriggerLiveCompile;
-};
 
 /**
  * Registers the §7 auxiliary windows (docs/ARCHITECTURE.md §7) as nomad dockable tabs under the same
@@ -59,7 +39,6 @@ public:
 	static const FName PromptsTabId;
 	static const FName ResourcesTabId;
 	static const FName SerializationCheckTabId;
-	static const FName ExtensionsTabId;
 
 	/**
 	 * Open (or focus, if already open) the Serialization Check tab. Static so the footer "Check" button and the
@@ -79,8 +58,7 @@ public:
 		const TSharedRef<FUnrealMcpEditorViewModel>& InViewModel,
 		TFunction<TArray<FUnrealMcpToolListEntry>()> InToolListProvider,
 		TFunction<TArray<FUnrealMcpFeatureEntry>()> InPromptProvider,
-		TFunction<TArray<FUnrealMcpFeatureEntry>()> InResourceProvider,
-		FUnrealMcpExtensionsPanelWiring InExtensionsWiring = FUnrealMcpExtensionsPanelWiring());
+		TFunction<TArray<FUnrealMcpFeatureEntry>()> InResourceProvider);
 
 	/** Unregister the tab spawners (Shutdown). Idempotent. Neutralizes the providers first. */
 	void Unregister();
@@ -98,14 +76,11 @@ private:
 	TSharedRef<SDockTab> SpawnPromptsTab(const FSpawnTabArgs& Args);
 	TSharedRef<SDockTab> SpawnResourcesTab(const FSpawnTabArgs& Args);
 	TSharedRef<SDockTab> SpawnSerializationCheckTab(const FSpawnTabArgs& Args);
-	TSharedRef<SDockTab> SpawnExtensionsTab(const FSpawnTabArgs& Args);
 
 	TSharedPtr<FUnrealMcpEditorViewModel> ViewModel;
 	TFunction<TArray<FUnrealMcpToolListEntry>()> ToolListProvider;
 	TFunction<TArray<FUnrealMcpFeatureEntry>()> PromptProvider;
 	TFunction<TArray<FUnrealMcpFeatureEntry>()> ResourceProvider;
-	// §7 Extensions panel (install channel #3) wiring; InstalledProvider is alive-flag-guarded like the Tools provider.
-	FUnrealMcpExtensionsPanelWiring ExtensionsWiring;
 	// Shared with every widget-held copy of the registry-touching provider; NeutralizeProviders() flips it
 	// false during teardown so a surviving widget's next paint returns empty rather than dereferencing freed memory.
 	TSharedPtr<bool> ProvidersAlive;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.cpp
@@ -26,7 +26,8 @@ void FUnrealMcpMainWindowTab::Register(
 	FSimpleDelegate InOnRestartBridge,
 	TFunction<FString()> InBridgeStatusProvider,
 	TFunction<FAiAgentConnectionInfo()> InConnectionInfoProvider,
-	TFunction<bool(const TSharedPtr<FJsonObject>&)> InSendAgentConfigRequest)
+	TFunction<bool(const TSharedPtr<FJsonObject>&)> InSendAgentConfigRequest,
+	FUnrealMcpExtensionsPanelWiring InExtensionsWiring)
 {
 	if (bRegistered)
 		return;
@@ -37,6 +38,7 @@ void FUnrealMcpMainWindowTab::Register(
 	BridgeStatusProvider = MoveTemp(InBridgeStatusProvider);
 	ConnectionInfoProvider = MoveTemp(InConnectionInfoProvider);
 	SendAgentConfigRequest = MoveTemp(InSendAgentConfigRequest);
+	ExtensionsWiring = MoveTemp(InExtensionsWiring);
 
 	// Slate may be unavailable in a commandlet / -nullrhi headless run without a slate application; guard so
 	// the Automation/smoke runs (which load the module) never crash on tab registration. IsInitialized() alone
@@ -91,7 +93,8 @@ TSharedRef<SDockTab> FUnrealMcpMainWindowTab::SpawnTab(const FSpawnTabArgs& Args
 		.OnRestartBridge(OnRestartBridge)
 		.BridgeStatusProvider(BridgeStatusProvider)
 		.ConnectionInfoProvider(ConnectionInfoProvider)
-		.SendAgentConfigRequest(SendAgentConfigRequest);
+		.SendAgentConfigRequest(SendAgentConfigRequest)
+		.ExtensionsWiring(ExtensionsWiring);
 	// Track the live window (weak) so the runtime's agent-config-result feed reaches its panel; a re-spawn
 	// (re-opened tab) replaces it, and a closed tab leaves a stale weak ptr that DeliverAgentConfigResult ignores.
 	ActiveWindow = Window;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpMainWindowTab.h
@@ -6,6 +6,7 @@
 #include "CoreMinimal.h"
 #include "Delegates/Delegate.h"
 #include "UI/UnrealMcpAgentConfigModels.h"
+#include "UI/SUnrealMcpExtensionsWindow.h" // FUnrealMcpExtensionsPanelWiring (the embedded Extensions section wiring, issue #179)
 
 class FUnrealMcpEditorViewModel;
 class FJsonObject;
@@ -42,7 +43,8 @@ public:
 		FSimpleDelegate InOnRestartBridge,
 		TFunction<FString()> InBridgeStatusProvider,
 		TFunction<FAiAgentConnectionInfo()> InConnectionInfoProvider,
-		TFunction<bool(const TSharedPtr<FJsonObject>&)> InSendAgentConfigRequest = nullptr);
+		TFunction<bool(const TSharedPtr<FJsonObject>&)> InSendAgentConfigRequest = nullptr,
+		FUnrealMcpExtensionsPanelWiring InExtensionsWiring = FUnrealMcpExtensionsPanelWiring());
 
 	/** Unregister the tab spawner (Shutdown). Idempotent. */
 	void Unregister();
@@ -63,6 +65,9 @@ private:
 	TFunction<FString()> BridgeStatusProvider;
 	TFunction<FAiAgentConnectionInfo()> ConnectionInfoProvider;
 	TFunction<bool(const TSharedPtr<FJsonObject>&)> SendAgentConfigRequest;
+	// §7 item 10 (issue #179): wiring for the main window's embedded Extensions section, forwarded to each
+	// spawned SUnrealMcpMainWindow. The coordinator guards its InstalledProvider with a teardown alive-flag.
+	FUnrealMcpExtensionsPanelWiring ExtensionsWiring;
 	// The currently-spawned main window (weak so a closed tab does not keep it alive); the agent-config-result
 	// feed forwards through it to the panel.
 	TWeakPtr<SUnrealMcpMainWindow> ActiveWindow;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
@@ -318,67 +318,24 @@ void FUnrealMcpEditorCoordinator::Startup()
 		});
 	}
 
-	// Register the nomad dockable tab + Window-menu entry (§7). A manual "Restart bridge" force-relaunches the
-	// sidecar; the bridge-status line reflects the sidecar's run state.
-	FUnrealMcpSidecarManager* SidecarPtr = SidecarManager.Get();
-	MainWindowTab = MakeUnique<FUnrealMcpMainWindowTab>();
-	MainWindowTab->Register(
-		ViewModel.ToSharedRef(),
-		PluginVersion,
-		FSimpleDelegate::CreateLambda([SidecarPtr, BoundPort, Token]()
-		{
-			if (SidecarPtr)
-			{
-				SidecarPtr->Stop();
-				SidecarPtr->StartForPort(BoundPort, Token);
-			}
-		}),
-		[SidecarPtr]() -> FString
-		{
-			if (SidecarPtr && SidecarPtr->IsRunning())
-				return FString::Printf(TEXT("Running (restarts: %d)"), SidecarPtr->GetRestartCount());
-			return TEXT("Stopped");
-		},
-		// §7/§8 AI Agent Configurators: yield the live connection facts so the assembled STDIO/HTTP snippets
-		// reflect the current config. Re-resolve the §8 config on each call (the user may have just edited the
-		// host/token in the same window) and read the bound IPC port from the bridge. The local server binary
-		// path is owned by the cli/§6 install layout — not the plugin — so it is left empty here; the STDIO
-		// snippet is still a valid template (the user supplies the binary, exactly the cli's stance), and the
-		// HTTP form is fully self-contained.
-		[BridgeServerPtr]() -> FAiAgentConnectionInfo
-		{
-			const FUnrealMcpConfig Live = FUnrealMcpConfig::LoadAndResolve();
-			const int32 Port = BridgeServerPtr ? BridgeServerPtr->GetBoundPort() : 0;
-			return FAiAgentConnectionInfo::FromPluginConfig(Live, /*ServerPath*/ FString(), Port);
-		},
-		// §7 (issue #101) AI Agent Configurators: send a configurator request to the sidecar over IPC. Returns
-		// false when no sidecar is connected — the thin panel then shows its graceful "bridge not connected"
-		// state and re-requests on the next handshake. The result returns via the status sink's
-		// `agent-config-result` route above.
-		[BridgeServerPtr](const TSharedPtr<FJsonObject>& Request) -> bool
-		{
-			return BridgeServerPtr ? BridgeServerPtr->SendAgentConfigMessage(Request) : false;
-		});
-
-	// §7 auxiliary windows (MCP Tools / Prompts / Resources). The Tools window snapshots the registry on open for
-	// its list — a §5 extension hot-reload can change the set after boot, so an already-open window shows its
-	// open-time snapshot and reopen refreshes it. Prompts/Resources have no plugin-side feed yet (the .NET sidecar
-	// owns those features, §2) — their providers return empty and the windows render an honest empty state rather
-	// than a fabricated registry. Connection settings (incl. the read-only IPC-bridge-port line) live in the
-	// single "AI Game Developer" main window, not an aux window (issue #107, Unity-MCP parity).
-	// §7 item 10 Extensions panel (install channel #3): wire the catalog fetch (HTTP, on-demand), the install
-	// service (FUnrealMcpExtensionInstaller — fetch → place in Plugins/ → edit .uproject → compile-on-open), and
-	// the §5 hot-load enable toggle (ExtensionManager::SetExtensionEnabled → manifest revision bump → bridge
-	// re-proxies). The InstalledProvider snapshots the runtime extension manager's live records; the aux-windows
-	// guards it with the teardown alive-flag. No catalog fetch happens at boot (empty InitialCatalog) so the
-	// headless smoke / Automation runs never block on the network.
+	// §7 item 10 Extensions panel (install channel #3, issue #179 — Unity-parity): the per-extension
+	// Install / Update / Installed list is now hosted INSIDE the "AI Game Developer" main window's Extensions
+	// section (no separate window to find). Wire the catalog fetch (HTTP, on-demand), the install service
+	// (FUnrealMcpExtensionInstaller — fetch → place in Plugins/ → edit .uproject → compile-on-open), and the §5
+	// hot-load enable toggle (ExtensionManager::SetExtensionEnabled → manifest revision bump → bridge re-proxies).
+	// The InstalledProvider snapshots the runtime extension manager's live records, guarded by the teardown
+	// alive-flag (ExtProvidersAlive) so a deferred main-window paint after Shutdown frees the manager returns
+	// empty rather than dereferencing freed memory. No catalog fetch happens at boot (empty InitialCatalog) so
+	// the headless smoke / Automation runs never block on the network.
+	ExtProvidersAlive = MakeShared<bool>(true);
+	TSharedPtr<bool> ExtAlive = ExtProvidersAlive;
 	FUnrealMcpExtensionManager* ExtMgrPtr = ExtensionManager.Get();
 	const FString ExtProjectDir = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
 	FUnrealMcpExtensionsPanelWiring ExtWiring;
 	ExtWiring.ProjectDir = ExtProjectDir;
-	ExtWiring.InstalledProvider = [ExtMgrPtr]() -> TArray<FUnrealMcpExtensionRecord>
+	ExtWiring.InstalledProvider = [ExtAlive, ExtMgrPtr]() -> TArray<FUnrealMcpExtensionRecord>
 	{
-		return ExtMgrPtr ? ExtMgrPtr->GetExtensions() : TArray<FUnrealMcpExtensionRecord>();
+		return (ExtAlive.IsValid() && *ExtAlive && ExtMgrPtr) ? ExtMgrPtr->GetExtensions() : TArray<FUnrealMcpExtensionRecord>();
 	};
 	ExtWiring.CatalogFetcher = [](TArray<FUnrealMcpCatalogEntry>& Out, FString& Err) -> bool
 	{
@@ -424,6 +381,57 @@ void FUnrealMcpEditorCoordinator::Startup()
 #endif
 	};
 
+	// Register the nomad dockable tab + Window-menu entry (§7). A manual "Restart bridge" force-relaunches the
+	// sidecar; the bridge-status line reflects the sidecar's run state. The Extensions wiring above rides along so
+	// the spawned main window's Extensions section hosts the live Install/Update list (issue #179).
+	FUnrealMcpSidecarManager* SidecarPtr = SidecarManager.Get();
+	MainWindowTab = MakeUnique<FUnrealMcpMainWindowTab>();
+	MainWindowTab->Register(
+		ViewModel.ToSharedRef(),
+		PluginVersion,
+		FSimpleDelegate::CreateLambda([SidecarPtr, BoundPort, Token]()
+		{
+			if (SidecarPtr)
+			{
+				SidecarPtr->Stop();
+				SidecarPtr->StartForPort(BoundPort, Token);
+			}
+		}),
+		[SidecarPtr]() -> FString
+		{
+			if (SidecarPtr && SidecarPtr->IsRunning())
+				return FString::Printf(TEXT("Running (restarts: %d)"), SidecarPtr->GetRestartCount());
+			return TEXT("Stopped");
+		},
+		// §7/§8 AI Agent Configurators: yield the live connection facts so the assembled STDIO/HTTP snippets
+		// reflect the current config. Re-resolve the §8 config on each call (the user may have just edited the
+		// host/token in the same window) and read the bound IPC port from the bridge. The local server binary
+		// path is owned by the cli/§6 install layout — not the plugin — so it is left empty here; the STDIO
+		// snippet is still a valid template (the user supplies the binary, exactly the cli's stance), and the
+		// HTTP form is fully self-contained.
+		[BridgeServerPtr]() -> FAiAgentConnectionInfo
+		{
+			const FUnrealMcpConfig Live = FUnrealMcpConfig::LoadAndResolve();
+			const int32 Port = BridgeServerPtr ? BridgeServerPtr->GetBoundPort() : 0;
+			return FAiAgentConnectionInfo::FromPluginConfig(Live, /*ServerPath*/ FString(), Port);
+		},
+		// §7 (issue #101) AI Agent Configurators: send a configurator request to the sidecar over IPC. Returns
+		// false when no sidecar is connected — the thin panel then shows its graceful "bridge not connected"
+		// state and re-requests on the next handshake. The result returns via the status sink's
+		// `agent-config-result` route above.
+		[BridgeServerPtr](const TSharedPtr<FJsonObject>& Request) -> bool
+		{
+			return BridgeServerPtr ? BridgeServerPtr->SendAgentConfigMessage(Request) : false;
+		},
+		MoveTemp(ExtWiring)); // issue #179: the embedded Extensions section wiring
+
+	// §7 auxiliary windows (MCP Tools / Prompts / Resources). The Tools window snapshots the registry on open for
+	// its list — a §5 extension hot-reload can change the set after boot, so an already-open window shows its
+	// open-time snapshot and reopen refreshes it. Prompts/Resources have no plugin-side feed yet (the .NET sidecar
+	// owns those features, §2) — their providers return empty and the windows render an honest empty state rather
+	// than a fabricated registry. Connection settings (incl. the read-only IPC-bridge-port line) live in the
+	// single "AI Game Developer" main window, not an aux window (issue #107, Unity-MCP parity). The Extensions
+	// panel is no longer an aux tab either (issue #179) — its wiring went to the main-window tab above.
 	AuxWindows = MakeUnique<FUnrealMcpAuxWindows>();
 	AuxWindows->Register(
 		ViewModel.ToSharedRef(),
@@ -442,8 +450,7 @@ void FUnrealMcpEditorCoordinator::Startup()
 			return Entries;
 		},
 		[]() -> TArray<FUnrealMcpFeatureEntry> { return {}; },  // prompts (none surfaced to the plugin yet)
-		[]() -> TArray<FUnrealMcpFeatureEntry> { return {}; },  // resources (none surfaced to the plugin yet)
-		MoveTemp(ExtWiring));
+		[]() -> TArray<FUnrealMcpFeatureEntry> { return {}; }); // resources (none surfaced to the plugin yet)
 
 	// DEV-ONLY inject/control HTTP bridge (docs/ARCHITECTURE.md §7). Started ONLY when the editor process env
 	// UNREAL_MCP_DEV_CONTROL == "1" — OFF by default, so a shipped plugin never opens a port. The port comes
@@ -495,6 +502,12 @@ void FUnrealMcpEditorCoordinator::Shutdown()
 	if (!bStarted)
 		return;
 	bStarted = false;
+
+	// issue #179: neutralize the embedded Extensions panel's InstalledProvider FIRST — before the main-window tab
+	// close and the ExtensionManager reset below — so a deferred main-window paint (a queued RequestCloseTab) reads
+	// an empty list instead of dereferencing the soon-to-be-freed extension manager. Mirrors the aux-windows guard.
+	if (ExtProvidersAlive.IsValid())
+		*ExtProvidersAlive = false;
 
 	if (PreExitHandle.IsValid())
 	{

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.h
@@ -67,6 +67,13 @@ private:
 	TUniquePtr<FUnrealMcpMainWindowTab> MainWindowTab;
 	TUniquePtr<FUnrealMcpAuxWindows> AuxWindows;
 
+	// Teardown alive-flag guarding the embedded Extensions panel's InstalledProvider (issue #179). The provider
+	// captures the raw FUnrealMcpExtensionManager*; a deferred main-window paint (a queued RequestCloseTab) could
+	// otherwise fire after Shutdown frees the extension manager. Flipped false at the START of Shutdown() — before
+	// the main-window tab close and the ExtensionManager reset — so any surviving widget read returns empty. This
+	// mirrors FUnrealMcpAuxWindows::ProvidersAlive for the Tools provider (the lifetime owner holds the flag here).
+	TSharedPtr<bool> ExtProvidersAlive;
+
 	// DEV-ONLY inject/control HTTP bridge over the live dock (docs/ARCHITECTURE.md §7). Created + started in
 	// Startup() ONLY when the editor process env UNREAL_MCP_DEV_CONTROL == "1"; null (never listening) otherwise.
 	TUniquePtr<FUnrealMcpDevControlServer> DevControlServer;


### PR DESCRIPTION
## Summary
- Host T5's per-extension **Install / Update / Installed** list inside the "AI Game Developer" main window's Extensions section (Unity-parity), reusing the **same** `SUnrealMcpExtensionsWindow` widget in a new **embedded mode** and the **same** catalog + `FUnrealMcpExtensionInstaller` install path — no duplicated install logic.
- Remove the standalone "Extensions" nomad tab: the list is no longer a separate window the user must find. The coordinator wires the panel straight to `FUnrealMcpMainWindowTab`.
- Carry over the compile-on-install hint, the Live Coding affordance, and the per-extension error badge unchanged; guard the `InstalledProvider` with a coordinator-owned teardown alive-flag (mirrors the aux-windows Tools-provider guard) so a deferred main-window paint after Shutdown is safe.

## Test plan
- [x] Suite 1 (UBT editor build): exit 0
- [x] Suite 2 (headless boot smoke): `[Unreal-MCP] plugin loaded`
- [x] Suite 3 (Automation specs): failed=0, succeeded=333 (no regression); `.uplugin` restored byte-identical
- [ ] Windowed/visual confirmation of the embedded panel: pending operator (Slate window rendering is not headless-verifiable per the profile)

Editor-module-only change (`UnrealMcpEditor/**`) — no `UnrealMcpRuntime/**` touched, so Suite 1b (BuildPlugin) is not a gate here.

Closes #179