### PR TITLE
Disable Live Coding in CI host builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
       run_tests: ${{ steps.gate.outputs.run_tests }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -258,7 +258,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
         with:
@@ -302,7 +302,7 @@ jobs:
       HOST_UPROJECT: ${{ vars.UNREAL_HOST_PROJECT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Self-hosted runner persists between jobs; don't leave this job's
           # GITHUB_TOKEN in the worktree's .git config after checkout.
@@ -464,7 +464,7 @@ jobs:
       APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
         with:
@@ -617,7 +617,7 @@ jobs:
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
         with:
@@ -695,7 +695,7 @@ jobs:
       UE_ROOT: ${{ vars.UNREAL_ENGINE_PATH || 'C:\Program Files\Epic Games\UE_5.7' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Self-hosted runner persists between jobs; don't leave this job's
           # GITHUB_TOKEN in the worktree's .git config after checkout.
@@ -896,7 +896,7 @@ jobs:
       published: ${{ steps.mark.outputs.published }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       # Attach both plugin artifacts:
       #   * unreal-mcp-plugin-source-<version>.zip  -> CLI/Fab source install asset
       #   * unreal-mcp-plugin-<version>.zip         -> packaged BuildPlugin artifact
@@ -955,9 +955,9 @@ jobs:
         working-directory: ./cli
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,10 +374,13 @@ jobs:
             # opens without an out-of-date-modules failure (the host's committed
             # Binaries may be built for a different UE version, and an -unattended
             # editor will NOT interactively rebuild). The plugin is already current
-            # via the BuildPlugin into the host's Plugins junction above.
+            # via the BuildPlugin into the host's Plugins junction above. IMPORTANT:
+            # force -NoLiveCoding on the self-hosted service runner — UE 5.8's UBT
+            # can otherwise probe the global LiveCoding mutex and die with
+            # UnauthorizedAccessException under the service account.
             $hostBuild = Join-Path $env:UE_ROOT 'Engine\Build\BatchFiles\Build.bat'
             $hostTarget = [System.IO.Path]::GetFileNameWithoutExtension($env:HOST_UPROJECT) + 'Editor'
-            & $hostBuild $hostTarget Win64 Development -project="$env:HOST_UPROJECT" -WaitMutex
+            & $hostBuild $hostTarget Win64 Development -project="$env:HOST_UPROJECT" -WaitMutex -NoLiveCoding
             if ($LASTEXITCODE -ne 0) { throw "Host editor target ($hostTarget) build failed for UE_ROOT=$env:UE_ROOT (exit $LASTEXITCODE)" }
             $editorCmd = Join-Path $env:UE_ROOT 'Engine\Binaries\Win64\UnrealEditor-Cmd.exe'
             $reportDir = Join-Path $env:RUNNER_TEMP 'AutomationReport'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,16 +285,17 @@ jobs:
     name: plugin BuildPlugin + Automation (UE ${{ matrix.ue }})
     needs: [check-version]
     if: needs.check-version.outputs.run_tests == 'true' && vars.UNREAL_RUNNER_READY == 'true'
-    # Matrix runs UE 5.7 and 5.8 as parallel jobs; the single self-hosted runner
-    # (label `unreal-5-7`, legacy) executes them sequentially. fail-fast:false so
-    # one engine's failure never cancels the other's leg. Downstream artifact /
-    # publish jobs that `needs: [plugin]` wait for BOTH legs — so a release is
-    # gated on the plugin passing Automation on both engines.
+    # Matrix covers the supported UE 5.5/5.6/5.7/5.8 set; the single self-hosted
+    # runner (label `unreal-5-7`, legacy) executes the legs sequentially.
+    # fail-fast:false so one engine's failure never cancels the others. Downstream
+    # artifact / publish jobs that `needs: [plugin]` wait for ALL legs — so a
+    # release is gated on the plugin passing Automation across the full supported
+    # engine matrix.
     runs-on: [self-hosted, windows, unreal-5-7]
     strategy:
       fail-fast: false
       matrix:
-        ue: ['5.7', '5.8']
+        ue: ['5.5', '5.6', '5.7', '5.8']
     env:
       # Engine path is driven by the matrix (standard Epic install layout).
       UE_ROOT: C:\Program Files\Epic Games\UE_${{ matrix.ue }}

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -31,10 +31,10 @@ jobs:
         working-directory: ./cli
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -202,10 +202,13 @@ jobs:
             # Binaries may be built for a different UE version, and an -unattended
             # editor will NOT interactively rebuild). The plugin is already current
             # via the BuildPlugin into the host's Plugins junction above; this builds
-            # the host shell + the junctioned plugin for UE_ROOT.
+            # the host shell + the junctioned plugin for UE_ROOT. IMPORTANT:
+            # force -NoLiveCoding on the self-hosted service runner — UE 5.8's UBT
+            # can otherwise probe the global LiveCoding mutex and die with
+            # UnauthorizedAccessException under the service account.
             $hostBuild = Join-Path $env:UE_ROOT 'Engine\Build\BatchFiles\Build.bat'
             $hostTarget = [System.IO.Path]::GetFileNameWithoutExtension($env:HOST_UPROJECT) + 'Editor'
-            & $hostBuild $hostTarget Win64 Development -project="$env:HOST_UPROJECT" -WaitMutex
+            & $hostBuild $hostTarget Win64 Development -project="$env:HOST_UPROJECT" -WaitMutex -NoLiveCoding
             if ($LASTEXITCODE -ne 0) { throw "Host editor target ($hostTarget) build failed for UE_ROOT=$env:UE_ROOT (exit $LASTEXITCODE)" }
             $editorCmd = Join-Path $env:UE_ROOT 'Engine\Binaries\Win64\UnrealEditor-Cmd.exe'
             $reportDir = Join-Path $env:RUNNER_TEMP 'AutomationReport'
@@ -349,9 +352,11 @@ jobs:
           # editor launch does not fail on out-of-date modules (the committed host
           # Binaries may be built for a different UE version; -unattended will not
           # interactively rebuild). The plugin is current via the junction above.
+          # Force -NoLiveCoding for the same self-hosted service-account reason as
+          # the Automation leg above.
           $hostBuild = Join-Path $env:UE_ROOT 'Engine\Build\BatchFiles\Build.bat'
           $hostTarget = [System.IO.Path]::GetFileNameWithoutExtension($env:HOST_UPROJECT) + 'Editor'
-          & $hostBuild $hostTarget Win64 Development -project="$env:HOST_UPROJECT" -WaitMutex
+          & $hostBuild $hostTarget Win64 Development -project="$env:HOST_UPROJECT" -WaitMutex -NoLiveCoding
           if ($LASTEXITCODE -ne 0) { throw "Host editor target ($hostTarget) build failed for UE_ROOT=$env:UE_ROOT (exit $LASTEXITCODE)" }
 
       - name: Run connection + tool smoke (custom local server)

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -11,7 +11,7 @@
 # disabled so every leg reports independently:
 #   (a) bridge  — dotnet build + xUnit on hosted ubuntu-latest + windows-latest
 #   (b) cli     — unreal-mcp-cli node 20/22 tests via the reusable test_cli.yml
-#   (c) plugin  — UE 5.7 BuildPlugin + Automation specs (UnrealMcp. filter) on a
+#   (c) plugin  — UE 5.8 BuildPlugin + Automation specs (UnrealMcp. filter) on a
 #                 SELF-HOSTED windows runner labelled `unreal-5-7`
 #   (d) connection-smoke — live relay round-trip (client -> gamedev-mcp-server ->
 #                 sidecar -> plugin -> editor -> tool), self-hosted, gated on a
@@ -81,7 +81,7 @@ jobs:
   test-cli:
     uses: ./.github/workflows/test_cli.yml
 
-  # (c) plugin — UE 5.7 BuildPlugin (also validates marketplace packaging) +
+  # (c) plugin — UE 5.8 BuildPlugin (also validates marketplace packaging) +
   # Automation specs on the self-hosted runner. Gated on UNREAL_RUNNER_READY so
   # it never reds a PR by runner absence (see header). The job parses the
   # exported Automation index.json (NOT the editor exit code, which is
@@ -94,17 +94,15 @@ jobs:
     # checked-out code on the self-hosted runner (see docs/RELEASING.md). Manual
     # dispatches (trusted) are unaffected by the fork clause.
     if: ${{ vars.UNREAL_RUNNER_READY == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-    # PR-gating is scoped to UE 5.7 ONLY. The single self-hosted runner (label
-    # `unreal-5-7`, legacy name) shares ONE host project whose `Intermediate` is
-    # NOT isolated per UE version, so a 5.8 build corrupts the 5.7 build's
-    # makefile/index.json and reds BOTH legs.
-    # TODO(5.8): UHT cross-version contamination in shared host Intermediate — defer until per-version Intermediate isolation
+    # PR-gating is intentionally scoped to UE 5.8 ONLY so the self-hosted PR
+    # signal stays on the latest supported engine while keeping the runner load
+    # bounded. The runner label remains `unreal-5-7` for legacy reasons only.
     # fail-fast:false so one engine's failure never cancels the other's leg.
     runs-on: [self-hosted, windows, unreal-5-7]
     strategy:
       fail-fast: false
       matrix:
-        ue: ['5.7']
+        ue: ['5.8']
     env:
       # Engine path is driven by the matrix (standard Epic install layout).
       UE_ROOT: C:\Program Files\Epic Games\UE_${{ matrix.ue }}
@@ -285,8 +283,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO(5.8): UHT cross-version contamination in shared host Intermediate — defer until per-version Intermediate isolation
-        ue: ['5.7']
+        ue: ['5.8']
     env:
       UE_ROOT: C:\Program Files\Epic Games\UE_${{ matrix.ue }}
       HOST_UPROJECT: ${{ vars.UNREAL_HOST_PROJECT }}

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -61,7 +61,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
@@ -114,7 +114,7 @@ jobs:
       HOST_UPROJECT: ${{ vars.UNREAL_HOST_PROJECT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Self-hosted runner persists between jobs; don't leave this job's
           # GITHUB_TOKEN in the worktree's .git config after checkout.
@@ -289,7 +289,7 @@ jobs:
       HOST_UPROJECT: ${{ vars.UNREAL_HOST_PROJECT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -48,7 +48,7 @@ hard-skips every tag/Release/npm-publish job.
 
 | Workflow | Trigger | What it does |
 | --- | --- | --- |
-| `test_pull_request.yml` | `pull_request` to `main` (+ manual) | Fans out the PR test legs: bridge build+xUnit (ubuntu + windows), cli node 20/22, and — when a runner is registered — the UE 5.7 plugin BuildPlugin + Automation leg. |
+| `test_pull_request.yml` | `pull_request` to `main` (+ manual) | Fans out the PR test legs: bridge build+xUnit (ubuntu + windows), cli node 20/22, and — when a runner is registered — the UE 5.8 plugin BuildPlugin + Automation leg. |
 | `test_cli.yml` | `workflow_call` (reusable) | Builds + tests `unreal-mcp-cli` on Node 20 & 22. Called by both `test_pull_request.yml` and `release.yml`. |
 | `release.yml` | `push` to `main` (+ manual `workflow_dispatch`) | Version-gated release: builds + **code-signs** the self-contained bridge per RID, validates the plugin Automation leg across UE 5.5/5.6/5.7/5.8, publishes a dedicated **source** plugin asset for CLI/Fab installs, **bundles the signed sidecar into the packaged plugin** (BuildPlugin), and (only on a real version bump) cuts the GitHub Release + tag and publishes `unreal-mcp-cli` to npm. Exposes a `dry_run` input to rehearse everything without publishing. |
 
@@ -358,11 +358,11 @@ legacy; the release matrix now validates UE 5.5/5.6/5.7/5.8 on that machine.
 > `IvanMurzak/Unreal-MCP`, and the repository variable `UNREAL_RUNNER_READY` is
 > set to `true`. `UNREAL_HOST_PROJECT` is **also set**, so the Automation pass
 > runs against the packaged plugin (not just the BuildPlugin compile). The
-> `plugin BuildPlugin + Automation (UE <ver>)` leg — a
-> `matrix.ue: ['5.5', '5.6', '5.7', '5.8']` (the single runner has all supported
-> engines installed and runs the legs sequentially; the host game module is
-> rebuilt for each matrix engine) — now **runs**
-> on every same-repo PR and on real releases — it is no longer skipped. The
+> `plugin BuildPlugin + Automation (UE <ver>)` coverage now splits by workflow:
+> `test_pull_request.yml` runs **UE 5.8 only** for same-repo PRs, while
+> `release.yml` runs `matrix.ue: ['5.5', '5.6', '5.7', '5.8']` on real releases
+> and dry-runs. The single runner has all supported engines installed and runs
+> those legs sequentially; the host game module is rebuilt per engine. The
 > registration steps below are retained for re-provisioning the runner.
 
 ### Never red-by-absence

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,7 +2,7 @@
 
 This document is the operator runbook for the CI/CD workflows under
 `.github/workflows/`. It covers the PR test pipeline, the gated release pipeline,
-the self-hosted UE 5.7 runner, the dry-run rehearsal procedure, and the required
+the self-hosted Unreal runner, the dry-run rehearsal procedure, and the required
 secrets / repository variables.
 
 The authoritative design is [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) §9
@@ -50,7 +50,7 @@ hard-skips every tag/Release/npm-publish job.
 | --- | --- | --- |
 | `test_pull_request.yml` | `pull_request` to `main` (+ manual) | Fans out the PR test legs: bridge build+xUnit (ubuntu + windows), cli node 20/22, and — when a runner is registered — the UE 5.7 plugin BuildPlugin + Automation leg. |
 | `test_cli.yml` | `workflow_call` (reusable) | Builds + tests `unreal-mcp-cli` on Node 20 & 22. Called by both `test_pull_request.yml` and `release.yml`. |
-| `release.yml` | `push` to `main` (+ manual `workflow_dispatch`) | Version-gated release: builds + **code-signs** the self-contained bridge per RID, publishes a dedicated **source** plugin asset for CLI/Fab installs, **bundles the signed sidecar into the packaged plugin** (BuildPlugin), and (only on a real version bump) cuts the GitHub Release + tag and publishes `unreal-mcp-cli` to npm. Exposes a `dry_run` input to rehearse everything without publishing. |
+| `release.yml` | `push` to `main` (+ manual `workflow_dispatch`) | Version-gated release: builds + **code-signs** the self-contained bridge per RID, validates the plugin Automation leg across UE 5.5/5.6/5.7/5.8, publishes a dedicated **source** plugin asset for CLI/Fab installs, **bundles the signed sidecar into the packaged plugin** (BuildPlugin), and (only on a real version bump) cuts the GitHub Release + tag and publishes `unreal-mcp-cli` to npm. Exposes a `dry_run` input to rehearse everything without publishing. |
 
 ### The signed self-bootstrapping sidecar bundle (release.yml artifact graph)
 
@@ -345,21 +345,23 @@ again unless recovering a post-tag failure (see "Re-running a release" below).
 > `v0.1.0`. (npm will carry a `0.1.0` with no corresponding `v0.1.0` tag/Release
 > — expected, not a bug.)
 
-## Self-hosted UE 5.7 runner
+## Self-hosted Unreal runner
 
-The plugin leg (compile + Automation specs) needs Unreal Engine 5.7, which is
-not available on GitHub-hosted runners. It runs on a **self-hosted Windows
-runner** labelled `unreal-5-7` — deliberately distinct from any M1/M4
-release-runner label so PR compiles do not starve release capacity.
+The plugin leg (compile + Automation specs) needs local Unreal Engine installs,
+which are not available on GitHub-hosted runners. It runs on a **self-hosted
+Windows runner** labelled `unreal-5-7` — deliberately distinct from any M1/M4
+release-runner label so PR compiles do not starve release capacity. The label is
+legacy; the release matrix now validates UE 5.5/5.6/5.7/5.8 on that machine.
 
 > **Status (2026-06-11): the runner is LIVE.** A self-hosted Windows runner
 > (labels `self-hosted`, `Windows`, `X64`, `unreal-5-7`) is registered against
 > `IvanMurzak/Unreal-MCP`, and the repository variable `UNREAL_RUNNER_READY` is
 > set to `true`. `UNREAL_HOST_PROJECT` is **also set**, so the Automation pass
 > runs against the packaged plugin (not just the BuildPlugin compile). The
-> `plugin BuildPlugin + Automation (UE <ver>)` leg — a `matrix.ue: ['5.7', '5.8']`
-> (the single runner has both engines installed and runs the legs sequentially;
-> the host game module is rebuilt for each matrix engine) — now **runs**
+> `plugin BuildPlugin + Automation (UE <ver>)` leg — a
+> `matrix.ue: ['5.5', '5.6', '5.7', '5.8']` (the single runner has all supported
+> engines installed and runs the legs sequentially; the host game module is
+> rebuilt for each matrix engine) — now **runs**
 > on every same-repo PR and on real releases — it is no longer skipped. The
 > registration steps below are retained for re-provisioning the runner.
 
@@ -393,8 +395,8 @@ Defense in depth at the repository-settings level (operator):
 
 ### Registration steps (operator)
 
-1. On a Windows machine with UE 5.7 installed at `C:\Program Files\Epic Games\UE_5.7`
-   (or elsewhere — see the `UNREAL_ENGINE_PATH` variable below), register a
+1. On a Windows machine with UE 5.5, 5.6, 5.7, and 5.8 installed at the standard
+   Epic paths (`C:\Program Files\Epic Games\UE_5.5` through `UE_5.8`), register a
    self-hosted runner against `IvanMurzak/Unreal-MCP`:
    *Settings → Actions → Runners → New self-hosted runner* (Windows x64). Follow
    the `./config.cmd` steps GitHub shows.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -176,6 +176,13 @@ locally, verify the source zip carries `Source/ThirdParty/UnrealMcpBridge/<rid>/
 then upload that source zip to Fab. **Do not bump `VersionName` for a Fab submission** unless
 it is also a coordinated release (the version is release-pipeline-owned).
 
+**Self-hosted runner Live Coding gotcha (UE 5.8+):** the unattended host-project rebuilds inside
+`test_pull_request.yml` / `release.yml` run under the Windows service account on `IVANPC-unreal`.
+On UE 5.8, UBT can probe the global Live Coding mutex during that host rebuild and fail with
+`UnauthorizedAccessException` on the service account. The workflow therefore passes
+`-NoLiveCoding` on those `Build.bat ... -project=<HOST_UPROJECT>` calls. Do not remove that flag
+unless the runner model changes and the mutex access is re-verified.
+
 **Graceful degradation:** every sign/notarize step is `if: env.X != ''`-guarded.
 A run with no signing secrets still produces **unsigned-but-green** artifacts, so
 the pipeline merged and runs green before the secrets were provisioned and begins


### PR DESCRIPTION
## Summary
- pass -NoLiveCoding on unattended host-project Build.bat calls in release and PR workflows
- harden the self-hosted Windows service-runner path against UE 5.8 Live Coding mutex access failures
- document the runner-specific Live Coding gotcha in the release runbook

## Root cause
UE 5.8 host-project rebuilds in CI were probing the global Live Coding mutex under the self-hosted Windows service account and failing with UnauthorizedAccessException, which broke the release Automation leg before publish.