### PR TITLE
feat(config): configurator UI — MapSettings token drop + editor sign-in state (mcp-authorize PR 5)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentConfigurators.cpp
@@ -128,10 +128,15 @@ TSharedPtr<FJsonObject> SUnrealMcpAgentConfigurators::BuildSettings() const
 	Settings->SetNumberField(TEXT("port"), Connection.Port);
 	Settings->SetNumberField(TEXT("timeoutMs"), 30000);
 	Settings->SetStringField(TEXT("host"), Connection.HttpUrl);
-	// The REAL bearer is forwarded so the sidecar can inject it into the written config; it is NEVER logged here.
-	Settings->SetStringField(TEXT("token"), Connection.Token);
+	// mcp-authorize PR 5 (design 06, D11): the DEFAULT path is native MCP OAuth — the sidecar writes a
+	// credential-free config, so DON'T forward the bearer there ("HTTP configs: stop embedding tokens"). The REAL
+	// bearer is forwarded ONLY on the "Advanced: use access token" escape hatch (Flow C), where the sidecar injects
+	// it into the legacy Bearer shape. It is NEVER logged here.
+	Settings->SetStringField(TEXT("token"), Connection.bUseAccessToken ? Connection.Token : FString());
 	Settings->SetStringField(TEXT("connectionMode"), bCloud ? TEXT("Cloud") : TEXT("Local"));
 	Settings->SetBoolField(TEXT("authRequired"), Connection.bAuthRequired);
+	// The explicit escape-hatch opt-in — the sidecar keys the HttpCredentialMode.AccessToken path off this.
+	Settings->SetBoolField(TEXT("useAccessToken"), Connection.bUseAccessToken);
 	return Settings;
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAgentConfigModels.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAgentConfigModels.cpp
@@ -23,6 +23,15 @@ FAiAgentConnectionInfo FAiAgentConnectionInfo::FromPluginConfig(const FUnrealMcp
 	Info.bAuthRequired = bCloud || Config.AuthOption == EUnrealMcpAuthOption::Required;
 	Info.Token = Config.ResolveEffectiveToken();
 
+	// mcp-authorize PR 5 (design 06, Flow C): the "Advanced: use access token" escape hatch. The DEFAULT path is
+	// native MCP OAuth (URL-only, no bearer) — with the device-flow machine credential store (PR 2) the token is no
+	// longer required input. Only an explicit Custom-mode Required-auth WITH a non-empty token opts into the legacy
+	// Bearer shape for clients that cannot do MCP OAuth. Cloud is ALWAYS native OAuth (its auth is server-enforced,
+	// never a user-pasted PAT), so it never triggers the escape hatch.
+	Info.bUseAccessToken = !bCloud
+		&& Config.AuthOption == EUnrealMcpAuthOption::Required
+		&& !Info.Token.IsEmpty();
+
 	return Info;
 }
 
@@ -73,6 +82,9 @@ FUnrealMcpAgentDescription FUnrealMcpAgentDescription::FromJson(const TSharedPtr
 	Json->TryGetBoolField(TEXT("isConfigured"), Desc.bIsConfigured);
 	Json->TryGetBoolField(TEXT("isInstalled"), Desc.bIsInstalled);
 	Json->TryGetBoolField(TEXT("supportsSkills"), Desc.bSupportsSkills);
+	// mcp-authorize PR 5 (design 06): the native-OAuth capability. Absent in an older sidecar → leave the default
+	// true (assume OAuth-capable) so the escape hatch is only surfaced for an explicit supportsOAuth=false.
+	Json->TryGetBoolField(TEXT("supportsOAuth"), Desc.bSupportsOAuth);
 	Json->TryGetStringField(TEXT("downloadUrl"), Desc.DownloadUrl);
 	Json->TryGetStringField(TEXT("tutorialUrl"), Desc.TutorialUrl);
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAgentConfigModels.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAgentConfigModels.h
@@ -30,6 +30,9 @@ class FJsonObject;
  *  - Port        — the deterministic IPC port for this project (§1.1).
  *  - HttpUrl     — the resolved MCP-client URL the HTTP form points at: <effective host>/mcp.
  *  - bAuthRequired / Token — whether a bearer is sent and its real value (the REAL bearer — masking is the UI's job).
+ *  - bUseAccessToken — mcp-authorize PR 5 (design 06, Flow C): whether the "Advanced: use access token" escape
+ *                  hatch is active (Custom mode + Required auth + a non-empty token). The default path is native
+ *                  MCP OAuth (URL-only, no bearer); ONLY this flag makes the sidecar write the legacy Bearer shape.
  */
 struct FAiAgentConnectionInfo
 {
@@ -38,6 +41,8 @@ struct FAiAgentConnectionInfo
 	FString HttpUrl;
 	bool bAuthRequired = false;
 	FString Token;
+	// mcp-authorize PR 5: the explicit "Advanced: use access token" opt-in (Flow C). False on the default OAuth path.
+	bool bUseAccessToken = false;
 
 	/** Resolve the connection facts from the live plugin config (the same builder the panel/runtime used pre-#101). */
 	static UNREALMCPEDITOR_API FAiAgentConnectionInfo FromPluginConfig(const FUnrealMcpConfig& Config, const FString& InServerPath, int32 InPort);
@@ -118,6 +123,10 @@ struct FUnrealMcpAgentDescription
 	EAiAgentConfiguratorStatus Status = EAiAgentConfiguratorStatus::NotConfigured;
 	bool bIsInstalled = false;
 	bool bSupportsSkills = false;
+	// mcp-authorize PR 5 (design 06): whether this agent can do native MCP OAuth. Default true (credential-free
+	// config + client-side authorize). A false value is the signal to offer the "Advanced: use access token" (PAT)
+	// escape hatch for that agent; an older/absent field degrades to true so the default OAuth path is assumed.
+	bool bSupportsOAuth = true;
 	FString DownloadUrl;
 	FString TutorialUrl;
 	// 6.9.0 top-level Link items (download / tutorial / docs) — each a Link-kind item with Text + Url the panel

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfigModelsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfigModelsSpec.cpp
@@ -183,6 +183,21 @@ void FUnrealMcpAgentConfigModelsSpec::Define()
 			const FUnrealMcpAgentDescription Desc = FUnrealMcpAgentDescription::FromJson(AgentConfigModelsParseObject(Json));
 			TestEqual("default status", Desc.Status, EAiAgentConfiguratorStatus::NotConfigured);
 			TestEqual("no links", Desc.Links.Num(), 0);
+			// mcp-authorize PR 5: supportsOAuth absent → default true (assume OAuth-capable; no escape hatch surfaced).
+			TestTrue("default supportsOAuth", Desc.bSupportsOAuth);
+		});
+
+		It("parses the mcp-authorize PR 5 supportsOAuth capability flag", [this]()
+		{
+			// A SupportsOAuth == false agent is the signal for the editor to offer the "Advanced: use access token"
+			// escape hatch. The plugin-side model must carry it verbatim from the DTO.
+			const FString JsonFalse = TEXT(R"JSON({ "agentId": "legacy-client", "agentName": "Legacy", "supportsOAuth": false })JSON");
+			const FUnrealMcpAgentDescription DescFalse = FUnrealMcpAgentDescription::FromJson(AgentConfigModelsParseObject(JsonFalse));
+			TestFalse("supportsOAuth false round-trips", DescFalse.bSupportsOAuth);
+
+			const FString JsonTrue = TEXT(R"JSON({ "agentId": "claude-code", "agentName": "Claude Code", "supportsOAuth": true })JSON");
+			const FUnrealMcpAgentDescription DescTrue = FUnrealMcpAgentDescription::FromJson(AgentConfigModelsParseObject(JsonTrue));
+			TestTrue("supportsOAuth true round-trips", DescTrue.bSupportsOAuth);
 		});
 
 		It("returns an empty description for a null/invalid object", [this]()
@@ -244,6 +259,50 @@ void FUnrealMcpAgentConfigModelsSpec::Define()
 			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, FString(), 0);
 			TestTrue("cloud requires auth", Info.bAuthRequired);
 			TestTrue("httpUrl ends with /mcp", Info.HttpUrl.EndsWith(TEXT("/mcp")));
+		});
+
+		// mcp-authorize PR 5 (design 06, Flow C): bUseAccessToken drives the "Advanced: use access token" escape hatch.
+		// It is true ONLY for a Custom-mode Required-auth WITH a non-empty token — the default path (and Cloud, whose
+		// auth is server-enforced native OAuth, never a user PAT) stays on the credential-free OAuth path.
+		It("does not opt into the access-token escape hatch on the default Custom path", [this]()
+		{
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.CustomHost = TEXT("http://localhost:8080");
+			Config.AuthOption = EUnrealMcpAuthOption::None;
+			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, FString(), 31234);
+			TestFalse("no escape hatch on default path", Info.bUseAccessToken);
+		});
+
+		It("opts into the access-token escape hatch for Custom + Required + a token", [this]()
+		{
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.CustomHost = TEXT("http://localhost:8080");
+			Config.AuthOption = EUnrealMcpAuthOption::Required;
+			Config.CustomToken = TEXT("pat-secret-value");
+			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, FString(), 31234);
+			TestTrue("escape hatch active", Info.bUseAccessToken);
+			TestEqual("token forwarded", Info.Token, FString(TEXT("pat-secret-value")));
+		});
+
+		It("does not opt in for Custom + Required but an EMPTY token", [this]()
+		{
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.AuthOption = EUnrealMcpAuthOption::Required;
+			Config.CustomToken = FString();
+			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, FString(), 31234);
+			TestFalse("no token → no escape hatch", Info.bUseAccessToken);
+		});
+
+		It("never opts into the escape hatch in Cloud mode (native OAuth, not a user PAT)", [this]()
+		{
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Cloud;
+			Config.CloudToken = TEXT("cloud-bearer-value");
+			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, FString(), 0);
+			TestFalse("cloud never uses the PAT escape hatch", Info.bUseAccessToken);
 		});
 	});
 }

--- a/bridge/src/AgentConfig/AgentConfigService.cs
+++ b/bridge/src/AgentConfig/AgentConfigService.cs
@@ -18,6 +18,7 @@ using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
 using Microsoft.Extensions.Logging;
 using McpAuthOption = com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server.AuthOption;
 using McpConnectionMode = com.IvanMurzak.McpPlugin.AgentConfig.ConnectionMode;
+using McpHttpCredentialMode = com.IvanMurzak.McpPlugin.AgentConfig.HttpCredentialMode;
 using McpTransport = com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server.TransportMethod;
 
 namespace com.IvanMurzak.Unreal.MCP.Bridge.AgentConfig
@@ -111,9 +112,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.AgentConfig
             var transport = ParseTransport(request.Transport);
             try
             {
+                // mcp-authorize PR 5 (design 06): the DEFAULT path is native MCP OAuth — the written HTTP config is
+                // credential-free (HttpCredentialMode.Oauth). Only the explicit "Advanced: use access token" opt-in
+                // (with a token) writes the legacy Bearer shape (Flow C) for the clients that cannot do MCP OAuth.
                 var config = transport == McpTransport.stdio
                     ? configurator.GetStdioConfig(settings, _logger)
-                    : configurator.GetHttpConfig(settings, _logger);
+                    : configurator.GetHttpConfig(settings, _logger, ResolveCredentialMode(request.Settings));
                 result.Ok = config.Configure();
                 if (!result.Ok)
                     result.Error = $"Configure returned false for '{request.AgentId}' ({transport}).";
@@ -248,6 +252,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.AgentConfig
                 Status = description.Status.ToString(),
                 IsInstalled = description.IsInstalled,
                 SupportsSkills = configurator.SupportsSkills,
+                // mcp-authorize PR 5 (design 06): forward the native-OAuth capability so the editor UI knows which
+                // agents need the "Advanced: use access token" (PAT) escape hatch — SupportsOAuth == false clients.
+                SupportsOAuth = configurator.SupportsOAuth,
                 DownloadUrl = configurator.DownloadUrl,
                 TutorialUrl = configurator.TutorialUrl,
                 // 6.9.0: the top-level Link items (download / tutorial / docs), carried with their Url so the plugin
@@ -273,23 +280,53 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.AgentConfig
         private static AgentItemDto MapItem(global::com.IvanMurzak.McpPlugin.AgentConfig.ConfigurationItem item) =>
             new() { Kind = item.Kind.ToString(), Text = item.Text, Url = item.Url ?? string.Empty };
 
-        /// <summary>Map the inline IPC settings DTO into the shared library's host-aware settings.</summary>
+        /// <summary>
+        /// Map the inline IPC settings DTO into the shared library's host-aware settings.
+        ///
+        /// <para>
+        /// mcp-authorize PR 5 (design 06, D11): the token is NO LONGER required input on the default path. With the
+        /// device-flow machine credential store (PR 2) the client authorizes natively (MCP OAuth) and the written
+        /// config is credential-free — the shared library's <c>GetHttpConfig</c> defaults to
+        /// <c>HttpCredentialMode.Oauth</c> and never embeds a bearer. So <c>authOption</c> + <c>token</c> are carried
+        /// ONLY for the explicit "Advanced: use access token" escape hatch (Flow C); <c>dto.AuthRequired</c> alone
+        /// (which Cloud enforcement sets) no longer forces a bearer-carrying config. This drops the previous
+        /// "AuthRequired ⇒ authOption.required" gating that made the default path token-required.
+        /// </para>
+        /// </summary>
         private static AgentConfiguratorSettings MapSettings(AgentSettingsDto dto)
         {
             var connectionMode = string.Equals(dto.ConnectionMode, "Cloud", StringComparison.OrdinalIgnoreCase)
                 ? McpConnectionMode.Cloud
                 : McpConnectionMode.Local;
-            var authOption = dto.AuthRequired ? McpAuthOption.required : McpAuthOption.none;
+            var useAccessToken = UsesAccessToken(dto);
+            var authOption = useAccessToken ? McpAuthOption.required : McpAuthOption.none;
             return AgentConfiguratorSettings.CreateForHost(
                 projectRootPath: dto.ProjectRootPath,
                 executableFullPath: dto.ExecutableFullPath,
                 port: dto.Port,
                 timeoutMs: dto.TimeoutMs,
                 host: dto.Host,
-                token: string.IsNullOrEmpty(dto.Token) ? null : dto.Token,
+                token: useAccessToken ? dto.Token : null,
                 connectionMode: connectionMode,
                 authOption: authOption);
         }
+
+        /// <summary>
+        /// Whether a request opts into the "Advanced: use access token" escape hatch (mcp-authorize PR 5, design 06,
+        /// Flow C): the plugin explicitly set <see cref="AgentSettingsDto.UseAccessToken"/> AND supplied a non-empty
+        /// <see cref="AgentSettingsDto.Token"/>. Everything else is the default credential-free native-OAuth path.
+        /// </summary>
+        private static bool UsesAccessToken(AgentSettingsDto? dto) =>
+            dto != null && dto.UseAccessToken && !string.IsNullOrEmpty(dto.Token);
+
+        /// <summary>
+        /// Resolve the HTTP credential mode for a request (mcp-authorize PR 5, design 06). The default is native MCP
+        /// OAuth (<see cref="McpHttpCredentialMode.Oauth"/>, URL-only — no embedded bearer); only the "Advanced: use
+        /// access token" opt-in (see <see cref="UsesAccessToken"/>) selects <see cref="McpHttpCredentialMode.AccessToken"/>
+        /// so the legacy Bearer shape is written for clients that cannot do MCP OAuth.
+        /// </summary>
+        private static McpHttpCredentialMode ResolveCredentialMode(AgentSettingsDto? dto) =>
+            UsesAccessToken(dto) ? McpHttpCredentialMode.AccessToken : McpHttpCredentialMode.Oauth;
 
         private static McpTransport ParseTransport(string? transport) =>
             string.Equals(transport, "stdio", StringComparison.OrdinalIgnoreCase)

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -946,6 +946,18 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             return connected ? "Connected" : "Connecting";
         }
 
+        /// <summary>
+        /// Resolve the cloud sign-in indicator for a status emit (mcp-authorize PR 5, design 06 / D12). Cloud mode
+        /// reports <c>"Authorized"</c> when EITHER an in-session bearer was issued (an in-editor device flow) OR the
+        /// shared machine credential store already holds a credential (zero-button sign-in — a CLI login, an
+        /// enrollment, or another engine/project signed in once-per-machine). This is what surfaces the signed-in
+        /// state in the editor even when sign-in happened out-of-editor. <c>null</c> in Custom mode, or when no
+        /// credential of either kind is present. Pure + static so the bridge xUnit suite locks the matrix without a
+        /// live SignalR link or machine store.
+        /// </summary>
+        internal static string? ResolveCloudAuthState(bool isCloudMode, bool hasSessionBearer, bool machineCredentialExists) =>
+            isCloudMode && (hasSessionBearer || machineCredentialExists) ? "Authorized" : null;
+
         /// <summary>Fully disconnect SignalR (auth-revoke / Disconnect), then surface a Disconnected status.</summary>
         private async Task HandleDisconnectAsync(CancellationToken ct)
         {
@@ -1301,9 +1313,13 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                     }
                     _logger?.LogInformation(ok ? "SignalR connected." : "SignalR initial connect returned false; client will keep retrying.");
                     // §7 live status: surface the connection result to the plugin's view-model. Only a CLOUD-mode
-                    // bearer is a cloud authorization — a Custom-mode token is a local bearer and must NOT light the
-                    // "Authorized — cloud token stored" indicator (ApplyStatus latches it and never demotes).
-                    var cloudAuthState = _isCloudMode && !string.IsNullOrEmpty(BearerToken) ? "Authorized" : null;
+                    // credential is a cloud authorization — a Custom-mode token is a local bearer and must NOT light
+                    // the "Authorized" indicator (ApplyStatus latches it and never demotes). mcp-authorize PR 5
+                    // (design 06, D12): the machine credential store being populated ALSO counts as signed-in, so a
+                    // zero-button boot (sign-in done out-of-editor: a CLI login, an enrollment, another engine/project)
+                    // surfaces the signed-in state without an in-editor device flow.
+                    var cloudAuthState = ResolveCloudAuthState(
+                        _isCloudMode, !string.IsNullOrEmpty(BearerToken), _credentialStore?.Exists == true);
                     await EmitStatusAsync(ok ? "Connected" : "Connecting", cloudAuthState).ConfigureAwait(false);
                     // §7 (issue #109): once connected, seed the AI-agent roster (with retry/backoff) so the row is
                     // populated even before the first OnClientsChanged push. Fire-and-forget on a background task —

--- a/bridge/src/Ipc/AgentConfigMessages.cs
+++ b/bridge/src/Ipc/AgentConfigMessages.cs
@@ -44,12 +44,25 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         [JsonPropertyName("timeoutMs")] public int TimeoutMs { get; set; } = IpcProtocol.DefaultToolTimeoutMs;
         /// <summary>The streamableHttp server URL (http transport <c>url</c>).</summary>
         [JsonPropertyName("host")] public string Host { get; set; } = string.Empty;
-        /// <summary>Bearer token, or empty/null when auth is not configured. NEVER logged (§8).</summary>
+        /// <summary>
+        /// The access token for the "Advanced: use access token" escape hatch (Flow C), or empty/null otherwise.
+        /// NEVER logged (§8). No longer required input on the default path (mcp-authorize PR 5): with the device-flow
+        /// machine credential store (PR 2) the default config is credential-free (native MCP OAuth), so this is
+        /// carried ONLY when <see cref="UseAccessToken"/> is set.
+        /// </summary>
         [JsonPropertyName("token")] public string? Token { get; set; }
         /// <summary>One of <c>Local</c> / <c>Cloud</c> (case-insensitive). Cloud always requires auth.</summary>
         [JsonPropertyName("connectionMode")] public string ConnectionMode { get; set; } = "Local";
         /// <summary>Whether bearer-token auth is required (independent of cloud enforcement).</summary>
         [JsonPropertyName("authRequired")] public bool AuthRequired { get; set; }
+        /// <summary>
+        /// The "Advanced: use access token" escape hatch opt-in (mcp-authorize PR 5, design 06, Flow C). Default
+        /// <c>false</c> → the credential-free native-OAuth path (D11): HTTP configs carry <c>type</c> + <c>url</c>
+        /// only, no embedded bearer. When <c>true</c> AND a non-empty <see cref="Token"/> is supplied, the HTTP
+        /// config is written with the legacy Bearer shape (<c>HttpCredentialMode.AccessToken</c>) for the few
+        /// clients that cannot do MCP OAuth (<see cref="AgentConfiguratorDescriptionDto.SupportsOAuth"/> == false).
+        /// </summary>
+        [JsonPropertyName("useAccessToken")] public bool UseAccessToken { get; set; }
     }
 
     /// <summary>plugin → sidecar: enumerate the available agents and (optionally) their status for a transport.</summary>
@@ -164,6 +177,14 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         [JsonPropertyName("status")] public string Status { get; set; } = "NotConfigured";
         [JsonPropertyName("isInstalled")] public bool IsInstalled { get; set; }
         [JsonPropertyName("supportsSkills")] public bool SupportsSkills { get; set; }
+        /// <summary>
+        /// Whether this agent can complete native MCP OAuth against the server URL (mcp-authorize PR 5, design 06).
+        /// Default <c>true</c> — the plugin writes the credential-free config and the client's own authorize flow
+        /// completes the loop. A <c>false</c> value is the signal for the editor UI to offer the "Advanced: use
+        /// access token" (PAT) escape hatch (Flow C) for that agent. Forwarded verbatim from the shared
+        /// configurator's <c>SupportsOAuth</c>.
+        /// </summary>
+        [JsonPropertyName("supportsOAuth")] public bool SupportsOAuth { get; set; } = true;
         [JsonPropertyName("downloadUrl")] public string? DownloadUrl { get; set; }
         [JsonPropertyName("tutorialUrl")] public string? TutorialUrl { get; set; }
         /// <summary>

--- a/bridge/tests/AgentConfigServiceTests.cs
+++ b/bridge/tests/AgentConfigServiceTests.cs
@@ -43,7 +43,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             catch { /* best-effort temp cleanup */ }
         }
 
-        private AgentSettingsDto Settings(string mode = "Local", bool authRequired = false, string? token = null, string host = "http://localhost:12345/mcp") => new()
+        private AgentSettingsDto Settings(string mode = "Local", bool authRequired = false, string? token = null, string host = "http://localhost:12345/mcp", bool useAccessToken = false) => new()
         {
             ProjectRootPath = _projectRoot,
             ExecutableFullPath = Path.Combine(_projectRoot, "server.exe"),
@@ -53,6 +53,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             Token = token,
             ConnectionMode = mode,
             AuthRequired = authRequired,
+            UseAccessToken = useAccessToken,
         };
 
         [Fact]
@@ -245,6 +246,73 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             Assert.True(remove.Ok);
             Assert.NotNull(remove.Description);
             Assert.False(remove.Description!.IsConfigured);
+        }
+
+        [Fact]
+        public void Configure_DefaultPath_WritesUrlOnly_NoBearer_EvenWhenAuthRequired()
+        {
+            // mcp-authorize PR 5 (design 06, D11): the token is NO LONGER required input on the default path. Even with
+            // authRequired set AND a token supplied, the default path (useAccessToken = false → native MCP OAuth) writes
+            // a credential-free HTTP config — the client authorizes natively, so no bearer lands in .mcp.json.
+            const string pat = "secret-pat-should-not-be-written";
+            var configure = _service.HandleConfigure(new AgentConfigureRequestMessage
+            {
+                RequestId = "cfg-default", AgentId = "claude-code", Transport = "streamableHttp",
+                Settings = Settings(authRequired: true, token: pat, useAccessToken: false),
+            });
+            Assert.True(configure.Ok);
+            Assert.True(configure.Description!.IsConfigured);
+
+            // The written project-local .mcp.json carries only the URL — never the bearer/token on the default path.
+            var mcpJson = Path.Combine(_projectRoot, ".mcp.json");
+            Assert.True(File.Exists(mcpJson));
+            var content = File.ReadAllText(mcpJson);
+            Assert.DoesNotContain(pat, content);
+            Assert.DoesNotContain("Authorization", content);
+            Assert.DoesNotContain("Bearer", content);
+        }
+
+        [Fact]
+        public void Configure_AdvancedAccessToken_WritesTheLegacyBearer()
+        {
+            // mcp-authorize PR 5 (design 06, Flow C): the "Advanced: use access token" escape hatch (useAccessToken =
+            // true, a token supplied) writes the legacy Bearer shape for clients that cannot do MCP OAuth — the PAT
+            // lands in the config the shared library's HttpCredentialMode.AccessToken path produces.
+            const string pat = "advanced-pat-abc123";
+            var configure = _service.HandleConfigure(new AgentConfigureRequestMessage
+            {
+                RequestId = "cfg-advanced", AgentId = "claude-code", Transport = "streamableHttp",
+                Settings = Settings(authRequired: true, token: pat, useAccessToken: true),
+            });
+            Assert.True(configure.Ok);
+
+            // The advanced escape hatch DOES embed the PAT (the legacy Bearer shape `headers.Authorization: Bearer …`)
+            // — the deliberate Flow C trade-off for clients that cannot do MCP OAuth. Assert on the written file, the
+            // real deliverable; the refreshed Description's IsConfigured is Oauth-mode (the shared library's Describe
+            // has no credentialMode), so it reports ReconfigureNeeded here — a known status-detection limitation, not a
+            // write failure (see design_notes).
+            var mcpJson = Path.Combine(_projectRoot, ".mcp.json");
+            Assert.True(File.Exists(mcpJson));
+            var content = File.ReadAllText(mcpJson);
+            Assert.Contains(pat, content);
+            Assert.Contains("Bearer", content);
+        }
+
+        [Fact]
+        public void List_ForwardsSupportsOAuth_ForEveryAgent()
+        {
+            // mcp-authorize PR 5 (design 06): the description DTO forwards each configurator's SupportsOAuth so the
+            // editor UI knows which agents need the "Advanced: use access token" escape hatch (SupportsOAuth == false).
+            var result = _service.HandleList(new AgentsListRequestMessage
+            {
+                RequestId = "oauth", Transport = "streamableHttp", Settings = Settings(),
+            });
+            Assert.True(result.Ok);
+            Assert.NotNull(result.Agents);
+            // Every built-in agent in the current registry supports native MCP OAuth (all default true); the field is
+            // wired through so a future SupportsOAuth == false agent surfaces the escape-hatch signal to the plugin.
+            Assert.Contains(result.Agents!, a => a.AgentId == "claude-code" && a.SupportsOAuth);
+            Assert.All(result.Agents!, a => Assert.True(a.SupportsOAuth));
         }
 
         [Fact]

--- a/bridge/tests/SidecarHostConnectionDropTests.cs
+++ b/bridge/tests/SidecarHostConnectionDropTests.cs
@@ -154,5 +154,27 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             // Exactly one Connected + one drop status — the superseded first subscription is disposed, so no duplicates.
             Assert.Equal(2, emitted.Count);
         }
+
+        // mcp-authorize PR 5 (design 06 / D12): the cloud sign-in indicator surfaces the signed-in state in the editor
+        // from EITHER an in-session bearer (an in-editor device flow) OR a populated machine credential store (a
+        // zero-button boot — sign-in done out-of-editor via a CLI login / enrollment / another engine or project).
+        [Theory]
+        // Custom mode is never a cloud authorization — neither a local bearer nor a store credential lights it.
+        [InlineData(false, false, false, null)]
+        [InlineData(false, true, false, null)]
+        [InlineData(false, false, true, null)]
+        [InlineData(false, true, true, null)]
+        // Cloud mode with no credential of either kind → not signed in.
+        [InlineData(true, false, false, null)]
+        // Cloud mode with an in-session bearer (in-editor device flow) → signed in.
+        [InlineData(true, true, false, "Authorized")]
+        // Cloud mode with ONLY a machine-store credential (zero-button boot, out-of-editor sign-in) → signed in.
+        [InlineData(true, false, true, "Authorized")]
+        [InlineData(true, true, true, "Authorized")]
+        public void ResolveCloudAuthState_SurfacesSignedIn_FromSessionBearerOrMachineStore(
+            bool isCloudMode, bool hasSessionBearer, bool machineCredentialExists, string? expected)
+        {
+            Assert.Equal(expected, SidecarHost.ResolveCloudAuthState(isCloudMode, hasSessionBearer, machineCredentialExists));
+        }
     }
 }


### PR DESCRIPTION
## Summary

PR 5 of the mcp-authorize `f1` decomposition (PRs #210/#212/#214/#216 landed). The configurator-UI surface:

- **Bridge `AgentConfigService.MapSettings` — token requirement dropped on the default path.** With the device-flow machine credential store (PR 2) the client authorizes natively via MCP OAuth, so the default HTTP config is credential-free (`HttpCredentialMode.Oauth`, URL-only). `authOption`/`token` are carried ONLY for the explicit "Advanced: use access token" opt-in; `authRequired` alone (Cloud enforcement) no longer forces a bearer-carrying config.
- **Advanced escape hatch (Flow C).** A new `useAccessToken` opt-in on the settings DTO selects `HttpCredentialMode.AccessToken`, writing the legacy Bearer shape for the few clients that cannot do MCP OAuth (`SupportsOAuth == false`). The sidecar forwards each configurator's `SupportsOAuth` in the description DTO so the editor knows which agents need it.
- **Sign-in STATE surfaced from the sidecar.** Reuses the existing `status.cloudAuthState` channel — a populated machine credential store now reports "Authorized" so the editor reflects the zero-button signed-in state even when sign-in happened out-of-editor (a CLI login / enrollment / another engine or project, D12).
- **Editor Slate/model.** Parses `supportsOAuth`; wires the `useAccessToken` escape hatch from Custom-mode Required-auth + a token; Cloud stays native OAuth (never a user PAT); the bearer is no longer forwarded on the default path.

Out of scope (untouched): device flow / machine store / handshake / marker / IPC-port (PRs 2-4); IPC schema redesign (minimal additions only — one DTO bool each); enroll-redemption + live e2e (PR 6). No version bump, no NuGet-pin bump, no release actions.

## Test plan

- [x] bridge `dotnet build` + `dotnet test` — **256/256** (new: default path writes URL-only/no bearer even when auth is required; the Advanced path writes the Bearer; `SupportsOAuth` forwarded for every agent; `cloudAuthState` machine-store sign-in matrix).
- [x] UE plugin gate Suites 1 (UBT editor build, exit 0) + 2 (headless boot smoke, `[Unreal-MCP] plugin loaded`) + 3 (Automation specs, `failed=0, succeeded=338`) — all green (editor-only change; Suite 1b not required). New `UnrealMcp.AgentConfigModels` specs: `supportsOAuth` parse + `bUseAccessToken` resolution matrix.

Known follow-up (consumed NuGet, not fixable here): the shared library's `Describe`/IsConfigured re-check has no `credentialMode`, so an advanced-PAT config reports `ReconfigureNeeded` even though the Bearer is written correctly — filed for the MCP-Plugin-dotnet owner. Windowed Slate rendering is not headless-verifiable; the data/model layer is spec-covered (windowed verification pending operator).

Closes #217