### PR TITLE
feat(bridge): instance-metadata handshake + ProjectIdentity/marker wiring (mcp-authorize PR 3)

### DIFF
--- a/bridge/src/Host/ProjectConnectionResolver.cs
+++ b/bridge/src/Host/ProjectConnectionResolver.cs
@@ -1,0 +1,167 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.IO;
+using System.Linq;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
+{
+    /// <summary>
+    /// The resolved connection identity of the editor's project (mcp-authorize PR 3, design docs 04/06):
+    /// the routing <see cref="Pin"/> + deterministic local <see cref="Port"/> (McpPlugin
+    /// <see cref="ProjectIdentity"/>), the enrolled <see cref="ServerTarget"/> and the full
+    /// <see cref="ProjectPathHash"/> read/derived from the committable project marker + project root, plus the
+    /// ready-to-attach <see cref="Metadata"/> handshake payload. Every field is derived deterministically —
+    /// no live socket, no shared state.
+    /// </summary>
+    internal sealed record ProjectConnection(
+        string Pin,
+        int Port,
+        bool PortIsOverridden,
+        string? ServerTarget,
+        string ProjectPathHash,
+        string ProjectName,
+        ConnectionInstanceMetadata Metadata);
+
+    /// <summary>
+    /// Resolves the sidecar's <b>connection identity</b> for the editor's project (mcp-authorize PR 3,
+    /// design docs 04/06). Given the project root the C++ plugin reports over IPC (the handshake-ack
+    /// <c>projectPath</c> — <c>FPaths::ConvertRelativePathToFull(FPaths::ProjectDir())</c>), it:
+    /// <list type="bullet">
+    ///   <item>reads the committable project marker <c>&lt;project&gt;/.ai-game-dev/project.json</c>
+    ///         (<see cref="ProjectMarker"/>) for the user's optional port override + the enrolled server target;</item>
+    ///   <item>derives the routing pin + deterministic local port via the single-source
+    ///         <see cref="ProjectIdentity"/> — byte-for-byte the committed golden vectors (trim trailing
+    ///         separators, <c>ToLowerInvariant</c> only, separators NOT converted);</item>
+    ///   <item>builds the <see cref="ConnectionInstanceMetadata"/> the sidecar attaches to its SignalR hub
+    ///         connection (via <see cref="ConnectionConfig.InstanceMetadata"/>) so the server's account+instance
+    ///         pairing plane (b3) registers THIS editor session under the resolved account.</item>
+    /// </list>
+    /// Pure/stateless — the bridge xUnit suite locks the golden-vector parity + marker round-trip without a socket.
+    /// This PR wires the pin + server-target RESOLUTION in C#; it does not add a new IPC message and does not
+    /// change the C++ deterministic port (PR 4).
+    /// </summary>
+    internal static class ProjectConnectionResolver
+    {
+        /// <summary>The engine identifier this sidecar reports in its instance metadata (design 04/06).</summary>
+        internal const string Engine = "unreal";
+
+        /// <summary>
+        /// Resolve the full connection identity for <paramref name="projectRoot"/>. Reads the on-disk project
+        /// marker (may be absent) for the port override + server target, derives the pin/port, and builds the
+        /// instance-metadata handshake payload. <paramref name="instanceId"/> is the per-editor-session GUID
+        /// (stable across reconnects); <paramref name="machineName"/> defaults to the host machine name.
+        /// </summary>
+        public static ProjectConnection Resolve(string projectRoot, string instanceId, string? machineName = null)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+            if (string.IsNullOrEmpty(instanceId))
+                throw new ArgumentException("InstanceId must be non-empty.", nameof(instanceId));
+
+            var marker = SafeReadMarker(projectRoot);
+            var identity = ProjectIdentity.Derive(projectRoot, marker);
+            var projectName = ResolveProjectName(projectRoot);
+
+            // ConnectionInstanceMetadata.Create derives projectPathHash from the SAME normalized root the pin
+            // came from, so the server can pin-match the session (pin is a prefix of the hash by construction).
+            var metadata = ConnectionInstanceMetadata.Create(
+                engine: Engine,
+                projectName: projectName,
+                projectRootPath: projectRoot,
+                instanceId: instanceId,
+                machineName: machineName);
+
+            return new ProjectConnection(
+                Pin: identity.Pin,
+                Port: identity.Port,
+                PortIsOverridden: identity.PortIsOverridden,
+                ServerTarget: marker?.ServerTarget,
+                ProjectPathHash: metadata.ProjectPathHash,
+                ProjectName: projectName,
+                Metadata: metadata);
+        }
+
+        /// <summary>
+        /// The human-facing project name: the basename (no extension) of the first top-level <c>*.uproject</c>
+        /// in <paramref name="projectRoot"/> (matches <c>FApp::GetProjectName()</c>), falling back to the
+        /// trimmed directory name when no <c>.uproject</c> is present (or the path cannot be read). Never throws.
+        /// </summary>
+        public static string ResolveProjectName(string projectRoot)
+        {
+            if (string.IsNullOrWhiteSpace(projectRoot))
+                return string.Empty;
+
+            try
+            {
+                if (Directory.Exists(projectRoot))
+                {
+                    var uproject = Directory
+                        .EnumerateFiles(projectRoot, "*.uproject", SearchOption.TopDirectoryOnly)
+                        .FirstOrDefault();
+                    if (!string.IsNullOrEmpty(uproject))
+                        return Path.GetFileNameWithoutExtension(uproject);
+                }
+            }
+            catch
+            {
+                // Fall through to the directory-name fallback — a name is best-effort (the routing key is the hash).
+            }
+
+            var trimmed = projectRoot.TrimEnd('/', '\\');
+            var name = Path.GetFileName(trimmed);
+            return string.IsNullOrEmpty(name) ? trimmed : name;
+        }
+
+        /// <summary>
+        /// Read the project marker for <paramref name="projectRoot"/>, returning <c>null</c> when it is absent or
+        /// unreadable (a project that has never been enrolled/configured, or a malformed file — never fatal to a
+        /// connect). Wraps <see cref="ProjectMarker.Read"/> so a resolution never throws on marker IO.
+        /// </summary>
+        public static ProjectMarker? SafeReadMarker(string projectRoot)
+        {
+            if (string.IsNullOrWhiteSpace(projectRoot))
+                return null;
+            try
+            {
+                return ProjectMarker.Read(projectRoot);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Persist the enrolled <paramref name="serverTarget"/> into the committable project marker
+        /// <c>&lt;project&gt;/.ai-game-dev/project.json</c>, preserving any existing port override. Read-modify-write
+        /// and idempotent: a no-op returning <c>false</c> when the marker already records the same target (no file
+        /// churn), else it writes and returns <c>true</c>. Non-secret — credentials NEVER land in the marker (design 06).
+        /// The write is the counterpart of <see cref="SafeReadMarker"/>: a target written here resolves back through
+        /// <see cref="Resolve"/>'s <see cref="ProjectConnection.ServerTarget"/>.
+        /// </summary>
+        public static bool PersistServerTarget(string projectRoot, string? serverTarget)
+        {
+            if (string.IsNullOrWhiteSpace(projectRoot) || string.IsNullOrWhiteSpace(serverTarget))
+                return false;
+
+            var marker = SafeReadMarker(projectRoot) ?? new ProjectMarker();
+            if (string.Equals(marker.ServerTarget, serverTarget, StringComparison.Ordinal))
+                return false;
+
+            marker.ServerTarget = serverTarget;
+            marker.Write(projectRoot);
+            return true;
+        }
+    }
+}

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -107,6 +107,15 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         private Reflector? _reflector;
         private int _signalRConnectStarted;
 
+        // mcp-authorize PR 3 (design 04/06): the instance-metadata handshake identity. _instanceId is minted ONCE
+        // per sidecar process — the sidecar is a child of one editor session, so a single GUID reused across every
+        // (re)connect is exactly the "InstanceId minted per editor session, stable across reconnects" the pairing
+        // plane (b3) expects. _projectRootPath caches the project root the plugin reported in the handshake-ack
+        // (FPaths::ProjectDir()); Volatile-guarded because ApplyProjectIdentity writes it on the IPC reader thread
+        // while a later marker-write path could read it off a background task.
+        private readonly string _instanceId = Guid.NewGuid().ToString();
+        private string? _projectRootPath;
+
         // §7 AI-agent configurator service, backed by the shared com.IvanMurzak.McpPlugin.AgentConfig library
         // (the single cross-engine implementation). Serves the plugin's thin Slate panel over IPC.
         private readonly AgentConfigService _agentConfig;
@@ -245,6 +254,17 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
         /// <summary>Test seam: the wired machine-credential provider (null unless a store was supplied).</summary>
         internal PluginCredentialProvider? CredentialProvider => _credentialProvider;
+
+        /// <summary>
+        /// Test seam: the instance-metadata handshake payload the sidecar will attach to the SignalR hub connection
+        /// (mcp-authorize PR 3), or null before a handshake-ack carried a project path. Set by
+        /// <see cref="ApplyProjectIdentity"/>; read by the McpPlugin connection layer via
+        /// <see cref="ConnectionConfig.InstanceMetadata"/>.
+        /// </summary>
+        internal ConnectionInstanceMetadata? InstanceMetadata => _config.InstanceMetadata;
+
+        /// <summary>Test seam: the per-editor-session instance id (stable across reconnects) reported in the metadata.</summary>
+        internal string InstanceId => _instanceId;
 
         /// <summary>
         /// Resolve the bearer the SignalR client should present on the next dial (wired to
@@ -412,6 +432,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             // mode-aware host/token/keepConnected selection lives in ApplyConnectionConfig.
             ApplyConnectionConfig(ack.Config);
 
+            // mcp-authorize PR 3 (design 04/06): resolve THIS project's connection identity from the reported
+            // project root and attach the instance-metadata handshake payload BEFORE the connect below dials —
+            // ConnectionConfig.InstanceMetadata is read by the McpPlugin HubConnectionProvider on each dial.
+            ApplyProjectIdentity(ack.ProjectPath);
+
             _logger?.LogInformation("Handshake accepted (plugin {PluginVersion}, engine {Engine}); connecting SignalR to {Host}.",
                 ack.PluginVersion, ack.EngineVersion, _config.Host);
 
@@ -422,6 +447,39 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 _ = ConnectSignalRAsync();
             else
                 _logger?.LogDebug("Handshake re-accepted; SignalR connect already initiated (KeepConnected handles reconnection).");
+        }
+
+        /// <summary>
+        /// Resolve THIS project's connection identity (mcp-authorize PR 3, design 04/06) from the project root the
+        /// plugin reported in the handshake-ack (<c>FPaths::ConvertRelativePathToFull(FPaths::ProjectDir())</c>) and
+        /// attach the instance-metadata handshake payload to <see cref="ConnectionConfig.InstanceMetadata"/> — the
+        /// McpPlugin connection layer sends it as non-secret query params on the SignalR hub URL, so the server's
+        /// account+instance pairing plane (b3) registers this editor session. Also caches the project root (for the
+        /// marker-write path) and sets <see cref="ConnectionConfig.ProjectRootPath"/>. Idempotent: a re-handshake
+        /// (IPC reconnect) re-resolves the same values with the SAME <see cref="_instanceId"/>. A blank project path
+        /// leaves the metadata null (the pre-b7 behaviour — the server falls back to a synthetic single instance).
+        /// Never throws (a malformed path must not tear down the read loop). Internal so the bridge xUnit suite
+        /// asserts the resolved metadata without driving a live connect (mirrors <see cref="ApplyConnectionConfig"/>).
+        /// </summary>
+        internal void ApplyProjectIdentity(string? projectPath)
+        {
+            if (string.IsNullOrWhiteSpace(projectPath))
+                return;
+
+            Volatile.Write(ref _projectRootPath, projectPath);
+            try
+            {
+                var resolved = ProjectConnectionResolver.Resolve(projectPath!, _instanceId);
+                _config.InstanceMetadata = resolved.Metadata;
+                _config.ProjectRootPath = projectPath;
+                _logger?.LogInformation(
+                    "Resolved project identity for '{ProjectName}' (pin {Pin}, port {Port}{Override}, instance {InstanceId}); attaching instance metadata to the hub handshake.",
+                    resolved.ProjectName, resolved.Pin, resolved.Port, resolved.PortIsOverridden ? " [user override]" : string.Empty, _instanceId);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Failed to resolve project identity from '{ProjectPath}': {Message}", projectPath, ex.Message);
+            }
         }
 
         internal void OnConfigReceived(JsonObject config)

--- a/bridge/tests/ProjectConnectionResolverTests.cs
+++ b/bridge/tests/ProjectConnectionResolverTests.cs
@@ -1,0 +1,178 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.IO;
+using System.Linq;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.Unreal.MCP.Bridge.Host;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>
+    /// Proves the sidecar's project connection-identity resolution (mcp-authorize PR 3, design 04/06):
+    /// the golden-vector pin/port parity of the consumed McpPlugin <see cref="ProjectIdentity"/>, the
+    /// instance-metadata handshake payload the sidecar attaches to the hub connection, the project-name
+    /// derivation, and the project-marker read/write round-trip (server target + port override) — all
+    /// deterministically, without a live socket.
+    /// </summary>
+    public class ProjectConnectionResolverTests
+    {
+        // Canonical cross-language golden vectors, copied verbatim from the committed
+        // McpPlugin/src/AgentConfig/ProjectIdentity.GoldenVectors.json. This locks that the McpPlugin version the
+        // bridge consumes still derives the byte-for-byte pin+port the whole mcp-authorize routing plane pins on —
+        // a future McpPlugin bump that silently changed the derivation would fail here.
+        [Theory]
+        [InlineData("/home/user/my-game", "34ea75f2", 23940)]
+        [InlineData("/home/user/my-game/", "34ea75f2", 23940)]  // trailing slash trimmed
+        [InlineData("/home/USER/My-Game", "34ea75f2", 23940)]   // ToLowerInvariant case-fold
+        [InlineData("C:\\Users\\user\\my-game", "8ef72cf7", 29310)]
+        [InlineData("C:\\Users\\user\\my-game\\", "8ef72cf7", 29310)] // trailing backslash trimmed
+        [InlineData("C:/Users/user/my-game", "5a87324e", 24298)] // forward-slash DIFFERS — separators NOT normalized
+        [InlineData("/home/İstanbul/game", "672d80a7", 25303)] // U+0130 — ToLowerInvariant leaves it unchanged
+        [InlineData("/srv/games/space sim", "08c6cbb6", 27816)] // path with a space
+        public void ProjectIdentity_MatchesGoldenVectors(string path, string expectedPin, int expectedPort)
+        {
+            var identity = ProjectIdentity.Derive(path);
+            Assert.Equal(expectedPin, identity.Pin);
+            Assert.Equal(expectedPort, identity.Port);
+            Assert.False(identity.PortIsOverridden);
+        }
+
+        [Fact]
+        public void Resolve_BuildsInstanceMetadata_WithUnrealEngineAndDerivedHash()
+        {
+            const string root = "/home/user/my-game";
+            var resolved = ProjectConnectionResolver.Resolve(root, instanceId: "inst-123", machineName: "DESKTOP-X");
+
+            Assert.Equal("unreal", resolved.Metadata.Engine);
+            Assert.Equal("inst-123", resolved.Metadata.InstanceId);
+            Assert.Equal("DESKTOP-X", resolved.Metadata.MachineName);
+            // The pin is the first 8 hex chars of the full project-path hash by construction (server pin-match).
+            Assert.Equal("34ea75f2", resolved.Pin);
+            Assert.Equal(64, resolved.ProjectPathHash.Length);
+            Assert.StartsWith(resolved.Pin, resolved.ProjectPathHash, StringComparison.Ordinal);
+            Assert.Equal(resolved.ProjectPathHash, resolved.Metadata.ProjectPathHash);
+            Assert.Equal(ProjectIdentity.DeriveProjectPathHash(root), resolved.ProjectPathHash);
+            // No marker present → no server target, hash-derived (non-overridden) port.
+            Assert.Null(resolved.ServerTarget);
+            Assert.Equal(23940, resolved.Port);
+            Assert.False(resolved.PortIsOverridden);
+        }
+
+        [Fact]
+        public void Resolve_Metadata_TravelsAsHubQueryAndUrl()
+        {
+            var resolved = ProjectConnectionResolver.Resolve("/home/user/my-game", "inst-abc", "DESKTOP-X");
+
+            var query = resolved.Metadata.ToQuery();
+            Assert.Contains("inst-abc", query.Values);                       // InstanceId always present
+            Assert.Contains(resolved.ProjectPathHash, query.Values);         // full hash for pin-match
+            Assert.Contains("unreal", query.Values);
+
+            // The hash is hex (no URL-escaping) so it appears verbatim on the appended hub URL; the token never does.
+            var url = resolved.Metadata.AppendToUrl("https://ai-game.dev/mcp/hub/mcp-server");
+            Assert.Contains(resolved.ProjectPathHash, url);
+            Assert.StartsWith("https://ai-game.dev/mcp/hub/mcp-server?", url);
+        }
+
+        [Fact]
+        public void ResolveProjectName_PrefersUProjectBasename_ThenDirectoryName()
+        {
+            RunInTempDir(dir =>
+            {
+                // No .uproject yet → directory-name fallback (matches the trimmed leaf).
+                Assert.Equal(Path.GetFileName(dir.TrimEnd('/', '\\')), ProjectConnectionResolver.ResolveProjectName(dir));
+
+                // A .uproject whose basename differs from the folder name (the testbed shape: test-project/UnrealTestProject.uproject).
+                File.WriteAllText(Path.Combine(dir, "MyGame.uproject"), "{}");
+                Assert.Equal("MyGame", ProjectConnectionResolver.ResolveProjectName(dir));
+            });
+        }
+
+        [Fact]
+        public void ResolveProjectName_BlankOrMissingRoot_IsSafe()
+        {
+            Assert.Equal(string.Empty, ProjectConnectionResolver.ResolveProjectName(""));
+            Assert.Equal(string.Empty, ProjectConnectionResolver.ResolveProjectName("   "));
+            // A non-existent path yields the leaf directory name (best-effort; never throws).
+            Assert.Equal("does-not-exist", ProjectConnectionResolver.ResolveProjectName("/no/such/does-not-exist"));
+        }
+
+        [Fact]
+        public void Marker_WriteThenResolve_RoundTripsServerTarget()
+        {
+            RunInTempDir(dir =>
+            {
+                // No marker → null server target.
+                Assert.Null(ProjectConnectionResolver.SafeReadMarker(dir));
+                Assert.Null(ProjectConnectionResolver.Resolve(dir, "id").ServerTarget);
+
+                // WRITE the enrolled server target, then RESOLVE it back.
+                Assert.True(ProjectConnectionResolver.PersistServerTarget(dir, "https://ai-game.dev"));
+                Assert.True(File.Exists(Path.Combine(dir, ProjectMarker.DirectoryName, ProjectMarker.FileName)));
+                Assert.Equal("https://ai-game.dev", ProjectConnectionResolver.Resolve(dir, "id").ServerTarget);
+
+                // Idempotent: re-persisting the SAME value is a no-op (no file churn).
+                Assert.False(ProjectConnectionResolver.PersistServerTarget(dir, "https://ai-game.dev"));
+                // A changed value writes again.
+                Assert.True(ProjectConnectionResolver.PersistServerTarget(dir, "http://localhost:5383"));
+                Assert.Equal("http://localhost:5383", ProjectConnectionResolver.Resolve(dir, "id").ServerTarget);
+            });
+        }
+
+        [Fact]
+        public void Marker_PortOverride_WinsOverDerivedPort_AndPreservedOnServerTargetWrite()
+        {
+            RunInTempDir(dir =>
+            {
+                new ProjectMarker { ServerTarget = "https://ai-game.dev", PortOverride = 25555 }.Write(dir);
+
+                var resolved = ProjectConnectionResolver.Resolve(dir, "id");
+                Assert.Equal(25555, resolved.Port);
+                Assert.True(resolved.PortIsOverridden);
+                Assert.Equal("https://ai-game.dev", resolved.ServerTarget);
+
+                // Re-persisting a DIFFERENT server target must PRESERVE the user's port override.
+                Assert.True(ProjectConnectionResolver.PersistServerTarget(dir, "http://localhost:5383"));
+                var reread = ProjectMarker.Read(dir)!;
+                Assert.Equal(25555, reread.PortOverride);
+                Assert.Equal("http://localhost:5383", reread.ServerTarget);
+            });
+        }
+
+        [Fact]
+        public void PersistServerTarget_BlankInputs_AreNoOps()
+        {
+            RunInTempDir(dir =>
+            {
+                Assert.False(ProjectConnectionResolver.PersistServerTarget(dir, null));
+                Assert.False(ProjectConnectionResolver.PersistServerTarget(dir, "   "));
+                Assert.False(File.Exists(Path.Combine(dir, ProjectMarker.DirectoryName, ProjectMarker.FileName)));
+            });
+        }
+
+        private static void RunInTempDir(Action<string> body)
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "umcp-pcr-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                body(dir);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { /* best-effort cleanup */ }
+            }
+        }
+    }
+}

--- a/bridge/tests/SidecarHostInstanceMetadataTests.cs
+++ b/bridge/tests/SidecarHostInstanceMetadataTests.cs
@@ -1,0 +1,80 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.Unreal.MCP.Bridge.Host;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>
+    /// Proves the sidecar attaches the mcp-authorize PR 3 instance-metadata handshake payload to the SignalR
+    /// hub connection when the plugin's handshake-ack reports a project path (design 04/06). Drives
+    /// <see cref="SidecarHost.ApplyProjectIdentity"/> directly — the seam the handshake-ack routes through —
+    /// so no live socket is needed (mirrors <c>ConnectionConfigTests</c>).
+    /// </summary>
+    public class SidecarHostInstanceMetadataTests
+    {
+        private static SidecarHost BuildHost()
+        {
+            var ipc = new IpcClient("127.0.0.1", 39997, token: "test-token", sidecarVersion: "0.1.0");
+            var host = new SidecarHost(ipc, "0.1.0");
+            host.Build();
+            return host;
+        }
+
+        [Fact]
+        public void ApplyProjectIdentity_SetsInstanceMetadata_FromReportedProjectPath()
+        {
+            const string projectPath = "/home/user/my-game";
+            using var host = BuildHost();
+
+            // Before a project path is known, the pre-b7 behaviour holds — no instance metadata attached.
+            Assert.Null(host.InstanceMetadata);
+
+            host.ApplyProjectIdentity(projectPath);
+
+            var meta = host.InstanceMetadata;
+            Assert.NotNull(meta);
+            Assert.Equal("unreal", meta!.Engine);
+            Assert.Equal(host.InstanceId, meta.InstanceId);
+            Assert.Equal(ProjectIdentity.DeriveProjectPathHash(projectPath), meta.ProjectPathHash);
+            // The connection layer anchors relative skills paths (disabled here) against the reported root.
+            Assert.Equal(projectPath, host.Config.ProjectRootPath);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void ApplyProjectIdentity_BlankPath_LeavesMetadataNull(string? projectPath)
+        {
+            using var host = BuildHost();
+            host.ApplyProjectIdentity(projectPath);
+            Assert.Null(host.InstanceMetadata);
+        }
+
+        [Fact]
+        public void ApplyProjectIdentity_ReAppliedOnReconnect_KeepsSameInstanceId()
+        {
+            const string projectPath = "/home/user/my-game";
+            using var host = BuildHost();
+
+            host.ApplyProjectIdentity(projectPath);
+            var firstInstanceId = host.InstanceMetadata!.InstanceId;
+
+            // A re-handshake (IPC reconnect) re-resolves the identity — the per-editor-session id is stable.
+            host.ApplyProjectIdentity(projectPath);
+            Assert.Equal(firstInstanceId, host.InstanceMetadata!.InstanceId);
+            Assert.Equal(host.InstanceId, firstInstanceId);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- On connect, the sidecar resolves THIS project's connection identity from the project root the plugin already reports in the handshake-ack (`FPaths::ProjectDir()`) and attaches a `ConnectionInstanceMetadata` payload `{instanceId (per editor session), engine:"unreal", projectName, projectPathHash, machineName}` to the SignalR hub connection via `ConnectionConfig.InstanceMetadata` — the McpPlugin `HubConnectionProvider` sends it as non-secret query params, so the server's account+instance pairing plane (b3) registers this editor session. **No new IPC message.**
- New `ProjectConnectionResolver` (bridge-side) reads/writes the committable project marker `<project>/.ai-game-dev/project.json` and derives the routing pin + deterministic local port via McpPlugin 7.0's `ProjectIdentity` — byte-for-byte the committed golden vectors (trim trailing separators, `ToLowerInvariant` only, separators NOT converted) — so the server target + port override resolve from the marker.
- No C++/IPC-schema change and **no C++ port change** (PR 4); no version/pin bumps.

mcp-authorize `f1` PR 3 of ~6 — builds on PR 1 (#210) + PR 2 (#212), both on `main`.

## Test plan

- [x] Bridge `dotnet build` + `dotnet test` — 240/240 green (20 new xUnit): ProjectIdentity golden-vector parity, instance-metadata payload/query/URL, project-name derivation (`.uproject` basename), and marker read/write round-trip (server target + port-override precedence).
- [x] Pure `bridge/**` change (no `UnrealMcp*/**` touched) → local gate is Suite 4 per the profile; the `test-pull-request` CI rollup runs the plugin BuildPlugin + Automation + connection-smoke legs.

Closes #213