### PR TITLE
fix(cli): correct device-auth endpoint in login

### DIFF
--- a/cli/src/lib/login.ts
+++ b/cli/src/lib/login.ts
@@ -13,7 +13,7 @@ import { emitProgress } from './progress.js';
 import type { ProgressCallback } from './types.js';
 
 const DEFAULT_BASE_URL = 'https://ai-game.dev';
-const DEFAULT_DEVICE_PATH = '/api/auth/device/code';
+const DEFAULT_DEVICE_PATH = '/api/auth/device/authorize';
 const DEFAULT_TOKEN_PATH = '/api/auth/device/token';
 /** Per-request deadline so a hung endpoint can't stall the flow forever. */
 const PER_REQUEST_TIMEOUT_MS = 30_000;

--- a/cli/tests/login.test.ts
+++ b/cli/tests/login.test.ts
@@ -18,7 +18,7 @@ function tmp(): string {
 function deviceFlowFetch(pendingCount: number): typeof fetch {
   let tokenCalls = 0;
   return (async (url: string) => {
-    if (String(url).endsWith('/code')) {
+    if (String(url).endsWith('/authorize')) {
       return fakeResponse({
         ok: true,
         status: 200,
@@ -72,7 +72,7 @@ describe('login (device flow)', () => {
   it('increases the poll interval persistently after slow_down (RFC 8628)', async () => {
     let tokenCalls = 0;
     const fetchImpl = (async (url: string) => {
-      if (String(url).endsWith('/code')) {
+      if (String(url).endsWith('/authorize')) {
         return fakeResponse({ ok: true, status: 200, body: JSON.stringify({ device_code: 'd', user_code: 'u', verification_uri: 'v', interval: 1 }) });
       }
       tokenCalls += 1;
@@ -92,7 +92,7 @@ describe('login (device flow)', () => {
 
   it('fails on access_denied', async () => {
     const fetchImpl = (async (url: string) => {
-      if (String(url).endsWith('/code')) {
+      if (String(url).endsWith('/authorize')) {
         return fakeResponse({ ok: true, status: 200, body: JSON.stringify({ device_code: 'd', user_code: 'u', verification_uri: 'v', interval: 1 }) });
       }
       return fakeResponse({ ok: false, status: 400, body: JSON.stringify({ error: 'access_denied' }) });
@@ -105,7 +105,7 @@ describe('login (device flow)', () => {
   it('times out when the user never authorizes', async () => {
     let clock = 0;
     const fetchImpl = (async (url: string) => {
-      if (String(url).endsWith('/code')) {
+      if (String(url).endsWith('/authorize')) {
         return fakeResponse({ ok: true, status: 200, body: JSON.stringify({ device_code: 'd', user_code: 'u', verification_uri: 'v', interval: 1 }) });
       }
       return fakeResponse({ ok: false, status: 400, body: JSON.stringify({ error: 'authorization_pending' }) });


### PR DESCRIPTION
## Summary
- `unreal-mcp-cli login` POSTed the device-authorization request to `/api/auth/device/code`, which returns **HTTP 404** on the live ai-game.dev server — the login flow could never start.
- Point `DEFAULT_DEVICE_PATH` at the working `/api/auth/device/authorize` endpoint (verified live: 200 with the `{device_code,user_code,verification_uri,verification_uri_complete,expires_in,interval}` shape `DeviceCodeResponse` already expects).
- Token poll path `DEFAULT_TOKEN_PATH` (`/api/auth/device/token`) is already correct — left unchanged.
- Updated the vitest device-flow mocks to discriminate the device request on `/authorize` instead of `/code`.
- No version bump (release pipeline owns versions); scope limited to the `cli/` leg.

## Test plan
- [x] `npm run build` (tsc) clean.
- [x] `login.test.ts` device-flow suite: 5/5 pass, referencing the corrected endpoint.

Closes #196