### PR TITLE
chore(deps): bump bridge McpPlugin 6.10.0 -> 6.11.0 and server pin 8.0.1 -> 8.0.3

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
@@ -31,7 +31,7 @@
 
 // Single source of the consumed shared-server version. Kept in lockstep with cli/src/lib/server-version.ts
 // (SERVER_VERSION) and Unity's McpServerManager.ServerVersion — the three plugins consume the SAME server.
-const TCHAR* FUnrealMcpServerManager::ServerVersion = TEXT("8.0.1");
+const TCHAR* FUnrealMcpServerManager::ServerVersion = TEXT("8.0.3");
 const TCHAR* FUnrealMcpServerManager::ServerPathEnvVar = TEXT("UNREAL_MCP_SERVER_PATH");
 
 namespace

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpServerManagerSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpServerManagerSpec.cpp
@@ -175,7 +175,7 @@ void FUnrealMcpServerManagerSpec::Define()
 	{
 		It("is pinned to the lockstep value (kept in sync with cli/src/lib/server-version.ts)", [this]()
 		{
-			TestEqual(TEXT("pinned server version"), FString(FUnrealMcpServerManager::ServerVersion), FString(TEXT("8.0.1")));
+			TestEqual(TEXT("pinned server version"), FString(FUnrealMcpServerManager::ServerVersion), FString(TEXT("8.0.3")));
 		});
 	});
 

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -51,7 +51,7 @@
 
   <!--
     Reused NuGet pins, kept in lockstep with Godot-MCP (Godot-MCP.csproj):
-    McpPlugin 6.10.0 + ReflectorNet 5.3.1. The MCP/reflection stack is NOT forked —
+    McpPlugin 6.11.0 + ReflectorNet 5.3.1. The MCP/reflection stack is NOT forked —
     pins are owned by the upstream release pipelines. The 6.8.0 bump consumed the new
     shared engine-agnostic com.IvanMurzak.McpPlugin.AgentConfig module (the AI-agent
     configurators + the AgentConfiguratorDescription UI-DTO) so the sidecar hosts the
@@ -64,12 +64,12 @@
     stale). 6.10.0 extends AgentConfiguratorDescription.Sections further — per-agent
     "Troubleshooting" sections and the Custom agent's Docker command content. Both flow
     through the existing generic Sections passthrough in AgentConfigService.Describe (no
-    code change needed). 6.10.0 keeps the ReflectorNet 5.3.1 dependency, so the lockstep
-    with Godot-MCP holds.
+    code change needed). 6.11.0 is a minor bump (also adopted by Unity-MCP 0.83.0) that
+    keeps the ReflectorNet 5.3.1 dependency, so the lockstep with Godot-MCP holds.
   -->
   <ItemGroup>
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.10.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.11.0" />
   </ItemGroup>
 
   <!-- The xUnit suite exercises a couple of internal helpers (e.g. ProxyTool.CalculateTokenCount). -->

--- a/cli/src/lib/server-version.ts
+++ b/cli/src/lib/server-version.ts
@@ -9,4 +9,4 @@
 // (with all `gamedev-mcp-server-<rid>.zip` assets) MUST already exist on
 // GameDev-MCP-Server BEFORE a CLI release that pins it (docs/RELEASING.md).
 
-export const SERVER_VERSION = '8.0.1';
+export const SERVER_VERSION = '8.0.3';


### PR DESCRIPTION
## Summary

- Bump the bridge NuGet pin `com.IvanMurzak.McpPlugin` `6.10.0` -> `6.11.0` (minor bump already adopted cleanly by Unity-MCP 0.83.0; `com.IvanMurzak.ReflectorNet` stays `5.3.1`, so the Godot-MCP lockstep holds).
- Bump the consumed shared-server pin `SERVER_VERSION` `8.0.1` -> `8.0.3` in `cli/src/lib/server-version.ts` (GameDev-MCP-Server `v8.0.3`, built on McpPlugin.Server 6.11.0, is already published).
- Maintainer-authorized dependency-freshness bump. The plugin `.uplugin` `VersionName` is deliberately untouched (owned by the release pipeline).

## Test plan

- [x] Bridge: `dotnet restore` + `build` (0 warn / 0 err) + `dotnet test` — 211/211 xUnit pass (McpPlugin 6.11.0 introduced no API break).
- [x] CLI: `tsc` build clean + `vitest` — 340 pass / 1 skipped (run with a CI-clean env; the 3 transient local fails were `.worktree.env`'s `UNREAL_MCP_TOKEN` leaking into `resolveConnection` config tests, not a code change).
- [x] Verified the `v8.0.3` GameDev-MCP-Server release exists (not draft/prerelease) before advancing the pin.

Closes #206