### PR TITLE
feat(cli): complete the extensions catalog with all 6 Unreal-MCP extensions + release 0.6.1

### DIFF
--- a/UnrealMCP/UnrealMCP.uplugin
+++ b/UnrealMCP/UnrealMCP.uplugin
@@ -1,7 +1,7 @@
 {
   "FileVersion": 3,
   "Version": 1,
-  "VersionName": "0.6.0",
+  "VersionName": "0.6.1",
   "FriendlyName": "Unreal MCP (AI Game Developer)",
   "Description": "Model Context Protocol (MCP) integration for the Unreal Editor. Exposes editor operations as AI Tools so MCP-aware AI assistants (Claude, Cursor, Copilot, ...) can inspect and drive your Unreal project. Requires Unreal Engine 5.5+ (no EngineVersion pin: UE treats that field as an exact-build match, not a floor, and would refuse to load on newer engines).",
   "Category": "AI",

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>com.IvanMurzak.Unreal.MCP.Bridge</RootNamespace>
     <AssemblyName>unreal-mcp-bridge</AssemblyName>
-    <Version>0.6.0</Version>
+    <Version>0.6.1</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2026 Ivan Murzak</Copyright>

--- a/cli/extensions.catalog.json
+++ b/cli/extensions.catalog.json
@@ -15,6 +15,91 @@
         { "name": "niagara-get-system", "description": "Inspect a single Niagara system asset (read-only) and report its emitters." },
         { "name": "niagara-spawn-component", "description": "Spawn a Niagara component for a system into the active editor world at a location." }
       ]
+    },
+    {
+      "extensionId": "com.ivanmurzak.unreal-ai-enhanced-input",
+      "name": "EnhancedInput Tools",
+      "description": "AI tools for Unreal's Enhanced Input system (list/inspect Input Actions & Mapping Contexts, create actions/contexts, add key mappings).",
+      "pluginName": "UnrealAIEnhancedInput",
+      "repo": "IvanMurzak/Unreal-AI-EnhancedInput",
+      "version": "0.1.0",
+      "minCoreVersion": "0.5.0",
+      "enginePlugins": ["EnhancedInput"],
+      "tools": [
+        { "name": "enhanced-input-list", "description": "Lists every Enhanced Input asset in the project via the Asset Registry, without loading any of them: Input Actions (UInputAction) and Mapping Contexts (UInputMappingContext). Optionally filter by a content-path prefix." },
+        { "name": "enhanced-input-get", "description": "Inspects a single Enhanced Input asset (read-only): for a UInputAction reports its value type; for a UInputMappingContext reports its key -> action mappings." },
+        { "name": "enhanced-input-action-create", "description": "Creates a UInputAction asset (an Enhanced Input action) at a content path, with an optional value type (Boolean | Axis1D | Axis2D | Axis3D). Optionally saves it to disk." },
+        { "name": "enhanced-input-context-create", "description": "Creates a UInputMappingContext asset (an Enhanced Input mapping context) at a content path. Optionally saves it to disk." },
+        { "name": "enhanced-input-add-mapping", "description": "Adds a key -> action mapping to a UInputMappingContext, binding an FKey to a UInputAction. Optionally saves it to disk." }
+      ]
+    },
+    {
+      "extensionId": "com.ivanmurzak.unreal-ai-pcg",
+      "name": "PCG Tools",
+      "description": "AI tools for Unreal's Procedural Content Generation (PCG) framework (list/inspect graphs, add & inspect PCG components, trigger generation).",
+      "pluginName": "UnrealAIPCG",
+      "repo": "IvanMurzak/Unreal-AI-PCG",
+      "version": "0.1.0",
+      "minCoreVersion": "0.5.0",
+      "enginePlugins": ["PCG"],
+      "tools": [
+        { "name": "pcg-list-graphs", "description": "Lists every PCG graph (UPCGGraph) asset in the project via the Asset Registry, without loading any of them. Optionally filter by a content-path prefix." },
+        { "name": "pcg-get-graph", "description": "Inspects a single PCG graph asset (read-only) and reports its nodes." },
+        { "name": "pcg-add-component", "description": "Adds a UPCGComponent to a named actor in the active editor world, optionally bound to a PCG graph asset." },
+        { "name": "pcg-get-component", "description": "Inspects the UPCGComponent on a named actor in the active editor world (read-only): its bound graph and generation state." },
+        { "name": "pcg-generate", "description": "Triggers PCG generation (refresh) on the UPCGComponent of a named actor in the active editor world." }
+      ]
+    },
+    {
+      "extensionId": "com.ivanmurzak.unreal-ai-gas",
+      "name": "GAS Tools",
+      "description": "AI tools for Unreal's Gameplay Ability System (list abilities/effects/attribute sets, inspect an ability, grant an ability to an actor).",
+      "pluginName": "UnrealAIGAS",
+      "repo": "IvanMurzak/Unreal-AI-GAS",
+      "version": "0.1.0",
+      "minCoreVersion": "0.5.0",
+      "enginePlugins": ["GameplayAbilities"],
+      "tools": [
+        { "name": "gas-list-abilities", "description": "Lists every Gameplay Ability class (UGameplayAbility subclass — native C++ and Blueprint) known to the project via the Asset Registry, without loading any of them. Optionally filter by a class-path prefix." },
+        { "name": "gas-list-effects", "description": "Lists every Gameplay Effect class (UGameplayEffect subclass — native C++ and Blueprint) known to the project via the Asset Registry, without loading any of them. Optionally filter by a class-path prefix." },
+        { "name": "gas-list-attribute-sets", "description": "Lists every Attribute Set class (UAttributeSet subclass — native C++ and Blueprint) known to the project via the Asset Registry, without loading any of them. Optionally filter by a class-path prefix." },
+        { "name": "gas-inspect-ability", "description": "Inspects a single Gameplay Ability class (read-only) by loading its class default object and reporting its configuration: gameplay tags, cost/cooldown Gameplay Effect classes, and instancing policy." },
+        { "name": "gas-grant-ability", "description": "Grants a Gameplay Ability to a named actor's AbilitySystemComponent in the active editor world (the actor must already own an AbilitySystemComponent)." }
+      ]
+    },
+    {
+      "extensionId": "com.ivanmurzak.unreal-ai-landscape",
+      "name": "Landscape Tools",
+      "description": "AI tools for Unreal's Landscape + Water systems (inspect landscapes, water bodies & zones).",
+      "pluginName": "UnrealAILandscape",
+      "repo": "IvanMurzak/Unreal-AI-Landscape",
+      "version": "0.1.0",
+      "minCoreVersion": "0.5.0",
+      "enginePlugins": ["Water"],
+      "tools": [
+        { "name": "landscape-list-actors", "description": "Lists every Landscape actor / proxy in the active editor world (read-only), reporting class, whether it is the primary ALandscape (vs a streaming proxy), and component count." },
+        { "name": "landscape-get-actor", "description": "Inspects a single Landscape actor by name (read-only): section layout (componentSizeQuads / subsectionSizeQuads / numSubsections), component count, landscape material, and paint layers." },
+        { "name": "landscape-list-water-bodies", "description": "Lists every Water body actor in the active editor world (read-only), reporting its type (River / Lake / Ocean / Custom) and spline-point count." },
+        { "name": "landscape-get-water-body", "description": "Inspects a single Water body by name (read-only): type, spline-point count, water material, and owning water zone." },
+        { "name": "landscape-list-water-zones", "description": "Lists every Water zone actor in the active editor world (read-only), reporting world location and 2D zone extent." }
+      ]
+    },
+    {
+      "extensionId": "com.ivanmurzak.unreal-ai-control-rig",
+      "name": "ControlRig Tools",
+      "description": "AI tools for Unreal's Control Rig (list/inspect rig blueprints, controls, bones, and actor components).",
+      "pluginName": "UnrealAIControlRig",
+      "repo": "IvanMurzak/Unreal-AI-ControlRig",
+      "version": "0.1.1",
+      "minCoreVersion": "0.5.0",
+      "enginePlugins": ["ControlRig"],
+      "tools": [
+        { "name": "control-rig-list", "description": "Lists every Control Rig blueprint (UControlRigBlueprint) asset in the project via the Asset Registry, without loading any of them. Optionally filter by a content-path prefix. Returns { count, controlRigs:[{ name, path }] }." },
+        { "name": "control-rig-get", "description": "Inspects a single Control Rig blueprint asset (read-only) and reports its rig element hierarchy. Returns { path, name, boneCount, nullCount, controlCount, curveCount, elementCount, elements:[{ name, type }] }." },
+        { "name": "control-rig-list-controls", "description": "Lists the control elements of a Control Rig blueprint (read-only), each with its control type (e.g. Float, Transform, Bool). Returns { path, controlCount, controls:[{ name, controlType }] }." },
+        { "name": "control-rig-list-bones", "description": "Lists the bone elements of a Control Rig blueprint (read-only), each with its immediate parent bone (empty for a root). Returns { path, boneCount, bones:[{ name, parent }] }." },
+        { "name": "control-rig-get-component", "description": "Inspects the Control Rig component of an actor in the active editor world (read-only). Looks the actor up by its label. Returns { actorName, componentName, controlRigClass, hasControlRig } (controlRigClass is the bound rig instance's class, or \"None\" when no rig is bound) or a defensive error if the actor or component is not found." }
+      ]
     }
   ]
 }

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unreal-mcp-cli",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^13.1.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Cross-platform CLI tool for Unreal-MCP (Skills & MCP). Resolves and launches the Unreal editor with MCP connection env vars, runs MCP/system tools over HTTP, probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and manages the UnrealMCP plugin. Works with Claude Code, Cursor, Copilot, and any MCP client.",
   "type": "module",
   "main": "dist/lib.js",

--- a/cli/src/utils/extensions-catalog.ts
+++ b/cli/src/utils/extensions-catalog.ts
@@ -117,6 +117,194 @@ export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [
       },
     ],
   },
+  {
+    extensionId: 'com.ivanmurzak.unreal-ai-enhanced-input',
+    name: 'EnhancedInput Tools',
+    description:
+      "AI tools for Unreal's Enhanced Input system (list/inspect Input Actions & Mapping Contexts, create actions/contexts, add key mappings).",
+    pluginName: 'UnrealAIEnhancedInput',
+    repo: 'IvanMurzak/Unreal-AI-EnhancedInput',
+    version: '0.1.0',
+    minCoreVersion: '0.5.0',
+    enginePlugins: ['EnhancedInput'],
+    tools: [
+      {
+        name: 'enhanced-input-list',
+        description:
+          'Lists every Enhanced Input asset in the project via the Asset Registry, without loading any of them: Input Actions (UInputAction) and Mapping Contexts (UInputMappingContext). Optionally filter by a content-path prefix.',
+      },
+      {
+        name: 'enhanced-input-get',
+        description:
+          'Inspects a single Enhanced Input asset (read-only): for a UInputAction reports its value type; for a UInputMappingContext reports its key -> action mappings.',
+      },
+      {
+        name: 'enhanced-input-action-create',
+        description:
+          'Creates a UInputAction asset (an Enhanced Input action) at a content path, with an optional value type (Boolean | Axis1D | Axis2D | Axis3D). Optionally saves it to disk.',
+      },
+      {
+        name: 'enhanced-input-context-create',
+        description:
+          'Creates a UInputMappingContext asset (an Enhanced Input mapping context) at a content path. Optionally saves it to disk.',
+      },
+      {
+        name: 'enhanced-input-add-mapping',
+        description:
+          'Adds a key -> action mapping to a UInputMappingContext, binding an FKey to a UInputAction. Optionally saves it to disk.',
+      },
+    ],
+  },
+  {
+    extensionId: 'com.ivanmurzak.unreal-ai-pcg',
+    name: 'PCG Tools',
+    description:
+      "AI tools for Unreal's Procedural Content Generation (PCG) framework (list/inspect graphs, add & inspect PCG components, trigger generation).",
+    pluginName: 'UnrealAIPCG',
+    repo: 'IvanMurzak/Unreal-AI-PCG',
+    version: '0.1.0',
+    minCoreVersion: '0.5.0',
+    enginePlugins: ['PCG'],
+    tools: [
+      {
+        name: 'pcg-list-graphs',
+        description:
+          'Lists every PCG graph (UPCGGraph) asset in the project via the Asset Registry, without loading any of them. Optionally filter by a content-path prefix.',
+      },
+      {
+        name: 'pcg-get-graph',
+        description: 'Inspects a single PCG graph asset (read-only) and reports its nodes.',
+      },
+      {
+        name: 'pcg-add-component',
+        description:
+          'Adds a UPCGComponent to a named actor in the active editor world, optionally bound to a PCG graph asset.',
+      },
+      {
+        name: 'pcg-get-component',
+        description:
+          'Inspects the UPCGComponent on a named actor in the active editor world (read-only): its bound graph and generation state.',
+      },
+      {
+        name: 'pcg-generate',
+        description:
+          'Triggers PCG generation (refresh) on the UPCGComponent of a named actor in the active editor world.',
+      },
+    ],
+  },
+  {
+    extensionId: 'com.ivanmurzak.unreal-ai-gas',
+    name: 'GAS Tools',
+    description:
+      "AI tools for Unreal's Gameplay Ability System (list abilities/effects/attribute sets, inspect an ability, grant an ability to an actor).",
+    pluginName: 'UnrealAIGAS',
+    repo: 'IvanMurzak/Unreal-AI-GAS',
+    version: '0.1.0',
+    minCoreVersion: '0.5.0',
+    enginePlugins: ['GameplayAbilities'],
+    tools: [
+      {
+        name: 'gas-list-abilities',
+        description:
+          'Lists every Gameplay Ability class (UGameplayAbility subclass — native C++ and Blueprint) known to the project via the Asset Registry, without loading any of them. Optionally filter by a class-path prefix.',
+      },
+      {
+        name: 'gas-list-effects',
+        description:
+          'Lists every Gameplay Effect class (UGameplayEffect subclass — native C++ and Blueprint) known to the project via the Asset Registry, without loading any of them. Optionally filter by a class-path prefix.',
+      },
+      {
+        name: 'gas-list-attribute-sets',
+        description:
+          'Lists every Attribute Set class (UAttributeSet subclass — native C++ and Blueprint) known to the project via the Asset Registry, without loading any of them. Optionally filter by a class-path prefix.',
+      },
+      {
+        name: 'gas-inspect-ability',
+        description:
+          'Inspects a single Gameplay Ability class (read-only) by loading its class default object and reporting its configuration: gameplay tags, cost/cooldown Gameplay Effect classes, and instancing policy.',
+      },
+      {
+        name: 'gas-grant-ability',
+        description:
+          "Grants a Gameplay Ability to a named actor's AbilitySystemComponent in the active editor world (the actor must already own an AbilitySystemComponent).",
+      },
+    ],
+  },
+  {
+    extensionId: 'com.ivanmurzak.unreal-ai-landscape',
+    name: 'Landscape Tools',
+    description: "AI tools for Unreal's Landscape + Water systems (inspect landscapes, water bodies & zones).",
+    pluginName: 'UnrealAILandscape',
+    repo: 'IvanMurzak/Unreal-AI-Landscape',
+    version: '0.1.0',
+    minCoreVersion: '0.5.0',
+    enginePlugins: ['Water'],
+    tools: [
+      {
+        name: 'landscape-list-actors',
+        description:
+          'Lists every Landscape actor / proxy in the active editor world (read-only), reporting class, whether it is the primary ALandscape (vs a streaming proxy), and component count.',
+      },
+      {
+        name: 'landscape-get-actor',
+        description:
+          'Inspects a single Landscape actor by name (read-only): section layout (componentSizeQuads / subsectionSizeQuads / numSubsections), component count, landscape material, and paint layers.',
+      },
+      {
+        name: 'landscape-list-water-bodies',
+        description:
+          'Lists every Water body actor in the active editor world (read-only), reporting its type (River / Lake / Ocean / Custom) and spline-point count.',
+      },
+      {
+        name: 'landscape-get-water-body',
+        description:
+          'Inspects a single Water body by name (read-only): type, spline-point count, water material, and owning water zone.',
+      },
+      {
+        name: 'landscape-list-water-zones',
+        description:
+          'Lists every Water zone actor in the active editor world (read-only), reporting world location and 2D zone extent.',
+      },
+    ],
+  },
+  {
+    extensionId: 'com.ivanmurzak.unreal-ai-control-rig',
+    name: 'ControlRig Tools',
+    description:
+      "AI tools for Unreal's Control Rig (list/inspect rig blueprints, controls, bones, and actor components).",
+    pluginName: 'UnrealAIControlRig',
+    repo: 'IvanMurzak/Unreal-AI-ControlRig',
+    version: '0.1.1',
+    minCoreVersion: '0.5.0',
+    enginePlugins: ['ControlRig'],
+    tools: [
+      {
+        name: 'control-rig-list',
+        description:
+          'Lists every Control Rig blueprint (UControlRigBlueprint) asset in the project via the Asset Registry, without loading any of them. Optionally filter by a content-path prefix. Returns { count, controlRigs:[{ name, path }] }.',
+      },
+      {
+        name: 'control-rig-get',
+        description:
+          'Inspects a single Control Rig blueprint asset (read-only) and reports its rig element hierarchy. Returns { path, name, boneCount, nullCount, controlCount, curveCount, elementCount, elements:[{ name, type }] }.',
+      },
+      {
+        name: 'control-rig-list-controls',
+        description:
+          'Lists the control elements of a Control Rig blueprint (read-only), each with its control type (e.g. Float, Transform, Bool). Returns { path, controlCount, controls:[{ name, controlType }] }.',
+      },
+      {
+        name: 'control-rig-list-bones',
+        description:
+          'Lists the bone elements of a Control Rig blueprint (read-only), each with its immediate parent bone (empty for a root). Returns { path, boneCount, bones:[{ name, parent }] }.',
+      },
+      {
+        name: 'control-rig-get-component',
+        description:
+          'Inspects the Control Rig component of an actor in the active editor world (read-only). Looks the actor up by its label. Returns { actorName, componentName, controlRigClass, hasControlRig } (controlRigClass is the bound rig instance\'s class, or "None" when no rig is bound) or a defensive error if the actor or component is not found.',
+      },
+    ],
+  },
 ] as const;
 
 /** True when a descriptor carries a concrete version pin (drives the up-to-date / update decision). */


### PR DESCRIPTION
## Summary

Lands the full `unreal-mcp-cli` extensions catalog: all **6** Unreal-MCP extensions, then bumps the shared version to **0.6.1** so the merge publishes the completed catalog.

Previously only **Niagara** was in the catalog. This adds the 5 remaining descriptors, parity-locked across `cli/extensions.catalog.json` and its typed mirror `cli/src/utils/extensions-catalog.ts` (the parity test enforces value-equivalence):

| Extension | Version | enginePlugins | Tools |
| --- | --- | --- | --- |
| Niagara (existing) | 0.1.0 | Niagara | 3 |
| **EnhancedInput** | 0.1.0 | EnhancedInput | 5 |
| **PCG** | 0.1.0 | PCG | 5 |
| **GAS** | 0.1.0 | GameplayAbilities | 5 |
| **Landscape** | 0.1.0 | Water | 5 |
| **ControlRig** | 0.1.1 | ControlRig | 5 |

Each version was verified against the extension's GitHub Release (`gh release view`); `minCoreVersion` is `0.5.0` for all. Tool names/descriptions were sourced from each extension's `IUnrealMcpToolProvider` module + `.uplugin`.

Supersedes the stale prepared catalog PRs **#181** (Landscape) and **#182** (ControlRig), now closed.

## Version bump

`0.6.0 → 0.6.1` via `commands/bump-version.ps1` — `.uplugin` VersionName, bridge csproj `<Version>`, and `cli/package.json` (+ lock) in lockstep.

## Validation

- `npm run build` (tsc) clean
- `npm test` — **297 passed / 1 skipped**, including the catalog parity test (`extensions-catalog-parity.test.ts`, 3 assertions)

## CI note

The non-required `plugin BuildPlugin + Automation (UE 5.7)` leg is a KNOWN, deferred host-editor-crash regression (packaged host editor crashes at boot — missing `index.json`), red on every current PR and tracked separately. This catalog change is CLI-only (no plugin/bridge C++ touched). The required/validating checks — `bridge build + xUnit` (×2), `connection + tool smoke (UE 5.7)`, `test-cli / cli` (node 20/22) — must be green; the `plugin` leg is merged past with owner approval.