### PR TITLE
chore(deps): adopt McpPlugin 7.0.0-preview.1 (bridge) + migrate ConnectionConfig.Token -> CredentialProvider

### DIFF
--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -70,6 +70,15 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             GenerateSkillFiles = false,
         };
 
+        // McpPlugin 7.0 removed the static ConnectionConfig.Token string; the connection layer now pulls the
+        // bearer from ConnectionConfig.CredentialProvider (a Func<Task<string?>>) on each dial. The sidecar still
+        // resolves a STATIC bearer — the plugin pushes the effective token over IPC (§8), and the full device-flow
+        // / machine-credential-store auth lands in later mcp-authorize PRs — so we hold that bearer here and expose
+        // it through the provider wired in the constructor. Volatile-guarded: the provider callback runs on the
+        // connection layer's thread while the IPC reader thread / transition tasks mutate it (the same cross-thread
+        // access the pre-7.0 auto-property already had, now made explicit).
+        private string? _bearerToken;
+
         private IMcpPlugin? _plugin;
         private ManifestRegistrar? _registrar;
         // §A.1 (P1) prompt manifest registrar. Null when the built McpPlugin has no PromptManager (defensive —
@@ -165,6 +174,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _fallbackHost = fallbackHost;
             _fallbackToken = fallbackToken;
             _clientLabel = clientLabel;
+            // McpPlugin 7.0: the connection layer pulls the bearer from ConnectionConfig.CredentialProvider on each
+            // dial instead of reading a static ConnectionConfig.Token. Wire it once, here, to the sidecar's resolved
+            // bearer so the SAME token the plugin pushes over IPC (or the Build()-time env fallback) flows to SignalR,
+            // behavior-identical to the pre-7.0 static-token path. The provider's return type is Task<string?>, so a
+            // null bearer flows through as null → anonymous connection, exactly as the old null ConnectionConfig.Token did.
+            _config.CredentialProvider = () => Task.FromResult<string?>(BearerToken);
             // Default to the real IPC send; SetStatusEmitterForTest swaps it in the xUnit suite.
             _statusEmitter = status => _ipc.SendToPluginAsync(status, CancellationToken.None);
             _agentConfig = new AgentConfigService(loggerProvider?.CreateLogger(nameof(AgentConfigService)));
@@ -183,6 +198,26 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
         public IMcpPlugin? Plugin => _plugin;
         public ConnectionConfig Config => _config;
+
+        /// <summary>
+        /// The static bearer the sidecar currently holds — the value <see cref="ConnectionConfig.CredentialProvider"/>
+        /// returns to the connection layer (McpPlugin 7.0 replaced the old <c>ConnectionConfig.Token</c> string with
+        /// this async provider callback). Volatile so the provider's cross-thread read sees the latest write.
+        /// </summary>
+        private string? BearerToken
+        {
+            get => Volatile.Read(ref _bearerToken);
+            set => Volatile.Write(ref _bearerToken, value);
+        }
+
+        /// <summary>
+        /// Test seam: the bearer the connection layer would resolve from <see cref="ConnectionConfig.CredentialProvider"/>
+        /// right now, obtained by invoking the provider (so it proves the provider is wired to the stored bearer, not
+        /// merely that the field is set). The sidecar's provider completes synchronously (a <see cref="Task.FromResult{TResult}"/>),
+        /// so this never blocks. Replaces the pre-7.0 <c>host.Config.Token</c> the bridge xUnit suite asserted.
+        /// </summary>
+        internal string? CurrentBearer =>
+            _config.CredentialProvider is { } provider ? provider().GetAwaiter().GetResult() : null;
 
         /// <summary>
         /// Test seam: substitute a fake <see cref="IMcpPlugin"/> for the real one <see cref="Build"/> creates,
@@ -220,7 +255,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             if (!string.IsNullOrWhiteSpace(_fallbackHost))
                 _config.Host = _fallbackHost!;
             if (!string.IsNullOrWhiteSpace(_fallbackToken))
-                _config.Token = _fallbackToken;
+                BearerToken = _fallbackToken;
 
             // ProxyTools are schema-blind (raw JSON in/out, §2.1), so a bare reflector suffices — no
             // engine type converters are needed sidecar-side.
@@ -331,13 +366,13 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             // armed must also re-dial (below) — otherwise SignalR stays bound to the stale endpoint.
             var wasKeepConnected = _config.KeepConnected;
             var priorHost = _config.Host;
-            var priorToken = _config.Token;
+            var priorToken = BearerToken;
             ApplyConnectionConfig(config);
             _logger?.LogInformation("Applied updated connection config (mode-aware host {Host}).", _config.Host);
 
             var hostOrTokenChanged =
                 !string.Equals(priorHost, _config.Host, StringComparison.Ordinal) ||
-                !string.Equals(priorToken, _config.Token, StringComparison.Ordinal);
+                !string.Equals(priorToken, BearerToken, StringComparison.Ordinal);
 
             switch (DecideConfigTransition(wasKeepConnected, _config.KeepConnected, hostOrTokenChanged))
             {
@@ -416,9 +451,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 _config.Host = isCloud ? AppendCloudHubPath(selected!) : selected!;
 
             // Token: the plugin already applied mode+auth resolution (empty in Custom+None). An absent key
-            // leaves the existing token; an explicit empty value clears it (anonymous connection).
+            // leaves the existing token; an explicit empty value clears it (anonymous connection). The resolved
+            // bearer flows to SignalR through ConnectionConfig.CredentialProvider (McpPlugin 7.0), which reads
+            // this stored value on the next dial.
             if (token != null)
-                _config.Token = string.IsNullOrEmpty(token) ? null : token;
+                BearerToken = string.IsNullOrEmpty(token) ? null : token;
 
             if (config["keepConnected"] is JsonValue keepNode && keepNode.TryGetValue<bool>(out var keepConnected))
                 _config.KeepConnected = keepConnected;
@@ -476,7 +513,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 case IpcProtocol.Type.AuthRevoke:
                     _authCts?.Cancel();
                     // Clear the stored cloud bearer so a subsequent (re)connect is anonymous until re-authorized.
-                    _config.Token = null;
+                    BearerToken = null;
                     _logger?.LogInformation("Cloud token revoked (auth-revoke); cleared the in-memory bearer.");
                     break;
             }
@@ -604,7 +641,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         {
             if (ct.IsCancellationRequested)
                 return;
-            _config.Token = token; // the issued cloud bearer is NEVER logged (§8)
+            BearerToken = token; // the issued cloud bearer is NEVER logged (§8)
             // Re-dial (only when still armed) and surface the HONEST status + the cloud-authorized indicator. When
             // the user is DISARMED — they clicked Disconnect (keepConnected=false) before authorizing — store the
             // bearer WITHOUT dialing: claiming Connected here would build a live link Disconnect could never tear
@@ -1015,7 +1052,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                     // §7 live status: surface the connection result to the plugin's view-model. Only a CLOUD-mode
                     // bearer is a cloud authorization — a Custom-mode token is a local bearer and must NOT light the
                     // "Authorized — cloud token stored" indicator (ApplyStatus latches it and never demotes).
-                    var cloudAuthState = _isCloudMode && !string.IsNullOrEmpty(_config.Token) ? "Authorized" : null;
+                    var cloudAuthState = _isCloudMode && !string.IsNullOrEmpty(BearerToken) ? "Authorized" : null;
                     await EmitStatusAsync(ok ? "Connected" : "Connecting", cloudAuthState).ConfigureAwait(false);
                     // §7 (issue #109): once connected, seed the AI-agent roster (with retry/backoff) so the row is
                     // populated even before the first OnClientsChanged push. Fire-and-forget on a background task —

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -50,26 +50,33 @@
   </PropertyGroup>
 
   <!--
-    Reused NuGet pins, kept in lockstep with Godot-MCP (Godot-MCP.csproj):
-    McpPlugin 6.11.0 + ReflectorNet 5.3.1. The MCP/reflection stack is NOT forked —
-    pins are owned by the upstream release pipelines. The 6.8.0 bump consumed the new
-    shared engine-agnostic com.IvanMurzak.McpPlugin.AgentConfig module (the AI-agent
-    configurators + the AgentConfiguratorDescription UI-DTO) so the sidecar hosts the
-    AI-agent configuration service instead of the duplicated C++ Agents/ implementation.
-    6.9.0 carried the AgentConfig parity fix (Kilo/Zoo: disabled=false + HTTP
-    type="streamable-http") plus the AgentConfiguratorDescription DTO extension — the new
-    ConfigurationItemKind.Link + ConfigurationItem.Url (clickable open-URL items), the
-    ConfiguratorStatus tri-state (NotConfigured/Configured/ReconfigureNeeded) on a Status
-    field, and a Links collection (with a prepended "Reconfiguration Required" Alert when
-    stale). 6.10.0 extends AgentConfiguratorDescription.Sections further — per-agent
-    "Troubleshooting" sections and the Custom agent's Docker command content. Both flow
-    through the existing generic Sections passthrough in AgentConfigService.Describe (no
-    code change needed). 6.11.0 is a minor bump (also adopted by Unity-MCP 0.83.0) that
-    keeps the ReflectorNet 5.3.1 dependency, so the lockstep with Godot-MCP holds.
+    Reused NuGet pins — normally owned by the upstream release pipelines and kept in lockstep
+    with Godot-MCP (Godot-MCP.csproj). Current: McpPlugin 7.0.0-preview.1 + ReflectorNet 5.3.2.
+    The MCP/reflection stack is NOT forked. Historical context: the 6.8.0 bump consumed the new
+    shared engine-agnostic com.IvanMurzak.McpPlugin.AgentConfig module (the AI-agent configurators
+    + the AgentConfiguratorDescription UI-DTO) so the sidecar hosts the AI-agent configuration
+    service instead of the duplicated C++ Agents/ implementation. 6.9.0 carried the AgentConfig
+    parity fix (Kilo/Zoo: disabled=false + HTTP type="streamable-http") plus the
+    AgentConfiguratorDescription DTO extension — ConfigurationItemKind.Link + ConfigurationItem.Url
+    (clickable open-URL items), the ConfiguratorStatus tri-state (NotConfigured/Configured/
+    ReconfigureNeeded) on a Status field, and a Links collection (with a prepended "Reconfiguration
+    Required" Alert when stale). 6.10.0 extends AgentConfiguratorDescription.Sections further
+    (per-agent "Troubleshooting" sections + the Custom agent's Docker command), all via the generic
+    Sections passthrough in AgentConfigService.Describe. 6.11.0 was a minor bump keeping ReflectorNet
+    5.3.1.
+    ⚠ DEVIATION (mcp-authorize f1, PR 1/~6 — maintainer-authorized dependency-freshness bump, per the
+    PIPELINE.md "Freshness-bump carve-out"): 6.11.0 -> 7.0.0-preview.1 is the breaking-major adoption
+    of the mcp-authorize connection layer. In 7.0 ConnectionConfig's static bearer becomes a credential
+    PROVIDER (the migrated call sites live in Host/SidecarHost.cs); this PR migrates the existing
+    static-token flow onto that new API shape, behavior-preserving, with NO new auth features (RFC 8628
+    device flow, machine credential store, etc. land in later PRs). 7.0.0-preview.1
+    transitively requires ReflectorNet >= 5.3.2, so its explicit pin advances 5.3.1 -> 5.3.2 in the
+    same bump (NU1605 downgrade otherwise). Both versions are published on nuget.org. The Godot-MCP
+    lockstep is temporarily broken until the sibling Godot adoption PR lands.
   -->
   <ItemGroup>
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.11.0" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.2" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.0.0-preview.1" />
   </ItemGroup>
 
   <!-- The xUnit suite exercises a couple of internal helpers (e.g. ProxyTool.CalculateTokenCount). -->

--- a/bridge/tests/AgentConfigServiceTests.cs
+++ b/bridge/tests/AgentConfigServiceTests.cs
@@ -165,13 +165,21 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         }
 
         [Fact]
-        public void Status_WhenStale_ReportsReconfigureNeeded_AndPrependsAReconfigurationAlert()
+        public void Status_ConnectionSettingDrift_StaysConfigured_Under7xDeterministicUrl()
         {
-            // A stale config = an entry detected on disk that no longer matches the current connection settings.
-            // We drive this hermetically through claude-code, whose config is the project-local .mcp.json under the
-            // isolated temp _projectRoot (no host-home dependency) — mirroring the shared library's authoritative
-            // ReconfigureNeeded test (MCP-Plugin-dotnet AgentConfiguratorDescriptionTests.Status_StaleConfigOnDisk_*).
-            // Configure once at one Host so the entry lands on disk...
+            // McpPlugin 7.0 (mcp-authorize) made the written HTTP config URL project-DETERMINISTIC — a project pin
+            // + a derived per-project port (SHA256(projectRoot) → 20000–29999) and NO embedded token — so the raw
+            // host/port carried in the settings no longer drives the on-disk entry (the library writes e.g.
+            // `http://localhost:<derived>/mcp/p/<pin>`). Consequence: a connection-setting change alone (here a
+            // different Host, same project root) no longer makes the entry "stale" — the desired URL recomputes
+            // identically from the same project, so the shared library reports Configured, NOT ReconfigureNeeded,
+            // and emits no "Reconfiguration Required" alert. (Pre-7.0 this exact scenario returned ReconfigureNeeded;
+            // this test was updated when the 7.0 dependency was adopted. `AgentConfigService.Describe` is unchanged
+            // and still forwards whatever tri-state the library produces — it just no longer produces ReconfigureNeeded
+            // for host/port drift. The engine-side reconciliation of the new config model — MapSettings token drop,
+            // the 8080→derived-port migration — is a later mcp-authorize PR; this locks the adopted 7.0 behavior so
+            // that later change is deliberate.)
+            // Configure once so the entry lands on disk (project-local .mcp.json under the isolated temp _projectRoot)...
             var configure = _service.HandleConfigure(new AgentConfigureRequestMessage
             {
                 RequestId = "r2c-cfg", AgentId = "claude-code", Transport = "streamableHttp",
@@ -180,7 +188,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             Assert.True(configure.Ok);
             Assert.True(configure.Description!.IsConfigured);
 
-            // ...then describe with a DIFFERENT Host: the entry is detected but no longer matches → ReconfigureNeeded.
+            // ...then describe with a DIFFERENT Host: under 7.0 the entry is still detected AND still matches (the URL
+            // derives from the project, not this host), so it stays Configured with no reconfiguration alert.
             var result = _service.HandleStatus(new AgentStatusRequestMessage
             {
                 RequestId = "r2c", AgentId = "claude-code", Transport = "streamableHttp",
@@ -189,11 +198,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
 
             Assert.True(result.Ok);
             var d = result.Description!;
-            Assert.Equal("ReconfigureNeeded", d.Status);
-            // The library prepends a "Reconfiguration Required" section whose first item is an Alert-kind line.
-            var reconfig = d.Sections.FirstOrDefault(s => s.Heading == "Reconfiguration Required");
-            Assert.NotNull(reconfig);
-            Assert.Contains(reconfig!.Items, i => i.Kind == "Alert");
+            Assert.True(d.IsConfigured);
+            Assert.Equal("Configured", d.Status);
+            Assert.DoesNotContain(d.Sections, s => s.Heading == "Reconfiguration Required");
         }
 
         [Fact]

--- a/bridge/tests/ConnectionConfigTests.cs
+++ b/bridge/tests/ConnectionConfigTests.cs
@@ -51,7 +51,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             // The cloud serves the SignalR hub behind the /mcp nginx prefix, so the McpPlugin connection host
             // MUST carry it (the client appends /hub/mcp-server) — otherwise it dials the frontend SPA → 404.
             Assert.Equal("https://ai-game.dev/mcp", host.Config.Host);
-            Assert.Equal("cloud-bearer", host.Config.Token);
+            Assert.Equal("cloud-bearer", host.CurrentBearer);
         }
 
         [Fact]
@@ -100,7 +100,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             // Custom mode uses the host VERBATIM — no /mcp hub suffix (a local/self-hosted server exposes the
             // hub at the root, mirroring Unity/Godot Custom mode).
             Assert.Equal("http://localhost:5200", host.Config.Host);
-            Assert.Equal("custom-bearer", host.Config.Token);
+            Assert.Equal("custom-bearer", host.CurrentBearer);
         }
 
         [Fact]
@@ -110,7 +110,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             host.ApplyConnectionConfig(Config("Custom", host: "http://localhost:5200", cloudUrl: null, token: ""));
 
             Assert.Equal("http://localhost:5200", host.Config.Host);
-            Assert.Null(host.Config.Token); // Custom+None sends no bearer (plugin resolved token to empty)
+            Assert.Null(host.CurrentBearer); // Custom+None sends no bearer (plugin resolved token to empty)
         }
 
         [Fact]
@@ -121,7 +121,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             host.ApplyConnectionConfig(new JsonObject { ["mode"] = "Custom" }); // no host/cloudUrl/token
 
             Assert.Equal("http://localhost:5170", host.Config.Host);
-            Assert.Equal("env-token", host.Config.Token);
+            Assert.Equal("env-token", host.CurrentBearer);
         }
 
         [Fact]
@@ -158,10 +158,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         {
             using var host = BuildHost();
             host.ApplyConnectionConfig(Config("Cloud", host: null, cloudUrl: "https://ai-game.dev", token: "cloud-bearer"));
-            Assert.Equal("cloud-bearer", host.Config.Token);
+            Assert.Equal("cloud-bearer", host.CurrentBearer);
 
             host.HandleAuthMessage(IpcProtocol.Type.AuthRevoke);
-            Assert.Null(host.Config.Token);
+            Assert.Null(host.CurrentBearer);
         }
 
         [Theory]
@@ -173,7 +173,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             host.ApplyConnectionConfig(Config("Custom", host: "http://localhost:5200", cloudUrl: null, token: "keep"));
 
             host.HandleAuthMessage(type); // must not throw and must not touch the bearer
-            Assert.Equal("keep", host.Config.Token);
+            Assert.Equal("keep", host.CurrentBearer);
         }
 
         // --- AppendCloudHubPath / StripCloudHubPath helper specs (the /mcp hub-prefix round-trip) -----------

--- a/bridge/tests/DeviceCodeAuthenticatorTests.cs
+++ b/bridge/tests/DeviceCodeAuthenticatorTests.cs
@@ -197,11 +197,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             using var cts = new CancellationTokenSource();
             cts.Cancel();
             await host.CommitAuthorizedSessionAsync("cloud-bearer-abc", cts.Token);
-            Assert.Null(host.Config.Token); // the guard bailed — the just-cancelled bearer is NOT stored
+            Assert.Null(host.CurrentBearer); // the guard bailed — the just-cancelled bearer is NOT stored
 
             // Control: an uncancelled commit DOES store the bearer, proving the guard (not a no-op) blocks it.
             await host.CommitAuthorizedSessionAsync("cloud-bearer-abc", CancellationToken.None);
-            Assert.Equal("cloud-bearer-abc", host.Config.Token);
+            Assert.Equal("cloud-bearer-abc", host.CurrentBearer);
         }
 
         [Theory]
@@ -251,7 +251,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
 
             await host.CommitAuthorizedSessionAsync("cloud-bearer-abc", CancellationToken.None);
 
-            Assert.Equal("cloud-bearer-abc", host.Config.Token); // the authorized bearer is stored even while disarmed
+            Assert.Equal("cloud-bearer-abc", host.CurrentBearer); // the authorized bearer is stored even while disarmed
             Assert.False(host.Config.KeepConnected); // and the disarmed intent is untouched — no silent re-arm
         }
     }


### PR DESCRIPTION
## Summary
- Foundation PR (1 of ~6) of **mcp-authorize**: adopt the shared `com.IvanMurzak.McpPlugin` `6.11.0 → 7.0.0-preview.1` breaking-major in the `bridge/` sidecar; **behavior-preserving, compile-green only** (no new user-facing behavior).
- Migrate the 7 `ConnectionConfig.Token` (static bearer `string`, removed in 7.0) call sites in `bridge/src/Host/SidecarHost.cs` onto the new `ConnectionConfig.CredentialProvider` (`Func<Task<string?>>`) API — the sidecar holds the static bearer and the provider returns it, so the same credential flows to SignalR unchanged (a null bearer → anonymous connection, as before).
- Advance the explicit `com.IvanMurzak.ReflectorNet` pin `5.3.1 → 5.3.2` (7.0.0-preview.1 transitively requires `>= 5.3.2`; both versions published on nuget.org). Maintainer-authorized dependency-freshness bump.
- Adapt one `AgentConfigServiceTests` case: 7.0's AgentConfig library makes the written HTTP config URL project-deterministic (pin + derived port, no embedded token), so a host/port change no longer marks a config stale → `Configured`, not `ReconfigureNeeded`. `AgentConfigService` is unchanged; only the test's premise moved.

Out of scope (deferred to later mcp-authorize PRs): RFC 8628 device flow, machine credential store, boot auto-adopt, instance-metadata handshake, ProjectIdentity wiring, the new IPC message, the 8080→derived-port migration, editor UI sign-in, `AgentConfigService.MapSettings` token drop, enroll-redemption, live e2e against a 9.0 server. No version bump; no release action.

## Test plan
- [x] Target-specific local tests passed: `bridge/` `dotnet build` (0 warn/0 err) + `dotnet test` (211 passed, 0 failed). Plugin/cli legs untouched (bridge-only change) — validated by `test-pull-request` CI.

Closes #209