### PR TITLE
Fix Unreal CI engine compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@
 #                        unreal-mcp-plugin-source-<version>.zip, runs BuildPlugin -Rocket
 #                        (RuntimeDependencies stage Source/ThirdParty/UnrealMcpBridge/ ->
 #                        Binaries/ThirdParty/UnrealMcpBridge/<rid>/), zips the PACKAGED
-#                        plugin as unreal-mcp-plugin-<version>.zip ->
+#                        plugin with the latest supported UE as unreal-mcp-plugin-<version>.zip ->
 #                        publish-release attaches both plugin zips + the 4 signed bridge zips.
 # Signing is GRACEFULLY DEGRADING: every sign/notarize step is `if: env.X != ''`
 # guarded, so a run with NO secrets produces UNSIGNED-but-green artifacts. The
@@ -331,6 +331,20 @@ jobs:
             if ($mods -contains 'UnrealMcpEditorTests') {
               throw "Distributed package SHIPS UnrealMcpEditorTests — Fab review would flag it (C2 regression)."
             }
+          }
+      - name: Resolve runner-local host project
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $runnerRoot = Split-Path -Parent (Split-Path -Parent $env:RUNNER_TEMP)
+          $runnerLocalHost = Join-Path $runnerRoot 'host\UnrealTestProject\UnrealTestProject.uproject'
+          if (Test-Path $runnerLocalHost) {
+            "HOST_UPROJECT=$runnerLocalHost" >> $env:GITHUB_ENV
+            Write-Host "Using runner-local host project: $runnerLocalHost"
+          } elseif (-not [string]::IsNullOrWhiteSpace($env:HOST_UPROJECT) -and (Test-Path $env:HOST_UPROJECT)) {
+            Write-Host "Using UNREAL_HOST_PROJECT fallback: $env:HOST_UPROJECT"
+          } else {
+            throw "No host .uproject found. Expected runner-local '$runnerLocalHost' or a valid UNREAL_HOST_PROJECT repo variable."
           }
       - name: Run Automation specs (UnrealMcp. filter — test module rebuilt in)
         shell: pwsh
@@ -680,19 +694,23 @@ jobs:
   # `unreal-mcp-plugin-source-<version>.zip` (CLI/Fab install path, no
   # EngineVersion pin, test-free descriptor) AND the PACKAGED BuildPlugin asset
   # `unreal-mcp-plugin-<version>.zip` with the signed bridge bundled in under
-  # Binaries/ThirdParty/. Self-hosted, gated like the plugin test job. Skipped
-  # when no runner is registered; for a real release the runner must be ready
-  # (publish-release `needs` this job). Depends on the two signed-bridge jobs so
-  # the 4 signed RID payloads can be staged into the plugin tree before the
-  # source asset is cut and BuildPlugin packages them (docs/ARCHITECTURE.md §6
-  # BUNDLE model, T4).
+  # Binaries/ThirdParty/. The single packaged artifact is built with the latest
+  # supported UE; the source artifact stays engine-version unpinned and the
+  # release matrix still validates the lower supported engines. Self-hosted,
+  # gated like the plugin test job. Skipped when no runner is registered; for a
+  # real release the runner must be ready (publish-release `needs` this job).
+  # Depends on the plugin matrix so its UE 5.8 BuildPlugin cannot overlap the UE
+  # 5.8 validation leg on the same machine's AutomationTool lock. Also depends
+  # on the two signed-bridge jobs so the 4 signed RID payloads can be staged into
+  # the plugin tree before the source asset is cut and BuildPlugin packages them
+  # (docs/ARCHITECTURE.md §6 BUNDLE model, T4).
   build-plugin-zip:
-    name: build plugin release zips (UE 5.7)
-    needs: [check-version, build-bridge-macos, build-bridge-windows]
+    name: build plugin release zips (UE 5.8)
+    needs: [check-version, plugin, build-bridge-macos, build-bridge-windows]
     if: needs.check-version.outputs.run_tests == 'true' && vars.UNREAL_RUNNER_READY == 'true'
     runs-on: [self-hosted, windows, unreal-5-7]
     env:
-      UE_ROOT: ${{ vars.UNREAL_ENGINE_PATH || 'C:\Program Files\Epic Games\UE_5.7' }}
+      UE_ROOT: ${{ vars.UNREAL_ENGINE_PATH || 'C:\Program Files\Epic Games\UE_5.8' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -148,6 +148,21 @@ jobs:
             }
           }
 
+      - name: Resolve runner-local host project
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $runnerRoot = Split-Path -Parent (Split-Path -Parent $env:RUNNER_TEMP)
+          $runnerLocalHost = Join-Path $runnerRoot 'host\UnrealTestProject\UnrealTestProject.uproject'
+          if (Test-Path $runnerLocalHost) {
+            "HOST_UPROJECT=$runnerLocalHost" >> $env:GITHUB_ENV
+            Write-Host "Using runner-local host project: $runnerLocalHost"
+          } elseif (-not [string]::IsNullOrWhiteSpace($env:HOST_UPROJECT) -and (Test-Path $env:HOST_UPROJECT)) {
+            Write-Host "Using UNREAL_HOST_PROJECT fallback: $env:HOST_UPROJECT"
+          } else {
+            throw "No host .uproject found. Expected runner-local '$runnerLocalHost' or a valid UNREAL_HOST_PROJECT repo variable."
+          }
+
       - name: Run Automation specs (UnrealMcp. filter — test module rebuilt in)
         shell: pwsh
         run: |
@@ -278,6 +293,7 @@ jobs:
   #     release job does).
   connection-smoke:
     name: connection + tool smoke (UE ${{ matrix.ue }}, custom server)
+    needs: [plugin]
     if: ${{ vars.UNREAL_SMOKE_READY == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: [self-hosted, windows, unreal-5-7]
     strategy:
@@ -310,6 +326,21 @@ jobs:
           $bridge = Join-Path $env:GITHUB_WORKSPACE 'bridge\src\bin\Debug\net9.0\unreal-mcp-bridge.exe'
           if (-not (Test-Path $bridge)) { throw "bridge binary not found at $bridge" }
           echo "UNREAL_MCP_BRIDGE_PATH=$bridge" >> $env:GITHUB_ENV
+
+      - name: Resolve runner-local host project
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $runnerRoot = Split-Path -Parent (Split-Path -Parent $env:RUNNER_TEMP)
+          $runnerLocalHost = Join-Path $runnerRoot 'host\UnrealTestProject\UnrealTestProject.uproject'
+          if (Test-Path $runnerLocalHost) {
+            "HOST_UPROJECT=$runnerLocalHost" >> $env:GITHUB_ENV
+            Write-Host "Using runner-local host project: $runnerLocalHost"
+          } elseif (-not [string]::IsNullOrWhiteSpace($env:HOST_UPROJECT) -and (Test-Path $env:HOST_UPROJECT)) {
+            Write-Host "Using UNREAL_HOST_PROJECT fallback: $env:HOST_UPROJECT"
+          } else {
+            throw "No host .uproject found. Expected runner-local '$runnerLocalHost' or a valid UNREAL_HOST_PROJECT repo variable."
+          }
 
       - name: BuildPlugin into the host junction target
         shell: pwsh

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpBlueprintTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpBlueprintTools.cpp
@@ -32,7 +32,11 @@
 #include "Misc/PackageName.h"
 #include "Logging/TokenizedMessage.h"
 #include "Misc/UObjectToken.h"
+#if __has_include("Misc/StringOutputDevice.h")
 #include "Misc/StringOutputDevice.h"
+#else
+#include "Containers/UnrealString.h"
+#endif
 
 /**
  * The Blueprint tool family (docs/ARCHITECTURE.md §10). MVP floor — read + structure-edit + compile +

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpEditorTools.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Tools/UnrealMcpEditorTools.cpp
@@ -18,7 +18,11 @@
 #include "Engine/World.h"
 #include "GameFramework/Actor.h"
 #include "Misc/PackageName.h"
+#if __has_include("Misc/StringOutputDevice.h")
 #include "Misc/StringOutputDevice.h"
+#else
+#include "Containers/UnrealString.h"
+#endif
 #include "PlayInEditorDataTypes.h"
 #include "ScopedTransaction.h"
 #include "UObject/Class.h"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -69,7 +69,7 @@ artifact jobs in `release.yml`:
   self-contained and signs the `.exe` via **Azure Trusted Signing**, then uploads
   the raw signed dir + the release zip. (signtool is Windows-only; codesign /
   notarytool are macOS-only — hence the two-runner split.)
-- **`build-plugin-zip`** (self-hosted UE 5.7) — downloads the four signed RID
+- **`build-plugin-zip`** (self-hosted UE 5.8) — downloads the four signed RID
   dirs, **stages them into the Fab-surviving `UnrealMCP/Source/ThirdParty/UnrealMcpBridge/<rid>/`**
   (#139/#187 — the engine-canonical `Source/ThirdParty/` folder declared in `Config/FilterPlugin.ini`
   that survives a Fab strip; the `UnrealMcpRuntime.Build.cs` `RuntimeDependencies` two-arg form then
@@ -83,7 +83,9 @@ artifact jobs in `release.yml`:
   A post-BuildPlugin guard copies the binaries from `Source/ThirdParty/UnrealMcpBridge/<rid>/` into the
   package's `Binaries/ThirdParty/...` output if `RuntimeDependencies` did not stage
   them, and asserts the surviving `Source/ThirdParty/UnrealMcpBridge/<rid>/` payload shipped (the form Epic's
-  Fab recompile stages from).
+  Fab recompile stages from). The packaged zip job waits for the plugin matrix
+  so its UE 5.8 `BuildPlugin` run does not overlap the UE 5.8 validation leg on
+  the same machine's AutomationTool lock.
 
 ### Packaged-game sidecar bundling (R2)
 
@@ -353,16 +355,22 @@ Windows runner** labelled `unreal-5-7` — deliberately distinct from any M1/M4
 release-runner label so PR compiles do not starve release capacity. The label is
 legacy; the release matrix now validates UE 5.5/5.6/5.7/5.8 on that machine.
 
-> **Status (2026-06-11): the runner is LIVE.** A self-hosted Windows runner
-> (labels `self-hosted`, `Windows`, `X64`, `unreal-5-7`) is registered against
+> **Status (2026-06-11): the runner is LIVE.** Self-hosted Windows runners
+> (labels `self-hosted`, `Windows`, `X64`, `unreal-5-7`) are registered against
 > `IvanMurzak/Unreal-MCP`, and the repository variable `UNREAL_RUNNER_READY` is
-> set to `true`. `UNREAL_HOST_PROJECT` is **also set**, so the Automation pass
-> runs against the packaged plugin (not just the BuildPlugin compile). The
+> set to `true`. Each runner should carry its own
+> `<runner-root>\host\UnrealTestProject\UnrealTestProject.uproject`; the
+> workflows prefer that runner-local host and keep `UNREAL_HOST_PROJECT` only as
+> a fallback. That keeps parallel Automation jobs from sharing one mutable
+> `Plugins\UnrealMCP` junction while still exercising the packaged plugin. The
 > `plugin BuildPlugin + Automation (UE <ver>)` coverage now splits by workflow:
 > `test_pull_request.yml` runs **UE 5.8 only** for same-repo PRs, while
 > `release.yml` runs `matrix.ue: ['5.5', '5.6', '5.7', '5.8']` on real releases
-> and dry-runs. The single runner has all supported engines installed and runs
-> those legs sequentially; the host game module is rebuilt per engine. The
+> and dry-runs. Multiple registered runners can process those legs in parallel;
+> the host game module is rebuilt per engine on each runner-local host. The
+> PR smoke job waits for the plugin job, because both use UE 5.8 `RunUAT` on the
+> same machine and Unreal's AutomationTool permits only one same-engine instance
+> at a time.
 > registration steps below are retained for re-provisioning the runner.
 
 ### Never red-by-absence
@@ -401,9 +409,10 @@ Defense in depth at the repository-settings level (operator):
    *Settings → Actions → Runners → New self-hosted runner* (Windows x64). Follow
    the `./config.cmd` steps GitHub shows.
 2. Give the runner the labels `self-hosted`, `windows`, and **`unreal-5-7`**.
-3. Prepare a host `.uproject` on the runner that has the `UnrealMCP` plugin
-   available (the analog of the infra `Unreal-Test-Project/`, plugin junctioned
-   or copied into its `Plugins/`). Note its absolute path.
+3. Prepare a host `.uproject` under that runner root at
+   `host\UnrealTestProject\UnrealTestProject.uproject`. For multiple runners,
+   copy the host project into each runner root so parallel jobs do not share the
+   same `Plugins\UnrealMCP` junction.
 4. Set the repository variables (below).
 5. Open a throwaway PR (or re-run an existing one) and confirm the `plugin` leg
    now runs and is green.
@@ -416,9 +425,9 @@ Set via `gh variable set --repo IvanMurzak/Unreal-MCP <NAME> --body <VALUE>`
 | Variable | Required | Purpose |
 | --- | --- | --- |
 | `UNREAL_RUNNER_READY` | to enable the plugin legs | **Currently `true`** — a `unreal-5-7` runner is registered (2026-06-11), so the plugin legs run. Unset/anything-else → plugin legs skip. |
-| `UNREAL_ENGINE_PATH` | optional | UE 5.7 install root on the runner. Defaults to `C:\Program Files\Epic Games\UE_5.7`. |
-| `UNREAL_HOST_PROJECT` | for the Automation pass | **Currently set (2026-06-11)** — absolute path on the runner to the host `.uproject` (with the UnrealMCP plugin) the Automation specs run against (`C:\actions-runner-unreal\host\UnrealTestProject\UnrealTestProject.uproject`, whose `Plugins\UnrealMCP` junctions to the BuildPlugin package output in the runner workspace temp, so Automation exercises the PR's packaged plugin). |
-| `UNREAL_SMOKE_READY` | to enable the `connection-smoke` leg | Gates the live relay round-trip leg (client → `gamedev-mcp-server` → sidecar → plugin → editor → tool, via `scripts/connection_smoke.py --mode custom`). **Separate from `UNREAL_RUNNER_READY`** so the smoke leg stays SKIPPED — never red-by-absence — until validated once on the runner. The leg builds the bridge (→ `UNREAL_MCP_BRIDGE_PATH`), runs its own `BuildPlugin` into the `UNREAL_HOST_PROJECT` junction target (`$RUNNER_TEMP\UnrealMCP-Package`), downloads the public `gamedev-mcp-server` release, and asserts a tool battery. Set to `true` to enable; reuses `UNREAL_HOST_PROJECT` + `UNREAL_ENGINE_PATH`. |
+| `UNREAL_ENGINE_PATH` | optional | Packaged-plugin UE install root on the runner. Defaults to the latest supported engine, `C:\Program Files\Epic Games\UE_5.8`. |
+| `UNREAL_HOST_PROJECT` | fallback only | Optional fallback absolute path for older single-runner setups. Current workflows first look for `<runner-root>\host\UnrealTestProject\UnrealTestProject.uproject`, derived from `RUNNER_TEMP`, so multi-runner CI should provision that path per runner instead of sharing one repo variable path. |
+| `UNREAL_SMOKE_READY` | to enable the `connection-smoke` leg | Gates the live relay round-trip leg (client → `gamedev-mcp-server` → sidecar → plugin → editor → tool, via `scripts/connection_smoke.py --mode custom`). **Separate from `UNREAL_RUNNER_READY`** so the smoke leg stays SKIPPED — never red-by-absence — until validated once on the runner. The leg builds the bridge (→ `UNREAL_MCP_BRIDGE_PATH`), runs its own `BuildPlugin` into the runner-local host project junction target (`$RUNNER_TEMP\UnrealMCP-Package`), downloads the public `gamedev-mcp-server` release, and asserts a tool battery. Set to `true` to enable; reuses the resolved host project + `UNREAL_ENGINE_PATH`. |
 
 Variables (not secrets) are correct here: none of these values are sensitive.
 


### PR DESCRIPTION
## Summary

- Fix UE 5.5/5.6 BuildPlugin failures by falling back to `Containers/UnrealString.h` when `Misc/StringOutputDevice.h` is not available.
- Move the single packaged plugin release zip job from UE 5.7 to UE 5.8, the latest supported engine, while keeping the source asset engine-version unpinned and the release matrix coverage across UE 5.5/5.6/5.7/5.8.
- Resolve the Automation host project from the current runner root before falling back to `UNREAL_HOST_PROJECT`, so multiple self-hosted runners can run UE jobs in parallel without sharing one mutable host `Plugins\UnrealMCP` junction.
- Serialize the PR smoke job after plugin validation, and the release packaged zip after the plugin matrix, to avoid same-machine UE 5.8 AutomationTool lock conflicts.
- Update release docs for UE 5.8 packaged zip, per-runner host project provisioning, and the intentional serialization points.

## Root cause

UE 5.5 and UE 5.6 do not ship `Misc/StringOutputDevice.h`; `FStringOutputDevice` lives in `Containers/UnrealString.h` there. UE 5.7/5.8 do ship the newer `Misc/StringOutputDevice.h`, so the previous include only worked on newer supported engines.

After registering multiple local runners, the PR smoke job also exposed that two UE 5.8 `RunUAT` jobs can conflict on the same machine's AutomationTool lock if they run at the same time. The workflow now keeps the parts that use the same UE 5.8 AutomationTool serialized.

## Validation

- `RunUAT.bat BuildPlugin -Plugin=C:\Projects\Unreal-MCP\UnrealMCP\UnrealMCP.uplugin -Package=%TEMP%\UnrealMCP-Codex-UE55-Package -TargetPlatforms=Win64 -Rocket` against UE 5.5: passed.
- Parsed `.github/workflows/release.yml` and `.github/workflows/test_pull_request.yml` with PyYAML: passed.
- `git diff --check`: passed.
- Verified GitHub sees four online `Unreal-MCP` self-hosted runners: `IVANPC-unreal`, `IVANPC-unreal-2`, `IVANPC-unreal-3`, `IVANPC-unreal-4`.
