### PR TITLE
fix(cli): publish dedicated source install asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,12 @@
 #                  └─ build-plugin-zip ◄────────┘  downloads the 4 signed RID
 #                        dirs, stages them under the FAB-SURVIVING source folder
 #                        UnrealMCP/Source/ThirdParty/UnrealMcpBridge/<rid>/ (#139/#187;
-#                        Fab strips Binaries/), runs BuildPlugin -Rocket (RuntimeDependencies
-#                        stage Source/ThirdParty/UnrealMcpBridge/ ->
-#                        Binaries/ThirdParty/UnrealMcpBridge/<rid>/), zips ->
-#                        publish-release attaches the plugin zip (bundle inside) +
-#                        the 4 signed bridge zips.
+#                        Fab strips Binaries/), emits the dedicated SOURCE install asset
+#                        unreal-mcp-plugin-source-<version>.zip, runs BuildPlugin -Rocket
+#                        (RuntimeDependencies stage Source/ThirdParty/UnrealMcpBridge/ ->
+#                        Binaries/ThirdParty/UnrealMcpBridge/<rid>/), zips the PACKAGED
+#                        plugin as unreal-mcp-plugin-<version>.zip ->
+#                        publish-release attaches both plugin zips + the 4 signed bridge zips.
 # Signing is GRACEFULLY DEGRADING: every sign/notarize step is `if: env.X != ''`
 # guarded, so a run with NO secrets produces UNSIGNED-but-green artifacts. The
 # Unreal-MCP repo has no signing secrets yet (the owner mirrors the 9 from
@@ -671,14 +672,18 @@ jobs:
   # <rid>.zip) and is released there; the CLI downloads the release pinned by
   # cli/src/lib/server-version.ts SERVER_VERSION.
 
-  # Engine-agnostic source plugin zip (BuildPlugin output) WITH the signed bridge
-  # bundled in. Self-hosted, gated like the plugin test job. Skipped when no
-  # runner is registered; for a real release the runner must be ready
+  # Release plugin zips: the dedicated SOURCE install asset
+  # `unreal-mcp-plugin-source-<version>.zip` (CLI/Fab install path, no
+  # EngineVersion pin, test-free descriptor) AND the PACKAGED BuildPlugin asset
+  # `unreal-mcp-plugin-<version>.zip` with the signed bridge bundled in under
+  # Binaries/ThirdParty/. Self-hosted, gated like the plugin test job. Skipped
+  # when no runner is registered; for a real release the runner must be ready
   # (publish-release `needs` this job). Depends on the two signed-bridge jobs so
-  # the 4 signed RID payloads can be staged into the plugin tree before
-  # BuildPlugin packages them (docs/ARCHITECTURE.md §6 BUNDLE model, T4).
+  # the 4 signed RID payloads can be staged into the plugin tree before the
+  # source asset is cut and BuildPlugin packages them (docs/ARCHITECTURE.md §6
+  # BUNDLE model, T4).
   build-plugin-zip:
-    name: build plugin zip (UE 5.7)
+    name: build plugin release zips (UE 5.7)
     needs: [check-version, build-bridge-macos, build-bridge-windows]
     if: needs.check-version.outputs.run_tests == 'true' && vars.UNREAL_RUNNER_READY == 'true'
     runs-on: [self-hosted, windows, unreal-5-7]
@@ -743,6 +748,63 @@ jobs:
             Write-Host "Staged $($files.Count) file(s) for $rid -> $ridDest"
             if ($files.Count -lt 1) { throw "No files staged for RID '$rid'." }
           }
+      - name: Build source plugin zip
+        shell: pwsh
+        env:
+          PLUGIN_VERSION: ${{ needs.check-version.outputs.version }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $pluginRoot = Join-Path $env:GITHUB_WORKSPACE 'UnrealMCP'
+          $uplugin = Join-Path $pluginRoot 'UnrealMCP.uplugin'
+          $descriptor = Get-Content $uplugin -Raw | ConvertFrom-Json
+          $hasEngineVersion = ($descriptor.PSObject.Properties.Name -contains 'EngineVersion') -and -not [string]::IsNullOrWhiteSpace([string]$descriptor.EngineVersion)
+          if ($hasEngineVersion) {
+            throw "The distributed source descriptor must not pin EngineVersion (found '$($descriptor.EngineVersion)')."
+          }
+          $modules = @($descriptor.Modules.Name)
+          if ($modules -contains 'UnrealMcpEditorTests') {
+            throw "The distributed source descriptor must not ship UnrealMcpEditorTests."
+          }
+          $stageRoot = Join-Path $env:RUNNER_TEMP 'UnrealMCP-Source-Package'
+          if (Test-Path $stageRoot) { Remove-Item $stageRoot -Recurse -Force }
+          $pluginStage = Join-Path $stageRoot 'UnrealMCP'
+          New-Item -ItemType Directory -Force -Path $pluginStage | Out-Null
+          foreach ($rel in @(
+            'UnrealMCP.uplugin',
+            'Config',
+            'Resources',
+            'Source\UnrealMcpRuntime',
+            'Source\UnrealMcpEditor',
+            'Source\ThirdParty',
+            'ThirdPartyNotices.txt'
+          )) {
+            $src = Join-Path $pluginRoot $rel
+            if (-not (Test-Path $src)) { throw "Source-asset input missing: $src" }
+            $dst = Join-Path $pluginStage $rel
+            $dstParent = Split-Path -Parent $dst
+            if (-not [string]::IsNullOrWhiteSpace($dstParent)) {
+              New-Item -ItemType Directory -Force -Path $dstParent | Out-Null
+            }
+            if (Test-Path $src -PathType Container) {
+              Copy-Item -Path $src -Destination $dst -Recurse -Force
+            } else {
+              Copy-Item -Path $src -Destination $dst -Force
+            }
+          }
+          if (Test-Path (Join-Path $pluginStage 'Source\UnrealMcpEditorTests')) {
+            throw "The source asset staging unexpectedly included UnrealMcpEditorTests."
+          }
+          foreach ($rid in @('win-x64', 'osx-arm64', 'osx-x64', 'linux-x64')) {
+            $ridDir = Join-Path $pluginStage "Source\ThirdParty\UnrealMcpBridge\$rid"
+            $fileCount = @(Get-ChildItem -Path $ridDir -Recurse -File -ErrorAction SilentlyContinue).Count
+            Write-Host "Source asset bridge for ${rid}: $fileCount file(s)."
+            if ($fileCount -lt 1) { throw "Source asset is missing the staged bridge payload for RID '$rid'." }
+          }
+          $out = Join-Path $env:GITHUB_WORKSPACE 'dist'
+          New-Item -ItemType Directory -Force -Path $out | Out-Null
+          $zip = Join-Path $out "unreal-mcp-plugin-source-$env:PLUGIN_VERSION.zip"
+          if (Test-Path $zip) { Remove-Item $zip -Force }
+          Compress-Archive -Path $pluginStage -DestinationPath $zip -Force
       - name: BuildPlugin + zip
         shell: pwsh
         env:
@@ -789,20 +851,27 @@ jobs:
           $out = Join-Path $env:GITHUB_WORKSPACE 'dist'
           New-Item -ItemType Directory -Force -Path $out | Out-Null
           Compress-Archive -Path (Join-Path $package '*') -DestinationPath (Join-Path $out "unreal-mcp-plugin-$version.zip") -Force
-      - name: Upload plugin zip
+      - name: Upload source plugin zip
         uses: actions/upload-artifact@v4
         with:
-          name: unreal-mcp-plugin-zip
-          path: ./dist/*.zip
+          name: unreal-mcp-plugin-source-zip
+          path: ./dist/unreal-mcp-plugin-source-${{ needs.check-version.outputs.version }}.zip
+          if-no-files-found: error
+          retention-days: 7
+      - name: Upload packaged plugin zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: unreal-mcp-plugin-packaged-zip
+          path: ./dist/unreal-mcp-plugin-${{ needs.check-version.outputs.version }}.zip
           if-no-files-found: error
           retention-days: 7
 
   # ── PUBLISH (gated on a REAL release: tag absent + version bumped, NOT a
   #    dry-run). Every job here is hard-skipped during the ci-workflows dry-run. ─
 
-  # Create the GitHub Release + `v<version>` tag with the bridge/plugin zips
-  # attached and auto-generated notes. (Server zips are released from the
-  # shared GameDev-MCP-Server repo, not here.)
+  # Create the GitHub Release + `v<version>` tag with the bridge zips, the
+  # dedicated SOURCE install asset, and the PACKAGED BuildPlugin zip attached.
+  # (Server zips are released from the shared GameDev-MCP-Server repo, not here.)
   publish-release:
     name: publish GitHub Release
     needs:
@@ -824,9 +893,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      # The END-USER artifact is the plugin zip (the signed bridge is bundled
-      # INSIDE it). The per-RID signed bridge zips are also attached for
-      # debugging / UNREAL_MCP_BRIDGE_PATH users.
+      # Attach both plugin artifacts:
+      #   * unreal-mcp-plugin-source-<version>.zip  -> CLI/Fab source install asset
+      #   * unreal-mcp-plugin-<version>.zip         -> packaged BuildPlugin artifact
+      # The per-RID signed bridge zips are also attached for debugging /
+      # UNREAL_MCP_BRIDGE_PATH users.
       - name: Download bridge release zips (osx + linux)
         uses: actions/download-artifact@v4
         with:
@@ -837,10 +908,15 @@ jobs:
         with:
           name: bridge-release-zips-win
           path: ./assets
-      - name: Download plugin zip
+      - name: Download source plugin zip
         uses: actions/download-artifact@v4
         with:
-          name: unreal-mcp-plugin-zip
+          name: unreal-mcp-plugin-source-zip
+          path: ./assets
+      - name: Download packaged plugin zip
+        uses: actions/download-artifact@v4
+        with:
+          name: unreal-mcp-plugin-packaged-zip
           path: ./assets
       - name: List assembled release assets
         run: ls -la ./assets

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Because Fab ships precompiled binaries and the Epic Launcher updates them in pla
 
 ## Option B — `unreal-mcp-cli` (current / advanced)
 
-The CLI is the recommended path **today**, until the Fab listing is live. Install it from npm — **no repo clone, no build step**. By default `install-plugin` / `update` use a local `UnrealMCP/` checkout when one is present; otherwise they download the packaged plugin zip from the public GitHub Release that matches the CLI version. `--plugin-source <dir>` remains the offline / CI / dev override. The CLI copies (or, for dev, junctions) the plugin into your project and, on **update**, automatically clears the stale UE build cache so you always get a clean recompile of the new code (see [Updating the plugin](#updating-the-plugin)).
+The CLI is the recommended path **today**, until the Fab listing is live. Install it from npm — **no repo clone, no build step**. By default `install-plugin` / `update` use a local `UnrealMCP/` checkout when one is present; otherwise they download the dedicated `unreal-mcp-plugin-source-<version>.zip` source asset from the public GitHub Release that matches the CLI version. That source asset keeps the distributed descriptor semantics (**no `EngineVersion` pin**) and carries the signed bridge payload under `Source/ThirdParty/UnrealMcpBridge/<rid>/`; the installer materializes it into `Binaries/ThirdParty/...` for first-open convenience. `--plugin-source <dir>` remains the offline / CI / dev override. The CLI copies (or, for dev, junctions) the plugin into your project and, on **update**, automatically clears the stale UE build cache so you always get a clean recompile of the new code (see [Updating the plugin](#updating-the-plugin)).
 
 ```bash
 # 1. Install unreal-mcp-cli (or use `npx unreal-mcp-cli@latest <command>` for a one-off, no install)
@@ -129,7 +129,7 @@ See [`cli/README.md`](cli/README.md) for the full 16-command reference.
 
 The sidecar binary (`unreal-mcp-bridge`) is **bundled inside the plugin** in a packaged release: a prebuilt, self-contained binary for your platform ships under `UnrealMCP/Binaries/ThirdParty/UnrealMcpBridge/<rid>/` and the editor **auto-spawns it on startup with zero user action** — no .NET install, no env var, no manual launch (ARCHITECTURE §6). The first Cloud OAuth device-code browser approval is the only remaining human step; after that, reconnect on later launches is zero-click (the cloud token is cached in `Saved/Config/UnrealMcp/`).
 
-When you build the plugin **from source** (the only option until the first GitHub Release / Fab listing), the bundled binary is not present — the plugin then resolves the sidecar from the `UNREAL_MCP_BRIDGE_PATH` environment variable instead: point that at a locally built sidecar, or run `unreal-mcp-cli bootstrap-local` to build the bridge from source into `<YourProject>/Intermediate/UnrealMCP/` and set the var to the result. With neither a bundled binary nor the env var resolved, the plugin's TCP listener still starts but logs `[Unreal-MCP] no sidecar binary resolved for rid <rid> …` and spawns nothing.
+When you copy the repo **source checkout directly** (Option C/manual or a live dev junction), the bundled binary is not present — the plugin then resolves the sidecar from the `UNREAL_MCP_BRIDGE_PATH` environment variable instead: point that at a locally built sidecar, or run `unreal-mcp-cli bootstrap-local` to build the bridge from source into `<YourProject>/Intermediate/UnrealMCP/` and set the var to the result. With neither a bundled binary nor the env var resolved, the plugin's TCP listener still starts but logs `[Unreal-MCP] no sidecar binary resolved for rid <rid> …` and spawns nothing.
 
 ![AI Game Developer — Unreal MCP](https://github.com/IvanMurzak/Unreal-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
 
@@ -138,7 +138,7 @@ When you build the plugin **from source** (the only option until the first GitHu
 Updating in place must always leave you running the **new** code. The risk is UE's incremental compiler: if the plugin source changes (new `.cpp` files, a new module) but the old `UnrealMCP/Intermediate/` build cache survives, UE can do a partial recompile against a stale module file-list and silently leave you on old/partial code. Each channel handles this differently:
 
 - **Fab / Epic Marketplace → automatic.** The Epic Games Launcher replaces the precompiled binaries in place; nothing to compile, no cache to clear. This is why Fab is the recommended channel.
-- **`unreal-mcp-cli update` → automatic clean rebuild.** `update` re-copies the plugin source and, by **default**, deletes the installed plugin's stale `Intermediate/` and the C++ `Binaries/` so UE performs a clean compile on the next editor launch — no manual steps. The bundled sidecar bridge under `Binaries/ThirdParty/UnrealMcpBridge/<rid>/` is **always preserved** (only the C++ module outputs are cleared). Dev **junction** installs are never cleaned (that would wipe your live source tree's outputs). Pass `--no-clean` to opt out of the cache wipe.
+- **`unreal-mcp-cli update` → automatic clean rebuild.** `update` re-copies the plugin source and, by **default**, deletes the installed plugin's stale `Intermediate/` and the C++ `Binaries/` so UE performs a clean compile on the next editor launch — no manual steps. The bundled sidecar bridge under `Binaries/ThirdParty/UnrealMcpBridge/<rid>/` is kept intact: release-source installs refresh it from `Source/ThirdParty/...`, while repo/dev installs preserve the previously bundled copy when needed. Dev **junction** installs are never cleaned (that would wipe your live source tree's outputs). Pass `--no-clean` to opt out of the cache wipe.
 
   ```bash
   node bin/unreal-mcp-cli.js update <YourProject>            # default: clean rebuild on version change
@@ -334,7 +334,7 @@ The full 16-command surface:
 | `create-project` | Scaffold a minimal Unreal Engine C++ project |
 | `open` | Launch the Unreal Editor for a project, wiring MCP connection env vars |
 | `close` | Terminate the Unreal Editor process running a project |
-| `install-plugin` | Install the UnrealMCP plugin into `<project>/Plugins` (copy or `--junction`) |
+| `install-plugin` | Install the UnrealMCP plugin into `<project>/Plugins` (copy or `--junction`) from a local checkout or the version-matched GitHub source asset |
 | `remove-plugin` | Remove the UnrealMCP plugin from `<project>/Plugins` |
 | `configure` | Write `UNREAL_MCP_*` values into `<project>/.env` and gitignore `.env` |
 | `setup-mcp` | Write an MCP client config snippet for an agent |
@@ -344,7 +344,7 @@ The full 16-command surface:
 | `run-tool` | Invoke an MCP tool via the project's local MCP server (HTTP) |
 | `run-system-tool` | Invoke a system tool via the project's local MCP server (HTTP) |
 | `bootstrap-local` | Build the bridge from source into `<project>/Intermediate/UnrealMCP` (the server is downloaded by `setup-mcp`, not built) |
-| `update` | Update the UnrealMCP plugin installed in a project from the repo source |
+| `update` | Update the UnrealMCP plugin installed in a project from a local checkout or the version-matched GitHub source asset |
 | `install-engine` | Detect installed Unreal engines; for a missing version, link to the Epic launcher |
 | `setup-skills` | Write a Claude-Code skill stub that drives this project's Unreal MCP server |
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -33,9 +33,12 @@ Requires Node `^20.19.0 || >=22.12.0`. See the
 > itself is **Fab / Epic Marketplace** (precompiled per-engine binaries, auto-updated by the Epic
 > Games Launcher — zero compile, zero stale-build risk). This CLI is the current/advanced/dev path
 > until the Fab listing is live; its `install-plugin` / `update` commands use a local `UnrealMCP/`
-> checkout when present, otherwise they download the public GitHub Release asset that matches the
-> CLI version, then copy the plugin into a project and keep its build cache clean on update (see
-> the `update` row below). `--plugin-source <dir>` remains the offline / CI / dev override.
+> checkout when present, otherwise they download the dedicated `unreal-mcp-plugin-source-<version>.zip`
+> GitHub Release asset that matches the CLI version. That source asset keeps the distributed
+> descriptor semantics (**no `EngineVersion` pin**) and carries the signed bridge payload under
+> `Source/ThirdParty/UnrealMcpBridge/<rid>/`, which the installer materializes into
+> `Binaries/ThirdParty/...` for first-open convenience. `--plugin-source <dir>` remains the offline /
+> CI / dev override.
 
 ## Commands (docs/ARCHITECTURE.md §9.1)
 
@@ -44,7 +47,7 @@ Requires Node `^20.19.0 || >=22.12.0`. See the
 | `create-project <path>` | Scaffold a minimal Unreal Engine C++ project |
 | `open [path]` | Launch the Unreal Editor, wiring `UNREAL_MCP_*` env vars (engine resolved via `EngineAssociation` + `LauncherInstalled.dat`) |
 | `close [path]` | Terminate the editor process running a project |
-| `install-plugin [path]` | Copy (or `--junction`) the UnrealMCP plugin into `<project>/Plugins` — default source = local repo checkout when present, else the version-matched GitHub Release zip |
+| `install-plugin [path]` | Copy (or `--junction`) the UnrealMCP plugin into `<project>/Plugins` — default source = local repo checkout when present, else the version-matched GitHub source asset |
 | `remove-plugin [path]` | Remove the installed plugin |
 | `install-extension <id> [path]` | Install a third-party Unreal-MCP **extension** plugin into `<project>/Plugins/<name>`, enable it + its gating engine plugins (e.g. `Niagara`) in the `.uproject`, and (re)compile (on next editor open, or now with `--build`). `--source <dir>` installs from a local copy (offline/CI); `--version <x.y.z>` overrides the catalog pin. Idempotent. See [Extensions](#extensions) |
 | `configure` | Write `UNREAL_MCP_*` into `<project>/.env` and gitignore `.env` (§8) |
@@ -55,7 +58,7 @@ Requires Node `^20.19.0 || >=22.12.0`. See the
 | `run-tool <tool>` | Invoke an MCP tool over the local HTTP path |
 | `run-system-tool <tool>` | Invoke a system tool over the local HTTP path |
 | `bootstrap-local [path]` | Build the bridge from source into `Intermediate/UnrealMCP/` (§6) — the MCP server is downloaded from GameDev-MCP-Server releases, not built here |
-| `update [path]` | Re-sync the installed plugin from a local source or the version-matched GitHub Release zip. On a version change it **auto-cleans** the stale UE C++ build cache (`Intermediate/` + C++ `Binaries/`) so the editor recompiles cleanly — the bundled sidecar bridge under `Binaries/ThirdParty/` is preserved, junction (dev) installs are never cleaned, and `--no-clean` opts out |
+| `update [path]` | Re-sync the installed plugin from a local source or the version-matched GitHub source asset. On a version change it **auto-cleans** the stale UE C++ build cache (`Intermediate/` + C++ `Binaries/`) so the editor recompiles cleanly — the bundled sidecar bridge under `Binaries/ThirdParty/` is refreshed from `Source/ThirdParty/` when the release source asset ships it, otherwise preserved, junction (dev) installs are never cleaned, and `--no-clean` opts out |
 | `install-engine [version]` | Detect installed engines from `LauncherInstalled.dat`; link to the Epic launcher for missing versions (never installs directly) |
 | `setup-skills` | Write a Claude-Code skill stub that drives the project's MCP server |
 

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -23,8 +23,31 @@ import type {
 const PLUGIN_DIRNAME = 'UnrealMCP';
 /** Subtree under `Binaries/` holding the bundled bridge (ARCHITECTURE §6.1). */
 const BUNDLED_BRIDGE_REL = path.join('Binaries', 'ThirdParty');
+/** Bridge root under `Binaries/ThirdParty/` after a release/source-asset install. */
+const BUNDLED_BRIDGE_ROOT_REL = path.join(BUNDLED_BRIDGE_REL, 'UnrealMcpBridge');
+/** Fab-surviving source-side bridge root shipped by the dedicated source asset. */
+const SOURCE_BUNDLED_BRIDGE_ROOT_REL = path.join('Source', 'ThirdParty', 'UnrealMcpBridge');
 /** `Binaries/ThirdParty` with forward slashes, for the copy filter's keep-check. */
 const BUNDLED_BRIDGE_REL_POSIX = BUNDLED_BRIDGE_REL.split(path.sep).join('/');
+
+function hasBundledBridgePayload(root: string): boolean {
+  if (!fs.existsSync(root)) return false;
+  const queue: string[] = [root];
+  while (queue.length > 0) {
+    const dir = queue.shift()!;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const next = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(next);
+        continue;
+      }
+      if (entry.isFile() && /^unreal-mcp-bridge(?:\.exe)?$/i.test(entry.name)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 /**
  * Decide whether `srcAbs` (an absolute path inside `pluginSourceDir`) should be
@@ -95,21 +118,23 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     }
     if (opts.junction === true && resolvedSource.sourceKind !== 'local') {
       warnings.push(
-        'Junction mode requires a stable local plugin source; falling back to copy for the downloaded GitHub release.',
+        'Junction mode requires a stable local plugin source; falling back to copy for the downloaded GitHub source asset.',
       );
       useJunction = false;
     }
 
-    // Preserve the bundled sidecar bridge across a COPY re-install. A prior
-    // (release-packaged) install ships `Binaries/ThirdParty/UnrealMcpBridge/`,
-    // but the plugin SOURCE we copy from (a dev/source checkout) does not — so
-    // a naive rm-then-copy would strip the bridge and leave the plugin unable
-    // to spawn its sidecar (ARCHITECTURE §6). Stash the existing bridge subtree
-    // to a temp dir before clearing, then restore it after the copy IF the new
-    // source did not provide its own. Junction installs never go through this
-    // path (the junction points at the live source — nothing to preserve).
+    // Preserve or refresh the bundled sidecar bridge across a COPY re-install.
+    // A prior release install ships `Binaries/ThirdParty/UnrealMcpBridge/`, but
+    // a dev/source checkout does not; the dedicated GitHub source asset instead
+    // ships the RID payload under `Source/ThirdParty/UnrealMcpBridge/`. Stash the
+    // existing `Binaries/ThirdParty/` subtree before clearing, then after the copy
+    // either materialize a fresh `Binaries/ThirdParty/UnrealMcpBridge/` from the
+    // source-side payload, or restore the prior bundled bridge when the new source
+    // has no bridge at all. Junction installs never go through this path.
     let stashedBridge: string | null = null;
     const priorBridge = path.join(installedPath, BUNDLED_BRIDGE_REL);
+    const installedBridgeRoot = path.join(installedPath, BUNDLED_BRIDGE_ROOT_REL);
+    const sourceBridgeRoot = path.join(pluginSourceDir, SOURCE_BUNDLED_BRIDGE_ROOT_REL);
     const installedIsRealDir = fs.existsSync(installedPath) && !isSymlink(installedPath);
     if (!useJunction && installedIsRealDir && fs.existsSync(priorBridge)) {
       stashedBridge = fs.mkdtempSync(path.join(os.tmpdir(), 'unreal-mcp-bridge-stash-'));
@@ -158,10 +183,18 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
       throw copyErr;
     }
 
-    // Restore the stashed bridge if the freshly-copied source did not ship one.
+    // The dedicated source asset ships the bridge payload under Source/ThirdParty;
+    // materialize it into Binaries/ThirdParty so the first editor open has the
+    // staged runtime path even before a local recompile runs.
+    if (!fs.existsSync(installedBridgeRoot) && hasBundledBridgePayload(sourceBridgeRoot)) {
+      fs.mkdirSync(path.dirname(installedBridgeRoot), { recursive: true });
+      fs.cpSync(sourceBridgeRoot, installedBridgeRoot, { recursive: true });
+    }
+
+    // Restore the stashed bridge if the freshly-copied source still did not ship one.
     if (stashedBridge) {
       try {
-        if (!fs.existsSync(priorBridge)) {
+        if (!fs.existsSync(installedBridgeRoot)) {
           fs.mkdirSync(path.dirname(priorBridge), { recursive: true });
           fs.cpSync(stashedBridge, priorBridge, { recursive: true });
           warnings.push('Preserved the previously-bundled sidecar bridge across the re-install.');

--- a/cli/src/lib/plugin-source.ts
+++ b/cli/src/lib/plugin-source.ts
@@ -3,11 +3,11 @@
 // is:
 //   1. explicit local `pluginSourceDir`
 //   2. local repo checkout (`UnrealMCP/`)
-//   3. GitHub Release asset that matches THIS CLI's package version
+//   3. GitHub Release SOURCE asset that matches THIS CLI's package version
 //
 // The version coupling is intentional: Unreal-MCP plugin / bridge / CLI share
 // one semver and are released together, so the published CLI can safely fetch
-// `unreal-mcp-plugin-<PACKAGE_VERSION>.zip`.
+// `unreal-mcp-plugin-source-<PACKAGE_VERSION>.zip`.
 
 import * as fs from 'fs';
 import * as os from 'os';
@@ -27,10 +27,10 @@ import type { ProgressCallback } from './types.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 
-/** GitHub repo releasing the packaged core UnrealMCP plugin zip. */
-export const CORE_PLUGIN_RELEASE_REPO = 'IvanMurzak/Unreal-MCP';
-/** Release-asset basename for the packaged core plugin. */
-export const CORE_PLUGIN_ZIP_BASENAME = 'unreal-mcp-plugin';
+/** GitHub repo releasing the core UnrealMCP source-install asset. */
+export const CORE_PLUGIN_SOURCE_RELEASE_REPO = 'IvanMurzak/Unreal-MCP';
+/** Release-asset basename for the source-install core plugin asset. */
+export const CORE_PLUGIN_SOURCE_ZIP_BASENAME = 'unreal-mcp-plugin-source';
 
 export interface ResolvePluginSourceOptions {
   /**
@@ -52,17 +52,17 @@ export interface ResolvedPluginSource {
   cleanup: () => void;
 }
 
-/** `unreal-mcp-plugin-<version>.zip` (asset uses the bare version, not `v`). */
-export function corePluginAssetName(version: string = PACKAGE_VERSION): string {
-  return `${CORE_PLUGIN_ZIP_BASENAME}-${stripLeadingV(version)}.zip`;
+/** `unreal-mcp-plugin-source-<version>.zip` (asset uses the bare version, not `v`). */
+export function corePluginSourceAssetName(version: string = PACKAGE_VERSION): string {
+  return `${CORE_PLUGIN_SOURCE_ZIP_BASENAME}-${stripLeadingV(version)}.zip`;
 }
 
 /**
- * Release-asset URL for the packaged core plugin zip, version-locked to the CLI
- * unless the caller overrides it for tests.
+ * Release-asset URL for the dedicated core-plugin SOURCE asset, version-locked
+ * to the CLI unless the caller overrides it for tests.
  */
-export function corePluginDownloadUrl(version: string = PACKAGE_VERSION): string {
-  return `https://${TRUSTED_DOWNLOAD_HOST}/${CORE_PLUGIN_RELEASE_REPO}/releases/download/${releaseTag(version)}/${corePluginAssetName(version)}`;
+export function corePluginSourceDownloadUrl(version: string = PACKAGE_VERSION): string {
+  return `https://${TRUSTED_DOWNLOAD_HOST}/${CORE_PLUGIN_SOURCE_RELEASE_REPO}/releases/download/${releaseTag(version)}/${corePluginSourceAssetName(version)}`;
 }
 
 /** Resolve the nearest repo checkout's `UnrealMCP/` dir from this package, if any. */
@@ -116,8 +116,9 @@ export function findUPluginFile(root: string): string | null {
 }
 
 /**
- * Resolve the core plugin source for install/update. Falls back to the packaged
- * GitHub Release zip that matches THIS CLI's version when no local source exists.
+ * Resolve the core plugin source for install/update. Falls back to the dedicated
+ * GitHub Release SOURCE asset that matches THIS CLI's version when no local
+ * source exists.
  */
 export async function resolvePluginSource(
   opts: ResolvePluginSourceOptions = {},
@@ -143,7 +144,7 @@ export async function resolvePluginSource(
   }
 
   const version = PACKAGE_VERSION;
-  const url = corePluginDownloadUrl(version);
+  const url = corePluginSourceDownloadUrl(version);
   assertTrustedDownloadUrl(url);
   emitProgress(opts.onProgress, {
     phase: 'info',
@@ -161,7 +162,7 @@ export async function resolvePluginSource(
   const zipBytes = new Uint8Array(await response.arrayBuffer());
   emitProgress(opts.onProgress, {
     phase: 'info',
-    message: `Extracting ${corePluginAssetName(version)}`,
+    message: `Extracting ${corePluginSourceAssetName(version)}`,
   });
 
   const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unreal-mcp-plugin-'));
@@ -180,7 +181,23 @@ export async function resolvePluginSource(
     const pluginFile = findUPluginFile(stagingDir);
     if (!pluginFile) {
       throw new Error(
-        `Downloaded plugin archive ${corePluginAssetName(version)} did not contain an UnrealMCP.uplugin descriptor.`,
+        `Downloaded plugin archive ${corePluginSourceAssetName(version)} did not contain an UnrealMCP.uplugin descriptor.`,
+      );
+    }
+    let descriptor: Record<string, unknown>;
+    try {
+      descriptor = JSON.parse(fs.readFileSync(pluginFile, 'utf-8')) as Record<string, unknown>;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Downloaded plugin archive ${corePluginSourceAssetName(version)} contained an unreadable UnrealMCP.uplugin descriptor: ${message}`,
+      );
+    }
+    const engineVersion = typeof descriptor['EngineVersion'] === 'string' ? descriptor['EngineVersion'].trim() : '';
+    if (engineVersion !== '') {
+      throw new Error(
+        `Downloaded plugin asset ${corePluginSourceAssetName(version)} is not a source install bundle: UnrealMCP.uplugin pins EngineVersion '${engineVersion}'. ` +
+          `Verify the ${releaseTag(version)} release published ${corePluginSourceAssetName(version)}, or pass --plugin-source <dir> for an offline/dev install.`,
       );
     }
 

--- a/cli/tests/install-plugin.test.ts
+++ b/cli/tests/install-plugin.test.ts
@@ -115,13 +115,13 @@ describe('installPlugin (copy)', () => {
     expect(fs.readFileSync(installedBridge, 'utf-8')).toBe('BRIDGE-PAYLOAD');
   });
 
-  it('downloads the packaged plugin zip from GitHub when no local source is available', async () => {
+  it('downloads the dedicated source asset from GitHub when no local source is available', async () => {
     const project = tmp();
     writeUProject(project, 'DownloadInstall');
     const fetchImpl = zipResponse({
-      'UnrealMCP.uplugin': strToU8(JSON.stringify({ VersionName: PACKAGE_VERSION })),
-      'Source/marker.txt': strToU8('downloaded'),
-      'Source/ThirdParty/UnrealMcpBridge/win-x64/unreal-mcp-bridge.exe': strToU8('BRIDGE'),
+      'UnrealMCP/UnrealMCP.uplugin': strToU8(JSON.stringify({ VersionName: PACKAGE_VERSION, Installed: false })),
+      'UnrealMCP/Source/marker.txt': strToU8('downloaded'),
+      'UnrealMCP/Source/ThirdParty/UnrealMcpBridge/win-x64/unreal-mcp-bridge.exe': strToU8('BRIDGE'),
     });
     const r = await installPlugin({ projectDir: project, fetchImpl });
     expect(r.kind).toBe('success');
@@ -129,9 +129,18 @@ describe('installPlugin (copy)', () => {
     expect(r.mode).toBe('copy');
     expect(fs.existsSync(path.join(r.installedPath, 'UnrealMCP.uplugin'))).toBe(true);
     expect(fs.existsSync(path.join(r.installedPath, 'Source', 'marker.txt'))).toBe(true);
+    const descriptor = JSON.parse(
+      fs.readFileSync(path.join(r.installedPath, 'UnrealMCP.uplugin'), 'utf-8'),
+    ) as Record<string, unknown>;
+    expect(descriptor['EngineVersion']).toBeUndefined();
     expect(
       fs.existsSync(
         path.join(r.installedPath, 'Source', 'ThirdParty', 'UnrealMcpBridge', 'win-x64', 'unreal-mcp-bridge.exe'),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(r.installedPath, 'Binaries', 'ThirdParty', 'UnrealMcpBridge', 'win-x64', 'unreal-mcp-bridge.exe'),
       ),
     ).toBe(true);
   });
@@ -140,14 +149,42 @@ describe('installPlugin (copy)', () => {
     const project = tmp();
     writeUProject(project, 'DownloadJunction');
     const fetchImpl = zipResponse({
-      'UnrealMCP.uplugin': strToU8(JSON.stringify({ VersionName: PACKAGE_VERSION })),
-      'Source/marker.txt': strToU8('downloaded'),
+      'UnrealMCP/UnrealMCP.uplugin': strToU8(JSON.stringify({ VersionName: PACKAGE_VERSION, Installed: false })),
+      'UnrealMCP/Source/marker.txt': strToU8('downloaded'),
     });
     const r = await installPlugin({ projectDir: project, junction: true, fetchImpl });
     expect(r.kind).toBe('success');
     if (r.kind !== 'success') return;
     expect(r.mode).toBe('copy');
     expect(r.warnings.some((w) => /stable local plugin source/i.test(w))).toBe(true);
+  });
+
+  it('refreshes a legacy packaged install with the source-asset bridge payload instead of restoring the stale bridge', async () => {
+    const project = tmp();
+    const legacy = makePluginSource();
+    const oldBridge = path.join(legacy, 'Binaries', 'ThirdParty', 'UnrealMcpBridge', 'win-x64');
+    fs.mkdirSync(oldBridge, { recursive: true });
+    fs.writeFileSync(path.join(oldBridge, 'unreal-mcp-bridge.exe'), 'OLD-BRIDGE', 'utf-8');
+    await installPlugin({ projectDir: project, pluginSourceDir: legacy });
+
+    const sourceAsset = makePluginSource();
+    const newBridge = path.join(sourceAsset, 'Source', 'ThirdParty', 'UnrealMcpBridge', 'win-x64');
+    fs.mkdirSync(newBridge, { recursive: true });
+    fs.writeFileSync(path.join(newBridge, 'unreal-mcp-bridge.exe'), 'NEW-BRIDGE', 'utf-8');
+
+    const r = await installPlugin({ projectDir: project, pluginSourceDir: sourceAsset });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    const installedBridge = path.join(
+      r.installedPath,
+      'Binaries',
+      'ThirdParty',
+      'UnrealMcpBridge',
+      'win-x64',
+      'unreal-mcp-bridge.exe',
+    );
+    expect(fs.existsSync(installedBridge)).toBe(true);
+    expect(fs.readFileSync(installedBridge, 'utf-8')).toBe('NEW-BRIDGE');
   });
 });
 

--- a/cli/tests/plugin-source.test.ts
+++ b/cli/tests/plugin-source.test.ts
@@ -3,8 +3,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { zipSync, strToU8 } from 'fflate';
 import {
-  corePluginAssetName,
-  corePluginDownloadUrl,
+  corePluginSourceAssetName,
+  corePluginSourceDownloadUrl,
   findUPluginFile,
   resolveLocalPluginRoot,
   resolvePluginSource,
@@ -35,9 +35,9 @@ function zipResponse(entries: Record<string, Uint8Array>): typeof fetch {
 
 describe('core plugin release helpers', () => {
   it('builds the version-matched core plugin asset name + URL', () => {
-    expect(corePluginAssetName('0.6.2')).toBe('unreal-mcp-plugin-0.6.2.zip');
-    expect(corePluginDownloadUrl('0.6.2')).toBe(
-      'https://github.com/IvanMurzak/Unreal-MCP/releases/download/v0.6.2/unreal-mcp-plugin-0.6.2.zip',
+    expect(corePluginSourceAssetName('0.6.2')).toBe('unreal-mcp-plugin-source-0.6.2.zip');
+    expect(corePluginSourceDownloadUrl('0.6.2')).toBe(
+      'https://github.com/IvanMurzak/Unreal-MCP/releases/download/v0.6.2/unreal-mcp-plugin-source-0.6.2.zip',
     );
   });
 });
@@ -63,8 +63,8 @@ describe('resolvePluginSource', () => {
   it('downloads + extracts the core plugin release when no local source is supplied', async () => {
     const result = await resolvePluginSource({
       fetchImpl: zipResponse({
-        'UnrealMCP.uplugin': strToU8(JSON.stringify({ VersionName: PACKAGE_VERSION })),
-        'Source/marker.txt': strToU8('downloaded'),
+        'UnrealMCP/UnrealMCP.uplugin': strToU8(JSON.stringify({ VersionName: PACKAGE_VERSION, Installed: false })),
+        'UnrealMCP/Source/marker.txt': strToU8('downloaded'),
       }),
     });
     try {
@@ -74,6 +74,16 @@ describe('resolvePluginSource', () => {
     } finally {
       result.cleanup();
     }
+  });
+
+  it('rejects a downloaded packaged plugin descriptor that pins EngineVersion', async () => {
+    await expect(
+      resolvePluginSource({
+        fetchImpl: zipResponse({
+          'UnrealMCP/UnrealMCP.uplugin': strToU8(JSON.stringify({ VersionName: PACKAGE_VERSION, EngineVersion: '5.7.0' })),
+        }),
+      }),
+    ).rejects.toThrow(/EngineVersion/i);
   });
 
   it('rejects zip-slip paths in the downloaded archive', async () => {

--- a/cli/tests/update.test.ts
+++ b/cli/tests/update.test.ts
@@ -147,7 +147,7 @@ describe('update', () => {
     expect(calls).toEqual([]);
   });
 
-  it('downloads the packaged plugin zip when no local source exists and the installed version differs', async () => {
+  it('downloads the dedicated source asset when no local source exists and the installed version differs', async () => {
     const project = tmp();
     await update({ projectDir: project, pluginSourceDir: makeSource('0.1.0') });
     const calls: string[] = [];
@@ -155,8 +155,9 @@ describe('update', () => {
       projectDir: project,
       fetchImpl: zipResponse(
         {
-          'UnrealMCP.uplugin': strToU8(JSON.stringify({ VersionName: PACKAGE_VERSION })),
-          'Source/marker.txt': strToU8('downloaded'),
+          'UnrealMCP/UnrealMCP.uplugin': strToU8(JSON.stringify({ VersionName: PACKAGE_VERSION, Installed: false })),
+          'UnrealMCP/Source/marker.txt': strToU8('downloaded'),
+          'UnrealMCP/Source/ThirdParty/UnrealMcpBridge/win-x64/unreal-mcp-bridge.exe': strToU8('BRIDGE'),
         },
         calls,
       ),
@@ -167,7 +168,12 @@ describe('update', () => {
     expect(r.fromVersion).toBe('0.1.0');
     expect(r.toVersion).toBe(PACKAGE_VERSION);
     expect(fs.existsSync(path.join(project, 'Plugins', 'UnrealMCP', 'Source', 'marker.txt'))).toBe(true);
-    expect(calls.some((url) => /unreal-mcp-plugin-/.test(url))).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(project, 'Plugins', 'UnrealMCP', 'Binaries', 'ThirdParty', 'UnrealMcpBridge', 'win-x64', 'unreal-mcp-bridge.exe'),
+      ),
+    ).toBe(true);
+    expect(calls.some((url) => /unreal-mcp-plugin-source-/.test(url))).toBe(true);
   });
 
   // --- issue #58: auto-clean stale build cache on update -------------------

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -563,7 +563,7 @@ UnrealMCP/                                  # plugin root (UnrealMCP.uplugin liv
 ├── Source/ThirdParty/UnrealMcpBridge/      # FAB-SURVIVING source location (#139/#187) — the
 │   └── <rid>/  unreal-mcp-bridge[.exe]     #   engine-canonical Source/ThirdParty/<Lib>/<platform>/
 │      (+ self-contained payload files)     #   layout, declared in Config/FilterPlugin.ini so it ships
-│                                           #   in the source zip (win-x64 / osx-arm64 / osx-x64 / linux-x64)
+│                                           #   in the dedicated source release zip (win-x64 / osx-arm64 / osx-x64 / linux-x64)
 └── Binaries/                               # STAGED location — UBT stages Source/ThirdParty/UnrealMcpBridge/<rid>/
     └── ThirdParty/                         #   here at compile time (RuntimeDependencies two-arg form). Fab
         └── UnrealMcpBridge/                #   STRIPS this whole folder from a source submission, so
@@ -685,8 +685,9 @@ The §1.5 state machine is unchanged in shape; only the `LaunchingSidecar` preco
 `RuntimeDependencies`'s two-arg form, #139/#187), and `.gitignore` keeps the
 `Source/ThirdParty/UnrealMcpBridge/<rid>/` payloads (and `Binaries/`) out of VCS — only the
 `Source/ThirdParty/UnrealMcpBridge/` folder STRUCTURE (`README.md` + per-RID `.gitkeep`) is
-tracked, so the source zip ships the folders while the payloads stay transient. A dev source checkout
-has empty `Source/ThirdParty/UnrealMcpBridge/<rid>/` (and `Binaries/ThirdParty/UnrealMcpBridge/`) → the resolver returns empty →
+tracked in git. The **release-produced** `unreal-mcp-plugin-source-<version>.zip` asset is created
+after staging, so it ships the real payloads; a dev source checkout still has empty
+`Source/ThirdParty/UnrealMcpBridge/<rid>/` (and `Binaries/ThirdParty/UnrealMcpBridge/`) → the resolver returns empty →
 devs use `UNREAL_MCP_BRIDGE_PATH`, exactly as before.
 
 ### 6.7 Fab (Epic marketplace) source-submission readiness (#139/#187)
@@ -702,8 +703,8 @@ all are handled in-repo (issues #139/#187), and submission itself remains an ope
    into `Binaries/ThirdParty/UnrealMcpBridge/<rid>/` by `RuntimeDependencies`, and is ALSO resolved
    directly from `Source/ThirdParty/UnrealMcpBridge/<rid>/` (§6.1 candidate list) so an Epic-compiled build
    resolves it even when `Binaries/` did not re-stage. This does not regress the GitHub-release/npm bundle
-   nor `release.yml`'s signed-binary staging — both now stage into `Source/ThirdParty/UnrealMcpBridge/<rid>/`
-   before BuildPlugin.
+   nor `release.yml`'s signed-binary staging — the dedicated CLI/Fab source asset and the packaged
+   BuildPlugin asset are both cut from the same staged `Source/ThirdParty/UnrealMcpBridge/<rid>/` payloads.
 2. **No shipped test/automation module.** Fab review flags shipped test modules, so the DISTRIBUTED
    `UnrealMCP.uplugin` omits `UnrealMcpEditorTests`. PR/dev CI still runs the `UnrealMcp.` Automation
    specs by transiently re-adding the module via `commands/test-module-uplugin.ps1` (idempotent
@@ -925,8 +926,10 @@ happens in each tool-family task against `Unreal-Test-Project` (Godot tool-wave 
   `RunUAT.bat BuildPlugin -Plugin=UnrealMCP.uplugin -Package=<out> -TargetPlatforms=Win64` (also
   validates marketplace packaging) and then runs the Automation filter against the testbed project.
 - `release.yml` (Godot `release.yml` skeleton: version-from-source job → gate compute → test fan-out
-  → artifact build → gated publish): artifacts = plugin zip (BuildPlugin output, engine-agnostic
-  source plugin), `unreal-mcp-bridge-<rid>.zip` ×4, npm publish, GitHub Release (server zips are
+  → artifact build → gated publish): artifacts = dedicated source plugin zip
+  (`unreal-mcp-plugin-source-<version>.zip`, CLI/Fab install asset), packaged plugin zip
+  (`unreal-mcp-plugin-<version>.zip`, BuildPlugin output with the staged bundle),
+  `unreal-mcp-bridge-<rid>.zip` ×4, npm publish, GitHub Release (server zips are
   released from the shared GameDev-MCP-Server repo, not here — §6).
   **Tag/release firing is Ivan-GATED**; full-rerun-only policy for artifact-passing
   workflows (gh-rerun lesson) documented in `docs/RELEASING.md`. `workflow_dispatch` exposes a

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -10,28 +10,27 @@ The authoritative design is [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) §9
 keep the two in lockstep, and keep the CI command surface 1:1 with the
 implement-task profile `test.md` (infra repo).
 
-## Release checklist — operator-gated leaves (NONE fired automatically)
+## Release checklist — operator-gated leaves
 
 The following actions are **deliberately operator-gated** and are **not** performed by a normal
-merge, by CI on a feature/docs PR, or by any automated task. As of this writing **none of them has
-fired** — Unreal-MCP has no GitHub Release, no `v*` tag, no published npm package, and no Fab
-listing. Each requires a deliberate human decision (and, for the first release, one-time setup):
+merge, by CI on a feature/docs PR, or by any automated task. GitHub Releases and npm publishes are
+now CI-backed once a deliberate version bump lands on `main`, but they still require an intentional
+operator release decision. Fab submission remains fully manual:
 
-- [ ] **First GitHub Release + `v<version>` tag.** Fires only when a deliberate `VersionName` bump
-      lands on `main` (run `commands/bump-version.ps1`, commit, merge) on an untagged version — or a
-      manual `workflow_dispatch` with `dry_run=false`. `release.yml`'s `check-version` gate keeps
-      this inert otherwise. Verify with `gh release list` (expect empty) and
-      `git ls-remote --tags` (expect no `v*` tags) until you intend to publish.
-- [ ] **First npm `unreal-mcp-cli` publish (one-time, manual — operator only).** The first publish of a
-      brand-new package **cannot** use OIDC Trusted Publishing — npm requires the package to already
-      exist on the registry before a Trusted Publisher can be configured for it. So the first publish
-      is a **manual operator step from a clean checkout**; CI takes over for every subsequent version.
-      The `cli/package.json` `private` flag has already been removed and the publish metadata
-      completed (issue #33 prep). The runbook is **[First npm publish](#first-npm-publish-one-time-manual)** below — do NOT run it from CI.
+- [ ] **GitHub Release + `v<version>` tag.** Fires only when a deliberate `VersionName` bump lands on
+      `main` (run `commands/bump-version.ps1`, commit, merge) on an untagged version — or a manual
+      `workflow_dispatch` with `dry_run=false`. `release.yml`'s `check-version` gate keeps this inert
+      otherwise.
+- [ ] **`unreal-mcp-cli` publish.** The initial npm bootstrap was manual; subsequent publishes are
+      CI-owned through `release.yml`'s OIDC `publish-npm` job. Do **not** hand-publish from a feature
+      branch or a normal docs/code PR. The historical one-time bootstrap runbook remains below for
+      reference.
 - [ ] **Fab (Epic marketplace) submission.** Entirely manual and **out of scope of every CI
-      workflow** — the release pipeline produces an engine-agnostic source-plugin zip
-      (BuildPlugin output), but no job submits to Fab. Fab carries its own metadata/screenshot
-      requirements and an Epic review; do it by hand when the listing is ready. The plugin is
+      workflow** — the release pipeline produces both a dedicated source-plugin zip
+      (`unreal-mcp-plugin-source-<version>.zip`, the CLI/Fab install asset) and the packaged
+      BuildPlugin zip (`unreal-mcp-plugin-<version>.zip`), but no job submits to Fab. Fab carries
+      its own metadata/screenshot requirements and an Epic review; do it by hand when the listing
+      is ready. The plugin is
       Fab source-submission READY (#139/#187): the sidecar survives Fab's `Binaries/` strip via
       `Source/ThirdParty/UnrealMcpBridge/<rid>/`, the distributed `.uplugin` ships no test module, and `FilterPlugin.ini`
       is complete — see [Fab source-submission readiness](#fab-epic-marketplace-source-submission-readiness-139187) below.
@@ -46,7 +45,7 @@ hard-skips every tag/Release/npm-publish job.
 | --- | --- | --- |
 | `test_pull_request.yml` | `pull_request` to `main` (+ manual) | Fans out the PR test legs: bridge build+xUnit (ubuntu + windows), cli node 20/22, and — when a runner is registered — the UE 5.7 plugin BuildPlugin + Automation leg. |
 | `test_cli.yml` | `workflow_call` (reusable) | Builds + tests `unreal-mcp-cli` on Node 20 & 22. Called by both `test_pull_request.yml` and `release.yml`. |
-| `release.yml` | `push` to `main` (+ manual `workflow_dispatch`) | Version-gated release: builds + **code-signs** the self-contained bridge per RID, **bundles the signed sidecar into the packaged plugin** (BuildPlugin), and (only on a real version bump) cuts the GitHub Release + tag and publishes `unreal-mcp-cli` to npm. Exposes a `dry_run` input to rehearse everything without publishing. |
+| `release.yml` | `push` to `main` (+ manual `workflow_dispatch`) | Version-gated release: builds + **code-signs** the self-contained bridge per RID, publishes a dedicated **source** plugin asset for CLI/Fab installs, **bundles the signed sidecar into the packaged plugin** (BuildPlugin), and (only on a real version bump) cuts the GitHub Release + tag and publishes `unreal-mcp-cli` to npm. Exposes a `dry_run` input to rehearse everything without publishing. |
 
 ### The signed self-bootstrapping sidecar bundle (release.yml artifact graph)
 
@@ -72,8 +71,10 @@ artifact jobs in `release.yml`:
   stages it into `Binaries/ThirdParty/UnrealMcpBridge/<rid>/` at compile time, the path the C++
   resolver reads — declared on the runtime module in R2 so the bridge bundles into
   packaged GAMES, not just editor packages; see
-  [Packaged-game sidecar bundling](#packaged-game-sidecar-bundling-r2) below), runs
-  `BuildPlugin -Rocket` so the staged binaries are packaged, then zips the plugin.
+  [Packaged-game sidecar bundling](#packaged-game-sidecar-bundling-r2) below), then emits
+  **two plugin zips**: the dedicated source install asset
+  `unreal-mcp-plugin-source-<version>.zip` (CLI/Fab source form, no `EngineVersion` pin, no test module)
+  and the packaged BuildPlugin asset `unreal-mcp-plugin-<version>.zip`.
   A post-BuildPlugin guard copies the binaries from `Source/ThirdParty/UnrealMcpBridge/<rid>/` into the
   package's `Binaries/ThirdParty/...` output if `RuntimeDependencies` did not stage
   them, and asserts the surviving `Source/ThirdParty/UnrealMcpBridge/<rid>/` payload shipped (the form Epic's
@@ -163,10 +164,11 @@ an entirely manual operator step (no CI job submits — see the checklist at the
   `"PlatformAllowList": ["Win64","Mac","Linux"]` (desktop-only — console/mobile cannot spawn the .NET
   sidecar), which Fab review expects.
 
-**Manual Fab submission (operator):** run `BuildPlugin -Rocket` against the committed
-(distributed, test-free) `UnrealMCP.uplugin` with the signed `Source/ThirdParty/UnrealMcpBridge/<rid>/` payloads
-in place, verify the package carries `Source/ThirdParty/UnrealMcpBridge/<rid>/` + a test-free `.uplugin`, then
-upload the source zip to Fab. **Do not bump `VersionName` for a Fab submission** unless
+**Manual Fab submission (operator):** prefer the release-produced
+`unreal-mcp-plugin-source-<version>.zip` asset — it is the distributed, test-free source form with
+the signed `Source/ThirdParty/UnrealMcpBridge/<rid>/` payloads already staged. If you must rebuild it
+locally, verify the source zip carries `Source/ThirdParty/UnrealMcpBridge/<rid>/` + a test-free `.uplugin`,
+then upload that source zip to Fab. **Do not bump `VersionName` for a Fab submission** unless
 it is also a coordinated release (the version is release-pipeline-owned).
 
 **Graceful degradation:** every sign/notarize step is `if: env.X != ''`-guarded.
@@ -247,14 +249,13 @@ legs run only if the self-hosted runner is registered (otherwise skipped);
 `publish-release` and `publish-npm` are **skipped**. A dry-run is the right way
 to confirm the bundle staging works end-to-end: when the runner is ready,
 inspect `build-plugin-zip`'s log for the per-RID "Packaged bridge for <rid>: N
-file(s)." lines (and download the `unreal-mcp-plugin-zip` artifact to confirm
-`Binaries/ThirdParty/UnrealMcpBridge/<rid>/` is populated for all four RIDs).
-Verify nothing was published:
-
-```bash
-gh release list --repo IvanMurzak/Unreal-MCP     # expect: empty
-git ls-remote --tags https://github.com/IvanMurzak/Unreal-MCP   # expect: no v* tags
-```
+file(s)." lines, then download both the `unreal-mcp-plugin-source-zip` artifact
+(to confirm `Source/ThirdParty/UnrealMcpBridge/<rid>/` shipped without an
+`EngineVersion` pin) and the `unreal-mcp-plugin-packaged-zip` artifact (to
+confirm `Binaries/ThirdParty/UnrealMcpBridge/<rid>/` is populated for all four
+RIDs).
+Verify the `publish-release` and `publish-npm` jobs were skipped. A dry-run should upload artifacts
+only; it must not create a new tag, GitHub Release, or npm publish for the current `VersionName`.
 
 ## First npm publish (one-time, manual)
 


### PR DESCRIPTION
## Summary
- switch unreal-mcp-cli installs to a dedicated `unreal-mcp-plugin-source-<version>.zip` asset
- materialize the bundled bridge from `Source/ThirdParty` into `Binaries/ThirdParty` and migrate legacy packaged installs safely
- publish both the source install asset and the packaged plugin zip in `release.yml`, with docs/tests updated accordingly

## Validation
- npm run build
- npm test