### PR TITLE
feat(cli): add Unreal-AI-ControlRig extension to the catalog

### DIFF
--- a/cli/extensions.catalog.json
+++ b/cli/extensions.catalog.json
@@ -22,7 +22,7 @@
       "description": "AI tools for Unreal's Control Rig (list/inspect rig blueprints, controls, bones, and actor components).",
       "pluginName": "UnrealAIControlRig",
       "repo": "IvanMurzak/Unreal-AI-ControlRig",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "minCoreVersion": "0.5.0",
       "enginePlugins": ["ControlRig"],
       "tools": [
@@ -30,7 +30,7 @@
         { "name": "control-rig-get", "description": "Inspects a single Control Rig blueprint asset (read-only) and reports its rig element hierarchy. Returns { path, name, boneCount, nullCount, controlCount, curveCount, elementCount, elements:[{ name, type }] }." },
         { "name": "control-rig-list-controls", "description": "Lists the control elements of a Control Rig blueprint (read-only), each with its control type (e.g. Float, Transform, Bool). Returns { path, controlCount, controls:[{ name, controlType }] }." },
         { "name": "control-rig-list-bones", "description": "Lists the bone elements of a Control Rig blueprint (read-only), each with its immediate parent bone (empty for a root). Returns { path, boneCount, bones:[{ name, parent }] }." },
-        { "name": "control-rig-get-component", "description": "Inspects the Control Rig component of an actor in the active editor world (read-only). Looks the actor up by its label. Returns { actorName, componentName, controlRigClass } or a defensive error if the actor or component is not found." }
+        { "name": "control-rig-get-component", "description": "Inspects the Control Rig component of an actor in the active editor world (read-only). Looks the actor up by its label. Returns { actorName, componentName, controlRigClass, hasControlRig } (controlRigClass is the bound rig instance's class, or \"None\" when no rig is bound) or a defensive error if the actor or component is not found." }
       ]
     }
   ]

--- a/cli/extensions.catalog.json
+++ b/cli/extensions.catalog.json
@@ -15,6 +15,23 @@
         { "name": "niagara-get-system", "description": "Inspect a single Niagara system asset (read-only) and report its emitters." },
         { "name": "niagara-spawn-component", "description": "Spawn a Niagara component for a system into the active editor world at a location." }
       ]
+    },
+    {
+      "extensionId": "com.ivanmurzak.unreal-ai-control-rig",
+      "name": "ControlRig Tools",
+      "description": "AI tools for Unreal's Control Rig (list/inspect rig blueprints, controls, bones, and actor components).",
+      "pluginName": "UnrealAIControlRig",
+      "repo": "IvanMurzak/Unreal-AI-ControlRig",
+      "version": "0.1.0",
+      "minCoreVersion": "0.5.0",
+      "enginePlugins": ["ControlRig"],
+      "tools": [
+        { "name": "control-rig-list", "description": "Lists every Control Rig blueprint (UControlRigBlueprint) asset in the project via the Asset Registry, without loading any of them. Optionally filter by a content-path prefix. Returns { count, controlRigs:[{ name, path }] }." },
+        { "name": "control-rig-get", "description": "Inspects a single Control Rig blueprint asset (read-only) and reports its rig element hierarchy. Returns { path, name, boneCount, nullCount, controlCount, curveCount, elementCount, elements:[{ name, type }] }." },
+        { "name": "control-rig-list-controls", "description": "Lists the control elements of a Control Rig blueprint (read-only), each with its control type (e.g. Float, Transform, Bool). Returns { path, controlCount, controls:[{ name, controlType }] }." },
+        { "name": "control-rig-list-bones", "description": "Lists the bone elements of a Control Rig blueprint (read-only), each with its immediate parent bone (empty for a root). Returns { path, boneCount, bones:[{ name, parent }] }." },
+        { "name": "control-rig-get-component", "description": "Inspects the Control Rig component of an actor in the active editor world (read-only). Looks the actor up by its label. Returns { actorName, componentName, controlRigClass } or a defensive error if the actor or component is not found." }
+      ]
     }
   ]
 }

--- a/cli/src/utils/extensions-catalog.ts
+++ b/cli/src/utils/extensions-catalog.ts
@@ -124,7 +124,7 @@ export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [
       "AI tools for Unreal's Control Rig (list/inspect rig blueprints, controls, bones, and actor components).",
     pluginName: 'UnrealAIControlRig',
     repo: 'IvanMurzak/Unreal-AI-ControlRig',
-    version: '0.1.0',
+    version: '0.1.1',
     minCoreVersion: '0.5.0',
     enginePlugins: ['ControlRig'],
     tools: [
@@ -151,7 +151,7 @@ export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [
       {
         name: 'control-rig-get-component',
         description:
-          'Inspects the Control Rig component of an actor in the active editor world (read-only). Looks the actor up by its label. Returns { actorName, componentName, controlRigClass } or a defensive error if the actor or component is not found.',
+          'Inspects the Control Rig component of an actor in the active editor world (read-only). Looks the actor up by its label. Returns { actorName, componentName, controlRigClass, hasControlRig } (controlRigClass is the bound rig instance\'s class, or "None" when no rig is bound) or a defensive error if the actor or component is not found.',
       },
     ],
   },

--- a/cli/src/utils/extensions-catalog.ts
+++ b/cli/src/utils/extensions-catalog.ts
@@ -117,6 +117,44 @@ export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [
       },
     ],
   },
+  {
+    extensionId: 'com.ivanmurzak.unreal-ai-control-rig',
+    name: 'ControlRig Tools',
+    description:
+      "AI tools for Unreal's Control Rig (list/inspect rig blueprints, controls, bones, and actor components).",
+    pluginName: 'UnrealAIControlRig',
+    repo: 'IvanMurzak/Unreal-AI-ControlRig',
+    version: '0.1.0',
+    minCoreVersion: '0.5.0',
+    enginePlugins: ['ControlRig'],
+    tools: [
+      {
+        name: 'control-rig-list',
+        description:
+          'Lists every Control Rig blueprint (UControlRigBlueprint) asset in the project via the Asset Registry, without loading any of them. Optionally filter by a content-path prefix. Returns { count, controlRigs:[{ name, path }] }.',
+      },
+      {
+        name: 'control-rig-get',
+        description:
+          'Inspects a single Control Rig blueprint asset (read-only) and reports its rig element hierarchy. Returns { path, name, boneCount, nullCount, controlCount, curveCount, elementCount, elements:[{ name, type }] }.',
+      },
+      {
+        name: 'control-rig-list-controls',
+        description:
+          'Lists the control elements of a Control Rig blueprint (read-only), each with its control type (e.g. Float, Transform, Bool). Returns { path, controlCount, controls:[{ name, controlType }] }.',
+      },
+      {
+        name: 'control-rig-list-bones',
+        description:
+          'Lists the bone elements of a Control Rig blueprint (read-only), each with its immediate parent bone (empty for a root). Returns { path, boneCount, bones:[{ name, parent }] }.',
+      },
+      {
+        name: 'control-rig-get-component',
+        description:
+          'Inspects the Control Rig component of an actor in the active editor world (read-only). Looks the actor up by its label. Returns { actorName, componentName, controlRigClass } or a defensive error if the actor or component is not found.',
+      },
+    ],
+  },
 ] as const;
 
 /** True when a descriptor carries a concrete version pin (drives the up-to-date / update decision). */


### PR DESCRIPTION
Adds `com.ivanmurzak.unreal-ai-control-rig` (https://github.com/IvanMurzak/Unreal-AI-ControlRig) to the shared extension catalog (parity-locked JSON + CLI mirror). Released v0.1.0.