### PR TITLE
feat(cli): expand setup-mcp agent roster from 3 to the full 14 (parity with unity/godot)

### DIFF
--- a/cli/src/commands/setup-mcp.ts
+++ b/cli/src/commands/setup-mcp.ts
@@ -1,17 +1,35 @@
 import { Command } from 'commander';
-import { setupMcp, listAgentIds } from '../lib/setup-mcp.js';
+import { setupMcp } from '../lib/setup-mcp.js';
+import { getAgentById, getAgentIds, listAgentTable } from '../utils/agents.js';
 import type { McpTransport } from '../lib/types.js';
 import * as ui from '../utils/ui.js';
 
 export const setupMcpCommand = new Command('setup-mcp')
-  .description(`Write an MCP client config snippet for an agent (${listAgentIds().join(', ')})`)
-  .argument('<agent>', `Agent id: ${listAgentIds().join(' | ')}`)
+  .description('Write an MCP client config snippet for an AI agent (use --list to see all)')
+  .argument('[agent]', 'Agent id (use --list to see all supported agents)')
   .option('-p, --path <dir>', 'Unreal project directory (defaults to cwd)')
   .option('--transport <t>', 'Transport: http | stdio (default http)')
   .option('--url <url>', 'Explicit MCP server URL override')
   .option('--token <token>', 'Bearer token override')
   .option('--dry-run', 'Print the snippet instead of writing it')
-  .action(async (agent: string, opts) => {
+  .option('--list', 'List all supported agent ids and their config paths')
+  .action(async (agent: string | undefined, opts) => {
+    if (opts.list) {
+      listAgentTable('Available AI Agents', 'Config Path', (a) => a.configPathDisplay);
+      return;
+    }
+    if (!agent) {
+      ui.error('Missing required argument: agent');
+      ui.info(`Available agents: ${getAgentIds().join(', ')} (or use --list)`);
+      process.exitCode = 1;
+      return;
+    }
+    if (!getAgentById(agent)) {
+      ui.error(`Unknown agent "${agent}".`);
+      ui.info(`Available agents: ${getAgentIds().join(', ')} (or use --list)`);
+      process.exitCode = 1;
+      return;
+    }
     const result = await setupMcp({
       agentId: agent,
       projectDir: opts.path,

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -25,7 +25,14 @@ export {
   unknownExtensionMessage,
 } from './utils/extensions-catalog.js';
 export { runTool, runSystemTool } from './lib/run-tool.js';
-export { setupMcp, listAgentIds, buildServerEntry } from './lib/setup-mcp.js';
+export { setupMcp, listAgentIds } from './lib/setup-mcp.js';
+export {
+  agentRegistry,
+  getAgentById,
+  getAgentIds,
+  MCP_SERVER_NAME,
+} from './utils/agents.js';
+export type { AgentDefinition } from './utils/agents.js';
 export {
   downloadServer,
   serverDownloadUrl,

--- a/cli/src/lib/setup-mcp.ts
+++ b/cli/src/lib/setup-mcp.ts
@@ -1,18 +1,26 @@
-// `setup-mcp` — write an MCP client config snippet for a supported agent
-// so it can reach the project's local Unreal MCP server. Library-safe.
+// `setup-mcp` — write an MCP client config snippet for a supported AI agent so
+// it can reach the project's local/cloud Unreal MCP server. Library-safe.
 //
-// Each agent has a project-relative config file and a merge strategy that
-// preserves any existing server entries under the agent's top-level key
-// (`mcpServers` for Claude Code / Cursor, `servers` for VS Code). The
-// snippet shape follows the MCP client convention shared by the Unity/Godot
-// CLIs.
+// The per-agent knowledge (config path, body key, config format, and the
+// stdio/http server-entry shapes) lives in the shared `utils/agents.ts`
+// registry — the same design the Unity and Godot CLIs use, so all three stay
+// consistent. This module is the orchestrator: it resolves the connection,
+// acquires the local `gamedev-mcp-server` binary for stdio transport (via the
+// §6 `download-server.ts` resolver), and merges the chosen agent's entry into
+// its config file (JSON or TOML), preserving any existing servers.
 
-import * as fs from 'fs';
 import * as path from 'path';
 import { platform } from 'os';
-import { resolveConnection } from '../utils/config.js';
+import { resolveConnection, appendMcp } from '../utils/config.js';
 import { asError } from '../utils/error.js';
 import { generatePortFromDirectory } from '../utils/port.js';
+import {
+  getAgentById,
+  getAgentIds,
+  writeJsonAgentConfig,
+  writeTomlAgentConfig,
+  MCP_SERVER_NAME,
+} from '../utils/agents.js';
 import {
   downloadServer,
   resolveServerBinaryPath,
@@ -26,85 +34,19 @@ import type { McpTransport, SetupMcpOptions, SetupMcpResult } from './types.js';
 // `download-server.ts` (single owner of the server-binary layout).
 export { resolveServerBinaryPath } from './download-server.js';
 
-const SERVER_KEY = 'unreal-mcp';
-
-/** Stdio launch parameters for the local `gamedev-mcp-server` binary (§6). */
-interface StdioServer {
-  /** Absolute path to the published server binary. */
-  serverPath: string;
-  /** Deterministic localhost port for the project's editor (§1.1). */
-  port: number;
-}
-
-interface AgentDef {
-  id: string;
-  /** Config file path relative to the project dir. */
-  relConfigPath: string;
-  /** Display label. */
-  label: string;
-  /**
-   * Top-level key the agent nests its MCP servers under. Claude Code and
-   * Cursor use `mcpServers`; VS Code's `.vscode/mcp.json` uses `servers`
-   * (writing `mcpServers` there is silently ignored by VS Code).
-   */
-  bodyKey: 'mcpServers' | 'servers';
-}
-
-const AGENTS: AgentDef[] = [
-  { id: 'claude-code', relConfigPath: '.mcp.json', label: 'Claude Code', bodyKey: 'mcpServers' },
-  { id: 'cursor', relConfigPath: path.join('.cursor', 'mcp.json'), label: 'Cursor', bodyKey: 'mcpServers' },
-  { id: 'vscode', relConfigPath: path.join('.vscode', 'mcp.json'), label: 'VS Code', bodyKey: 'servers' },
-];
-
 /** Valid agent ids accepted by `setupMcp`. Pure. */
 export function listAgentIds(): string[] {
-  return AGENTS.map((a) => a.id);
-}
-
-/**
- * Build the `mcpServers` entry for the given transport. HTTP points the
- * client at the running server; stdio launches the local `gamedev-mcp-server`
- * binary (the §6 install path) on demand, passing the deterministic port,
- * auth mode, and token as args (the shared GameDev-MCP-Server host's CLI
- * contract, shared with Unity/Godot). Pure — exported for tests.
- */
-export function buildServerEntry(
-  transport: McpTransport,
-  url: string,
-  token: string | undefined,
-  stdio?: StdioServer,
-): Record<string, unknown> {
-  if (transport === 'http') {
-    const entry: Record<string, unknown> = { type: 'http', url: `${url}/mcp` };
-    if (token) entry['headers'] = { Authorization: `Bearer ${token}` };
-    return entry;
-  }
-  // stdio — a bare binary name is not on PATH (the server lands under the
-  // project's Intermediate/ per §6), so an absolute command + port/token
-  // args are required for the entry to actually launch a working server.
-  if (!stdio) {
-    throw new Error('stdio transport requires a resolved server path + port.');
-  }
-  return {
-    type: 'stdio',
-    command: stdio.serverPath,
-    args: [
-      `port=${stdio.port}`,
-      'client-transport=stdio',
-      `authorization=${token ? 'required' : 'none'}`,
-      `token=${token ?? ''}`,
-    ],
-  };
+  return getAgentIds();
 }
 
 export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
   const warnings: string[] = [];
   const nextSteps: string[] = [];
   try {
-    const agent = AGENTS.find((a) => a.id === opts.agentId);
+    const agent = getAgentById(opts.agentId);
     if (!agent) {
       throw new Error(
-        `Unknown agent "${opts.agentId}". Valid agents: ${listAgentIds().join(', ')}.`,
+        `Unknown agent "${opts.agentId}". Valid agents: ${getAgentIds().join(', ')}.`,
       );
     }
     const transport: McpTransport = opts.transport ?? 'http';
@@ -112,17 +54,20 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
 
     const conn = resolveConnection({ projectDir, url: opts.url, token: opts.token });
 
-    // stdio needs a LOCAL server binary. Resolution: the UNREAL_MCP_SERVER_PATH
-    // override wins (no download, no version check — §6 dev-override semantics,
-    // mirroring UNREAL_MCP_BRIDGE_PATH); otherwise download/refresh the pinned
-    // gamedev-mcp-server release into the §6 install path. A failed download
-    // degrades to a warning (the config is still written and works once the
-    // binary is provided), never a hard failure.
-    let stdio: StdioServer | undefined;
+    // Build the agent's server-entry props for the chosen transport.
+    let props: Record<string, unknown>;
+    let removeKeys: string[];
+
     if (transport === 'stdio') {
+      // stdio needs a LOCAL server binary. Resolution: the UNREAL_MCP_SERVER_PATH
+      // override wins (no download, no version check — §6 dev-override semantics,
+      // mirroring UNREAL_MCP_BRIDGE_PATH); otherwise download/refresh the pinned
+      // gamedev-mcp-server release into the §6 install path. A failed download
+      // degrades to a warning (the config is still written and works once the
+      // binary is provided), never a hard failure.
       const env = opts.env ?? process.env;
       const osPlatform = platform() as NodeJS.Platform;
-      let serverPath = resolveServerOverride(env);
+      let serverPath: string | null = resolveServerOverride(env);
       if (!serverPath && opts.dryRun) {
         // Dry run must stay side-effect-free: report the would-be path.
         serverPath = resolveServerBinaryPath(projectDir, osPlatform);
@@ -140,39 +85,35 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
           );
         }
       }
-      stdio = { serverPath, port: generatePortFromDirectory(projectDir) };
+      const port = generatePortFromDirectory(projectDir);
+      const auth = conn.token ? 'required' : 'none';
+      props = agent.getStdioProps(serverPath, port, auth, conn.token ?? '');
+      removeKeys = agent.stdioRemoveKeys;
+    } else {
+      // http — point the agent at the resolved `<host>/mcp` client URL. The
+      // `/mcp` segment is appended ONCE here (idempotently, tolerating a URL
+      // that already ends in `/mcp`) so the agent closures use `url` verbatim;
+      // this avoids the historical `/mcp` double-append.
+      const httpUrl = appendMcp(conn.url);
+      const token = conn.token ?? '';
+      props = agent.getHttpProps(httpUrl, token, token.length > 0);
+      removeKeys = agent.httpRemoveKeys;
     }
-    const serverEntry = buildServerEntry(transport, conn.url, conn.token, stdio);
 
-    const configPath = path.join(projectDir, agent.relConfigPath);
+    const configPath = agent.getConfigPath(projectDir);
     emitProgress(opts.onProgress, {
       phase: 'start',
-      message: `Configuring ${agent.label} MCP for ${transport} transport`,
+      message: `Configuring ${agent.name} MCP for ${transport} transport`,
     });
 
-    // Merge into any existing config, preserving other servers.
-    let config: Record<string, unknown> = {};
-    if (fs.existsSync(configPath)) {
-      try {
-        const parsed = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-        if (parsed && typeof parsed === 'object') config = parsed as Record<string, unknown>;
-      } catch {
-        warnings.push(`Existing ${configPath} is not valid JSON — it will be replaced.`);
-      }
-    }
-    const servers = (config[agent.bodyKey] && typeof config[agent.bodyKey] === 'object'
-      ? (config[agent.bodyKey] as Record<string, unknown>)
-      : {});
-    servers[SERVER_KEY] = serverEntry;
-    config[agent.bodyKey] = servers;
-
-    const snippet = JSON.stringify(config, null, 2) + '\n';
+    const snippet =
+      agent.configFormat === 'toml'
+        ? writeTomlAgentConfig(configPath, agent.bodyPath, MCP_SERVER_NAME, props, removeKeys, opts.dryRun)
+        : writeJsonAgentConfig(configPath, agent.bodyPath, MCP_SERVER_NAME, props, removeKeys, opts.dryRun);
 
     if (opts.dryRun) {
       emitProgress(opts.onProgress, { phase: 'done', message: 'Dry run — config not written.' });
     } else {
-      fs.mkdirSync(path.dirname(configPath), { recursive: true });
-      fs.writeFileSync(configPath, snippet, 'utf-8');
       emitProgress(opts.onProgress, {
         phase: 'file-written',
         message: `Wrote ${configPath}`,
@@ -180,7 +121,7 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
       });
     }
 
-    nextSteps.push(`Restart ${agent.label} to pick up the new MCP server.`);
+    nextSteps.push(`Restart ${agent.name} to pick up the new MCP server.`);
     if (transport === 'http') {
       nextSteps.push('Ensure the Unreal Editor (and its MCP server) is running — see `unreal-mcp-cli status`.');
     }

--- a/cli/src/utils/agents.ts
+++ b/cli/src/utils/agents.ts
@@ -1,0 +1,676 @@
+// AI-agent MCP-client configurator registry for `unreal-mcp-cli`.
+//
+// Ported from the authoritative Unity registry
+// (`Unity-MCP/cli/src/utils/agents.ts`) and brought to parity with the Godot
+// registry (`Godot-MCP/cli/src/utils/agents.ts`) so the three CLIs stay
+// consistent. Each agent knows where its MCP-client config file lives, which
+// serialization format it uses (`json` | `toml`), the top-level body key its
+// servers nest under, and how to render both an HTTP-transport and a
+// stdio-transport server entry (plus the stale keys to strip when switching
+// transports on a re-run).
+//
+// Unreal specifics vs the siblings:
+// - The server entry key is `unreal-mcp` (Unity/Godot use `ai-game-developer`)
+//   — kept so existing users' configs stay stable (no behaviour change).
+// - stdio launches the local `gamedev-mcp-server` binary that lands under the
+//   project's `Intermediate/UnrealMCP/server/<rid>/` (§6 — resolved by
+//   `download-server.ts`), NOT Unity's `Library/mcp-server/<platform>/` path.
+// - The stdio arg vector mirrors the existing Unreal contract
+//   (`port`/`client-transport`/`authorization`/`token`) and deliberately omits
+//   Unity's `plugin-timeout` to preserve the current behaviour for the shared
+//   `gamedev-mcp-server` binary.
+// - Roster = the Godot 14: id `vscode` (not `vscode-copilot`), includes
+//   `custom`, omits the Unity-only `unity-ai`.
+
+import chalk from 'chalk';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Agent Definition
+// ---------------------------------------------------------------------------
+
+export interface AgentDefinition {
+  id: string;
+  name: string;
+  /** Per-agent project-relative skills directory, or `null` if the agent has none. */
+  skillsPath: string | null;
+  configPathDisplay: string;
+  /** Config-file serialization format. `toml` is the Codex branch. */
+  configFormat: 'json' | 'toml';
+  bodyPath: string;
+  /** Resolve the absolute config-file path for a given project root. */
+  getConfigPath(projectPath: string): string;
+  /** Build the stdio server entry launching the local `gamedev-mcp-server`. */
+  getStdioProps(
+    serverPath: string,
+    port: number,
+    auth: string,
+    token: string,
+  ): Record<string, unknown>;
+  /** Build the HTTP server entry pointing at the resolved `<host>/mcp` URL. */
+  getHttpProps(
+    url: string,
+    token: string,
+    authRequired: boolean,
+  ): Record<string, unknown>;
+  /** Keys to delete from a pre-existing entry before merging stdio props. */
+  stdioRemoveKeys: string[];
+  /** Keys to delete from a pre-existing entry before merging http props. */
+  httpRemoveKeys: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Platform helpers
+// ---------------------------------------------------------------------------
+
+function appData(): string {
+  return process.env['APPDATA'] ?? path.join(os.homedir(), 'AppData', 'Roaming');
+}
+
+function home(): string {
+  return os.homedir();
+}
+
+function isWindows(): boolean {
+  return process.platform === 'win32';
+}
+
+function isMac(): boolean {
+  return process.platform === 'darwin';
+}
+
+// ---------------------------------------------------------------------------
+// Shared stdio / http arg builders
+// ---------------------------------------------------------------------------
+
+/**
+ * The stdio arg vector passed to the local `gamedev-mcp-server` binary. Matches
+ * the existing Unreal contract (no `plugin-timeout` — see the file header).
+ */
+function stdioArgs(port: number, auth: string, token: string): string[] {
+  return [
+    `port=${port}`,
+    `client-transport=stdio`,
+    `authorization=${auth}`,
+    `token=${token}`,
+  ];
+}
+
+function authHeaders(
+  token: string,
+  authRequired: boolean,
+): Record<string, string> | undefined {
+  if (authRequired && token) {
+    return { Authorization: `Bearer ${token}` };
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Agent Registry
+// ---------------------------------------------------------------------------
+
+const MCP_SERVER_NAME = 'unreal-mcp';
+
+export const agentRegistry: readonly AgentDefinition[] = [
+  // ── Claude Code ──────────────────────────────────────────────
+  {
+    id: 'claude-code',
+    name: 'Claude Code',
+    skillsPath: '.claude/skills',
+    configPathDisplay: '.mcp.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: (p) => path.join(p, '.mcp.json'),
+    getStdioProps: (serverPath, port, auth, token) => ({
+      command: serverPath,
+      args: stdioArgs(port, auth, token),
+    }),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    stdioRemoveKeys: ['type', 'url'],
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Claude Desktop ───────────────────────────────────────────
+  {
+    id: 'claude-desktop',
+    name: 'Claude Desktop',
+    skillsPath: null,
+    configPathDisplay: '~/Claude/claude_desktop_config.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: () => {
+      if (isWindows()) {
+        return path.join(appData(), 'Claude', 'claude_desktop_config.json');
+      }
+      if (isMac()) {
+        return path.join(home(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+      }
+      return path.join(home(), '.config', 'Claude', 'claude_desktop_config.json');
+    },
+    getStdioProps: (serverPath, port, auth, token) => ({
+      type: 'stdio',
+      command: serverPath,
+      args: stdioArgs(port, auth, token),
+    }),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    stdioRemoveKeys: ['url'],
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Cursor ───────────────────────────────────────────────────
+  {
+    id: 'cursor',
+    name: 'Cursor',
+    skillsPath: '.cursor/skills',
+    configPathDisplay: '.cursor/mcp.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: (p) => path.join(p, '.cursor', 'mcp.json'),
+    getStdioProps: (serverPath, port, auth, token) => ({
+      type: 'stdio',
+      command: serverPath,
+      args: stdioArgs(port, auth, token),
+    }),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    stdioRemoveKeys: ['url'],
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── VS Code (Copilot) ────────────────────────────────────────
+  {
+    id: 'vscode',
+    name: 'Visual Studio Code (Copilot)',
+    skillsPath: '.github/skills',
+    configPathDisplay: '.vscode/mcp.json',
+    configFormat: 'json',
+    bodyPath: 'servers',
+    getConfigPath: (p) => path.join(p, '.vscode', 'mcp.json'),
+    getStdioProps: (serverPath, port, auth, token) => ({
+      type: 'stdio',
+      command: serverPath,
+      args: stdioArgs(port, auth, token),
+    }),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    stdioRemoveKeys: ['url'],
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Visual Studio (Copilot) ──────────────────────────────────
+  {
+    id: 'vs-copilot',
+    name: 'Visual Studio (Copilot)',
+    skillsPath: '.github/skills',
+    configPathDisplay: '.vs/mcp.json',
+    configFormat: 'json',
+    bodyPath: 'servers',
+    getConfigPath: (p) => path.join(p, '.vs', 'mcp.json'),
+    getStdioProps: (serverPath, port, auth, token) => ({
+      type: 'stdio',
+      command: serverPath,
+      args: stdioArgs(port, auth, token),
+    }),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    stdioRemoveKeys: ['url'],
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Rider (Junie) ───────────────────────────────────────────
+  {
+    id: 'rider-junie',
+    name: 'Rider (Junie)',
+    skillsPath: '.junie/skills',
+    configPathDisplay: '.junie/mcp/mcp.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: (p) => path.join(p, '.junie', 'mcp', 'mcp.json'),
+    getStdioProps: (serverPath, port, auth, token) => ({
+      enabled: true,
+      type: 'stdio',
+      command: serverPath,
+      args: stdioArgs(port, auth, token),
+    }),
+    getHttpProps: (url, token, authRequired) => ({
+      enabled: true,
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    stdioRemoveKeys: ['disabled', 'url'],
+    httpRemoveKeys: ['disabled', 'command', 'args'],
+  },
+
+  // ── GitHub Copilot CLI ──────────────────────────────────────
+  {
+    id: 'github-copilot-cli',
+    name: 'GitHub Copilot CLI',
+    skillsPath: '.github/skills',
+    configPathDisplay: '~/.copilot/mcp-config.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: () => path.join(home(), '.copilot', 'mcp-config.json'),
+    getStdioProps: (serverPath, port, auth, token) => ({
+      command: serverPath,
+      args: stdioArgs(port, auth, token),
+      tools: ['*'],
+    }),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      tools: ['*'],
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    stdioRemoveKeys: ['url', 'type'],
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Gemini ──────────────────────────────────────────────────
+  {
+    id: 'gemini',
+    name: 'Gemini',
+    skillsPath: '.gemini/skills',
+    configPathDisplay: '.gemini/settings.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: (p) => path.join(p, '.gemini', 'settings.json'),
+    getStdioProps: (serverPath, port, auth, token) => ({
+      type: 'stdio',
+      command: serverPath,
+      args: stdioArgs(port, auth, token),
+    }),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    stdioRemoveKeys: ['url'],
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Antigravity ─────────────────────────────────────────────
+  {
+    id: 'antigravity',
+    name: 'Antigravity',
+    skillsPath: '.agent/skills',
+    configPathDisplay: '~/.gemini/config/mcp_config.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: () => path.join(home(), '.gemini', 'config', 'mcp_config.json'),
+    // Antigravity uses a `serverUrl` key (not `url`) and a `disabled` flag.
+    getStdioProps: (serverPath, port, auth, token) => ({
+      disabled: false,
+      command: serverPath,
+      args: stdioArgs(port, auth, token),
+    }),
+    getHttpProps: (url, _token, _authRequired) => ({
+      disabled: false,
+      serverUrl: url,
+    }),
+    stdioRemoveKeys: ['url', 'serverUrl', 'type'],
+    httpRemoveKeys: ['command', 'args', 'url', 'type'],
+  },
+
+  // ── Cline ───────────────────────────────────────────────────
+  {
+    id: 'cline',
+    name: 'Cline',
+    skillsPath: '.cline/skills',
+    configPathDisplay: '~/Code/globalStorage/.../cline_mcp_settings.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: () => {
+      if (isWindows()) {
+        return path.join(
+          appData(),
+          'Code',
+          'User',
+          'globalStorage',
+          'saoudrizwan.claude-dev',
+          'settings',
+          'cline_mcp_settings.json',
+        );
+      }
+      const base = isMac()
+        ? path.join(home(), 'Library', 'Application Support', 'Code', 'User', 'globalStorage')
+        : path.join(home(), '.config', 'Code', 'User', 'globalStorage');
+      return path.join(base, 'saoudrizwan.claude-dev', 'settings', 'cline_mcp_settings.json');
+    },
+    getStdioProps: (serverPath, port, auth, token) => ({
+      type: 'stdio',
+      command: serverPath,
+      args: stdioArgs(port, auth, token),
+    }),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'streamableHttp',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    stdioRemoveKeys: ['url'],
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Open Code ───────────────────────────────────────────────
+  {
+    id: 'open-code',
+    name: 'Open Code',
+    skillsPath: '.opencode/skills',
+    configPathDisplay: 'opencode.json',
+    configFormat: 'json',
+    bodyPath: 'mcp',
+    getConfigPath: (p) => path.join(p, 'opencode.json'),
+    getStdioProps: (serverPath, port, auth, token) => ({
+      type: 'local',
+      enabled: true,
+      command: [serverPath, ...stdioArgs(port, auth, token)],
+    }),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'remote',
+      enabled: true,
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    stdioRemoveKeys: ['url', 'args'],
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Codex (TOML config) ─────────────────────────────────────
+  {
+    id: 'codex',
+    name: 'Codex',
+    skillsPath: '.agents/skills',
+    configPathDisplay: '.codex/config.toml',
+    configFormat: 'toml',
+    bodyPath: 'mcp_servers',
+    getConfigPath: (p) => path.join(p, '.codex', 'config.toml'),
+    // Codex's stdio arg vector omits the bearer token (it is not accepted on
+    // Codex's command line); auth still flows via `authorization=`.
+    getStdioProps: (serverPath, port, auth, _token) => ({
+      enabled: true,
+      command: serverPath,
+      args: [`port=${port}`, `client-transport=stdio`, `authorization=${auth}`],
+      tool_timeout_sec: 300,
+    }),
+    getHttpProps: (url, _token, _authRequired) => ({
+      enabled: true,
+      url,
+      tool_timeout_sec: 300,
+      startup_timeout_sec: 30,
+    }),
+    stdioRemoveKeys: ['url', 'type', 'startup_timeout_sec'],
+    httpRemoveKeys: ['command', 'args', 'type'],
+  },
+
+  // ── Kilo Code ───────────────────────────────────────────────
+  {
+    id: 'kilo-code',
+    name: 'Kilo Code',
+    skillsPath: '.kilocode/skills',
+    configPathDisplay: '.kilocode/mcp.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: (p) => path.join(p, '.kilocode', 'mcp.json'),
+    getStdioProps: (serverPath, port, auth, token) => ({
+      type: 'stdio',
+      disabled: false,
+      command: serverPath,
+      args: stdioArgs(port, auth, token),
+    }),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'streamable-http',
+      disabled: false,
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    stdioRemoveKeys: ['url'],
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Custom (generic mcpServers entry written to a caller path) ─
+  {
+    id: 'custom',
+    name: 'Custom (generic MCP client)',
+    skillsPath: null,
+    configPathDisplay: 'mcp.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: (p) => path.join(p, 'mcp.json'),
+    getStdioProps: (serverPath, port, auth, token) => ({
+      type: 'stdio',
+      command: serverPath,
+      args: stdioArgs(port, auth, token),
+    }),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    stdioRemoveKeys: ['url'],
+    httpRemoveKeys: ['command', 'args'],
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Lookup helpers
+// ---------------------------------------------------------------------------
+
+export function getAgentById(id: string): AgentDefinition | undefined {
+  return agentRegistry.find((a) => a.id === id);
+}
+
+export function getAgentIds(): string[] {
+  return agentRegistry.map((a) => a.id);
+}
+
+export function listAgentTable(
+  heading: string,
+  locationLabel: string,
+  locationFn: (agent: AgentDefinition) => string,
+): void {
+  const sorted = [...agentRegistry].sort((a, b) => a.id.localeCompare(b.id));
+
+  const colId = 'ID';
+  const colLoc = locationLabel;
+
+  const wId = Math.max(colId.length, ...sorted.map((a) => a.id.length));
+  const wLoc = Math.max(colLoc.length, ...sorted.map((a) => locationFn(a).length));
+
+  const sep = chalk.dim;
+  const hBar = (w: number) => '─'.repeat(w);
+
+  console.log(`\n${chalk.bold.cyan(heading)}\n`);
+
+  // Header
+  console.log(sep('  ┌─') + sep(hBar(wId)) + sep('─┬─') + sep(hBar(wLoc)) + sep('─┐'));
+  console.log(
+    sep('  │ ') + chalk.bold.white(colId.padEnd(wId)) + sep(' │ ') + chalk.bold.white(colLoc.padEnd(wLoc)) + sep(' │'),
+  );
+  console.log(sep('  ├─') + sep(hBar(wId)) + sep('─┼─') + sep(hBar(wLoc)) + sep('─┤'));
+
+  // Rows
+  for (const agent of sorted) {
+    const loc = locationFn(agent);
+    console.log(
+      sep('  │ ') + chalk.yellow(agent.id.padEnd(wId)) + sep(' │ ') + chalk.green(loc.padEnd(wLoc)) + sep(' │'),
+    );
+  }
+
+  // Footer
+  console.log(sep('  └─') + sep(hBar(wId)) + sep('─┴─') + sep(hBar(wLoc)) + sep('─┘'));
+  console.log('');
+}
+
+// ---------------------------------------------------------------------------
+// Config file writing — JSON
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge `props` into the `[bodyPath][serverName]` entry of the JSON config at
+ * `configPath`, preserving every other server entry, and return the serialized
+ * content. When `dryRun` is true the merged content is computed and returned
+ * but NOTHING is written (side-effect-free — no dir creation, no file write).
+ */
+export function writeJsonAgentConfig(
+  configPath: string,
+  bodyPath: string,
+  serverName: string,
+  props: Record<string, unknown>,
+  removeKeys: string[],
+  dryRun = false,
+): string {
+  let root: Record<string, unknown> = {};
+  if (fs.existsSync(configPath)) {
+    try {
+      root = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+    } catch {
+      // If the file is malformed, start fresh
+      root = {};
+    }
+    if (!root || typeof root !== 'object' || Array.isArray(root)) {
+      root = {};
+    }
+  }
+
+  // Navigate/create bodyPath
+  let body = root[bodyPath] as Record<string, unknown> | undefined;
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    body = {};
+    root[bodyPath] = body;
+  }
+
+  // Get or create the server entry
+  let entry = body[serverName] as Record<string, unknown> | undefined;
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    entry = {};
+  }
+
+  // Remove stale keys (drops the other transport's leftovers on a re-run)
+  for (const key of removeKeys) {
+    delete entry[key];
+  }
+
+  // Merge new properties
+  for (const [key, value] of Object.entries(props)) {
+    entry[key] = value;
+  }
+
+  body[serverName] = entry;
+  root[bodyPath] = body;
+
+  const content = JSON.stringify(root, null, 2) + '\n';
+  if (!dryRun) {
+    const dir = path.dirname(configPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(configPath, content);
+  }
+  return content;
+}
+
+// ---------------------------------------------------------------------------
+// Config file writing — TOML (Codex only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Write/merge a single `[bodyPath.serverName]` TOML section into `configPath`,
+ * mirroring the Unity/Godot CLI's Codex TOML branch, and return the serialized
+ * content. Existing sections under other headers are preserved; the target
+ * section is replaced wholesale (idempotent re-runs; stale keys dropped). Keys
+ * in `removeKeys` are never written. `dryRun` computes + returns the content
+ * without touching disk. A deliberately minimal TOML emitter — Codex's schema
+ * here is flat (string/number/bool/array scalars only).
+ */
+export function writeTomlAgentConfig(
+  configPath: string,
+  bodyPath: string,
+  serverName: string,
+  props: Record<string, unknown>,
+  removeKeys: string[],
+  dryRun = false,
+): string {
+  // Read existing content or start fresh
+  let lines: string[] = [];
+  if (fs.existsSync(configPath)) {
+    lines = fs.readFileSync(configPath, 'utf-8').split('\n');
+  }
+
+  const sectionHeader = `[${bodyPath}.${serverName}]`;
+
+  // Find existing section boundaries
+  const sectionIdx = lines.findIndex((l) => l.trim() === sectionHeader);
+
+  // Build TOML key-value pairs for the section
+  const tomlLines = [sectionHeader];
+  for (const [key, value] of Object.entries(props)) {
+    if (removeKeys.includes(key)) continue;
+    tomlLines.push(`${key} = ${tomlValue(value)}`);
+  }
+
+  if (sectionIdx >= 0) {
+    // Find end of section (next [...] header or EOF). The leading-`[` test is
+    // safe for the Codex schema, which emits only flat scalars (no inline-array
+    // value lines that would also start with `[`).
+    let endIdx = sectionIdx + 1;
+    while (endIdx < lines.length && !lines[endIdx].trim().startsWith('[')) {
+      endIdx++;
+    }
+    lines.splice(sectionIdx, endIdx - sectionIdx, ...tomlLines);
+  } else {
+    if (lines.length > 0 && lines[lines.length - 1].trim() !== '') {
+      lines.push('');
+    }
+    lines.push(...tomlLines);
+  }
+
+  const content = lines.join('\n') + '\n';
+  if (!dryRun) {
+    const dir = path.dirname(configPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(configPath, content);
+  }
+  return content;
+}
+
+function tomlValue(v: unknown): string {
+  if (typeof v === 'string') return `"${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  if (typeof v === 'boolean') return String(v);
+  if (typeof v === 'number') {
+    // TOML spells non-finite floats `nan` / `inf` / `-inf`, not JS's NaN/Infinity.
+    if (Number.isNaN(v)) return 'nan';
+    if (v === Infinity) return 'inf';
+    if (v === -Infinity) return '-inf';
+    return String(v);
+  }
+  if (Array.isArray(v)) {
+    return `[${v.map(tomlValue).join(', ')}]`;
+  }
+  // null/undefined/object have no valid TOML scalar form here; emit a quoted
+  // string so we never produce an invalid bare token (defensive fallback).
+  return `"${String(v).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+export { MCP_SERVER_NAME };

--- a/cli/tests/setup-mcp.test.ts
+++ b/cli/tests/setup-mcp.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
-import { setupMcp, listAgentIds, buildServerEntry } from '../src/lib/setup-mcp.js';
+import { setupMcp, listAgentIds } from '../src/lib/setup-mcp.js';
+import { agentRegistry, getAgentById, getAgentIds, MCP_SERVER_NAME } from '../src/utils/agents.js';
 import { makeTempDir, rmTempDir } from './helpers.js';
 
 const dirs: string[] = [];
@@ -14,42 +15,117 @@ function tmp(): string {
   return d;
 }
 
-describe('listAgentIds', () => {
-  it('includes the known agents', () => {
-    expect(listAgentIds()).toEqual(expect.arrayContaining(['claude-code', 'cursor', 'vscode']));
+// The full pinned roster (parity with unity/godot). Order-independent.
+const EXPECTED_IDS = [
+  'claude-code',
+  'claude-desktop',
+  'cursor',
+  'vscode',
+  'vs-copilot',
+  'rider-junie',
+  'github-copilot-cli',
+  'gemini',
+  'antigravity',
+  'cline',
+  'open-code',
+  'codex',
+  'kilo-code',
+  'custom',
+];
+
+describe('agent roster', () => {
+  it('exposes exactly the 14 pinned agents', () => {
+    expect(getAgentIds()).toHaveLength(14);
+    expect([...getAgentIds()].sort()).toEqual([...EXPECTED_IDS].sort());
+  });
+
+  it('listAgentIds() mirrors the registry', () => {
+    expect([...listAgentIds()].sort()).toEqual([...getAgentIds()].sort());
+  });
+
+  it('uses id `vscode` (not `vscode-copilot`), includes `custom`, omits `unity-ai`', () => {
+    expect(getAgentIds()).toContain('vscode');
+    expect(getAgentIds()).not.toContain('vscode-copilot');
+    expect(getAgentIds()).toContain('custom');
+    expect(getAgentIds()).not.toContain('unity-ai');
+  });
+
+  it('every agent carries the full closure surface', () => {
+    for (const a of agentRegistry) {
+      expect(typeof a.getConfigPath).toBe('function');
+      expect(typeof a.getStdioProps).toBe('function');
+      expect(typeof a.getHttpProps).toBe('function');
+      expect(['json', 'toml']).toContain(a.configFormat);
+      expect(typeof a.bodyPath).toBe('string');
+      expect(a.bodyPath.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('the server entry key is `unreal-mcp`', () => {
+    expect(MCP_SERVER_NAME).toBe('unreal-mcp');
+  });
+
+  it('exactly one agent (codex) uses the TOML format', () => {
+    const toml = agentRegistry.filter((a) => a.configFormat === 'toml').map((a) => a.id);
+    expect(toml).toEqual(['codex']);
   });
 });
 
-describe('buildServerEntry', () => {
-  it('builds an http entry with bearer header', () => {
-    const e = buildServerEntry('http', 'http://localhost:5220', 'tok');
-    expect(e).toMatchObject({ type: 'http', url: 'http://localhost:5220/mcp', headers: { Authorization: 'Bearer tok' } });
-  });
-  it('builds a stdio entry launching the absolute server binary with port + auth args', () => {
-    const e = buildServerEntry('stdio', 'http://x', 'tok', {
-      serverPath: '/abs/Intermediate/UnrealMCP/server/win-x64/gamedev-mcp-server.exe',
-      port: 5220,
-    });
-    expect(e).toMatchObject({
-      type: 'stdio',
-      command: '/abs/Intermediate/UnrealMCP/server/win-x64/gamedev-mcp-server.exe',
-    });
-    expect(e.args).toEqual(
-      expect.arrayContaining(['port=5220', 'client-transport=stdio', 'authorization=required', 'token=tok']),
-    );
+describe('per-agent server-entry shapes (pure closures)', () => {
+  it('antigravity uses serverUrl + disabled (no url/type)', () => {
+    const e = getAgentById('antigravity')!.getHttpProps('http://h/mcp', '', false);
+    expect(e).toMatchObject({ disabled: false, serverUrl: 'http://h/mcp' });
+    expect(e['url']).toBeUndefined();
+    expect(e['type']).toBeUndefined();
   });
 
-  it('stdio uses authorization=none when there is no token', () => {
-    const e = buildServerEntry('stdio', 'http://x', undefined, { serverPath: '/abs/srv', port: 1 });
-    expect(e.args).toEqual(expect.arrayContaining(['authorization=none', 'token=']));
+  it('cline uses type=streamableHttp', () => {
+    expect(getAgentById('cline')!.getHttpProps('http://h/mcp', '', false)).toMatchObject({
+      type: 'streamableHttp',
+      url: 'http://h/mcp',
+    });
   });
 
-  it('stdio without resolved server params throws (a bare PATH command would not launch)', () => {
-    expect(() => buildServerEntry('stdio', 'http://x', undefined)).toThrow();
+  it('kilo-code uses type=streamable-http + disabled', () => {
+    expect(getAgentById('kilo-code')!.getHttpProps('http://h/mcp', '', false)).toMatchObject({
+      type: 'streamable-http',
+      disabled: false,
+      url: 'http://h/mcp',
+    });
+  });
+
+  it('github-copilot-cli always advertises tools:["*"]', () => {
+    const e = getAgentById('github-copilot-cli')!.getHttpProps('http://h/mcp', 'tok', true);
+    expect(e).toMatchObject({ type: 'http', url: 'http://h/mcp', tools: ['*'] });
+    expect(e['headers']).toEqual({ Authorization: 'Bearer tok' });
+  });
+
+  it('rider-junie carries enabled:true on both transports', () => {
+    expect(getAgentById('rider-junie')!.getHttpProps('http://h/mcp', '', false)).toMatchObject({ enabled: true });
+    expect(getAgentById('rider-junie')!.getStdioProps('/srv', 5, 'none', '')).toMatchObject({ enabled: true });
+  });
+
+  it('open-code stdio uses an array `command`', () => {
+    const e = getAgentById('open-code')!.getStdioProps('/srv', 5, 'none', '');
+    expect(e).toMatchObject({ type: 'local', enabled: true });
+    expect(e['command']).toEqual([
+      '/srv',
+      'port=5',
+      'client-transport=stdio',
+      'authorization=none',
+      'token=',
+    ]);
+  });
+
+  it('codex stdio omits the bearer token from the arg vector', () => {
+    const e = getAgentById('codex')!.getStdioProps('/srv', 5, 'required', 'secret');
+    expect(e['command']).toBe('/srv');
+    expect(e['args']).toEqual(['port=5', 'client-transport=stdio', 'authorization=required']);
+    expect((e['args'] as string[]).some((a) => a.startsWith('token='))).toBe(false);
   });
 });
 
-describe('setupMcp', () => {
+describe('setupMcp — http transport', () => {
   it('writes .mcp.json for claude-code and merges with existing servers', async () => {
     const dir = tmp();
     fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({ mcpServers: { other: { type: 'stdio' } } }), 'utf-8');
@@ -59,8 +135,62 @@ describe('setupMcp', () => {
     const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
     expect(written.mcpServers.other).toBeDefined();
     expect(written.mcpServers['unreal-mcp'].url).toBe('http://localhost:5220/mcp');
+    expect(written.mcpServers['unreal-mcp'].type).toBe('http');
   });
 
+  it('adds a bearer header when a token is supplied', async () => {
+    const dir = tmp();
+    const r = await setupMcp({ agentId: 'claude-code', projectDir: dir, transport: 'http', url: 'http://h', token: 'tok' });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
+    expect(written.mcpServers['unreal-mcp'].url).toBe('http://h/mcp');
+    expect(written.mcpServers['unreal-mcp'].headers).toEqual({ Authorization: 'Bearer tok' });
+  });
+
+  it('appends `/mcp` exactly once (no double-append on a URL that already ends in /mcp)', async () => {
+    const dir = tmp();
+    const r = await setupMcp({ agentId: 'claude-code', projectDir: dir, transport: 'http', url: 'http://h/mcp' });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
+    expect(written.mcpServers['unreal-mcp'].url).toBe('http://h/mcp');
+  });
+
+  it('writes vscode config under the top-level `servers` key (not `mcpServers`)', async () => {
+    const dir = tmp();
+    const r = await setupMcp({ agentId: 'vscode', projectDir: dir, transport: 'http', url: 'http://localhost:5220' });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
+    expect(written.servers['unreal-mcp'].url).toBe('http://localhost:5220/mcp');
+    expect(written.mcpServers).toBeUndefined();
+  });
+
+  it('writes codex config as TOML under [mcp_servers.unreal-mcp]', async () => {
+    const dir = tmp();
+    const r = await setupMcp({ agentId: 'codex', projectDir: dir, transport: 'http', url: 'http://localhost:5220' });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.configPath).toMatch(/[\\/]\.codex[\\/]config\.toml$/);
+    const content = fs.readFileSync(r.configPath, 'utf-8');
+    expect(content).toContain('[mcp_servers.unreal-mcp]');
+    expect(content).toContain('url = "http://localhost:5220/mcp"');
+    expect(content).toContain('tool_timeout_sec = 300');
+  });
+
+  it('dry-run returns the snippet without writing', async () => {
+    const dir = tmp();
+    const r = await setupMcp({ agentId: 'cursor', projectDir: dir, dryRun: true, url: 'http://h' });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(fs.existsSync(r.configPath)).toBe(false);
+    expect(r.snippet).toContain('unreal-mcp');
+    expect(r.snippet).toContain('http://h/mcp');
+  });
+});
+
+describe('setupMcp — stdio transport', () => {
   it('writes a stdio entry with an absolute §6 server path and a port arg (download injected)', async () => {
     const dir = tmp();
     const serverPath = path.join(dir, 'Intermediate', 'UnrealMCP', 'server', 'win-x64', 'gamedev-mcp-server.exe');
@@ -80,14 +210,44 @@ describe('setupMcp', () => {
     expect(downloads).toEqual([dir]);
     const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
     const entry = written.mcpServers['unreal-mcp'];
-    expect(entry.type).toBe('stdio');
     expect(path.isAbsolute(entry.command)).toBe(true);
     expect(entry.command).toContain(path.join('Intermediate', 'UnrealMCP', 'server'));
     expect(entry.command).toMatch(/gamedev-mcp-server(\.exe)?$/);
+    expect(entry.args).toContain('client-transport=stdio');
     expect(entry.args.some((a: string) => /^port=\d+$/.test(a))).toBe(true);
   });
 
-  it('stdio honors the UNREAL_MCP_SERVER_PATH override and skips the download', async () => {
+  it('re-running stdio over a stale http entry drops the http-only keys', async () => {
+    const dir = tmp();
+    fs.writeFileSync(
+      path.join(dir, '.mcp.json'),
+      JSON.stringify({ mcpServers: { 'unreal-mcp': { type: 'http', url: 'http://old/mcp' } } }),
+      'utf-8',
+    );
+    const serverPath = path.join(dir, 'Intermediate', 'UnrealMCP', 'server', 'win-x64', 'gamedev-mcp-server.exe');
+    const r = await setupMcp({
+      agentId: 'claude-code',
+      projectDir: dir,
+      transport: 'stdio',
+      env: {},
+      downloadServerImpl: async () => ({
+        kind: 'success',
+        success: true,
+        serverPath,
+        source: 'download',
+        version: '8.0.0',
+        warnings: [],
+      }),
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    const entry = JSON.parse(fs.readFileSync(r.configPath, 'utf-8')).mcpServers['unreal-mcp'];
+    expect(entry.command).toBeDefined();
+    expect(entry.url).toBeUndefined();
+    expect(entry.type).toBeUndefined();
+  });
+
+  it('honors the UNREAL_MCP_SERVER_PATH override and skips the download', async () => {
     const dir = tmp();
     const override = path.join(dir, 'local-gamedev-mcp-server.exe');
     fs.writeFileSync(override, 'x');
@@ -109,7 +269,7 @@ describe('setupMcp', () => {
     expect(written.mcpServers['unreal-mcp'].command).toBe(override);
   });
 
-  it('stdio degrades a failed download to a warning (config still written with the §6 path)', async () => {
+  it('degrades a failed download to a warning (config still written with the §6 path)', async () => {
     const dir = tmp();
     const r = await setupMcp({
       agentId: 'claude-code',
@@ -131,7 +291,7 @@ describe('setupMcp', () => {
     expect(written.mcpServers['unreal-mcp'].command).toMatch(/gamedev-mcp-server(\.exe)?$/);
   });
 
-  it('stdio dry-run does not download (side-effect-free)', async () => {
+  it('dry-run does not download (side-effect-free)', async () => {
     const dir = tmp();
     let downloadCalled = false;
     const r = await setupMcp({
@@ -148,29 +308,12 @@ describe('setupMcp', () => {
     expect(r.kind).toBe('success');
     expect(downloadCalled).toBe(false);
     if (r.kind !== 'success') return;
+    expect(fs.existsSync(r.configPath)).toBe(false);
     expect(r.snippet).toContain('gamedev-mcp-server');
   });
+});
 
-  it('writes vscode config under the top-level `servers` key (not `mcpServers`)', async () => {
-    const dir = tmp();
-    const r = await setupMcp({ agentId: 'vscode', projectDir: dir, transport: 'http', url: 'http://localhost:5220' });
-    expect(r.kind).toBe('success');
-    if (r.kind !== 'success') return;
-    const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
-    // VS Code's .vscode/mcp.json uses `servers`; `mcpServers` is ignored.
-    expect(written.servers['unreal-mcp'].url).toBe('http://localhost:5220/mcp');
-    expect(written.mcpServers).toBeUndefined();
-  });
-
-  it('dry-run returns the snippet without writing', async () => {
-    const dir = tmp();
-    const r = await setupMcp({ agentId: 'cursor', projectDir: dir, dryRun: true, url: 'http://h' });
-    expect(r.kind).toBe('success');
-    if (r.kind !== 'success') return;
-    expect(fs.existsSync(r.configPath)).toBe(false);
-    expect(r.snippet).toContain('unreal-mcp');
-  });
-
+describe('setupMcp — errors', () => {
   it('fails for an unknown agent', async () => {
     const r = await setupMcp({ agentId: 'emacs', projectDir: tmp() });
     expect(r.kind).toBe('failure');


### PR DESCRIPTION
## Summary
- Expand `unreal-mcp-cli setup-mcp` from 3 agents (`claude-code`, `cursor`, `vscode`) to the full **14-agent** roster, parity with the Unity and Godot CLIs.
- Introduce a per-agent `cli/src/utils/agents.ts` registry (closures for `getConfigPath` / `getStdioProps` / `getHttpProps`, `configFormat` json|toml, `bodyPath`, transport remove-keys cleanup, `writeJsonAgentConfig` / `writeTomlAgentConfig`) ported from Unity's authoritative registry + Godot's proven port; rewrite `lib/setup-mcp.ts` as a thin orchestrator and drop the single fixed `buildServerEntry()`.
- Fix the `/mcp` double-append (append once, idempotently, via `appendMcp`) and add a `--list` flag.

Roster (14): `claude-code, claude-desktop, cursor, vscode, vs-copilot, rider-junie, github-copilot-cli, gemini, antigravity, cline, open-code, codex, kilo-code, custom` — id `vscode`, includes `custom`, omits the Unity-only `unity-ai`. Server entry key stays `unreal-mcp`; the stdio server-binary path stays Unreal-specific (`Intermediate/UnrealMCP/server/<rid>/gamedev-mcp-server`). Scope: `cli/` only — the `bridge/` sidecar is untouched. No npm release / version bump (separate gated follow-up).

## Test plan
- [x] Target-specific local tests passed: `npm run build` (tsc, 0 errors) + `npm test` (vitest, 340 passed / 1 pre-existing skip).
- [x] Ran the CLI: `setup-mcp --list` shows all 14 agents; spot-checked a JSON write (claude-code → `.mcp.json`, single `/mcp`), a Codex TOML write (`.codex/config.toml` → `[mcp_servers.unreal-mcp]`), an http dry-run (no write), and a stdio dry-run (Unreal-specific server path, no download).

Closes #199