### PR TITLE
ci(pull-request): scope PR-gating UE matrix to 5.7-only

### DIFF
--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -94,15 +94,17 @@ jobs:
     # checked-out code on the self-hosted runner (see docs/RELEASING.md). Manual
     # dispatches (trusted) are unaffected by the fork clause.
     if: ${{ vars.UNREAL_RUNNER_READY == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-    # The matrix runs UE 5.7 and 5.8 as parallel jobs; the single self-hosted
-    # runner (label `unreal-5-7`, legacy name) executes them sequentially. Both
-    # engines are installed at the standard Epic paths on the runner.
+    # PR-gating is scoped to UE 5.7 ONLY. The single self-hosted runner (label
+    # `unreal-5-7`, legacy name) shares ONE host project whose `Intermediate` is
+    # NOT isolated per UE version, so a 5.8 build corrupts the 5.7 build's
+    # makefile/index.json and reds BOTH legs.
+    # TODO(5.8): UHT cross-version contamination in shared host Intermediate — defer until per-version Intermediate isolation
     # fail-fast:false so one engine's failure never cancels the other's leg.
     runs-on: [self-hosted, windows, unreal-5-7]
     strategy:
       fail-fast: false
       matrix:
-        ue: ['5.7', '5.8']
+        ue: ['5.7']
     env:
       # Engine path is driven by the matrix (standard Epic install layout).
       UE_ROOT: C:\Program Files\Epic Games\UE_${{ matrix.ue }}
@@ -256,7 +258,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ue: ['5.7', '5.8']
+        # TODO(5.8): UHT cross-version contamination in shared host Intermediate — defer until per-version Intermediate isolation
+        ue: ['5.7']
     env:
       UE_ROOT: C:\Program Files\Epic Games\UE_${{ matrix.ue }}
       HOST_UPROJECT: ${{ vars.UNREAL_HOST_PROJECT }}


### PR DESCRIPTION
## What

Scope the **PR-gating** workflow (`test_pull_request.yml`) UE matrix to **5.7 only**, dropping the `5.8` entry from both the `plugin` and `connection-smoke` jobs.

## Why

The self-hosted runner shares **one** host project whose `Intermediate` is **not isolated per UE version**. Two change-independent failures result:

1. **UE 5.8 leg** perpetually reds on UHT cross-version contamination (`UnrealMcpRuntimeSettings.gen.cpp` C2440/C2660/C2078).
2. **UE 5.7 leg** flakes (corrupt makefile / missing Automation `index.json`) because the 5.8 build corrupts the 5.7 build's intermediate state.

Scoping PR-gating to 5.7-only removes the 5.8 red **and** eliminates the contamination that causes the 5.7 flake.

A `TODO(5.8)` marker is left on both jobs: re-enable 5.8 once the host `Intermediate` is isolated per UE version.

## Scope

- `release.yml` (the live release process) **keeps** its `5.7` + `5.8` matrix and is intentionally **untouched**.
- Only the two PR-gating matrix entries change; all build/test logic is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)