### PR TITLE
feat(cli): rename VS Code agent id to `vscode-copilot` (parity with unity-mcp-cli)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -51,7 +51,7 @@ Requires Node `^20.19.0 || >=22.12.0`. See the
 | `remove-plugin [path]` | Remove the installed plugin |
 | `install-extension <id> [path]` | Install a third-party Unreal-MCP **extension** plugin into `<project>/Plugins/<name>`, enable it + its gating engine plugins (e.g. `Niagara`) in the `.uproject`, and (re)compile (on next editor open, or now with `--build`). `--source <dir>` installs from a local copy (offline/CI); `--version <x.y.z>` overrides the catalog pin. Idempotent. See [Extensions](#extensions) |
 | `configure` | Write `UNREAL_MCP_*` into `<project>/.env` and gitignore `.env` (§8) |
-| `setup-mcp <agent>` | Write an MCP client config snippet (claude-code, cursor, vscode). With `--transport stdio` it also downloads the pinned shared [`gamedev-mcp-server`](https://github.com/IvanMurzak/GameDev-MCP-Server) release into `<project>/Intermediate/UnrealMCP/server/<rid>/` (skipped when `UNREAL_MCP_SERVER_PATH` points at a local build) |
+| `setup-mcp <agent>` | Write an MCP client config snippet (claude-code, cursor, vscode-copilot). With `--transport stdio` it also downloads the pinned shared [`gamedev-mcp-server`](https://github.com/IvanMurzak/GameDev-MCP-Server) release into `<project>/Intermediate/UnrealMCP/server/<rid>/` (skipped when `UNREAL_MCP_SERVER_PATH` points at a local build) |
 | `login` | OAuth device-code auth against ai-game.dev |
 | `status` | Report project + plugin + connection + live reachability |
 | `wait-for-ready` | Block until the project's MCP server responds to a ping |

--- a/cli/src/utils/agents.ts
+++ b/cli/src/utils/agents.ts
@@ -19,7 +19,8 @@
 //   (`port`/`client-transport`/`authorization`/`token`) and deliberately omits
 //   Unity's `plugin-timeout` to preserve the current behaviour for the shared
 //   `gamedev-mcp-server` binary.
-// - Roster = the Godot 14: id `vscode` (not `vscode-copilot`), includes
+// - Roster = the 14 shared ids brought to naming parity with unity-mcp-cli:
+//   the VS Code id is `vscode-copilot` (renamed from `vscode`), includes
 //   `custom`, omits the Unity-only `unity-ai`.
 
 import chalk from 'chalk';
@@ -193,7 +194,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
 
   // ── VS Code (Copilot) ────────────────────────────────────────
   {
-    id: 'vscode',
+    id: 'vscode-copilot',
     name: 'Visual Studio Code (Copilot)',
     skillsPath: '.github/skills',
     configPathDisplay: '.vscode/mcp.json',

--- a/cli/tests/setup-mcp.test.ts
+++ b/cli/tests/setup-mcp.test.ts
@@ -20,7 +20,7 @@ const EXPECTED_IDS = [
   'claude-code',
   'claude-desktop',
   'cursor',
-  'vscode',
+  'vscode-copilot',
   'vs-copilot',
   'rider-junie',
   'github-copilot-cli',
@@ -43,9 +43,9 @@ describe('agent roster', () => {
     expect([...listAgentIds()].sort()).toEqual([...getAgentIds()].sort());
   });
 
-  it('uses id `vscode` (not `vscode-copilot`), includes `custom`, omits `unity-ai`', () => {
-    expect(getAgentIds()).toContain('vscode');
-    expect(getAgentIds()).not.toContain('vscode-copilot');
+  it('uses id `vscode-copilot` (not `vscode`), includes `custom`, omits `unity-ai`', () => {
+    expect(getAgentIds()).toContain('vscode-copilot');
+    expect(getAgentIds()).not.toContain('vscode');
     expect(getAgentIds()).toContain('custom');
     expect(getAgentIds()).not.toContain('unity-ai');
   });
@@ -157,9 +157,9 @@ describe('setupMcp — http transport', () => {
     expect(written.mcpServers['unreal-mcp'].url).toBe('http://h/mcp');
   });
 
-  it('writes vscode config under the top-level `servers` key (not `mcpServers`)', async () => {
+  it('writes vscode-copilot config under the top-level `servers` key (not `mcpServers`)', async () => {
     const dir = tmp();
-    const r = await setupMcp({ agentId: 'vscode', projectDir: dir, transport: 'http', url: 'http://localhost:5220' });
+    const r = await setupMcp({ agentId: 'vscode-copilot', projectDir: dir, transport: 'http', url: 'http://localhost:5220' });
     expect(r.kind).toBe('success');
     if (r.kind !== 'success') return;
     const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));


### PR DESCRIPTION
## Summary
- Rename the VS Code (Copilot) AI-agent id in `unreal-mcp-cli` from `vscode` to `vscode-copilot`, matching the authoritative unity-mcp-cli naming (owner directive 2026-07-09).
- Only the id string changes — the agent's label, its `.vscode/mcp.json` config target, and its `servers` bodyPath are unchanged. The existing `custom` agent is kept.
- Updates the roster test assertions and the stale `setup-mcp <agent>` README example.

`setup-mcp --list` now reports the 14 ids: antigravity, claude-code, claude-desktop, cline, codex, cursor, custom, gemini, github-copilot-cli, kilo-code, open-code, rider-junie, vs-copilot, vscode-copilot.

Scope: `cli/` only — the `bridge/` sidecar is untouched. No version bump / release (handled by a separate release step; version is currently 0.7.0).

## Test plan
- [x] Target-specific local tests passed (Suite 6: `npm run build` (tsc) clean + `npm test` (vitest) 340 passed / 1 pre-existing skip)
- [x] Built CLI `setup-mcp --list` verified — 14 ids incl. `vscode-copilot` → `.vscode/mcp.json`

Closes #202