### PR TITLE
feat(bridge): RFC 8628 device flow + machine credential store + zero-button boot (mcp-authorize PR 2)

### DIFF
--- a/bridge/src/Auth/DeviceCodeAuthenticator.cs
+++ b/bridge/src/Auth/DeviceCodeAuthenticator.cs
@@ -9,8 +9,8 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -21,12 +21,15 @@ using Microsoft.Extensions.Logging;
 namespace com.IvanMurzak.Unreal.MCP.Bridge.Auth
 {
     /// <summary>
-    /// The real Cloud device-code authorization flow (docs/ARCHITECTURE.md §7 item 4 / §1.3), replacing PR #8's
-    /// <c>auth-start</c> / <c>auth-cancel</c> / <c>auth-revoke</c> stubs for the happy path. It is the RFC 8628
-    /// device-authorization grant against the ai-game.dev cloud — the SAME contract Unity-MCP's
-    /// <c>DeviceAuthService</c> uses: <c>POST {cloudUrl}/api/auth/device/authorize</c> →
-    /// <c>POST {cloudUrl}/api/auth/device/token</c> polled until an <c>access_token</c> is issued, the flow is
-    /// denied/expired, or it is cancelled.
+    /// The Cloud device-authorization sign-in flow (docs/ARCHITECTURE.md §7 / .claude/design/mcp-authorize
+    /// 03-auth-flows.md Flow B), on the **RFC 8628-conformant** ai-game.dev alias:
+    /// <c>POST {base}/oauth/device_authorization</c> (form: <c>client_id</c> + <c>scope=mcp:plugin</c>) →
+    /// <c>POST {base}/oauth/token</c> polled with the device-code grant
+    /// (<c>grant_type=urn:ietf:params:oauth:grant-type:device_code</c>) until the AS issues an ES256 JWT
+    /// (<c>access_token</c>, <c>aud=urn:agd:hub</c>) + a <c>refresh_token</c>, the flow is denied/expired,
+    /// or it is cancelled. This replaces the legacy <c>/api/auth/device/*</c> opaque-token path (retired with
+    /// the mcp-authorize breaking release); the caller persists the issued refresh token into the shared
+    /// machine credential store so sign-in happens once per machine (D12).
     ///
     /// As each step progresses it invokes the <c>emit</c> callback with a <see cref="DeviceAuthMessage"/> so the
     /// sidecar can forward it to the plugin (which renders the verification URL + user code, §7). The HTTP layer
@@ -35,13 +38,26 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Auth
     /// </summary>
     public sealed class DeviceCodeAuthenticator
     {
+        /// <summary>The public device-flow client identifier this engine plugin presents to the AS
+        /// (RFC 8628; the AS metadata advertises <c>token_endpoint_auth_methods_supported: ["none"]</c>,
+        /// so no client secret is used). The exact registered value is confirmed by the live-e2e against
+        /// the 9.0 server (mcp-authorize PR 6); the mocked-AS suites here do not depend on it.</summary>
+        public const string DefaultClientId = "unreal-mcp-plugin";
+
+        /// <summary>The device-flow scope that selects the ES256 MCP JWT + refresh-token response (design 03 Flow B).</summary>
+        public const string PluginScope = "mcp:plugin";
+
         private static readonly JsonSerializerOptions JsonOptions = new()
         {
             PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
             PropertyNameCaseInsensitive = true,
         };
 
+        private const string DeviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code";
+
         private readonly HttpClient _http;
+        private readonly string _clientId;
+        private readonly string _scope;
         private readonly ILogger? _logger;
         private readonly Func<TimeSpan, CancellationToken, Task> _delay;
         private readonly Func<DateTimeOffset> _now;
@@ -50,9 +66,13 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Auth
             HttpClient http,
             ILogger? logger = null,
             Func<TimeSpan, CancellationToken, Task>? delay = null,
-            Func<DateTimeOffset>? now = null)
+            Func<DateTimeOffset>? now = null,
+            string clientId = DefaultClientId,
+            string scope = PluginScope)
         {
             _http = http ?? throw new ArgumentNullException(nameof(http));
+            _clientId = clientId;
+            _scope = scope;
             _logger = logger;
             _delay = delay ?? ((d, ct) => Task.Delay(d, ct));
             // Injectable like _delay so the xUnit suite can drive the expires_in deadline deterministically.
@@ -63,13 +83,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Auth
         /// Run the full device-code flow against <paramref name="cloudUrl"/>. Emits a <c>pending</c>
         /// device-auth (with the verification URL + user code) as soon as the authorize call returns, polls the
         /// token endpoint honouring the server's <c>interval</c> (and <c>slow_down</c>), and returns the issued
-        /// bearer on success. On denial / expiry / cancellation it emits a terminal <c>failed</c> (or the flow's
-        /// own cancellation) and returns a non-success result. Never throws for an expected protocol outcome;
-        /// a transport exception bubbles as a failed result with the message.
+        /// ES256 JWT + refresh token on success. On denial / expiry / cancellation it emits a terminal
+        /// <c>failed</c> (or the flow's own cancellation) and returns a non-success result. Never throws for an
+        /// expected protocol outcome; a transport exception bubbles as a failed result with the message.
         /// </summary>
         public async Task<DeviceAuthResult> AuthorizeAsync(
             string cloudUrl,
-            string? clientLabel,
             Func<DeviceAuthMessage, Task> emit,
             CancellationToken ct)
         {
@@ -81,7 +100,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Auth
             DeviceAuthorizeResponse authorize;
             try
             {
-                authorize = await InitiateAsync(baseUrl, clientLabel, ct).ConfigureAwait(false);
+                authorize = await InitiateAsync(baseUrl, ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
@@ -149,13 +168,14 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Auth
 
                 if (!string.IsNullOrEmpty(token.AccessToken))
                 {
+                    var expiresAt = token.ExpiresIn > 0 ? _now() + TimeSpan.FromSeconds(token.ExpiresIn) : (DateTimeOffset?)null;
                     await SafeEmit(emit, new DeviceAuthMessage
                     {
                         State = "authorized",
                         Token = token.AccessToken,
                     }).ConfigureAwait(false);
-                    _logger?.LogInformation("Device-code flow authorized; cloud token stored."); // token NEVER logged (§8)
-                    return DeviceAuthResult.Authorized(token.AccessToken!);
+                    _logger?.LogInformation("Device-code flow authorized; cloud credential issued."); // token/refresh NEVER logged (§8)
+                    return DeviceAuthResult.Authorized(token.AccessToken!, token.RefreshToken, expiresAt);
                 }
 
                 switch (token.Error)
@@ -182,13 +202,15 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Auth
             return DeviceAuthResult.Cancelled();
         }
 
-        private async Task<DeviceAuthorizeResponse> InitiateAsync(string baseUrl, string? clientLabel, CancellationToken ct)
+        private async Task<DeviceAuthorizeResponse> InitiateAsync(string baseUrl, CancellationToken ct)
         {
-            var body = clientLabel != null
-                ? JsonSerializer.Serialize(new { client_label = clientLabel }, JsonOptions)
-                : "{}";
-            using var content = new StringContent(body, Encoding.UTF8, "application/json");
-            using var response = await _http.PostAsync($"{baseUrl}/api/auth/device/authorize", content, ct).ConfigureAwait(false);
+            // RFC 8628 §3.1: application/x-www-form-urlencoded { client_id, scope }.
+            using var content = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("client_id", _clientId),
+                new KeyValuePair<string, string>("scope", _scope),
+            });
+            using var response = await _http.PostAsync($"{baseUrl}/oauth/device_authorization", content, ct).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
             var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             return JsonSerializer.Deserialize<DeviceAuthorizeResponse>(json, JsonOptions)
@@ -197,11 +219,15 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Auth
 
         private async Task<DeviceTokenResponse> PollAsync(string baseUrl, string deviceCode, CancellationToken ct)
         {
-            var body = JsonSerializer.Serialize(
-                new { device_code = deviceCode, grant_type = "urn:ietf:params:oauth:grant-type:device_code" },
-                JsonOptions);
-            using var content = new StringContent(body, Encoding.UTF8, "application/json");
-            using var response = await _http.PostAsync($"{baseUrl}/api/auth/device/token", content, ct).ConfigureAwait(false);
+            // RFC 8628 §3.4: application/x-www-form-urlencoded device-code grant. The token endpoint returns a
+            // 400 with { error } while pending — do NOT EnsureSuccessStatusCode; read + decode the body either way.
+            using var content = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("grant_type", DeviceCodeGrantType),
+                new KeyValuePair<string, string>("device_code", deviceCode),
+                new KeyValuePair<string, string>("client_id", _clientId),
+            });
+            using var response = await _http.PostAsync($"{baseUrl}/oauth/token", content, ct).ConfigureAwait(false);
             var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             return JsonSerializer.Deserialize<DeviceTokenResponse>(json, JsonOptions)
                 ?? throw new InvalidOperationException("Empty device token response.");
@@ -227,21 +253,29 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Auth
         public sealed class DeviceTokenResponse
         {
             [JsonPropertyName("access_token")] public string? AccessToken { get; set; }
+            [JsonPropertyName("refresh_token")] public string? RefreshToken { get; set; }
             [JsonPropertyName("token_type")] public string? TokenType { get; set; }
+            [JsonPropertyName("expires_in")] public int ExpiresIn { get; set; }
             [JsonPropertyName("error")] public string? Error { get; set; }
             [JsonPropertyName("error_description")] public string? ErrorDescription { get; set; }
         }
     }
 
-    /// <summary>Terminal outcome of a device-code flow. The token is present only on <see cref="Success"/>.</summary>
+    /// <summary>
+    /// Terminal outcome of a device-code flow. The credential (access token + refresh token + expiry) is present
+    /// only on <see cref="Success"/>; the caller persists it into the machine credential store (D12).
+    /// </summary>
     public sealed class DeviceAuthResult
     {
         public bool Success { get; private init; }
         public bool WasCancelled { get; private init; }
         public string? Token { get; private init; }
+        public string? RefreshToken { get; private init; }
+        public DateTimeOffset? ExpiresAt { get; private init; }
         public string? Error { get; private init; }
 
-        public static DeviceAuthResult Authorized(string token) => new() { Success = true, Token = token };
+        public static DeviceAuthResult Authorized(string token, string? refreshToken = null, DateTimeOffset? expiresAt = null) =>
+            new() { Success = true, Token = token, RefreshToken = refreshToken, ExpiresAt = expiresAt };
         public static DeviceAuthResult Cancelled() => new() { WasCancelled = true, Error = "cancelled" };
         public static DeviceAuthResult Failed(string error) => new() { Error = error };
 

--- a/bridge/src/Auth/OAuthTokenRefresher.cs
+++ b/bridge/src/Auth/OAuthTokenRefresher.cs
@@ -1,0 +1,128 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Auth
+{
+    /// <summary>
+    /// The <see cref="ITokenRefresher"/> the shared <c>PluginCredentialProvider</c> (McpPlugin 7.0) calls to
+    /// renew the machine-stored credential — both PROACTIVELY (before <c>exp</c>, driven by the provider's
+    /// refresh-skew) and REACTIVELY (on the connection layer's <c>OnAuthorizationRejected</c> signal, wired via
+    /// <c>ConnectionCredentialCoordinator</c>). It runs the OAuth 2.1 refresh-token grant against the AS's
+    /// <c>POST {serverTarget}/oauth/token</c> (public client — <c>token_endpoint_auth_methods_supported: ["none"]</c>,
+    /// so no client secret). The AS ROTATES the refresh token (design 03 / a3), so the response's new
+    /// <c>refresh_token</c> is threaded back into the store by the provider; replaying the old one revokes the
+    /// family. The HTTP layer is injectable so the xUnit suite drives it with a scripted handler (no network).
+    /// Tokens are NEVER logged (§8).
+    /// </summary>
+    public sealed class OAuthTokenRefresher : ITokenRefresher
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            PropertyNameCaseInsensitive = true,
+        };
+
+        private readonly HttpClient _http;
+        private readonly string _clientId;
+        private readonly ILogger? _logger;
+        private readonly Func<DateTimeOffset> _now;
+
+        public OAuthTokenRefresher(
+            HttpClient http,
+            string clientId = DeviceCodeAuthenticator.DefaultClientId,
+            ILogger? logger = null,
+            Func<DateTimeOffset>? now = null)
+        {
+            _http = http ?? throw new ArgumentNullException(nameof(http));
+            _clientId = clientId;
+            _logger = logger;
+            _now = now ?? (() => DateTimeOffset.UtcNow);
+        }
+
+        public async Task<TokenRefreshResult> RefreshAsync(string refreshToken, string? serverTarget, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(refreshToken))
+                return TokenRefreshResult.Failure("No refresh token.");
+            if (string.IsNullOrWhiteSpace(serverTarget))
+                return TokenRefreshResult.Failure("No server target.");
+
+            var baseUrl = serverTarget.TrimEnd('/');
+
+            HttpResponseMessage response;
+            string json;
+            try
+            {
+                // OAuth 2.1 refresh grant, form-encoded (RFC 6749 §6). A rotated/expired refresh token comes back
+                // as a 400 with { error } — read + decode the body regardless of status, like the device poll.
+                using var content = new FormUrlEncodedContent(new[]
+                {
+                    new KeyValuePair<string, string>("grant_type", "refresh_token"),
+                    new KeyValuePair<string, string>("refresh_token", refreshToken),
+                    new KeyValuePair<string, string>("client_id", _clientId),
+                });
+                response = await _http.PostAsync($"{baseUrl}/oauth/token", content, cancellationToken).ConfigureAwait(false);
+                json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return TokenRefreshResult.Failure("cancelled");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogDebug("Token refresh transport error: {Message}", ex.Message);
+                return TokenRefreshResult.Failure(ex.Message);
+            }
+
+            RefreshTokenResponse? parsed;
+            try
+            {
+                parsed = JsonSerializer.Deserialize<RefreshTokenResponse>(json, JsonOptions);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogDebug("Token refresh response parse error: {Message}", ex.Message);
+                return TokenRefreshResult.Failure("Malformed token response.");
+            }
+
+            if (parsed == null || string.IsNullOrEmpty(parsed.AccessToken))
+            {
+                var reason = parsed?.Error ?? "no access token";
+                _logger?.LogWarning("Token refresh failed: {Reason}", reason); // never logs the token
+                return TokenRefreshResult.Failure(reason);
+            }
+
+            var expiresAt = parsed.ExpiresIn > 0 ? _now() + TimeSpan.FromSeconds(parsed.ExpiresIn) : (DateTimeOffset?)null;
+            // The AS may or may not rotate the refresh token; when it omits one, keep the existing (pass null so
+            // the provider retains it rather than clearing it).
+            var newRefresh = string.IsNullOrEmpty(parsed.RefreshToken) ? null : parsed.RefreshToken;
+            return TokenRefreshResult.Success(parsed.AccessToken!, newRefresh, expiresAt);
+        }
+
+        private sealed class RefreshTokenResponse
+        {
+            [JsonPropertyName("access_token")] public string? AccessToken { get; set; }
+            [JsonPropertyName("refresh_token")] public string? RefreshToken { get; set; }
+            [JsonPropertyName("token_type")] public string? TokenType { get; set; }
+            [JsonPropertyName("expires_in")] public int ExpiresIn { get; set; }
+            [JsonPropertyName("error")] public string? Error { get; set; }
+            [JsonPropertyName("error_description")] public string? ErrorDescription { get; set; }
+        }
+    }
+}

--- a/bridge/src/Auth/OAuthTokenRefresher.cs
+++ b/bridge/src/Auth/OAuthTokenRefresher.cs
@@ -65,7 +65,6 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Auth
 
             var baseUrl = serverTarget.TrimEnd('/');
 
-            HttpResponseMessage response;
             string json;
             try
             {
@@ -77,7 +76,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Auth
                     new KeyValuePair<string, string>("refresh_token", refreshToken),
                     new KeyValuePair<string, string>("client_id", _clientId),
                 });
-                response = await _http.PostAsync($"{baseUrl}/oauth/token", content, cancellationToken).ConfigureAwait(false);
+                // Dispose the response (as DeviceCodeAuthenticator does) so a long-lived session's proactive/on-401
+                // refreshes do not leak the HttpResponseMessage + its pooled connection until finalization.
+                using var response = await _http.PostAsync($"{baseUrl}/oauth/token", content, cancellationToken).ConfigureAwait(false);
                 json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -28,6 +28,9 @@ using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Logging;
 using R3;
 using McpVersion = com.IvanMurzak.McpPlugin.Common.Version;
+// The shared machine credential store + DTO (McpPlugin 7.0). Aliased to avoid colliding the two AgentConfig
+// namespaces (this one + the bridge-local com.IvanMurzak.Unreal.MCP.Bridge.AgentConfig imported above).
+using McpAgentConfig = com.IvanMurzak.McpPlugin.AgentConfig;
 
 namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 {
@@ -50,8 +53,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         /// <see cref="ConnectionConfig.Host"/>, so in Cloud mode the host MUST carry this prefix — otherwise
         /// the client dials <c>https://ai-game.dev/hub/mcp-server</c>, which nginx routes to the frontend SPA
         /// (404) and the sidecar never connects. Mirrors Unity-MCP's <c>CloudServerUrl => base + "/mcp"</c> and
-        /// Godot-MCP's <c>CloudHubPath = "/mcp"</c>. Device-code auth hits the BACKEND (<c>/api/auth/...</c>),
-        /// which is NOT behind this prefix, so it must use the stripped base (see <see cref="StripCloudHubPath"/>).
+        /// Godot-MCP's <c>CloudHubPath = "/mcp"</c>. Device-code auth + token refresh hit the AS (<c>/oauth/...</c>),
+        /// which is NOT behind this prefix, so they must use the stripped base (see <see cref="StripCloudHubPath"/>).
         /// </summary>
         internal const string CloudHubPath = "/mcp";
 
@@ -71,13 +74,27 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         };
 
         // McpPlugin 7.0 removed the static ConnectionConfig.Token string; the connection layer now pulls the
-        // bearer from ConnectionConfig.CredentialProvider (a Func<Task<string?>>) on each dial. The sidecar still
-        // resolves a STATIC bearer — the plugin pushes the effective token over IPC (§8), and the full device-flow
-        // / machine-credential-store auth lands in later mcp-authorize PRs — so we hold that bearer here and expose
-        // it through the provider wired in the constructor. Volatile-guarded: the provider callback runs on the
-        // connection layer's thread while the IPC reader thread / transition tasks mutate it (the same cross-thread
-        // access the pre-7.0 auto-property already had, now made explicit).
+        // bearer from ConnectionConfig.CredentialProvider (a Func<Task<string?>>) on each dial. In CUSTOM mode the
+        // sidecar resolves a STATIC bearer — the plugin pushes the effective local token over IPC (§8) — held here
+        // and returned by ResolveBearerAsync. In CLOUD mode the machine-stored ES256 JWT (below) wins. Volatile-
+        // guarded: the provider callback runs on the connection layer's thread while the IPC reader thread /
+        // transition tasks mutate it (the same cross-thread access the pre-7.0 auto-property already had).
         private string? _bearerToken;
+
+        // mcp-authorize (design 03 Flow B / 06): the shared machine credential store + the McpPlugin 7.0 credential
+        // provider that owns the once-per-machine ES256-JWT/refresh-token lifecycle. NULL unless the caller opted in
+        // by supplying a store (Program.cs → ~/.ai-game-dev; the xUnit suite → a temp dir). When null the sidecar
+        // behaves exactly as before (static bearer only), so the Custom/env paths are untouched. When present:
+        //  - ResolveBearerAsync returns the provider's auto-refreshed JWT in Cloud mode (the device-flow / boot
+        //    auto-adopt credential), else the static bearer;
+        //  - a successful device-code sign-in is persisted here (CommitAuthorizedSessionAsync) + adopted live;
+        //  - the coordinator refreshes on the connection's OnAuthorizationRejected (on-401 → refresh → reconnect);
+        //  - OnSignInRequired surfaces "sign in again" to the editor.
+        private readonly McpAgentConfig.MachineCredentialStore? _credentialStore;
+        private readonly PluginCredentialProvider? _credentialProvider;
+        private readonly ITokenRefresher? _tokenRefresher;
+        private ConnectionCredentialCoordinator? _credentialCoordinator;
+        private IDisposable? _signInRequiredSubscription;
 
         private IMcpPlugin? _plugin;
         private ManifestRegistrar? _registrar;
@@ -97,7 +114,6 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         // §7 Cloud device-code flow (replaces PR #8's auth stubs). The authenticator is injectable so the xUnit
         // suite drives the flow against a fake HTTP handler; _authCts cancels an in-progress flow (auth-cancel).
         private readonly DeviceCodeAuthenticator _authenticator;
-        private readonly string _clientLabel;
         private CancellationTokenSource? _authCts;
         // The HttpClient the default-path authenticator uses, owned here so Dispose() releases it (the
         // injected-authenticator path supplies its own client and leaves this null).
@@ -165,7 +181,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             string? fallbackHost = null,
             string? fallbackToken = null,
             DeviceCodeAuthenticator? authenticator = null,
-            string clientLabel = "Unreal-MCP-Bridge")
+            McpAgentConfig.MachineCredentialStore? credentialStore = null,
+            ITokenRefresher? tokenRefresher = null)
         {
             _ipc = ipc ?? throw new ArgumentNullException(nameof(ipc));
             _sidecarVersion = sidecarVersion;
@@ -173,26 +190,32 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _logger = loggerProvider?.CreateLogger(nameof(SidecarHost));
             _fallbackHost = fallbackHost;
             _fallbackToken = fallbackToken;
-            _clientLabel = clientLabel;
             // McpPlugin 7.0: the connection layer pulls the bearer from ConnectionConfig.CredentialProvider on each
-            // dial instead of reading a static ConnectionConfig.Token. Wire it once, here, to the sidecar's resolved
-            // bearer so the SAME token the plugin pushes over IPC (or the Build()-time env fallback) flows to SignalR,
-            // behavior-identical to the pre-7.0 static-token path. The provider's return type is Task<string?>, so a
-            // null bearer flows through as null → anonymous connection, exactly as the old null ConnectionConfig.Token did.
-            _config.CredentialProvider = () => Task.FromResult<string?>(BearerToken);
+            // dial instead of reading a static ConnectionConfig.Token. ResolveBearerAsync returns the Cloud machine-
+            // stored JWT when signed in, else the static bearer the plugin pushes over IPC (or the Build()-time env
+            // fallback) — behavior-identical to the pre-7.0 static-token path when no credential store is wired.
+            _config.CredentialProvider = ResolveBearerAsync;
             // Default to the real IPC send; SetStatusEmitterForTest swaps it in the xUnit suite.
             _statusEmitter = status => _ipc.SendToPluginAsync(status, CancellationToken.None);
             _agentConfig = new AgentConfigService(loggerProvider?.CreateLogger(nameof(AgentConfigService)));
-            if (authenticator != null)
-            {
-                _authenticator = authenticator;
-            }
-            else
-            {
-                // We OWN this HttpClient (the injected-authenticator path supplies its own); the authenticator
-                // never disposes it, so we track it here and release it in Dispose() for symmetry.
+
+            // A single owned HttpClient covers the default device authenticator AND the default token refresher; the
+            // injected-* paths (xUnit) supply their own, so we only mint one when a default actually needs it.
+            if (authenticator == null || (credentialStore != null && tokenRefresher == null))
                 _ownedHttpClient = new HttpClient();
-                _authenticator = new DeviceCodeAuthenticator(_ownedHttpClient, loggerProvider?.CreateLogger(nameof(DeviceCodeAuthenticator)));
+
+            _authenticator = authenticator
+                ?? new DeviceCodeAuthenticator(_ownedHttpClient!, loggerProvider?.CreateLogger(nameof(DeviceCodeAuthenticator)));
+
+            // mcp-authorize: wire the machine-credential lifecycle ONLY when the caller opted in with a store. Left
+            // null, the sidecar keeps the pre-existing static-bearer behavior exactly (Custom/env paths untouched).
+            if (credentialStore != null)
+            {
+                _credentialStore = credentialStore;
+                _tokenRefresher = tokenRefresher
+                    ?? new OAuthTokenRefresher(_ownedHttpClient!, logger: loggerProvider?.CreateLogger(nameof(OAuthTokenRefresher)));
+                _credentialProvider = new PluginCredentialProvider(
+                    _credentialStore, _tokenRefresher, loggerProvider?.CreateLogger(nameof(PluginCredentialProvider)));
             }
         }
 
@@ -212,12 +235,38 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
         /// <summary>
         /// Test seam: the bearer the connection layer would resolve from <see cref="ConnectionConfig.CredentialProvider"/>
-        /// right now, obtained by invoking the provider (so it proves the provider is wired to the stored bearer, not
-        /// merely that the field is set). The sidecar's provider completes synchronously (a <see cref="Task.FromResult{TResult}"/>),
-        /// so this never blocks. Replaces the pre-7.0 <c>host.Config.Token</c> the bridge xUnit suite asserted.
+        /// right now, obtained by invoking the provider (so it proves the provider is wired to the resolved bearer, not
+        /// merely that the field is set). In the static-bearer path it completes synchronously; a Cloud signed-in path
+        /// with a valid (non-expiring) stored token also returns synchronously. Replaces the pre-7.0
+        /// <c>host.Config.Token</c> the bridge xUnit suite asserted.
         /// </summary>
         internal string? CurrentBearer =>
             _config.CredentialProvider is { } provider ? provider().GetAwaiter().GetResult() : null;
+
+        /// <summary>Test seam: the wired machine-credential provider (null unless a store was supplied).</summary>
+        internal PluginCredentialProvider? CredentialProvider => _credentialProvider;
+
+        /// <summary>
+        /// Resolve the bearer the SignalR client should present on the next dial (wired to
+        /// <see cref="ConnectionConfig.CredentialProvider"/>). In CLOUD mode, once the machine credential provider is
+        /// signed in (device-flow sign-in or boot auto-adopt of a seeded store, D12), return its ES256 JWT — the
+        /// provider proactively refreshes it before <c>exp</c>. Otherwise return the static bearer the plugin pushed
+        /// over IPC (Custom mode) or the Build()-time env fallback — behavior-identical to the pre-mcp-authorize path.
+        /// A Custom-mode local token is never overridden by a cloud credential (the <see cref="_isCloudMode"/> guard).
+        /// </summary>
+        private Task<string?> ResolveBearerAsync()
+        {
+            var provider = _credentialProvider;
+            if (provider != null && _isCloudMode && provider.IsSignedIn)
+                return ResolveCloudBearerAsync(provider);
+            return Task.FromResult(BearerToken);
+        }
+
+        private async Task<string?> ResolveCloudBearerAsync(PluginCredentialProvider provider)
+        {
+            var jwt = await provider.GetAccessTokenAsync().ConfigureAwait(false);
+            return !string.IsNullOrEmpty(jwt) ? jwt : BearerToken;
+        }
 
         /// <summary>
         /// Test seam: substitute a fake <see cref="IMcpPlugin"/> for the real one <see cref="Build"/> creates,
@@ -331,6 +380,23 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             // config push fired. This is the "subscribe to the McpPlugin connection-lost/reconnecting event and emit a
             // fresh status" half of the bug-2 fix; the ViewModel optimistic demote on Stop is the other half.
             SubscribeToConnectionState(_plugin);
+
+            // mcp-authorize (design 03 Flow B / 06): when the machine-credential path is active, wire the on-401
+            // refresh→reconnect and the "sign in again" surfacing. The coordinator subscribes to the connection's
+            // OnAuthorizationRejected (3 consecutive SignalR rejections, §Flow E) and refreshes the credential via
+            // the provider; the connection layer re-pulls the freshened JWT through ResolveBearerAsync on its next
+            // dial. A terminal refresh failure raises OnSignInRequired → we emit a status carrying "SignInRequired".
+            // Boot auto-adopt needs no action here: the provider auto-loads a seeded store on construction, so if a
+            // credential exists the very first Cloud dial is already signed in (zero-button, D12).
+            if (_credentialProvider != null)
+            {
+                _credentialCoordinator = new ConnectionCredentialCoordinator(
+                    _plugin, _credentialProvider, _loggerProvider?.CreateLogger(nameof(ConnectionCredentialCoordinator)));
+                _signInRequiredSubscription = _credentialProvider.OnSignInRequired
+                    .Subscribe(signal => { _ = EmitStatusAsync(_config.KeepConnected ? "Connecting" : "Disconnected", cloudAuthState: "SignInRequired"); });
+                if (_credentialStore!.Exists)
+                    _logger?.LogInformation("Machine credential present; the sidecar will connect signed-in with no UI (zero-button boot, D12).");
+            }
 
             _ipc.HandshakeAccepted += OnHandshakeAccepted;
             _ipc.ConfigReceived += OnConfigReceived;
@@ -447,7 +513,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 // Cloud mode: suffix the SignalR host with the /mcp prefix the cloud serves the hub behind
                 // (idempotent — never /mcp/mcp). Custom mode: use the host verbatim (a local/self-hosted
                 // server exposes the hub at the root, like Unity/Godot Custom). Device-auth strips this back
-                // off in StartDeviceAuth (the backend /api/auth/... is NOT behind /mcp).
+                // off in StartDeviceAuth (the AS /oauth/... is NOT behind /mcp).
                 _config.Host = isCloud ? AppendCloudHubPath(selected!) : selected!;
 
             // Token: the plugin already applied mode+auth resolution (empty in Custom+None). An absent key
@@ -479,9 +545,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
         /// <summary>
         /// Strip a trailing <see cref="CloudHubPath"/> (<c>/mcp</c>) from a cloud host to recover the BASE URL
-        /// the cloud backend lives at (<c>https://ai-game.dev</c>) — device-code auth targets
-        /// <c>{base}/api/auth/device/…</c>, which is NOT behind the <c>/mcp</c> nginx prefix. The inverse of
-        /// <see cref="AppendCloudHubPath"/>; idempotent for a host with no suffix. Pure (unit-testable).
+        /// the cloud backend + AS live at (<c>https://ai-game.dev</c>) — device-code auth + token refresh target
+        /// <c>{base}/oauth/device_authorization</c> + <c>{base}/oauth/token</c>, which are NOT behind the
+        /// <c>/mcp</c> nginx prefix. The inverse of <see cref="AppendCloudHubPath"/>; idempotent for a host with
+        /// no suffix. Pure (unit-testable).
         /// </summary>
         internal static string StripCloudHubPath(string host)
         {
@@ -514,7 +581,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                     _authCts?.Cancel();
                     // Clear the stored cloud bearer so a subsequent (re)connect is anonymous until re-authorized.
                     BearerToken = null;
-                    _logger?.LogInformation("Cloud token revoked (auth-revoke); cleared the in-memory bearer.");
+                    // mcp-authorize sign-out (design 03 Flow B): wipe the persisted refresh token + clear the provider
+                    // so no signed-in state survives on this machine. (The /oauth/revoke network call to the AS and the
+                    // editor-UI sign-out button land in later mcp-authorize PRs; the local wipe is the security-critical half.)
+                    try { _credentialProvider?.SignOut(); _credentialStore?.Delete(); }
+                    catch (Exception ex) { _logger?.LogDebug("Sign-out credential wipe failed: {Message}", ex.Message); }
+                    _logger?.LogInformation("Cloud token revoked (auth-revoke); cleared the in-memory bearer + machine credential store.");
                     break;
             }
         }
@@ -604,8 +676,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             var cts = new CancellationTokenSource();
             _authCts = cts;
             // ApplyConnectionConfig suffixed the Cloud host with /mcp for the SignalR hub; the device-code flow
-            // hits the BACKEND ({base}/api/auth/device/…), which is NOT behind the /mcp nginx prefix, so strip
-            // it back off to recover the base (https://ai-game.dev). A no-op for a host without the suffix.
+            // hits the AS ({base}/oauth/device_authorization + /oauth/token), which is NOT behind the /mcp nginx
+            // prefix, so strip it back off to recover the base (https://ai-game.dev). A no-op for a host without the suffix.
             var cloudUrl = StripCloudHubPath(_config.Host);
             _logger?.LogInformation("auth-start received; beginning device-code flow against {Host}.", cloudUrl);
             _ = RunDeviceAuthAsync(cloudUrl, cts.Token);
@@ -617,17 +689,59 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             {
                 var result = await _authenticator.AuthorizeAsync(
                     cloudUrl,
-                    _clientLabel,
                     emit: msg => _ipc.SendToPluginAsync(msg, CancellationToken.None),
                     ct).ConfigureAwait(false);
 
                 if (result.Success && result.Token != null)
-                    await CommitAuthorizedSessionAsync(result.Token, ct).ConfigureAwait(false);
+                    await CommitAuthorizedSessionAsync(result, ct).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 _logger?.LogWarning("Device-code flow ended with an error: {Message}", ex.Message);
             }
+        }
+
+        /// <summary>
+        /// Commit a successful device-code sign-in: PERSIST the issued credential (ES256 JWT + refresh token +
+        /// expiry) into the shared machine credential store (D12) so sign-in is once-per-machine and survives
+        /// restarts, ADOPT it into the live provider, then store the in-memory bearer + reconnect. The persist step
+        /// is a no-op when no store is wired (Custom/legacy path) or the AS returned no refresh token. Guards the
+        /// same cancel/revoke race as the string overload — nothing is persisted once the flow was cancelled.
+        /// Tokens are NEVER logged (§8). Internal so the bridge xUnit suite drives it without the whole HTTP flow.
+        /// </summary>
+        internal async Task CommitAuthorizedSessionAsync(DeviceAuthResult result, CancellationToken ct)
+        {
+            if (ct.IsCancellationRequested || result.Token == null)
+                return;
+
+            if (_credentialStore != null && !string.IsNullOrEmpty(result.RefreshToken))
+            {
+                // The server target is the cloud BASE (no /mcp hub prefix), the same base device-auth ran against —
+                // the refresher reuses it for the refresh-token grant. Persist + adopt so the provider is signed in.
+                var serverTarget = StripCloudHubPath(_config.Host);
+                var creds = new McpAgentConfig.MachineCredentials
+                {
+                    Version = 1,
+                    AccessToken = result.Token,
+                    RefreshToken = result.RefreshToken,
+                    ExpiresAt = result.ExpiresAt,
+                    ServerTarget = string.IsNullOrWhiteSpace(serverTarget) ? null : serverTarget,
+                };
+                try
+                {
+                    _credentialStore.Write(creds);
+                    _credentialProvider?.Adopt(creds);
+                    _logger?.LogInformation("Cloud credential persisted to the machine store; signed in once-per-machine (D12).");
+                }
+                catch (Exception ex)
+                {
+                    // A store write failure must not lose the session — fall through to the in-memory bearer so this
+                    // editor session still connects signed-in; only the cross-restart persistence is degraded.
+                    _logger?.LogWarning("Failed to persist the cloud credential to the machine store: {Message}", ex.Message);
+                }
+            }
+
+            await CommitAuthorizedSessionAsync(result.Token, ct).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1087,6 +1201,13 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             ClearRoster();
             try { _authCts?.Cancel(); } catch { /* ignore */ }
             _authCts?.Dispose();
+            // mcp-authorize: drop the on-401 coordinator + sign-in-required subscription + credential provider so no
+            // late R3 callback touches a half-disposed host (the store itself is stateless/owned by the caller).
+            try { _signInRequiredSubscription?.Dispose(); } catch { /* ignore */ }
+            _signInRequiredSubscription = null;
+            try { _credentialCoordinator?.Dispose(); } catch { /* ignore */ }
+            _credentialCoordinator = null;
+            try { _credentialProvider?.Dispose(); } catch { /* ignore */ }
             // Tear down the transition CTS under _transitionLock so a concurrent RunConnectionTransition cannot
             // observe a half-disposed field (or have its captured predecessor disposed out from under it): take
             // and null the field inside the lock, then cancel/dispose outside (cancel runs continuations

--- a/bridge/src/Program.cs
+++ b/bridge/src/Program.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
 using com.IvanMurzak.Unreal.MCP.Bridge.Host;
 using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
 using com.IvanMurzak.Unreal.MCP.Bridge.Sidecar;
@@ -85,7 +86,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge
                 loggerProvider,
                 fallbackHost: Environment.GetEnvironmentVariable("UNREAL_MCP_HOST")
                               ?? Environment.GetEnvironmentVariable("UNREAL_MCP_CLOUD_URL"),
-                fallbackToken: Environment.GetEnvironmentVariable("UNREAL_MCP_TOKEN"));
+                fallbackToken: Environment.GetEnvironmentVariable("UNREAL_MCP_TOKEN"),
+                // mcp-authorize (D12): the shared machine credential store (~/.ai-game-dev/credentials.json, 0600 /
+                // DPAPI) — read by the engine plugins, the CLIs, and the local server so sign-in is once-per-machine.
+                // Its presence enables the device-code sign-in, boot auto-adopt (zero-button), and proactive/on-401
+                // refresh. Left default (~/.ai-game-dev); the xUnit suite injects a temp dir instead.
+                credentialStore: new MachineCredentialStore());
             host.Build();
 
             // No-orphan watchdogs (§6) ------------------------------------------------------------------

--- a/bridge/tests/DeviceCodeAuthenticatorTests.cs
+++ b/bridge/tests/DeviceCodeAuthenticatorTests.cs
@@ -22,20 +22,27 @@ using Xunit;
 namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
 {
     /// <summary>
-    /// Device-code flow specs (docs/ARCHITECTURE.md §7 item 4 / §1.3) — the real RFC 8628 grant the sidecar
-    /// now runs in place of PR #8's stub. Drives <see cref="DeviceCodeAuthenticator"/> against a scripted HTTP
-    /// handler (no network, no real waiting): asserts it emits a pending device-auth with the verification URL
-    /// + user code, polls until an access token is issued, surfaces denial/expiry, and honours cancellation.
+    /// Device-code flow specs (docs/ARCHITECTURE.md §7 / .claude/design/mcp-authorize 03 Flow B) — the RFC 8628
+    /// grant the sidecar runs on the ai-game.dev alias (<c>POST /oauth/device_authorization</c> →
+    /// <c>POST /oauth/token</c> device grant). Drives <see cref="DeviceCodeAuthenticator"/> against a scripted HTTP
+    /// handler (no network, no real waiting): asserts it posts the form-encoded <c>client_id</c> + <c>scope=mcp:plugin</c>
+    /// to the correct endpoints, emits a pending device-auth with the verification URL + user code, polls until an
+    /// ES256 JWT + refresh token are issued, surfaces denial/expiry, and honours cancellation.
     /// </summary>
     public class DeviceCodeAuthenticatorTests
     {
-        // A scripted handler: the /authorize call returns a fixed JSON; each /token call dequeues the next body.
+        // A scripted handler: the /oauth/device_authorization call returns a fixed JSON; each /oauth/token call
+        // dequeues the next body (as an RFC 8628 token endpoint would — 400 while pending/error, 200 on success).
         private sealed class ScriptedHandler : HttpMessageHandler
         {
             private readonly string _authorizeJson;
             private readonly Queue<string> _tokenJson;
             public int AuthorizeCalls { get; private set; }
             public int TokenCalls { get; private set; }
+            public string? LastAuthorizeUrl { get; private set; }
+            public string? LastAuthorizeBody { get; private set; }
+            public string? LastTokenUrl { get; private set; }
+            public string? LastTokenBody { get; private set; }
 
             public ScriptedHandler(string authorizeJson, IEnumerable<string> tokenJson)
             {
@@ -43,24 +50,33 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
                 _tokenJson = new Queue<string>(tokenJson);
             }
 
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 var url = request.RequestUri!.AbsoluteUri;
-                string body;
-                if (url.EndsWith("/api/auth/device/authorize", StringComparison.Ordinal))
+                var body = request.Content != null ? await request.Content.ReadAsStringAsync(cancellationToken) : "";
+                string responseBody;
+                var status = HttpStatusCode.OK;
+                if (url.EndsWith("/oauth/device_authorization", StringComparison.Ordinal))
                 {
                     AuthorizeCalls++;
-                    body = _authorizeJson;
+                    LastAuthorizeUrl = url;
+                    LastAuthorizeBody = body;
+                    responseBody = _authorizeJson;
                 }
                 else
                 {
                     TokenCalls++;
-                    body = _tokenJson.Count > 0 ? _tokenJson.Dequeue() : "{\"error\":\"authorization_pending\"}";
+                    LastTokenUrl = url;
+                    LastTokenBody = body;
+                    responseBody = _tokenJson.Count > 0 ? _tokenJson.Dequeue() : "{\"error\":\"authorization_pending\"}";
+                    // RFC 8628 §3.5: the token endpoint answers a pending/errored device grant with a 400 + { error }.
+                    if (responseBody.Contains("\"error\"", StringComparison.Ordinal))
+                        status = HttpStatusCode.BadRequest;
                 }
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                return new HttpResponseMessage(status)
                 {
-                    Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
-                });
+                    Content = new StringContent(responseBody, System.Text.Encoding.UTF8, "application/json"),
+                };
             }
         }
 
@@ -75,27 +91,38 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             "\"expires_in\":900,\"interval\":1}";
 
         [Fact]
-        public async Task HappyPath_EmitsPendingThenAuthorizesAndReturnsToken()
+        public async Task HappyPath_EmitsPendingThenAuthorizesAndReturnsCredential()
         {
             var handler = new ScriptedHandler(AuthorizeJson, new[]
             {
                 "{\"error\":\"authorization_pending\"}",
                 "{\"error\":\"authorization_pending\"}",
-                "{\"access_token\":\"cloud-bearer-abc\",\"token_type\":\"Bearer\"}",
+                "{\"access_token\":\"cloud-jwt-abc\",\"refresh_token\":\"refresh-xyz\",\"token_type\":\"Bearer\",\"expires_in\":3600}",
             });
             var auth = MakeAuth(handler);
 
             var emitted = new List<DeviceAuthMessage>();
-            var result = await auth.AuthorizeAsync("https://ai-game.dev", "Unreal", m => { emitted.Add(m); return Task.CompletedTask; }, CancellationToken.None);
+            var result = await auth.AuthorizeAsync("https://ai-game.dev", m => { emitted.Add(m); return Task.CompletedTask; }, CancellationToken.None);
 
             Assert.True(result.Success);
-            Assert.Equal("cloud-bearer-abc", result.Token);
+            Assert.Equal("cloud-jwt-abc", result.Token);
+            Assert.Equal("refresh-xyz", result.RefreshToken);           // the refresh token feeds the machine store (D12)
+            Assert.NotNull(result.ExpiresAt);                            // computed from expires_in for proactive refresh
+            Assert.True(result.ExpiresAt > DateTimeOffset.UtcNow);
+
+            // The RFC 8628 endpoints + the form-encoded client_id + scope=mcp:plugin authorize body.
+            Assert.EndsWith("/oauth/device_authorization", handler.LastAuthorizeUrl);
+            Assert.Contains("client_id=unreal-mcp-plugin", handler.LastAuthorizeBody);
+            Assert.Contains("scope=mcp", handler.LastAuthorizeBody); // "mcp:plugin" url-encodes the ':' — match the prefix
+            Assert.EndsWith("/oauth/token", handler.LastTokenUrl);
+            Assert.Contains("grant_type=urn", handler.LastTokenBody);   // device-code grant URN (':' url-encoded)
+            Assert.Contains("device_code=dev-123", handler.LastTokenBody);
 
             // First emit is the pending state with the verification URL + user code (what the UI renders, §7).
             Assert.Contains(emitted, m => m.State == "pending" && m.UserCode == "WXYZ-1234"
                 && m.VerificationUrl == "https://ai-game.dev/device?code=WXYZ-1234");
-            // The authorized emit carries the issued token.
-            Assert.Contains(emitted, m => m.State == "authorized" && m.Token == "cloud-bearer-abc");
+            // The authorized emit carries the issued access token (the plugin's UI feed; never logged).
+            Assert.Contains(emitted, m => m.State == "authorized" && m.Token == "cloud-jwt-abc");
             Assert.Equal(3, handler.TokenCalls); // pending, pending, success
         }
 
@@ -105,13 +132,14 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             var handler = new ScriptedHandler(AuthorizeJson, new[]
             {
                 "{\"error\":\"slow_down\"}",
-                "{\"access_token\":\"tok\"}",
+                "{\"access_token\":\"tok\",\"refresh_token\":\"r\"}",
             });
             var auth = MakeAuth(handler);
 
-            var result = await auth.AuthorizeAsync("https://ai-game.dev", null, _ => Task.CompletedTask, CancellationToken.None);
+            var result = await auth.AuthorizeAsync("https://ai-game.dev", _ => Task.CompletedTask, CancellationToken.None);
             Assert.True(result.Success);
             Assert.Equal("tok", result.Token);
+            Assert.Equal("r", result.RefreshToken);
         }
 
         [Fact]
@@ -121,7 +149,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             var auth = MakeAuth(handler);
 
             var emitted = new List<DeviceAuthMessage>();
-            var result = await auth.AuthorizeAsync("https://ai-game.dev", null, m => { emitted.Add(m); return Task.CompletedTask; }, CancellationToken.None);
+            var result = await auth.AuthorizeAsync("https://ai-game.dev", m => { emitted.Add(m); return Task.CompletedTask; }, CancellationToken.None);
 
             Assert.False(result.Success);
             Assert.Equal("access_denied", result.Error);
@@ -141,7 +169,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             var auth = new DeviceCodeAuthenticator(new HttpClient(handler), logger: null,
                 delay: (_, ct) => { cts.Cancel(); return Task.CompletedTask; });
 
-            var result = await auth.AuthorizeAsync("https://ai-game.dev", null, _ => Task.CompletedTask, cts.Token);
+            var result = await auth.AuthorizeAsync("https://ai-game.dev", _ => Task.CompletedTask, cts.Token);
             Assert.False(result.Success);
             Assert.True(result.WasCancelled);
         }
@@ -168,7 +196,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
                 now: () => clockReads++ == 0 ? start : start.AddSeconds(20));
 
             var emitted = new List<DeviceAuthMessage>();
-            var result = await auth.AuthorizeAsync("https://ai-game.dev", null, m => { emitted.Add(m); return Task.CompletedTask; }, CancellationToken.None);
+            var result = await auth.AuthorizeAsync("https://ai-game.dev", m => { emitted.Add(m); return Task.CompletedTask; }, CancellationToken.None);
 
             Assert.False(result.Success);
             Assert.Equal("expired_token", result.Error);
@@ -180,7 +208,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         {
             var handler = new ScriptedHandler(AuthorizeJson, Array.Empty<string>());
             var auth = MakeAuth(handler);
-            var result = await auth.AuthorizeAsync("", null, _ => Task.CompletedTask, CancellationToken.None);
+            var result = await auth.AuthorizeAsync("", _ => Task.CompletedTask, CancellationToken.None);
             Assert.False(result.Success);
             Assert.Equal(0, handler.AuthorizeCalls);
         }

--- a/bridge/tests/MachineCredentialTests.cs
+++ b/bridge/tests/MachineCredentialTests.cs
@@ -1,0 +1,253 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.Unreal.MCP.Bridge.Auth;
+using com.IvanMurzak.Unreal.MCP.Bridge.Host;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>
+    /// mcp-authorize (design 03 Flow B / 06, D12) machine-credential specs — the once-per-machine sign-in the
+    /// sidecar wires on top of McpPlugin 7.0's <c>MachineCredentialStore</c> + <c>PluginCredentialProvider</c>.
+    /// Covers: the OAuth refresh-token grant (<see cref="OAuthTokenRefresher"/>); persisting a successful device
+    /// sign-in into the shared store; boot auto-adopt of a seeded store (zero-button); Custom-mode precedence over
+    /// a cloud credential; and sign-out wiping the store. A per-test temp directory isolates the store from the
+    /// real <c>~/.ai-game-dev</c> (and from other tests) — no network, no shared machine state.
+    /// </summary>
+    public class MachineCredentialTests
+    {
+        private static string NewStoreDir()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "umcp-cred-" + Guid.NewGuid().ToString("N")[..12]);
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        private static IpcClient NewIpc() => new("127.0.0.1", 39998, token: "ipc-token", sidecarVersion: "0.1.0");
+
+        private static JsonObject CloudConfig(string cloudUrl = "https://ai-game.dev") =>
+            new() { ["mode"] = "Cloud", ["cloudUrl"] = cloudUrl };
+
+        // A scripted HTTP handler for the token endpoint: returns one fixed body + status, capturing the request.
+        private sealed class RefreshHandler : HttpMessageHandler
+        {
+            private readonly string _json;
+            private readonly HttpStatusCode _status;
+            public string? LastUrl { get; private set; }
+            public string? LastBody { get; private set; }
+
+            public RefreshHandler(string json, HttpStatusCode status)
+            {
+                _json = json;
+                _status = status;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastUrl = request.RequestUri!.AbsoluteUri;
+                LastBody = request.Content != null ? await request.Content.ReadAsStringAsync(cancellationToken) : "";
+                return new HttpResponseMessage(_status)
+                {
+                    Content = new StringContent(_json, Encoding.UTF8, "application/json"),
+                };
+            }
+        }
+
+        // --- OAuthTokenRefresher (ITokenRefresher) --------------------------------------------------------------
+
+        [Fact]
+        public async Task Refresher_ReturnsRotatedCredential_OnSuccess()
+        {
+            var handler = new RefreshHandler(
+                "{\"access_token\":\"new-jwt\",\"refresh_token\":\"rotated-refresh\",\"token_type\":\"Bearer\",\"expires_in\":3600}",
+                HttpStatusCode.OK);
+            var refresher = new OAuthTokenRefresher(new HttpClient(handler));
+
+            var result = await refresher.RefreshAsync("old-refresh", "https://ai-game.dev", CancellationToken.None);
+
+            Assert.True(result.Succeeded);
+            Assert.Equal("new-jwt", result.AccessToken);
+            Assert.Equal("rotated-refresh", result.RefreshToken); // the AS rotates the refresh token (design 03 / a3)
+            Assert.NotNull(result.ExpiresAt);
+
+            // OAuth 2.1 refresh grant, form-encoded, to /oauth/token.
+            Assert.EndsWith("/oauth/token", handler.LastUrl);
+            Assert.Contains("grant_type=refresh_token", handler.LastBody);
+            Assert.Contains("refresh_token=old-refresh", handler.LastBody);
+            Assert.Contains("client_id=unreal-mcp-plugin", handler.LastBody);
+        }
+
+        [Fact]
+        public async Task Refresher_ReturnsFailure_OnInvalidGrant()
+        {
+            // A revoked/expired (or reuse-detected) refresh token comes back as a 400 { error } — surfaced as a
+            // failure the provider raises OnSignInRequired for, NOT a thrown exception.
+            var handler = new RefreshHandler("{\"error\":\"invalid_grant\"}", HttpStatusCode.BadRequest);
+            var refresher = new OAuthTokenRefresher(new HttpClient(handler));
+
+            var result = await refresher.RefreshAsync("stale-refresh", "https://ai-game.dev", CancellationToken.None);
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("invalid_grant", result.FailureReason);
+        }
+
+        [Fact]
+        public async Task Refresher_FailsCleanly_OnMissingInputs()
+        {
+            var refresher = new OAuthTokenRefresher(new HttpClient(new RefreshHandler("{}", HttpStatusCode.OK)));
+            Assert.False((await refresher.RefreshAsync("", "https://ai-game.dev", CancellationToken.None)).Succeeded);
+            Assert.False((await refresher.RefreshAsync("r", "", CancellationToken.None)).Succeeded);
+        }
+
+        // --- Device-auth commit → machine store (D12) -----------------------------------------------------------
+
+        [Fact]
+        public async Task DeviceAuthCommit_PersistsCredentialToStore_AndSignsInProvider()
+        {
+            var dir = NewStoreDir();
+            using var host = new SidecarHost(NewIpc(), "0.1.0", credentialStore: new MachineCredentialStore(dir));
+            host.SetStatusEmitterForTest(_ => Task.CompletedTask); // no live IPC socket
+
+            // Cloud mode so the server-target resolves to the cloud base and CurrentBearer prefers the stored JWT.
+            host.ApplyConnectionConfig(CloudConfig());
+
+            var result = DeviceAuthResult.Authorized("cloud-jwt", "refresh-1", DateTimeOffset.UtcNow.AddHours(1));
+            await host.CommitAuthorizedSessionAsync(result, CancellationToken.None);
+
+            // Persisted to the shared machine store, server target stripped of the /mcp hub prefix.
+            var persisted = new MachineCredentialStore(dir);
+            Assert.True(persisted.Exists);
+            var creds = persisted.Read();
+            Assert.Equal("cloud-jwt", creds!.AccessToken);
+            Assert.Equal("refresh-1", creds.RefreshToken);
+            Assert.Equal("https://ai-game.dev", creds.ServerTarget);
+
+            // Adopted live → provider signed in → the Cloud dial presents the stored JWT (no UI).
+            Assert.True(host.CredentialProvider!.IsSignedIn);
+            Assert.Equal("cloud-jwt", host.CurrentBearer);
+        }
+
+        [Fact]
+        public async Task DeviceAuthCommit_WithoutRefreshToken_DoesNotWriteStore()
+        {
+            // A response missing a refresh token is not a persistable machine credential — don't half-write it.
+            var dir = NewStoreDir();
+            using var host = new SidecarHost(NewIpc(), "0.1.0", credentialStore: new MachineCredentialStore(dir));
+            host.SetStatusEmitterForTest(_ => Task.CompletedTask);
+            host.ApplyConnectionConfig(CloudConfig());
+
+            await host.CommitAuthorizedSessionAsync(DeviceAuthResult.Authorized("jwt-only", refreshToken: null), CancellationToken.None);
+
+            Assert.False(new MachineCredentialStore(dir).Exists);
+        }
+
+        // --- Boot auto-adopt (zero-button, D12) -----------------------------------------------------------------
+
+        [Fact]
+        public void BootAutoAdopt_SeededStore_SignsInWithoutUi_AndDrivesCloudBearer()
+        {
+            var dir = NewStoreDir();
+            new MachineCredentialStore(dir).Write(new MachineCredentials
+            {
+                Version = 1,
+                AccessToken = "seeded-jwt",
+                RefreshToken = "seeded-refresh",
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+                ServerTarget = "https://ai-game.dev",
+            });
+
+            // Fresh sidecar over the SAME store dir (what boot does): the provider auto-loads the seeded credential.
+            using var host = new SidecarHost(NewIpc(), "0.1.0", credentialStore: new MachineCredentialStore(dir));
+            Assert.True(host.CredentialProvider!.IsSignedIn); // zero-button: no device flow, no UI
+
+            host.ApplyConnectionConfig(CloudConfig());
+            Assert.Equal("seeded-jwt", host.CurrentBearer); // the boot credential authenticates the first Cloud dial
+        }
+
+        [Fact]
+        public void CustomMode_LocalTokenWins_OverSignedInCloudStore()
+        {
+            var dir = NewStoreDir();
+            new MachineCredentialStore(dir).Write(new MachineCredentials
+            {
+                Version = 1,
+                AccessToken = "cloud-jwt",
+                RefreshToken = "r",
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+                ServerTarget = "https://ai-game.dev",
+            });
+            using var host = new SidecarHost(NewIpc(), "0.1.0", credentialStore: new MachineCredentialStore(dir));
+
+            // Custom mode with a plugin-pushed local token: the LOCAL bearer is presented, never the cloud JWT.
+            host.ApplyConnectionConfig(new JsonObject { ["mode"] = "Custom", ["host"] = "http://localhost:8080", ["token"] = "local-tok" });
+            Assert.Equal("local-tok", host.CurrentBearer);
+        }
+
+        // --- Sign-out (auth-revoke) wipes the store -------------------------------------------------------------
+
+        [Fact]
+        public void AuthRevoke_WipesMachineStore_AndClearsProvider()
+        {
+            var dir = NewStoreDir();
+            new MachineCredentialStore(dir).Write(new MachineCredentials
+            {
+                Version = 1,
+                AccessToken = "cloud-jwt",
+                RefreshToken = "r",
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+                ServerTarget = "https://ai-game.dev",
+            });
+            using var host = new SidecarHost(NewIpc(), "0.1.0", credentialStore: new MachineCredentialStore(dir));
+            Assert.True(host.CredentialProvider!.IsSignedIn);
+
+            host.HandleAuthMessage(IpcProtocol.Type.AuthRevoke);
+
+            Assert.False(new MachineCredentialStore(dir).Exists);   // the stored refresh token is gone
+            Assert.False(host.CredentialProvider!.IsSignedIn);      // and the provider is signed out
+        }
+
+        // --- Build wiring smoke (on-401 coordinator + sign-in-required subscription) ----------------------------
+
+        [Fact]
+        public void Build_WithCredentialStore_WiresCoordinatorAndSubscription_WithoutThrowing()
+        {
+            // Build() constructs the ConnectionCredentialCoordinator (on-401 refresh→reconnect) against the real
+            // built plugin's IConnection + subscribes to OnSignInRequired. Prove that wiring is inert-safe (no
+            // connect, no throw) and that Dispose tears it down cleanly.
+            var dir = NewStoreDir();
+            new MachineCredentialStore(dir).Write(new MachineCredentials
+            {
+                Version = 1,
+                AccessToken = "cloud-jwt",
+                RefreshToken = "r",
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+                ServerTarget = "https://ai-game.dev",
+            });
+            var host = new SidecarHost(NewIpc(), "0.1.0", credentialStore: new MachineCredentialStore(dir));
+
+            host.Build(); // wires the coordinator + OnSignInRequired subscription against the real plugin
+            Assert.NotNull(host.CredentialProvider);
+            Assert.True(host.CredentialProvider!.IsSignedIn);
+
+            host.Dispose(); // disposes the coordinator + subscription + provider without throwing
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **mcp-authorize PR 2 of ~6** — wires the once-per-machine Cloud sign-in in the `bridge/` .NET sidecar. All C#-side; **no C++/plugin change**. Builds on #210 (McpPlugin `7.0.0-preview.1` adoption + `ConnectionConfig.CredentialProvider` migration).
- **RFC 8628 device flow** (`bridge/src/Auth/DeviceCodeAuthenticator.cs`): rewrite the legacy `/api/auth/device/*` opaque-token path onto the RFC 8628 alias — `POST /oauth/device_authorization` (form: `client_id` + `scope=mcp:plugin`) → poll `POST /oauth/token` (device-code grant) → ES256 JWT + `refresh_token` (+ `expires_in`). Emit contract (pending/authorized/failed) unchanged.
- **Machine credential store (D12)**: persist the issued credential into the shared `~/.ai-game-dev/credentials.json` (0600 POSIX / DPAPI Windows, handled by McpPlugin 7.0's `MachineCredentialStore`) — never in a project file / VCS. Sign-in is once-per-machine.
- **Boot auto-adopt (zero-button)** + refresh: `PluginCredentialProvider` auto-loads a seeded store, so the sidecar connects signed-in with **no UI**; proactive (pre-`exp`) + on-401 refresh→reconnect via a new `OAuthTokenRefresher` (`ITokenRefresher`) + `ConnectionCredentialCoordinator`. `ResolveBearerAsync` returns the auto-refreshed JWT in Cloud mode, else the static Custom/env bearer (behavior-identical when no store is wired — the opt-in store keeps every existing path deterministic). `auth-revoke` wipes the store + signs out.

Out of scope (later mcp-authorize PRs): instance-metadata handshake / ProjectIdentity + marker / enroll-redemption (PR 3); the new IPC `{pin,port,serverTarget}` + `FUnrealMcpServerManager` port migration + ANY C++ change (PR 4); editor UI sign-in / token-field removal / `AgentConfigService.MapSettings` (PR 5); live e2e against a running 9.0 server (PR 6). No version bump; no NuGet-pin bump; no release action.

## Test plan
- [x] Target-specific local tests passed: `bridge/` `dotnet build` (0 warn / 0 err) + `dotnet test` (**220 passed, 0 failed**), incl. new RFC 8628 flow specs (endpoints / form-encoding / `refresh_token` / expiry), refresher happy + `invalid_grant`, store persist, boot auto-adopt, Custom-mode precedence, revoke wipe, and Build-wiring smoke — all against a mocked AS, no live network.
- [x] Bridge-only change (no `UnrealMCP/**`, `cli/**`, or workflow files touched), so per the profile the plugin/cli suites do not apply; `test-pull-request` CI validates the hosted bridge legs (ubuntu + windows).

Closes #211