### PR TITLE
feat(cli): download plugin from GitHub releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Because Fab ships precompiled binaries and the Epic Launcher updates them in pla
 
 ## Option B — `unreal-mcp-cli` (current / advanced)
 
-The CLI is the recommended path **today**, until the Fab listing is live. Install it from npm — **no repo clone, no build step**. It copies (or, for dev, junctions) the plugin into your project and, on **update**, automatically clears the stale UE build cache so you always get a clean recompile of the new code (see [Updating the plugin](#updating-the-plugin)).
+The CLI is the recommended path **today**, until the Fab listing is live. Install it from npm — **no repo clone, no build step**. By default `install-plugin` / `update` use a local `UnrealMCP/` checkout when one is present; otherwise they download the packaged plugin zip from the public GitHub Release that matches the CLI version. `--plugin-source <dir>` remains the offline / CI / dev override. The CLI copies (or, for dev, junctions) the plugin into your project and, on **update**, automatically clears the stale UE build cache so you always get a clean recompile of the new code (see [Updating the plugin](#updating-the-plugin)).
 
 ```bash
 # 1. Install unreal-mcp-cli (or use `npx unreal-mcp-cli@latest <command>` for a one-off, no install)

--- a/cli/README.md
+++ b/cli/README.md
@@ -32,8 +32,10 @@ Requires Node `^20.19.0 || >=22.12.0`. See the
 > **Plugin distribution.** For end users, the **recommended** way to install the UnrealMCP plugin
 > itself is **Fab / Epic Marketplace** (precompiled per-engine binaries, auto-updated by the Epic
 > Games Launcher — zero compile, zero stale-build risk). This CLI is the current/advanced/dev path
-> until the Fab listing is live; its `install-plugin` / `update` commands copy the plugin into a
-> project and keep its build cache clean on update (see the `update` row below).
+> until the Fab listing is live; its `install-plugin` / `update` commands use a local `UnrealMCP/`
+> checkout when present, otherwise they download the public GitHub Release asset that matches the
+> CLI version, then copy the plugin into a project and keep its build cache clean on update (see
+> the `update` row below). `--plugin-source <dir>` remains the offline / CI / dev override.
 
 ## Commands (docs/ARCHITECTURE.md §9.1)
 
@@ -42,7 +44,7 @@ Requires Node `^20.19.0 || >=22.12.0`. See the
 | `create-project <path>` | Scaffold a minimal Unreal Engine C++ project |
 | `open [path]` | Launch the Unreal Editor, wiring `UNREAL_MCP_*` env vars (engine resolved via `EngineAssociation` + `LauncherInstalled.dat`) |
 | `close [path]` | Terminate the editor process running a project |
-| `install-plugin [path]` | Copy (or `--junction`) the UnrealMCP plugin into `<project>/Plugins` |
+| `install-plugin [path]` | Copy (or `--junction`) the UnrealMCP plugin into `<project>/Plugins` — default source = local repo checkout when present, else the version-matched GitHub Release zip |
 | `remove-plugin [path]` | Remove the installed plugin |
 | `install-extension <id> [path]` | Install a third-party Unreal-MCP **extension** plugin into `<project>/Plugins/<name>`, enable it + its gating engine plugins (e.g. `Niagara`) in the `.uproject`, and (re)compile (on next editor open, or now with `--build`). `--source <dir>` installs from a local copy (offline/CI); `--version <x.y.z>` overrides the catalog pin. Idempotent. See [Extensions](#extensions) |
 | `configure` | Write `UNREAL_MCP_*` into `<project>/.env` and gitignore `.env` (§8) |
@@ -53,7 +55,7 @@ Requires Node `^20.19.0 || >=22.12.0`. See the
 | `run-tool <tool>` | Invoke an MCP tool over the local HTTP path |
 | `run-system-tool <tool>` | Invoke a system tool over the local HTTP path |
 | `bootstrap-local [path]` | Build the bridge from source into `Intermediate/UnrealMCP/` (§6) — the MCP server is downloaded from GameDev-MCP-Server releases, not built here |
-| `update [path]` | Re-sync the installed plugin from the repo source. On a version change it **auto-cleans** the stale UE C++ build cache (`Intermediate/` + C++ `Binaries/`) so the editor recompiles cleanly — the bundled sidecar bridge under `Binaries/ThirdParty/` is preserved, junction (dev) installs are never cleaned, and `--no-clean` opts out |
+| `update [path]` | Re-sync the installed plugin from a local source or the version-matched GitHub Release zip. On a version change it **auto-cleans** the stale UE C++ build cache (`Intermediate/` + C++ `Binaries/`) so the editor recompiles cleanly — the bundled sidecar bridge under `Binaries/ThirdParty/` is preserved, junction (dev) installs are never cleaned, and `--no-clean` opts out |
 | `install-engine [version]` | Detect installed engines from `LauncherInstalled.dat`; link to the Epic launcher for missing versions (never installs directly) |
 | `setup-skills` | Write a Claude-Code skill stub that drives the project's MCP server |
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.6.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "chalk": "^5.6.2",
         "commander": "^13.1.0",
-        "fflate": "^0.8.3"
+        "fflate": "^0.8.3",
+        "yocto-spinner": "^1.1.0"
       },
       "bin": {
         "unreal-mcp-cli": "bin/unreal-mcp-cli.js"
@@ -560,6 +562,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/commander": {
@@ -1347,6 +1361,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yocto-spinner": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.2.1.tgz",
+      "integrity": "sha512-9cbFWLhbiZp+820O4pkHGNncI7+MrUGzBOjw8NMG+ewsY+aG0DdEXnr19Smxao32YOjLZRMdn1UtaxcrXOYOIg==",
+      "license": "MIT",
+      "dependencies": {
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.19"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/cli/package.json
+++ b/cli/package.json
@@ -68,8 +68,10 @@
     "access": "public"
   },
   "dependencies": {
+    "chalk": "^5.6.2",
     "commander": "^13.1.0",
-    "fflate": "^0.8.3"
+    "fflate": "^0.8.3",
+    "yocto-spinner": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.15.0",

--- a/cli/src/commands/install-extension.ts
+++ b/cli/src/commands/install-extension.ts
@@ -19,6 +19,7 @@ export const installExtensionCommand = new Command('install-extension')
       opts: { source?: string; version?: string; build?: boolean; engineRoot?: string; force?: boolean },
     ) => {
       const projectDir = path.resolve(pathArg ?? process.cwd());
+      const spinner = ui.startSpinner(`Installing extension ${id}...`);
 
       const result = await installExtension({
         projectDir,
@@ -28,16 +29,20 @@ export const installExtensionCommand = new Command('install-extension')
         build: opts.build,
         engineRoot: opts.engineRoot,
         force: opts.force,
+        onProgress: (event) => {
+          spinner.text = event.message;
+        },
       });
 
-      ui.printWarnings(result.warnings);
       if (result.kind === 'failure') {
-        ui.error(result.error.message);
+        spinner.error(result.error.message);
+        ui.printWarnings(result.warnings);
         process.exitCode = 1;
         return;
       }
 
-      ui.success(result.message);
+      spinner.success(result.message);
+      ui.printWarnings(result.warnings);
       ui.label('Installed at', result.installedPath);
       if (result.enabledPlugins.length > 0) {
         ui.label('Enabled plugins', result.enabledPlugins.join(', '));

--- a/cli/src/commands/install-plugin.ts
+++ b/cli/src/commands/install-plugin.ts
@@ -1,31 +1,29 @@
 import { Command } from 'commander';
-import { fileURLToPath } from 'url';
-import * as path from 'path';
 import { installPlugin } from '../lib/install-plugin.js';
-import { defaultPluginSource } from '../utils/repo.js';
 import * as ui from '../utils/ui.js';
 
-const HERE = path.dirname(fileURLToPath(import.meta.url));
-
 export const installPluginCommand = new Command('install-plugin')
-  .description('Install the UnrealMCP plugin into <project>/Plugins (copy or --junction)')
+  .description('Install the UnrealMCP plugin into <project>/Plugins (copy or --junction). Defaults to the local repo source when present, otherwise downloads the matching GitHub release.')
   .argument('[path]', 'Unreal project directory (defaults to cwd)')
-  .option('--plugin-source <dir>', 'UnrealMCP plugin source dir (defaults to the repo plugin)')
+  .option('--plugin-source <dir>', 'UnrealMCP plugin source dir (offline / CI / dev override)')
   .option('--junction', 'Create a dev junction instead of copying (Windows)')
   .action(async (pathArg: string | undefined, opts: { pluginSource?: string; junction?: boolean }) => {
     const projectDir = pathArg ?? process.cwd();
-    const pluginSourceDir = opts.pluginSource ?? defaultPluginSource(HERE);
-    if (!pluginSourceDir) {
-      ui.error('Could not locate the UnrealMCP plugin source. Pass --plugin-source <dir>.');
-      process.exitCode = 1;
-      return;
-    }
-    const result = await installPlugin({ projectDir, pluginSourceDir, junction: opts.junction });
-    ui.printWarnings(result.warnings);
+    const spinner = ui.startSpinner('Installing UnrealMCP plugin...');
+    const result = await installPlugin({
+      projectDir,
+      pluginSourceDir: opts.pluginSource,
+      junction: opts.junction,
+      onProgress: (event) => {
+        spinner.text = event.message;
+      },
+    });
     if (result.kind === 'failure') {
-      ui.error(result.error.message);
+      spinner.error(result.error.message);
+      ui.printWarnings(result.warnings);
       process.exitCode = 1;
       return;
     }
-    ui.success(`Installed plugin (${result.mode}) at ${result.installedPath}`);
+    spinner.success(`Installed plugin (${result.mode}) at ${result.installedPath}`);
+    ui.printWarnings(result.warnings);
   });

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -8,20 +8,21 @@ export const loginCommand = new Command('login')
   .option('--base-url <url>', 'Auth base URL (defaults to https://ai-game.dev)')
   .option('--timeout <ms>', 'Overall poll timeout in ms', (v) => parseInt(v, 10))
   .action(async (opts: { path?: string; baseUrl?: string; timeout?: number }) => {
+    const spinner = ui.startSpinner('Starting device-code login...');
     const result = await login({
       projectDir: opts.path,
       baseUrl: opts.baseUrl,
       timeoutMs: opts.timeout,
       onProgress: (e) => {
-        if (e.phase === 'info' || e.phase === 'start') ui.info(e.message);
+        if (e.phase === 'info' || e.phase === 'start') spinner.text = e.message;
       },
     });
     if (result.kind === 'failure') {
-      ui.error(`Login failed (${result.reason}): ${result.error.message}`);
+      spinner.error(`Login failed (${result.reason}): ${result.error.message}`);
       process.exitCode = 1;
       return;
     }
-    ui.success('Logged in.');
+    spinner.success('Logged in.');
     if (result.persisted) ui.info(`Token saved to ${result.envPath}`);
     else ui.info('Token not persisted (pass --path to save it into a project .env).');
   });

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -18,6 +18,7 @@ export const openCommand = new Command('open')
   .option('--start-server', 'UNREAL_MCP_START_SERVER=true')
   .option('--connection-mode <mode>', 'UNREAL_MCP_CONNECTION_MODE: Custom | Cloud | (default empty = plugin default)')
   .action(async (pathArg: string | undefined, opts) => {
+    const spinner = ui.startSpinner('Opening Unreal project...');
     const result = await openProject({
       projectDir: pathArg,
       engineRoot: opts.engineRoot,
@@ -31,14 +32,18 @@ export const openCommand = new Command('open')
       transport: opts.transport as McpTransport | undefined,
       startServer: opts.startServer,
       connectionMode: opts.connectionMode,
+      onProgress: (event) => {
+        spinner.text = event.message;
+      },
     });
-    ui.printWarnings(result.warnings);
     if (result.kind === 'failure') {
-      ui.error(result.errorMessage);
+      spinner.error(result.errorMessage);
+      ui.printWarnings(result.warnings);
       process.exitCode = 1;
       return;
     }
-    ui.success(`Launched Unreal Editor (PID: ${result.editorPid ?? 'unknown'})`);
+    spinner.success(`Launched Unreal Editor (PID: ${result.editorPid ?? 'unknown'})`);
+    ui.printWarnings(result.warnings);
     ui.label('editor', result.editorPath);
     ui.label('engine', result.engineRoot);
   });

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -1,16 +1,11 @@
 import { Command } from 'commander';
-import { fileURLToPath } from 'url';
-import * as path from 'path';
 import { update } from '../lib/update.js';
-import { defaultPluginSource } from '../utils/repo.js';
 import * as ui from '../utils/ui.js';
 
-const HERE = path.dirname(fileURLToPath(import.meta.url));
-
 export const updateCommand = new Command('update')
-  .description('Update the UnrealMCP plugin installed in a project from the repo source')
+  .description('Update the UnrealMCP plugin installed in a project from a local source or the matching GitHub release')
   .argument('[path]', 'Unreal project directory (defaults to cwd)')
-  .option('--plugin-source <dir>', 'UnrealMCP plugin source dir (defaults to the repo plugin)')
+  .option('--plugin-source <dir>', 'UnrealMCP plugin source dir (offline / CI / dev override)')
   .option('--force', 'Re-install even when versions match')
   .option(
     '--no-clean',
@@ -22,32 +17,31 @@ export const updateCommand = new Command('update')
       opts: { pluginSource?: string; force?: boolean; clean?: boolean },
     ) => {
       const projectDir = pathArg ?? process.cwd();
-      const pluginSourceDir = opts.pluginSource ?? defaultPluginSource(HERE);
-      if (!pluginSourceDir) {
-        ui.error('Could not locate the UnrealMCP plugin source. Pass --plugin-source <dir>.');
-        process.exitCode = 1;
-        return;
-      }
+      const spinner = ui.startSpinner('Checking installed UnrealMCP plugin...');
       // commander maps `--no-clean` to `opts.clean === false`; absent → undefined (clean).
       const result = await update({
         projectDir,
-        pluginSourceDir,
+        pluginSourceDir: opts.pluginSource,
         force: opts.force,
         noClean: opts.clean === false,
+        onProgress: (event) => {
+          spinner.text = event.message;
+        },
       });
-      ui.printWarnings(result.warnings);
       if (result.kind === 'failure') {
-        ui.error(result.error.message);
+        spinner.error(result.error.message);
+        ui.printWarnings(result.warnings);
         process.exitCode = 1;
         return;
       }
       if (result.updated) {
         const cleanedNote = result.cleaned ? ' (build cache cleaned)' : '';
-        ui.success(
+        spinner.success(
           `Updated plugin ${result.fromVersion ?? 'none'} -> ${result.toVersion ?? 'unknown'}${cleanedNote}`,
         );
       } else {
-        ui.info(`Plugin already up to date (${result.toVersion ?? 'unknown'}).`);
+        spinner.success(`Plugin already up to date (${result.toVersion ?? 'unknown'}).`);
       }
+      ui.printWarnings(result.warnings);
     },
   );

--- a/cli/src/commands/wait-for-ready.ts
+++ b/cli/src/commands/wait-for-ready.ts
@@ -10,6 +10,7 @@ export const waitForReadyCommand = new Command('wait-for-ready')
   .option('--timeout <ms>', 'Overall timeout in ms (default 120000)', (v) => parseInt(v, 10))
   .option('--interval <ms>', 'Poll interval in ms (default 2000)', (v) => parseInt(v, 10))
   .action(async (opts: { path?: string; url?: string; token?: string; timeout?: number; interval?: number }) => {
+    const spinner = ui.startSpinner('Waiting for Unreal MCP server...');
     const result = await waitForReady({
       projectDir: opts.path,
       url: opts.url,
@@ -17,13 +18,13 @@ export const waitForReadyCommand = new Command('wait-for-ready')
       timeoutMs: opts.timeout,
       intervalMs: opts.interval,
       onProgress: (e) => {
-        if (e.phase === 'info') ui.verbose(e.message);
+        if (e.phase === 'info' || e.phase === 'start') spinner.text = e.message;
       },
     });
     if (result.kind === 'failure') {
-      ui.error(`Not ready after ${result.elapsedMs}ms (${result.attempts} attempts): ${result.lastReason}`);
+      spinner.error(`Not ready after ${result.elapsedMs}ms (${result.attempts} attempts): ${result.lastReason}`);
       process.exitCode = 1;
       return;
     }
-    ui.success(`Ready after ${result.elapsedMs}ms (${result.attempts} attempt(s)) — ${result.url}`);
+    spinner.success(`Ready after ${result.elapsedMs}ms (${result.attempts} attempt(s)) — ${result.url}`);
   });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { PACKAGE_VERSION } from './version.js';
-import { setVerbose } from './utils/ui.js';
+import { configureStyledHelp, setVerbose } from './utils/ui.js';
 import { bootstrapLocalCommand } from './commands/bootstrap-local.js';
 import { closeCommand } from './commands/close.js';
 import { configureCommand } from './commands/configure.js';
@@ -50,8 +50,11 @@ const subcommands = [
 
 for (const cmd of subcommands) {
   cmd.option('-v, --verbose', 'Enable verbose diagnostic output');
+  configureStyledHelp(cmd);
   program.addCommand(cmd);
 }
+
+configureStyledHelp(program, PACKAGE_VERSION);
 
 program.hook('preAction', (_thisCommand, actionCommand) => {
   const opts = actionCommand.optsWithGlobals() as { verbose?: boolean };

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -12,6 +12,7 @@ import { isUnrealProjectDir } from '../utils/project.js';
 import { asError } from '../utils/error.js';
 import { isSymlink } from '../utils/fs.js';
 import { emitProgress } from './progress.js';
+import { resolvePluginSource } from './plugin-source.js';
 import type {
   InstallPluginOptions,
   InstallPluginResult,
@@ -53,12 +54,11 @@ function copyFilter(srcAbs: string, pluginSourceDir: string): boolean {
 
 export async function installPlugin(opts: InstallPluginOptions): Promise<InstallPluginResult> {
   const warnings: string[] = [];
+  let cleanupSource: (() => void) | undefined;
   try {
     if (!opts?.projectDir) throw new Error('projectDir is required.');
-    if (!opts?.pluginSourceDir) throw new Error('pluginSourceDir is required.');
 
     const projectDir = path.resolve(opts.projectDir);
-    const pluginSourceDir = path.resolve(opts.pluginSourceDir);
     if (!fs.existsSync(projectDir)) throw new Error(`Project directory does not exist: ${projectDir}`);
     // Guard against a wrong-cwd run silently scaffolding Plugins/UnrealMCP in
     // an arbitrary directory (consistent with `close`/`status`, which key on
@@ -67,6 +67,13 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     if (!isUnrealProjectDir(projectDir)) {
       warnings.push(`No .uproject found in ${projectDir} — is this an Unreal project directory?`);
     }
+    const resolvedSource = await resolvePluginSource({
+      pluginSourceDir: opts.pluginSourceDir,
+      fetchImpl: opts.fetchImpl,
+      onProgress: opts.onProgress,
+    });
+    cleanupSource = resolvedSource.cleanup;
+    const pluginSourceDir = path.resolve(resolvedSource.pluginSourceDir);
     if (!fs.existsSync(pluginSourceDir))
       throw new Error(`Plugin source directory does not exist: ${pluginSourceDir}`);
     if (!fs.existsSync(path.join(pluginSourceDir, 'UnrealMCP.uplugin'))) {
@@ -82,9 +89,15 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
       message: `Installing UnrealMCP plugin into ${installedPath}`,
     });
 
-    const useJunction = opts.junction === true && process.platform === 'win32';
-    if (opts.junction === true && !useJunction) {
+    let useJunction = opts.junction === true && process.platform === 'win32';
+    if (opts.junction === true && process.platform !== 'win32') {
       warnings.push('Junction mode is Windows-only; falling back to copy.');
+    }
+    if (opts.junction === true && resolvedSource.sourceKind !== 'local') {
+      warnings.push(
+        'Junction mode requires a stable local plugin source; falling back to copy for the downloaded GitHub release.',
+      );
+      useJunction = false;
     }
 
     // Preserve the bundled sidecar bridge across a COPY re-install. A prior
@@ -167,6 +180,8 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
       warnings,
       error: asError(err),
     };
+  } finally {
+    cleanupSource?.();
   }
 }
 

--- a/cli/src/lib/plugin-source.ts
+++ b/cli/src/lib/plugin-source.ts
@@ -1,0 +1,198 @@
+// Resolve/materialize the CORE UnrealMCP plugin source for `install-plugin` /
+// `update`. The npm package does NOT bundle the C++ plugin, so the default path
+// is:
+//   1. explicit local `pluginSourceDir`
+//   2. local repo checkout (`UnrealMCP/`)
+//   3. GitHub Release asset that matches THIS CLI's package version
+//
+// The version coupling is intentional: Unreal-MCP plugin / bridge / CLI share
+// one semver and are released together, so the published CLI can safely fetch
+// `unreal-mcp-plugin-<PACKAGE_VERSION>.zip`.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { unzipSync } from 'fflate';
+import { emitProgress } from './progress.js';
+import { PACKAGE_VERSION } from '../version.js';
+import { defaultPluginSource } from '../utils/repo.js';
+import {
+  TRUSTED_DOWNLOAD_HOST,
+  assertTrustedDownloadUrl,
+  releaseTag,
+  stripLeadingV,
+} from '../utils/extension-source.js';
+import type { ProgressCallback } from './types.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/** GitHub repo releasing the packaged core UnrealMCP plugin zip. */
+export const CORE_PLUGIN_RELEASE_REPO = 'IvanMurzak/Unreal-MCP';
+/** Release-asset basename for the packaged core plugin. */
+export const CORE_PLUGIN_ZIP_BASENAME = 'unreal-mcp-plugin';
+
+export interface ResolvePluginSourceOptions {
+  /**
+   * Explicit local plugin source. Accepts either the `UnrealMCP/` dir itself, or
+   * any parent dir that contains a `.uplugin` beneath it.
+   */
+  pluginSourceDir?: string;
+  /** Injectable fetch for tests. Defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+  onProgress?: ProgressCallback;
+}
+
+export interface ResolvedPluginSource {
+  /** Absolute path to the `UnrealMCP/` plugin dir to install from. */
+  pluginSourceDir: string;
+  /** Where the source came from. */
+  sourceKind: 'local' | 'github-release';
+  /** Best-effort cleanup hook (no-op for local sources). */
+  cleanup: () => void;
+}
+
+/** `unreal-mcp-plugin-<version>.zip` (asset uses the bare version, not `v`). */
+export function corePluginAssetName(version: string = PACKAGE_VERSION): string {
+  return `${CORE_PLUGIN_ZIP_BASENAME}-${stripLeadingV(version)}.zip`;
+}
+
+/**
+ * Release-asset URL for the packaged core plugin zip, version-locked to the CLI
+ * unless the caller overrides it for tests.
+ */
+export function corePluginDownloadUrl(version: string = PACKAGE_VERSION): string {
+  return `https://${TRUSTED_DOWNLOAD_HOST}/${CORE_PLUGIN_RELEASE_REPO}/releases/download/${releaseTag(version)}/${corePluginAssetName(version)}`;
+}
+
+/** Resolve the nearest repo checkout's `UnrealMCP/` dir from this package, if any. */
+export function defaultCorePluginSource(): string | null {
+  return defaultPluginSource(HERE);
+}
+
+/**
+ * Resolve a local source path for the core plugin. Preserve the current
+ * install/update semantics for explicit local dirs: if the dir exists we accept
+ * it even when it lacks `UnrealMCP.uplugin`, so the caller can still install the
+ * contents and surface a warning later. When the path is a repo/workspace parent
+ * that *does* contain the plugin dir, prefer that nested `UnrealMCP/`.
+ */
+export function resolveLocalPluginRoot(source: string): string {
+  const resolved = path.resolve(source);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`Plugin source directory does not exist: ${resolved}`);
+  }
+  if (!fs.statSync(resolved).isDirectory()) {
+    throw new Error(`Plugin source is not a directory: ${resolved}`);
+  }
+  if (fs.existsSync(path.join(resolved, 'UnrealMCP.uplugin'))) return resolved;
+  const nestedCore = path.join(resolved, 'UnrealMCP');
+  if (fs.existsSync(path.join(nestedCore, 'UnrealMCP.uplugin'))) return nestedCore;
+  const found = findUPluginFile(resolved);
+  return found ? path.dirname(found) : resolved;
+}
+
+/** Find the shallowest `*.uplugin` beneath `root`, breadth-first. */
+export function findUPluginFile(root: string): string | null {
+  const queue: string[] = [path.resolve(root)];
+  while (queue.length > 0) {
+    const dir = queue.shift()!;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    const file = entries
+      .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.uplugin'))
+      .map((entry) => path.join(dir, entry.name))
+      .sort()[0];
+    if (file) return file;
+    for (const entry of entries.filter((item) => item.isDirectory()).sort((a, b) => a.name.localeCompare(b.name))) {
+      queue.push(path.join(dir, entry.name));
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the core plugin source for install/update. Falls back to the packaged
+ * GitHub Release zip that matches THIS CLI's version when no local source exists.
+ */
+export async function resolvePluginSource(
+  opts: ResolvePluginSourceOptions = {},
+): Promise<ResolvedPluginSource> {
+  const explicit = (opts.pluginSourceDir ?? '').trim();
+  if (explicit !== '') {
+    return {
+      pluginSourceDir: resolveLocalPluginRoot(explicit),
+      sourceKind: 'local',
+      cleanup: () => {},
+    };
+  }
+
+  // `fetchImpl` is a test seam; when it is injected we intentionally suppress
+  // the repo fallback so tests can force the download path from inside this repo.
+  const repoSource = opts.fetchImpl ? null : defaultCorePluginSource();
+  if (repoSource) {
+    return {
+      pluginSourceDir: repoSource,
+      sourceKind: 'local',
+      cleanup: () => {},
+    };
+  }
+
+  const version = PACKAGE_VERSION;
+  const url = corePluginDownloadUrl(version);
+  assertTrustedDownloadUrl(url);
+  emitProgress(opts.onProgress, {
+    phase: 'info',
+    message: `Downloading UnrealMCP plugin ${version} from ${url}`,
+  });
+
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download UnrealMCP plugin ${version}: HTTP ${response.status} ${response.statusText} from ${url}. ` +
+        `Verify the ${releaseTag(version)} release exists, or pass --plugin-source <dir> for an offline/dev install.`,
+    );
+  }
+  const zipBytes = new Uint8Array(await response.arrayBuffer());
+  emitProgress(opts.onProgress, {
+    phase: 'info',
+    message: `Extracting ${corePluginAssetName(version)}`,
+  });
+
+  const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unreal-mcp-plugin-'));
+  try {
+    const entries = unzipSync(zipBytes);
+    for (const [entryName, data] of Object.entries(entries)) {
+      if (entryName.endsWith('/')) continue;
+      const target = path.join(stagingDir, entryName);
+      if (!path.resolve(target).startsWith(path.resolve(stagingDir) + path.sep)) {
+        throw new Error(`Refusing to extract suspicious zip entry outside the staging dir: ${entryName}`);
+      }
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, data);
+    }
+
+    const pluginFile = findUPluginFile(stagingDir);
+    if (!pluginFile) {
+      throw new Error(
+        `Downloaded plugin archive ${corePluginAssetName(version)} did not contain an UnrealMCP.uplugin descriptor.`,
+      );
+    }
+
+    return {
+      pluginSourceDir: path.dirname(pluginFile),
+      sourceKind: 'github-release',
+      cleanup: () => {
+        fs.rmSync(stagingDir, { recursive: true, force: true });
+      },
+    };
+  } catch (err: unknown) {
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+    throw err;
+  }
+}

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -209,10 +209,16 @@ export type CreateProjectResult = CreateProjectSuccess | CreateProjectFailure;
 export interface InstallPluginOptions {
   /** Target Unreal project root. */
   projectDir: string;
-  /** Source `UnrealMCP/` plugin directory to install. */
-  pluginSourceDir: string;
+  /**
+   * Optional source `UnrealMCP/` plugin directory to install. When omitted, the
+   * library uses a local repo checkout if one is present, otherwise it downloads
+   * the GitHub Release asset that matches the CLI package version.
+   */
+  pluginSourceDir?: string;
   /** Junction (dev) instead of copy. Windows only. Default `false`. */
   junction?: boolean;
+  /** Injectable fetch for tests (download path only). */
+  fetchImpl?: typeof fetch;
   onProgress?: ProgressCallback;
 }
 

--- a/cli/src/lib/update.ts
+++ b/cli/src/lib/update.ts
@@ -10,12 +10,19 @@ import { cleanPluginBuildCache } from './clean-plugin.js';
 import { asError } from '../utils/error.js';
 import { isSymlink } from '../utils/fs.js';
 import { emitProgress } from './progress.js';
+import { PACKAGE_VERSION } from '../version.js';
+import { defaultCorePluginSource, resolvePluginSource } from './plugin-source.js';
+import { stripLeadingV } from '../utils/extension-source.js';
 import type { ProgressCallback } from './types.js';
 
 export interface UpdateOptions {
   projectDir: string;
-  /** Plugin source to update from. */
-  pluginSourceDir: string;
+  /**
+   * Optional plugin source to update from. When omitted, the library uses a
+   * local repo checkout if present, otherwise the GitHub Release asset matching
+   * the CLI package version.
+   */
+  pluginSourceDir?: string;
   /** Re-install even when versions match. Default `false`. */
   force?: boolean;
   /**
@@ -27,6 +34,8 @@ export interface UpdateOptions {
    * way. Junction (dev) installs are never cleaned regardless of this flag.
    */
   noClean?: boolean;
+  /** Injectable fetch for tests (download path only). */
+  fetchImpl?: typeof fetch;
   onProgress?: ProgressCallback;
 }
 
@@ -72,17 +81,23 @@ export function readPluginVersion(upluginPath: string): string | null {
 
 export async function update(opts: UpdateOptions): Promise<UpdateResult> {
   const warnings: string[] = [];
+  let cleanupSource: (() => void) | undefined;
   try {
     if (!opts?.projectDir) throw new Error('projectDir is required.');
-    if (!opts?.pluginSourceDir) throw new Error('pluginSourceDir is required.');
     const projectDir = path.resolve(opts.projectDir);
-    const pluginSourceDir = path.resolve(opts.pluginSourceDir);
 
     const installedUplugin = path.join(projectDir, 'Plugins', 'UnrealMCP', 'UnrealMCP.uplugin');
-    const sourceUplugin = path.join(pluginSourceDir, 'UnrealMCP.uplugin');
     const fromVersion = readPluginVersion(installedUplugin);
-    const toVersion = readPluginVersion(sourceUplugin);
     const installedPath = path.join(projectDir, 'Plugins', 'UnrealMCP');
+    const localSource =
+      (opts.pluginSourceDir ?? '').trim() !== ''
+        ? path.resolve(opts.pluginSourceDir!)
+        : opts.fetchImpl
+          ? null
+          : defaultCorePluginSource();
+    const toVersion = localSource
+      ? readPluginVersion(path.join(localSource, 'UnrealMCP.uplugin'))
+      : PACKAGE_VERSION;
 
     emitProgress(opts.onProgress, {
       phase: 'start',
@@ -101,11 +116,21 @@ export async function update(opts: UpdateOptions): Promise<UpdateResult> {
     // installed: `null !== null` is `false`, so without the explicit
     // `fromVersion === null` clause an uninstalled plugin against an unreadable
     // source would short-circuit to "already up to date" and never install.
-    const needsUpdate = opts.force === true || fromVersion === null || fromVersion !== toVersion;
+    const needsUpdate =
+      opts.force === true ||
+      fromVersion === null ||
+      stripLeadingV(fromVersion ?? '') !== stripLeadingV(toVersion ?? '');
     if (!needsUpdate) {
       emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin already up to date.' });
       return { kind: 'success', success: true, fromVersion, toVersion, updated: false, cleaned: false, installedPath, warnings };
     }
+
+    const resolvedSource = await resolvePluginSource({
+      pluginSourceDir: localSource ?? undefined,
+      fetchImpl: opts.fetchImpl,
+      onProgress: opts.onProgress,
+    });
+    cleanupSource = resolvedSource.cleanup;
 
     // Preserve the existing install mode: a dev junction install must stay a
     // junction across `update --force` rather than being silently replaced
@@ -113,7 +138,7 @@ export async function update(opts: UpdateOptions): Promise<UpdateResult> {
     const installedAsJunction = isSymlink(installedPath);
     const installResult = await installPlugin({
       projectDir,
-      pluginSourceDir,
+      pluginSourceDir: resolvedSource.pluginSourceDir,
       junction: installedAsJunction,
       onProgress: opts.onProgress,
     });
@@ -161,5 +186,7 @@ export async function update(opts: UpdateOptions): Promise<UpdateResult> {
       warnings,
       error: asError(err),
     };
+  } finally {
+    cleanupSource?.();
   }
 }

--- a/cli/src/utils/ui.ts
+++ b/cli/src/utils/ui.ts
@@ -1,44 +1,209 @@
-// Minimal console UI helpers for the CLI command layer. The library layer
-// (`lib/*`, `utils/*` other than this file) must NEVER import this — all
-// stdout/stderr writes live here so the library stays side-effect-free.
+import chalk from 'chalk';
+import yoctoSpinner, { type Spinner } from 'yocto-spinner';
+import type { Command, Help } from 'commander';
 
 let verboseEnabled = false;
 
-export function setVerbose(on: boolean): void {
-  verboseEnabled = on;
+export function setVerbose(enabled: boolean): void {
+  verboseEnabled = enabled;
 }
 
 export function verbose(message: string): void {
-  if (verboseEnabled) process.stderr.write(`[verbose] ${message}\n`);
+  if (!verboseEnabled) return;
+  if (isTTY()) {
+    console.log(chalk.dim(`[verbose] ${message}`));
+  } else {
+    console.log(`[verbose] ${message}`);
+  }
+}
+
+function isTTY(): boolean {
+  return !!process.stdout.isTTY;
+}
+
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1B\[[0-9;]*m/g, '');
+}
+
+function drawBox(text: string): string {
+  const lines = text.split('\n');
+  const padding = 2;
+  const maxLen = Math.max(...lines.map((line) => stripAnsi(line).length));
+  const innerWidth = maxLen + padding * 2;
+  const pad = ' '.repeat(padding);
+  const top = chalk.cyan(`╭${'─'.repeat(innerWidth)}╮`);
+  const bottom = chalk.cyan(`╰${'─'.repeat(innerWidth)}╯`);
+  const middle = lines.map((line) => {
+    const visible = stripAnsi(line).length;
+    const right = ' '.repeat(maxLen - visible);
+    return `${chalk.cyan('│')}${pad}${line}${right}${pad}${chalk.cyan('│')}`;
+  });
+  return [top, ...middle, bottom].join('\n');
+}
+
+export function configureStyledHelp(cmd: Command, appVersion?: string): Command {
+  cmd.configureHelp({
+    formatHelp(target: Command, helper: Help): string {
+      const isRoot = !target.parent;
+      const lines: string[] = [];
+
+      if (isRoot && appVersion) {
+        lines.push(
+          drawBox(
+            `${chalk.bold.cyan('Unreal-MCP CLI')}  ${chalk.dim(`v${appVersion}`)}\n${chalk.dim('Bridge LLMs with Unreal via Model Context Protocol')}`,
+          ),
+        );
+      } else {
+        lines.push(
+          drawBox(`${chalk.bold.cyan(target.name())} ${chalk.dim('—')} ${target.description()}`),
+        );
+      }
+      lines.push('');
+      lines.push(`${chalk.bold('Usage:')} ${chalk.yellow(helper.commandUsage(target))}`);
+      lines.push('');
+
+      const subcommands = helper.visibleCommands(target);
+      if (subcommands.length > 0) {
+        lines.push(chalk.bold('Commands:'));
+        for (const sub of subcommands) {
+          lines.push(`  ${chalk.yellow(sub.name().padEnd(20))} ${chalk.dim(sub.description() || '')}`);
+        }
+        lines.push('');
+      }
+
+      const args = helper.visibleArguments(target);
+      if (args.length > 0) {
+        lines.push(chalk.bold('Arguments:'));
+        for (const arg of args) {
+          lines.push(
+            `  ${chalk.green(helper.argumentTerm(arg).padEnd(30))} ${chalk.dim(helper.argumentDescription(arg))}`,
+          );
+        }
+        lines.push('');
+      }
+
+      const options = helper.visibleOptions(target);
+      if (options.length > 0) {
+        lines.push(chalk.bold('Options:'));
+        for (const opt of options) {
+          lines.push(`  ${chalk.green(helper.optionTerm(opt).padEnd(30))} ${chalk.dim(helper.optionDescription(opt))}`);
+        }
+        lines.push('');
+      }
+
+      if (isRoot) {
+        lines.push(
+          chalk.dim('Run ') +
+            chalk.yellow('unreal-mcp-cli <command> --help') +
+            chalk.dim(' for detailed usage of each command.'),
+        );
+        lines.push('');
+      }
+
+      return lines.join('\n');
+    },
+  });
+  return cmd;
 }
 
 export function info(message: string): void {
-  process.stdout.write(`${message}\n`);
+  if (isTTY()) {
+    console.log(`${chalk.blue('ℹ')}  ${message}`);
+  } else {
+    console.log(`INFO: ${message}`);
+  }
 }
 
 export function success(message: string): void {
-  process.stdout.write(`✓ ${message}\n`);
+  if (isTTY()) {
+    console.log(`${chalk.green('✔')}  ${message}`);
+  } else {
+    console.log(`SUCCESS: ${message}`);
+  }
 }
 
 export function warn(message: string): void {
-  process.stderr.write(`! ${message}\n`);
+  if (isTTY()) {
+    console.log(`${chalk.yellow('⚠')}  ${chalk.yellow(message)}`);
+  } else {
+    console.log(`WARN: ${message}`);
+  }
 }
 
 export function error(message: string): void {
-  process.stderr.write(`✗ ${message}\n`);
+  if (isTTY()) {
+    console.error(`${chalk.red('✖')}  ${chalk.red(message)}`);
+  } else {
+    console.error(`ERROR: ${message}`);
+  }
 }
 
 export function heading(message: string): void {
-  process.stdout.write(`\n${message}\n`);
+  console.log(`\n${chalk.bold.cyan(message)}`);
 }
 
 export function label(key: string, value: string): void {
-  process.stdout.write(`  ${key}: ${value}\n`);
+  console.log(`  ${chalk.bold(`${key}:`)} ${value}`);
+}
+
+function createNoOpSpinner(text: string): Spinner {
+  console.log(text);
+  const self: Spinner = {
+    start: () => self,
+    stop: () => self,
+    success: (msg?: string) => {
+      if (msg) console.log(`SUCCESS: ${msg}`);
+      return self;
+    },
+    error: (msg?: string) => {
+      if (msg) console.error(`ERROR: ${msg}`);
+      return self;
+    },
+    warning: (msg?: string) => {
+      if (msg) console.log(`WARN: ${msg}`);
+      return self;
+    },
+    info: (msg?: string) => {
+      if (msg) console.log(`INFO: ${msg}`);
+      return self;
+    },
+    clear: () => self,
+    get text() {
+      return text;
+    },
+    set text(value: string) {
+      text = value;
+    },
+    get isSpinning() {
+      return false;
+    },
+    get color() {
+      return 'cyan' as const;
+    },
+    set color(_: string) {},
+  } as unknown as Spinner;
+  return self;
+}
+
+export function startSpinner(text: string): Spinner {
+  if (!isTTY()) return createNoOpSpinner(text);
+  const spinner = yoctoSpinner({ text, color: 'cyan' }).start();
+  const origSuccess = spinner.success.bind(spinner);
+  const origError = spinner.error.bind(spinner);
+  const origWarning = spinner.warning.bind(spinner);
+  const origInfo = spinner.info.bind(spinner);
+
+  spinner.success = (msg?: string) => origSuccess(msg ? ` ${msg}` : undefined);
+  spinner.error = (msg?: string) => origError(msg ? ` ${msg}` : undefined);
+  spinner.warning = (msg?: string) => origWarning(msg ? ` ${msg}` : undefined);
+  spinner.info = (msg?: string) => origInfo(msg ? ` ${msg}` : undefined);
+  return spinner;
 }
 
 /** Print a list of warnings (no-op when empty). */
 export function printWarnings(warnings: string[]): void {
-  for (const w of warnings) warn(w);
+  for (const warning of warnings) warn(warning);
 }
 
 /** Pretty-print a JSON value. */

--- a/cli/tests/install-plugin.test.ts
+++ b/cli/tests/install-plugin.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import { zipSync, strToU8 } from 'fflate';
 import { installPlugin, removePlugin } from '../src/lib/install-plugin.js';
-import { makeTempDir, rmTempDir } from './helpers.js';
+import { PACKAGE_VERSION } from '../src/version.js';
+import { makeTempDir, rmTempDir, writeUProject } from './helpers.js';
 
 const dirs: string[] = [];
 afterEach(() => {
@@ -20,6 +22,17 @@ function makePluginSource(): string {
   fs.mkdirSync(path.join(dir, 'Source'), { recursive: true });
   fs.writeFileSync(path.join(dir, 'Source', 'marker.txt'), 'hello', 'utf-8');
   return dir;
+}
+
+function zipResponse(entries: Record<string, Uint8Array>): typeof fetch {
+  const bytes = zipSync(entries);
+  return (async () =>
+    ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    }) as unknown as Response) as typeof fetch;
 }
 
 describe('installPlugin (copy)', () => {
@@ -100,6 +113,41 @@ describe('installPlugin (copy)', () => {
     const installedBridge = path.join(r.installedPath, 'Binaries', 'ThirdParty', 'UnrealMcpBridge', 'win-x64', 'unreal-mcp-bridge.exe');
     expect(fs.existsSync(installedBridge)).toBe(true);
     expect(fs.readFileSync(installedBridge, 'utf-8')).toBe('BRIDGE-PAYLOAD');
+  });
+
+  it('downloads the packaged plugin zip from GitHub when no local source is available', async () => {
+    const project = tmp();
+    writeUProject(project, 'DownloadInstall');
+    const fetchImpl = zipResponse({
+      'UnrealMCP.uplugin': strToU8(JSON.stringify({ VersionName: PACKAGE_VERSION })),
+      'Source/marker.txt': strToU8('downloaded'),
+      'Source/ThirdParty/UnrealMcpBridge/win-x64/unreal-mcp-bridge.exe': strToU8('BRIDGE'),
+    });
+    const r = await installPlugin({ projectDir: project, fetchImpl });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.mode).toBe('copy');
+    expect(fs.existsSync(path.join(r.installedPath, 'UnrealMCP.uplugin'))).toBe(true);
+    expect(fs.existsSync(path.join(r.installedPath, 'Source', 'marker.txt'))).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(r.installedPath, 'Source', 'ThirdParty', 'UnrealMcpBridge', 'win-x64', 'unreal-mcp-bridge.exe'),
+      ),
+    ).toBe(true);
+  });
+
+  it('falls back to copy when --junction targets a downloaded GitHub release', async () => {
+    const project = tmp();
+    writeUProject(project, 'DownloadJunction');
+    const fetchImpl = zipResponse({
+      'UnrealMCP.uplugin': strToU8(JSON.stringify({ VersionName: PACKAGE_VERSION })),
+      'Source/marker.txt': strToU8('downloaded'),
+    });
+    const r = await installPlugin({ projectDir: project, junction: true, fetchImpl });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.mode).toBe('copy');
+    expect(r.warnings.some((w) => /stable local plugin source/i.test(w))).toBe(true);
   });
 });
 

--- a/cli/tests/plugin-source.test.ts
+++ b/cli/tests/plugin-source.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { zipSync, strToU8 } from 'fflate';
+import {
+  corePluginAssetName,
+  corePluginDownloadUrl,
+  findUPluginFile,
+  resolveLocalPluginRoot,
+  resolvePluginSource,
+} from '../src/lib/plugin-source.js';
+import { PACKAGE_VERSION } from '../src/version.js';
+import { makeTempDir, rmTempDir } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+function zipResponse(entries: Record<string, Uint8Array>): typeof fetch {
+  const bytes = zipSync(entries);
+  return (async () =>
+    ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    }) as unknown as Response) as typeof fetch;
+}
+
+describe('core plugin release helpers', () => {
+  it('builds the version-matched core plugin asset name + URL', () => {
+    expect(corePluginAssetName('0.6.2')).toBe('unreal-mcp-plugin-0.6.2.zip');
+    expect(corePluginDownloadUrl('0.6.2')).toBe(
+      'https://github.com/IvanMurzak/Unreal-MCP/releases/download/v0.6.2/unreal-mcp-plugin-0.6.2.zip',
+    );
+  });
+});
+
+describe('resolveLocalPluginRoot / findUPluginFile', () => {
+  it('accepts the plugin dir directly', () => {
+    const dir = tmp();
+    fs.writeFileSync(path.join(dir, 'UnrealMCP.uplugin'), '{}', 'utf-8');
+    expect(resolveLocalPluginRoot(dir)).toBe(dir);
+  });
+
+  it('accepts a parent dir that contains the plugin', () => {
+    const dir = tmp();
+    const plugin = path.join(dir, 'nested', 'UnrealMCP');
+    fs.mkdirSync(plugin, { recursive: true });
+    fs.writeFileSync(path.join(plugin, 'UnrealMCP.uplugin'), '{}', 'utf-8');
+    expect(resolveLocalPluginRoot(dir)).toBe(plugin);
+    expect(findUPluginFile(dir)).toBe(path.join(plugin, 'UnrealMCP.uplugin'));
+  });
+});
+
+describe('resolvePluginSource', () => {
+  it('downloads + extracts the core plugin release when no local source is supplied', async () => {
+    const result = await resolvePluginSource({
+      fetchImpl: zipResponse({
+        'UnrealMCP.uplugin': strToU8(JSON.stringify({ VersionName: PACKAGE_VERSION })),
+        'Source/marker.txt': strToU8('downloaded'),
+      }),
+    });
+    try {
+      expect(result.sourceKind).toBe('github-release');
+      expect(fs.existsSync(path.join(result.pluginSourceDir, 'UnrealMCP.uplugin'))).toBe(true);
+      expect(fs.existsSync(path.join(result.pluginSourceDir, 'Source', 'marker.txt'))).toBe(true);
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  it('rejects zip-slip paths in the downloaded archive', async () => {
+    await expect(
+      resolvePluginSource({
+        fetchImpl: zipResponse({
+          '../escape/UnrealMCP.uplugin': strToU8('{}'),
+        }),
+      }),
+    ).rejects.toThrow(/suspicious zip entry/i);
+  });
+});

--- a/cli/tests/ui.test.ts
+++ b/cli/tests/ui.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
+import { configureStyledHelp } from '../src/utils/ui.js';
+import { PACKAGE_VERSION } from '../src/version.js';
+
+describe('configureStyledHelp', () => {
+  it('renders the Unreal banner on the root command', () => {
+    const program = new Command().name('unreal-mcp-cli').description('root');
+    configureStyledHelp(program, PACKAGE_VERSION);
+    const help = program.helpInformation();
+    expect(help).toContain('Unreal-MCP CLI');
+    expect(help).toContain(`v${PACKAGE_VERSION}`);
+    expect(help).toContain('unreal-mcp-cli <command> --help');
+  });
+});

--- a/cli/tests/update.test.ts
+++ b/cli/tests/update.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import { zipSync, strToU8 } from 'fflate';
 import { update, readPluginVersion } from '../src/lib/update.js';
+import { PACKAGE_VERSION } from '../src/version.js';
 import { makeTempDir, rmTempDir } from './helpers.js';
 
 const dirs: string[] = [];
@@ -18,6 +20,19 @@ function makeSource(version: string): string {
   const dir = tmp();
   fs.writeFileSync(path.join(dir, 'UnrealMCP.uplugin'), JSON.stringify({ VersionName: version }), 'utf-8');
   return dir;
+}
+
+function zipResponse(entries: Record<string, Uint8Array>, calls?: string[]): typeof fetch {
+  const bytes = zipSync(entries);
+  return (async (url: string) => {
+    calls?.push(url);
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    } as unknown as Response;
+  }) as typeof fetch;
 }
 
 /**
@@ -113,6 +128,46 @@ describe('update', () => {
       expect(r.toVersion).toBe('0.2.0');
       expect(r.updated).toBe(true);
     }
+  });
+
+  it('does not download when the installed version already matches the CLI version', async () => {
+    const project = tmp();
+    await update({ projectDir: project, pluginSourceDir: makeSource(PACKAGE_VERSION) });
+    const calls: string[] = [];
+    const r = await update({
+      projectDir: project,
+      fetchImpl: (async (url: string) => {
+        calls.push(url);
+        throw new Error('fetch should not have been called');
+      }) as typeof fetch,
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.updated).toBe(false);
+    expect(calls).toEqual([]);
+  });
+
+  it('downloads the packaged plugin zip when no local source exists and the installed version differs', async () => {
+    const project = tmp();
+    await update({ projectDir: project, pluginSourceDir: makeSource('0.1.0') });
+    const calls: string[] = [];
+    const r = await update({
+      projectDir: project,
+      fetchImpl: zipResponse(
+        {
+          'UnrealMCP.uplugin': strToU8(JSON.stringify({ VersionName: PACKAGE_VERSION })),
+          'Source/marker.txt': strToU8('downloaded'),
+        },
+        calls,
+      ),
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.updated).toBe(true);
+    expect(r.fromVersion).toBe('0.1.0');
+    expect(r.toVersion).toBe(PACKAGE_VERSION);
+    expect(fs.existsSync(path.join(project, 'Plugins', 'UnrealMCP', 'Source', 'marker.txt'))).toBe(true);
+    expect(calls.some((url) => /unreal-mcp-plugin-/.test(url))).toBe(true);
   });
 
   // --- issue #58: auto-clean stale build cache on update -------------------


### PR DESCRIPTION
## Summary
- make `install-plugin` and `update` resolve the core UnrealMCP plugin from the local repo when present or from the version-matched GitHub Release zip otherwise
- add `plugin-source` helpers plus targeted tests for source resolution, download/extract, junction fallback, and update behavior
- upgrade the Unreal CLI terminal UX with styled help, colors, and spinners to match the richer Unity/Godot experience

## Testing
- npm run build
- npm test