### PR TITLE
feat(ipc): sidecar<->C++ project-config IPC + FUnrealMcpServerManager derived-port migration (mcp-authorize PR 4)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
@@ -31,6 +31,8 @@
 #include "Misc/CoreDelegates.h"
 #include "Misc/Paths.h"
 #include "Misc/EngineVersion.h"
+#include "Misc/Guid.h"          // FGuid for the mcp-authorize PR 4 project-config request id
+#include "Dom/JsonObject.h"     // FJsonObject field getters in ApplyProjectConfigResult
 #include "Async/Async.h"
 #include "HAL/PlatformProcess.h"
 #include "Modules/ModuleManager.h"
@@ -176,19 +178,13 @@ void FUnrealMcpEditorCoordinator::Startup()
 	SidecarManager->StartForPort(BoundPort, Token);
 
 	// §7 in-UI local-server (issue #95): create the local gamedev-mcp-server manager. It does NOT auto-start —
-	// the user launches it from the MCP-server card's Start button (Custom+http only). Reattach to a server this
-	// plugin spawned in a previous module load (hot-reload survivor) so a later Stop / editor-quit tears it down
-	// instead of orphaning it — only meaningful in Custom+http.
+	// the user launches it from the MCP-server card's Start button (Custom+http only).
+	// mcp-authorize PR 4 (design 04/06): the local server now listens on the sidecar-DERIVED per-project port
+	// (McpPlugin ProjectIdentity + the marker's portOverride), delivered over IPC on handshake — NOT the fixed
+	// 8080 ParsePortFromHost default. That port is unknown until the sidecar handshakes, so the survivor REATTACH
+	// (hot-reload survivor so a later Stop / editor-quit tears it down instead of orphaning it) is deferred to
+	// ApplyProjectConfigResult (the first `project-config-result`). No 8080 fallback on the golden path.
 	ServerManager = MakeUnique<FUnrealMcpServerManager>();
-	if (FUnrealMcpServerManager::IsLaunchAllowed(
-			Config.ConnectionMode == EUnrealMcpConnectionMode::Custom,
-			Config.ResolveEffectiveTransport() == EUnrealMcpTransportMethod::Http))
-	{
-		const int32 ReattachPort = FUnrealMcpServerManager::ParsePortFromHost(Config.ResolveCustomHost());
-		ServerManager->ReattachIfRunning(
-			ReattachPort, /*PluginTimeoutMs*/ 10000,
-			Config.AuthOption == EUnrealMcpAuthOption::Required, Config.ResolveEffectiveToken());
-	}
 
 	// §7 UI: the main-window view-model owns all UI state; wire its side-effect sinks to the real subsystems.
 	// All config writes go config-store-first (Save) then push the §1.3 `config` to the sidecar (§7 ownership).
@@ -242,15 +238,26 @@ void FUnrealMcpEditorCoordinator::Startup()
 
 	// §7 in-UI local-server (issue #95): wire the MCP-server card's Start/Stop to the local server manager. The
 	// view-model already gates these to Custom+http (ToggleLocalServer no-ops otherwise) — the sinks just execute.
-	// Re-resolve the §8 config on each Start so the port (from the Custom host), auth, and token reflect what the
-	// user has set right now. The port the agent dials (Custom host) MUST equal the port the server listens on.
+	// mcp-authorize PR 4 (design 04/06): the server listens on the sidecar-DERIVED per-project port (delivered over
+	// IPC on handshake; marker portOverride wins), NOT the fixed 8080 ParsePortFromHost default. The sidecar is
+	// auto-spawned at plugin load, so the port is cached (DerivedLocalServerPort) well before the user can click
+	// Start; if it is somehow not yet known, fail cleanly rather than fall back to 8080. Auth/token still reflect
+	// the live §8 config. Runs on the game thread (the UI calls it there — same thread the status sink writes on).
 	FUnrealMcpServerManager* ServerPtr = ServerManager.Get();
-	ViewModel->OnStartLocalServer = [ServerPtr]() -> bool
+	FUnrealMcpEditorCoordinator* CoordinatorForStart = this;
+	ViewModel->OnStartLocalServer = [ServerPtr, CoordinatorForStart]() -> bool
 	{
 		if (!ServerPtr)
 			return false;
+		const int32 ServerPort = CoordinatorForStart->DerivedLocalServerPort;
+		if (ServerPort <= 0)
+		{
+			UE_LOG(LogUnrealMcp, Warning,
+				TEXT("[Unreal-MCP] cannot start the local server yet: the derived per-project port has not arrived ")
+				TEXT("from the sidecar. Wait for the bridge to connect, then try again."));
+			return false;
+		}
 		const FUnrealMcpConfig Live = FUnrealMcpConfig::LoadAndResolve();
-		const int32 ServerPort = FUnrealMcpServerManager::ParsePortFromHost(Live.ResolveCustomHost());
 		return ServerPtr->Start(
 			ServerPort, /*PluginTimeoutMs*/ 10000,
 			Live.AuthOption == EUnrealMcpAuthOption::Required, Live.ResolveEffectiveToken());
@@ -302,14 +309,23 @@ void FUnrealMcpEditorCoordinator::Startup()
 					VM->ApplyDeviceAuth(Message);
 				else if (Type == TEXT("agent-config-result") && CoordinatorPtr->MainWindowTab.IsValid())
 					CoordinatorPtr->MainWindowTab->DeliverAgentConfigResult(Message);
+				else if (Type == TEXT("project-config-result"))
+					// mcp-authorize PR 4: cache the sidecar-derived local-server port (and reattach a survivor on it).
+					CoordinatorPtr->ApplyProjectConfigResult(Message);
 			});
 		});
 
 		// Issue #99: on each sidecar handshake-complete, marshal to the game thread and flush a queued Cloud
 		// auth-start (a no-op unless Authorize is awaiting in the Connecting state). Same M9b marshalling + weak
 		// view-model guard as the status sink so a handshake straddling teardown is a no-op, not a use-after-free.
-		BridgeServerPtr->SetHandshakeSink([WeakViewModel]()
+		// mcp-authorize PR 4 (design 04/06): ALSO request THIS project's resolved connection identity ({pin,
+		// derived local-server port, serverTarget}). The result routes back through the status sink to
+		// ApplyProjectConfigResult. Sent directly on the IPC reader thread (SendProjectConfigRequest is
+		// thread-safe); the project root is captured by value so a handshake straddling teardown is still safe.
+		BridgeServerPtr->SetHandshakeSink([WeakViewModel, BridgeServerPtr, ProjectPath]()
 		{
+			if (BridgeServerPtr)
+				BridgeServerPtr->SendProjectConfigRequest(FGuid::NewGuid().ToString(), ProjectPath);
 			AsyncTask(ENamedThreads::GameThread, [WeakViewModel]()
 			{
 				if (TSharedPtr<FUnrealMcpEditorViewModel> VM = WeakViewModel.Pin())
@@ -495,6 +511,56 @@ void FUnrealMcpEditorCoordinator::Startup()
 
 	// §1.5: tear down on editor pre-exit so the sidecar never orphans (layer 1).
 	PreExitHandle = FCoreDelegates::OnEnginePreExit.AddLambda([this]() { Shutdown(); });
+}
+
+void FUnrealMcpEditorCoordinator::ApplyProjectConfigResult(const TSharedPtr<FJsonObject>& Message)
+{
+	// mcp-authorize PR 4 (design 04/06). Game thread (the bridge status sink marshals onto it). Cache the
+	// sidecar-DERIVED per-project local-server port and, on the FIRST result, reattach a survivor local server on
+	// it (Custom+http only) — the reattach that ran at Startup before PR 4 now runs here, because the derived port
+	// is unknown until the sidecar handshakes. A malformed / not-ok result is a no-op.
+	if (!Message.IsValid())
+		return;
+
+	bool bOk = false;
+	Message->TryGetBoolField(TEXT("ok"), bOk);
+	if (!bOk)
+	{
+		FString Error;
+		Message->TryGetStringField(TEXT("error"), Error);
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] project-config-result not ok: %s"), *Error);
+		return;
+	}
+
+	double PortNumber = 0.0;
+	if (!Message->TryGetNumberField(TEXT("port"), PortNumber) || PortNumber <= 0.0 || PortNumber > 65535.0)
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] project-config-result carried no valid derived port; ignoring."));
+		return;
+	}
+	const int32 DerivedPort = static_cast<int32>(PortNumber);
+
+	bool bPortIsOverridden = false;
+	Message->TryGetBoolField(TEXT("portIsOverridden"), bPortIsOverridden);
+
+	DerivedLocalServerPort = DerivedPort;
+	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] resolved derived local-server port %d%s from the sidecar."),
+		DerivedPort, bPortIsOverridden ? TEXT(" [user override]") : TEXT(""));
+
+	// One-time survivor reattach on the derived port (Custom+http only; a re-handshake must not repeat it).
+	if (bLocalServerReattachAttempted || !ServerManager.IsValid())
+		return;
+
+	const FUnrealMcpConfig Live = FUnrealMcpConfig::LoadAndResolve();
+	if (FUnrealMcpServerManager::IsLaunchAllowed(
+			Live.ConnectionMode == EUnrealMcpConnectionMode::Custom,
+			Live.ResolveEffectiveTransport() == EUnrealMcpTransportMethod::Http))
+	{
+		ServerManager->ReattachIfRunning(
+			DerivedPort, /*PluginTimeoutMs*/ 10000,
+			Live.AuthOption == EUnrealMcpAuthOption::Required, Live.ResolveEffectiveToken());
+	}
+	bLocalServerReattachAttempted = true;
 }
 
 void FUnrealMcpEditorCoordinator::Shutdown()

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.h
@@ -42,6 +42,14 @@ public:
 	void Startup();
 	void Shutdown();
 
+	/**
+	 * Handle a sidecar `project-config-result` (mcp-authorize PR 4, design 04/06): cache the DERIVED per-project
+	 * local-server port (ProjectIdentity + marker portOverride) and, on the FIRST result, reattach a survivor local
+	 * server on it (Custom+http only). Runs on the game thread (the bridge status sink marshals onto it). A no-op on
+	 * an `ok == false` / invalid-port result. Public so the wiring lambda routes to it (see Startup).
+	 */
+	void ApplyProjectConfigResult(const TSharedPtr<class FJsonObject>& Message);
+
 	FUnrealMcpToolRegistry* GetRegistry() const { return Registry.Get(); }
 	FUnrealMcpBridgeServer* GetBridgeServer() const { return BridgeServer.Get(); }
 	FUnrealMcpExtensionManager* GetExtensionManager() const { return ExtensionManager.Get(); }
@@ -77,6 +85,16 @@ private:
 	// DEV-ONLY inject/control HTTP bridge over the live dock (docs/ARCHITECTURE.md §7). Created + started in
 	// Startup() ONLY when the editor process env UNREAL_MCP_DEV_CONTROL == "1"; null (never listening) otherwise.
 	TUniquePtr<FUnrealMcpDevControlServer> DevControlServer;
+
+	// mcp-authorize PR 4 (design 04/06): the deterministic per-project LOCAL-server port the sidecar derives
+	// (McpPlugin ProjectIdentity + the project marker's portOverride) and delivers over IPC on each handshake.
+	// -1 until the first `project-config-result` arrives. Replaces the fixed-8080 ParsePortFromHost default for
+	// the local `gamedev-mcp-server` start. Game-thread only (written from the game-thread-marshalled bridge
+	// status sink, read by the OnStartLocalServer sink), so no lock is needed.
+	int32 DerivedLocalServerPort = -1;
+	// Guards the one-time survivor reattach: the reattach that used to run in Startup now runs when the first
+	// derived port arrives (the port is unknown until the sidecar handshakes) and must not repeat on a reconnect.
+	bool bLocalServerReattachAttempted = false;
 
 	FDelegateHandle PreExitHandle;
 	bool bStarted = false;

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.cpp
@@ -52,6 +52,11 @@ namespace
 	const FString TypeAgentSkillsPath = TEXT("agent-skills-path");
 	const FString TypeAgentGenerateSkills = TEXT("agent-generate-skills");
 	const FString TypeAgentConfigResult = TEXT("agent-config-result");
+	// mcp-authorize PR 4 IPC verbs (design 04/06): the plugin → sidecar `project-config` request and the
+	// sidecar → plugin `project-config-result`. The sidecar resolves THIS project's {pin, derived local-server
+	// port, serverTarget} via the shared C# ProjectIdentity + project marker (no C++ derivation duplication).
+	const FString TypeProjectConfig = TEXT("project-config");
+	const FString TypeProjectConfigResult = TEXT("project-config-result");
 	const FString TypePing = TEXT("ping");
 	const FString TypePong = TEXT("pong");
 	const FString TypeShutdown = TEXT("shutdown");
@@ -374,9 +379,10 @@ void FUnrealMcpBridgeServer::HandleLine(const FString& Line, int32 Generation)
 	{
 		// liveness already refreshed in Run()
 	}
-	else if (Type == TypeStatus || Type == TypeDeviceAuth || Type == TypeAgentConfigResult)
+	else if (Type == TypeStatus || Type == TypeDeviceAuth || Type == TypeAgentConfigResult || Type == TypeProjectConfigResult)
 	{
-		// §1.3 / §7: the live UI feed (connection status, device-auth, AND the AI-agent configurator results).
+		// §1.3 / §7 / mcp-authorize PR 4: the live UI + control feed (connection status, device-auth, the AI-agent
+		// configurator results, AND the resolved project-config result carrying the derived local-server port).
 		// Hand it to the registered sink (the view-model) WITHOUT touching any Slate/engine state here — the
 		// sink marshals onto the game thread (M9b) and routes by type. Copy the sink out under the lock so a
 		// concurrent window-close clear never invalidates the TFunction mid-call.
@@ -1087,6 +1093,21 @@ bool FUnrealMcpBridgeServer::SendAgentConfigMessage(const TSharedPtr<FJsonObject
 	if (!bClientConnected || !bHandshakeOk)
 		return false;
 
+	return SendMessage(Message);
+}
+
+bool FUnrealMcpBridgeServer::SendProjectConfigRequest(const FString& RequestId, const FString& InProjectPath)
+{
+	// mcp-authorize PR 4 (design 04/06): ask the sidecar to resolve THIS project's {pin, derived local-server
+	// port, serverTarget}. The result arrives as a `project-config-result` routed through the status sink. No verb
+	// allow-list needed (this is not a user-driven UI verb like the auth/agent-config sends) — a single fixed type.
+	if (!bClientConnected || !bHandshakeOk)
+		return false;
+
+	TSharedPtr<FJsonObject> Message = MakeShared<FJsonObject>();
+	Message->SetStringField(TEXT("type"), TypeProjectConfig);
+	Message->SetStringField(TEXT("requestId"), RequestId);
+	Message->SetStringField(TEXT("projectPath"), InProjectPath);
 	return SendMessage(Message);
 }
 

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.h
@@ -110,6 +110,16 @@ public:
 	static bool IsValidAgentConfigVerb(const FString& Type);
 
 	/**
+	 * Send a mcp-authorize PR 4 `project-config` request (design 04/06) to the connected sidecar, which resolves
+	 * THIS project's {pin, derived local-server port, enrolled server target} via the shared C# ProjectIdentity +
+	 * project marker and answers with a `project-config-result` routed back through the status sink. @p RequestId
+	 * correlates the response; @p InProjectPath is the plugin's project root the sidecar resolves from (the sidecar
+	 * falls back to the handshake-reported root when it is empty). Thread-safe; no-op (returns false) when no
+	 * sidecar is connected/handshaken. The UI/coordinator calls this; the frame is serialized through WriteMutex.
+	 */
+	bool SendProjectConfigRequest(const FString& RequestId, const FString& InProjectPath);
+
+	/**
 	 * Register a sink for the inbound sidecar→plugin `status` and `device-auth` feed (§1.3 / §7). The sink
 	 * is invoked ON THE IPC READER THREAD with the message type and parsed object — the caller (the §7
 	 * view-model) MUST marshal onto the game thread (AsyncTask(GameThread)) before touching any Slate state

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -746,7 +746,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 }
                 catch (Exception ex)
                 {
-                    var requestId = node["requestId"]?.GetValue<string>();
+                    // Recover the requestId defensively: this catch runs in a fire-and-forget Task.Run, so it must
+                    // itself never throw (GetValue<string>() would throw on a non-string requestId token — exactly the
+                    // malformed-request case that lands us here — turning a handled drop into an unobserved exception).
+                    string? requestId = null;
+                    if (node["requestId"] is JsonValue requestIdValue)
+                        requestIdValue.TryGetValue(out requestId);
                     if (string.IsNullOrEmpty(requestId))
                     {
                         _logger?.LogWarning("Dropped malformed project-config '{Type}' request: {Message}", type, ex.Message);

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -422,6 +422,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _ipc.ConfigReceived += OnConfigReceived;
             _ipc.AuthMessageReceived += HandleAuthMessage;
             _ipc.AgentConfigRequestReceived += HandleAgentConfigRequest;
+            _ipc.ProjectConfigRequestReceived += HandleProjectConfigRequest;
 
             _logger?.LogInformation("Sidecar host built (version {Version}); awaiting IPC handshake.", _sidecarVersion);
         }
@@ -723,6 +724,79 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                         Error = $"Unknown agent-config request type '{type}'.",
                     };
             }
+        }
+
+        /// <summary>
+        /// Serve a mcp-authorize PR 4 <c>project-config</c> request (design 04/06): resolve THIS project's
+        /// {pin, derived local-server port, portIsOverridden, serverTarget} via <see cref="ProjectConnectionResolver"/>
+        /// and send the terminal <c>project-config-result</c> back to the plugin. Runs the (file-IO) resolve off the
+        /// reader thread. Never throws — a malformed request or a resolve failure becomes an <c>ok == false</c> result
+        /// (or, when even the requestId cannot be recovered, a logged drop), so it cannot tear down the read loop.
+        /// Public so the bridge xUnit suite can drive the dispatch without a live socket.
+        /// </summary>
+        public void HandleProjectConfigRequest(string type, JsonObject node)
+        {
+            // Run off the reader thread: ProjectConnectionResolver.Resolve reads the on-disk project marker.
+            _ = Task.Run(async () =>
+            {
+                ProjectConfigResultMessage result;
+                try
+                {
+                    result = BuildProjectConfigResult(node);
+                }
+                catch (Exception ex)
+                {
+                    var requestId = node["requestId"]?.GetValue<string>();
+                    if (string.IsNullOrEmpty(requestId))
+                    {
+                        _logger?.LogWarning("Dropped malformed project-config '{Type}' request: {Message}", type, ex.Message);
+                        return;
+                    }
+                    result = new ProjectConfigResultMessage
+                    {
+                        RequestId = requestId!,
+                        Ok = false,
+                        Error = $"Sidecar failed to resolve project config: {ex.Message}",
+                    };
+                }
+                await _ipc.SendToPluginAsync(result, CancellationToken.None).ConfigureAwait(false);
+            });
+        }
+
+        /// <summary>
+        /// Resolve a <c>project-config</c> request into its terminal result. Prefers the project root the request
+        /// carries (race-free — the C++ plugin knows <c>FPaths::ProjectDir()</c>); falls back to the handshake-reported
+        /// root cached by <see cref="ApplyProjectIdentity"/>. Resolution goes through the SAME
+        /// <see cref="ProjectConnectionResolver.Resolve"/> PR 3 uses, so the returned pin/port carry byte-for-byte
+        /// <c>ProjectIdentity</c> golden-vector parity and the marker's <c>portOverride</c> precedence. Internal so the
+        /// bridge xUnit suite asserts the resolved DTO (parity + override) without the IPC send.
+        /// </summary>
+        internal ProjectConfigResultMessage BuildProjectConfigResult(JsonObject node)
+        {
+            var request = node.Deserialize<ProjectConfigRequestMessage>(IpcProtocol.JsonOptions) ?? new ProjectConfigRequestMessage();
+
+            var projectRoot = !string.IsNullOrWhiteSpace(request.ProjectPath)
+                ? request.ProjectPath
+                : Volatile.Read(ref _projectRootPath);
+
+            if (string.IsNullOrWhiteSpace(projectRoot))
+                return new ProjectConfigResultMessage
+                {
+                    RequestId = request.RequestId,
+                    Ok = false,
+                    Error = "No project path available to resolve the connection identity (handshake not applied and request carried none).",
+                };
+
+            var resolved = ProjectConnectionResolver.Resolve(projectRoot!, _instanceId);
+            return new ProjectConfigResultMessage
+            {
+                RequestId = request.RequestId,
+                Ok = true,
+                Pin = resolved.Pin,
+                Port = resolved.Port,
+                PortIsOverridden = resolved.PortIsOverridden,
+                ServerTarget = resolved.ServerTarget,
+            };
         }
 
         private void StartDeviceAuth()

--- a/bridge/src/Ipc/IpcClient.cs
+++ b/bridge/src/Ipc/IpcClient.cs
@@ -113,6 +113,15 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         /// </summary>
         public event Action<string, JsonObject>? AgentConfigRequestReceived;
 
+        /// <summary>
+        /// Raised when the plugin sends a mcp-authorize PR 4 <c>project-config</c> request (design 04/06): the C++
+        /// plugin asking the sidecar to resolve THIS project's {pin, derived local-server port, serverTarget}. The
+        /// arguments are the request <c>type</c> and the raw parsed JSON object; the host resolves it via
+        /// <c>ProjectConnectionResolver</c> and answers with a <c>project-config-result</c> via
+        /// <see cref="SendToPluginAsync"/> (off the reader thread).
+        /// </summary>
+        public event Action<string, JsonObject>? ProjectConfigRequestReceived;
+
         public IpcClient(string host, int port, string token, string sidecarVersion, ILogger? logger = null)
         {
             _host = host;
@@ -365,6 +374,13 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
                     // library and answers with an `agent-config-result` (off the reader thread).
                     if (node is JsonObject agentObj)
                         AgentConfigRequestReceived?.Invoke(type, agentObj);
+                    break;
+                case IpcProtocol.Type.ProjectConfig:
+                    // mcp-authorize PR 4: the plugin requests THIS project's resolved {pin, derived local-server
+                    // port, serverTarget}. The host resolves via ProjectConnectionResolver and answers with a
+                    // `project-config-result` (off the reader thread).
+                    if (node is JsonObject projectConfigObj)
+                        ProjectConfigRequestReceived?.Invoke(type, projectConfigObj);
                     break;
                 case IpcProtocol.Type.Status:
                 case IpcProtocol.Type.Log:

--- a/bridge/src/Ipc/IpcProtocol.cs
+++ b/bridge/src/Ipc/IpcProtocol.cs
@@ -95,6 +95,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
             // sidecar → plugin: the terminal result of one agent-config request (§7 AI-agent configurators).
             // Correlated to the originating request by requestId; carries the engine-agnostic DTO.
             public const string AgentConfigResult = "agent-config-result";
+            // sidecar → plugin: the resolved connection identity for the current project (mcp-authorize PR 4,
+            // design 04/06) — {pin, derived local-server port, portIsOverridden, serverTarget}. The terminal
+            // answer to a plugin `project-config` request, correlated by requestId.
+            public const string ProjectConfigResult = "project-config-result";
 
             // sidecar → plugin: fetch one prompt's rendered messages / read one resource's content (v2, §A.1).
             // Both round-trip through PendingCallRegistry by requestId, exactly like a tool-call, and reuse the
@@ -127,6 +131,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
             public const string AgentRemove = "agent-remove";     // remove the MCP entry (both transports)
             public const string AgentSkillsPath = "agent-skills-path"; // resolve the agent's skills folder (plugin writes the files)
             public const string AgentGenerateSkills = "agent-generate-skills"; // sidecar resolves the path + writes the SKILL.md files
+            // plugin → sidecar: request THIS project's resolved connection identity (mcp-authorize PR 4). The
+            // sidecar computes {pin, derived local-server port, serverTarget} from McpPlugin's ProjectIdentity +
+            // the project marker and answers with a `project-config-result`. Carries the project root to resolve from.
+            public const string ProjectConfig = "project-config";
 
             // either direction
             public const string Ping = "ping";

--- a/bridge/src/Ipc/ProjectConfigMessages.cs
+++ b/bridge/src/Ipc/ProjectConfigMessages.cs
@@ -1,0 +1,65 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
+{
+    /// <summary>
+    /// IPC message payloads for the mcp-authorize PR 4 project-config channel (design docs 04/06). Unlike Unity
+    /// and Godot — which host McpPlugin in-process and derive the pin/port in C# right where they need it — the
+    /// Unreal C++ plugin cannot host the .NET stack, so the deterministic <c>ProjectIdentity</c> derivation lives
+    /// only in the sidecar. When the C++ plugin needs the derived per-project <b>local-server port</b> (to start
+    /// <c>FUnrealMcpServerManager</c>), it asks the sidecar for it over this channel instead of duplicating the
+    /// SHA-256 derivation math in C++.
+    ///
+    /// The plugin sends a <see cref="ProjectConfigRequestMessage"/> (carrying its project root); the sidecar
+    /// resolves the identity via <c>ProjectConnectionResolver</c> (byte-for-byte <c>ProjectIdentity</c> golden-vector
+    /// parity + the project marker's <c>portOverride</c> precedence) and answers with a
+    /// <see cref="ProjectConfigResultMessage"/>. The marker port override always wins — it is baked into
+    /// <see cref="ProjectConfigResultMessage.Port"/> by the resolver, and surfaced via
+    /// <see cref="ProjectConfigResultMessage.PortIsOverridden"/> for logging.
+    /// </summary>
+
+    /// <summary>plugin → sidecar: request the resolved {pin, derived port, serverTarget} for the plugin's project.</summary>
+    public sealed class ProjectConfigRequestMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.ProjectConfig;
+        [JsonPropertyName("requestId")] public string RequestId { get; set; } = string.Empty;
+        /// <summary>
+        /// The plugin's project root (<c>FPaths::ConvertRelativePathToFull(FPaths::ProjectDir())</c>). The sidecar
+        /// resolves the identity from this; when empty it falls back to the root the handshake-ack reported (cached
+        /// in <c>SidecarHost.ApplyProjectIdentity</c>). Carrying it makes the request race-free against the ack.
+        /// </summary>
+        [JsonPropertyName("projectPath")] public string? ProjectPath { get; set; }
+    }
+
+    /// <summary>
+    /// sidecar → plugin: the resolved connection identity for the requested project (mcp-authorize PR 4). Correlated
+    /// to the request by <see cref="RequestId"/>. On <see cref="Ok"/> the fields are populated; otherwise
+    /// <see cref="Error"/> carries a short human-readable reason (never a secret).
+    /// </summary>
+    public sealed class ProjectConfigResultMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.ProjectConfigResult;
+        [JsonPropertyName("requestId")] public string RequestId { get; set; } = string.Empty;
+        [JsonPropertyName("ok")] public bool Ok { get; set; }
+        /// <summary>A short human-readable failure reason on <c>ok == false</c> (never a secret).</summary>
+        [JsonPropertyName("error")] public string? Error { get; set; }
+        /// <summary>The routing pin — first 8 hex chars of the ProjectIdentity SHA-256 (D14/D15).</summary>
+        [JsonPropertyName("pin")] public string? Pin { get; set; }
+        /// <summary>The deterministic per-project local-server port (marker <c>portOverride</c> if set, else the SHA-derived 20000–29999 port).</summary>
+        [JsonPropertyName("port")] public int Port { get; set; }
+        /// <summary>Whether <see cref="Port"/> came from the marker's user <c>portOverride</c> (informational; the override is already applied to <see cref="Port"/>).</summary>
+        [JsonPropertyName("portIsOverridden")] public bool PortIsOverridden { get; set; }
+        /// <summary>The enrolled server target (hosted vs local) from the project marker, or null when unenrolled.</summary>
+        [JsonPropertyName("serverTarget")] public string? ServerTarget { get; set; }
+    }
+}

--- a/bridge/tests/SidecarHostProjectConfigTests.cs
+++ b/bridge/tests/SidecarHostProjectConfigTests.cs
@@ -1,0 +1,154 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.Unreal.MCP.Bridge.Host;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>
+    /// Proves the mcp-authorize PR 4 project-config IPC channel (design 04/06): the new message round-trips over the
+    /// NDJSON wire, and the sidecar resolves a <c>project-config</c> request into the derived {pin, port, serverTarget}
+    /// with byte-for-byte <see cref="ProjectIdentity"/> golden-vector parity and the project marker's
+    /// <c>portOverride</c> precedence — all without a live socket (mirrors <c>SidecarHostInstanceMetadataTests</c>).
+    /// </summary>
+    public class SidecarHostProjectConfigTests
+    {
+        private static SidecarHost BuildHost()
+        {
+            var ipc = new IpcClient("127.0.0.1", 39996, token: "test-token", sidecarVersion: "0.1.0");
+            var host = new SidecarHost(ipc, "0.1.0");
+            host.Build();
+            return host;
+        }
+
+        private static JsonObject Request(string requestId, string? projectPath)
+        {
+            var node = new JsonObject
+            {
+                ["type"] = IpcProtocol.Type.ProjectConfig,
+                ["requestId"] = requestId,
+            };
+            if (projectPath != null)
+                node["projectPath"] = projectPath;
+            return node;
+        }
+
+        [Fact]
+        public void ProjectConfigMessages_RoundTripOverTheWire()
+        {
+            var request = new ProjectConfigRequestMessage { RequestId = "req-1", ProjectPath = "/home/user/my-game" };
+            var reqJson = JsonSerializer.Serialize(request, IpcProtocol.JsonOptions);
+            var reqBack = JsonSerializer.Deserialize<ProjectConfigRequestMessage>(reqJson, IpcProtocol.JsonOptions)!;
+            Assert.Equal(IpcProtocol.Type.ProjectConfig, reqBack.Type);
+            Assert.Equal("req-1", reqBack.RequestId);
+            Assert.Equal("/home/user/my-game", reqBack.ProjectPath);
+
+            var result = new ProjectConfigResultMessage
+            {
+                RequestId = "req-1",
+                Ok = true,
+                Pin = "34ea75f2",
+                Port = 23940,
+                PortIsOverridden = false,
+                ServerTarget = "https://ai-game.dev",
+            };
+            var resJson = JsonSerializer.Serialize(result, IpcProtocol.JsonOptions);
+            var resBack = JsonSerializer.Deserialize<ProjectConfigResultMessage>(resJson, IpcProtocol.JsonOptions)!;
+            Assert.Equal(IpcProtocol.Type.ProjectConfigResult, resBack.Type);
+            Assert.Equal("req-1", resBack.RequestId);
+            Assert.True(resBack.Ok);
+            Assert.Equal("34ea75f2", resBack.Pin);
+            Assert.Equal(23940, resBack.Port);
+            Assert.False(resBack.PortIsOverridden);
+            Assert.Equal("https://ai-game.dev", resBack.ServerTarget);
+        }
+
+        [Fact]
+        public void BuildProjectConfigResult_FromRequestPath_ReturnsGoldenPinPort()
+        {
+            using var host = BuildHost();
+
+            // Same canonical golden vector the resolver suite locks: /home/user/my-game → pin 34ea75f2, port 23940.
+            var result = host.BuildProjectConfigResult(Request("r-1", "/home/user/my-game"));
+
+            Assert.True(result.Ok);
+            Assert.Equal("r-1", result.RequestId);
+            Assert.Equal("34ea75f2", result.Pin);
+            Assert.Equal(23940, result.Port);
+            Assert.False(result.PortIsOverridden);
+            Assert.Null(result.ServerTarget); // no marker present
+        }
+
+        [Fact]
+        public void BuildProjectConfigResult_MarkerPortOverride_WinsAndSurfacesServerTarget()
+        {
+            RunInTempDir(dir =>
+            {
+                new ProjectMarker { ServerTarget = "http://localhost:5383", PortOverride = 25555 }.Write(dir);
+                using var host = BuildHost();
+
+                var result = host.BuildProjectConfigResult(Request("r-2", dir));
+
+                Assert.True(result.Ok);
+                Assert.Equal(25555, result.Port);              // user override wins over the SHA-derived port
+                Assert.True(result.PortIsOverridden);
+                Assert.Equal("http://localhost:5383", result.ServerTarget);
+            });
+        }
+
+        [Fact]
+        public void BuildProjectConfigResult_FallsBackToHandshakeRoot_WhenRequestOmitsPath()
+        {
+            using var host = BuildHost();
+            // The plugin's handshake-ack already reported the root; a request that omits projectPath resolves from it.
+            host.ApplyProjectIdentity("/home/user/my-game");
+
+            var result = host.BuildProjectConfigResult(Request("r-3", projectPath: null));
+
+            Assert.True(result.Ok);
+            Assert.Equal("34ea75f2", result.Pin);
+            Assert.Equal(23940, result.Port);
+        }
+
+        [Fact]
+        public void BuildProjectConfigResult_NoProjectPathAnywhere_ReturnsNotOk()
+        {
+            using var host = BuildHost(); // no ApplyProjectIdentity, request carries no path
+
+            var result = host.BuildProjectConfigResult(Request("r-4", projectPath: null));
+
+            Assert.False(result.Ok);
+            Assert.Equal("r-4", result.RequestId);
+            Assert.False(string.IsNullOrEmpty(result.Error));
+            Assert.Equal(0, result.Port);
+        }
+
+        private static void RunInTempDir(Action<string> body)
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "umcp-pcfg-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                body(dir);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { /* best-effort cleanup */ }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **IPC schema (small):** new plugin -> sidecar `project-config` request + sidecar -> plugin `project-config-result` carrying `{pin, port, portIsOverridden, serverTarget}`. The sidecar resolves it via the existing `ProjectConnectionResolver` (byte-for-byte `ProjectIdentity` golden-vector parity + the project marker's `portOverride` precedence). Mirrored in the C++ `UnrealMcpBridgeServer`.
- **C++ port migration:** the editor coordinator requests the project-config on each sidecar handshake, caches the derived per-project port, and starts/reattaches the local `gamedev-mcp-server` on it. The marker `portOverride` always wins; **no 8080 fallback on the golden path**. The 30000-39999 sidecar-IPC probing range is a different channel, left unchanged.

PR 4 of the mcp-authorize `f1` decomposition (PRs #210, #212, #214 already landed). PR 3 computed the pin + derived port in C#; this PR delivers that port to the C++ plugin over IPC and flips the C++ default off `8080`.

## Test plan

- [x] bridge `dotnet build` + xUnit — **245/245** (new: `project-config` message round-trip, golden-vector pin/port parity through the sidecar handler, marker `portOverride` precedence, handshake-root fallback, no-path error).
- [x] UE plugin gate Suites 1 (UBT build) + 1b (RunUAT BuildPlugin — runtime module touched) + 2 (headless boot smoke, `[Unreal-MCP] plugin loaded`) + 3 (Automation specs, `failed=0, succeeded=333`) — all green.
- No version bump, no NuGet-pin bump, no release actions (out of scope: PR 5 Slate sign-in / MapSettings token drop; PR 6 enroll-redemption + live e2e).

Closes #215