### PR TITLE
feat(cli): login → shared machine credential store + ProjectIdentity port parity

### DIFF
--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -3,8 +3,12 @@ import { login } from '../lib/login.js';
 import * as ui from '../utils/ui.js';
 
 export const loginCommand = new Command('login')
-  .description('Authorize against ai-game.dev via the OAuth device-code flow')
-  .option('-p, --path <dir>', 'Persist the token into this project\'s .env')
+  .description(
+    'Authorize against ai-game.dev via the OAuth device-code flow. Signs in once ' +
+      'per machine: the credential is saved to the shared machine store ' +
+      '(~/.ai-game-dev/credentials.json), never a project file.',
+  )
+  .option('-p, --path <dir>', 'Persist the credential into this project\'s .env (gitignored) instead of the shared machine store')
   .option('--base-url <url>', 'Auth base URL (defaults to https://ai-game.dev)')
   .option('--timeout <ms>', 'Overall poll timeout in ms', (v) => parseInt(v, 10))
   .action(async (opts: { path?: string; baseUrl?: string; timeout?: number }) => {
@@ -23,6 +27,9 @@ export const loginCommand = new Command('login')
       return;
     }
     spinner.success('Logged in.');
-    if (result.persisted) ui.info(`Token saved to ${result.envPath}`);
-    else ui.info('Token not persisted (pass --path to save it into a project .env).');
+    if (result.persistedTo === 'project-env') {
+      ui.info(`Credential saved to project ${result.credentialPath}`);
+    } else {
+      ui.info(`Signed in once for this machine — credential saved to ${result.credentialPath}`);
+    }
   });

--- a/cli/src/lib/login.ts
+++ b/cli/src/lib/login.ts
@@ -1,11 +1,16 @@
 // `login` — OAuth 2.0 device authorization flow against ai-game.dev.
 // Requests a device code, surfaces the verification URL + user code via
 // `onProgress`, then polls the token endpoint until the user authorizes
-// (or the flow times out). On success, optionally persists the token into
-// the project's `.env`. fetch + sleep + clock are injectable for tests.
-// Library-safe: never throws past the boundary.
+// (or the flow times out). On success, persists the credential into the
+// SHARED machine credential store (`~/.ai-game-dev/credentials.json`, mcp-authorize
+// design 06/09 D12) so sign-in happens once per machine — never into a
+// committable project file on the default path. The `--path` override still
+// keeps a project-local `.env` (gitignored) for per-project accounts.
+// fetch + sleep + clock are injectable for tests. Library-safe: never throws
+// past the boundary.
 
 import { writeEnvFile, ensureEnvGitignored } from '../utils/env-file.js';
+import { MachineCredentialStore, type MachineCredentials, CREDENTIALS_VERSION } from '../utils/machine-credentials.js';
 import * as path from 'path';
 import { asError } from '../utils/error.js';
 import { fetchWithTimeout } from '../utils/http.js';
@@ -20,8 +25,14 @@ const PER_REQUEST_TIMEOUT_MS = 30_000;
 
 export interface LoginOptions {
   baseUrl?: string;
-  /** Persist the token into `<projectDir>/.env` on success. */
+  /**
+   * When set, persist the credential into `<projectDir>/.env` (gitignored) instead
+   * of the shared machine store — the `--path` per-project override. Unset (the
+   * default) persists into the shared machine credential store.
+   */
   projectDir?: string;
+  /** Test seam: override the machine credential store base dir (default `~/.ai-game-dev`). */
+  storeBaseDir?: string;
   /** Overall poll deadline. Default 300000 ms (5 min). */
   timeoutMs?: number;
   fetchImpl?: typeof fetch;
@@ -30,12 +41,20 @@ export interface LoginOptions {
   onProgress?: ProgressCallback;
 }
 
+/** Where a successful login persisted its credential. */
+export type PersistTarget = 'machine-store' | 'project-env';
+
 export interface LoginSuccess {
   kind: 'success';
   success: true;
   token: string;
-  /** `true` when the token was written to a project `.env`. */
+  /** `true` when the credential was persisted (always true on success). */
   persisted: boolean;
+  /** Where the credential landed: the shared machine store (default) or a project `.env` (`--path`). */
+  persistedTo: PersistTarget;
+  /** Absolute path of the file the credential was written to. */
+  credentialPath: string;
+  /** Set only for the project-`.env` override path (back-compat convenience). */
   envPath?: string;
 }
 
@@ -113,18 +132,20 @@ export async function login(opts: LoginOptions = {}): Promise<LoginResult> {
       );
 
       if (tokenResp.ok) {
-        const body = (await tokenResp.json()) as { access_token?: string };
+        const body = (await tokenResp.json()) as TokenResponse;
         if (!body.access_token) {
           return fail('token-malformed', 'Token response missing access_token.');
         }
-        const persisted = persistToken(opts.projectDir, body.access_token);
+        const persisted = await persistCredential(opts, body, baseUrl, now);
         emitProgress(opts.onProgress, { phase: 'done', message: 'Login complete.' });
         return {
           kind: 'success',
           success: true,
           token: body.access_token,
-          persisted: persisted !== null,
-          envPath: persisted ?? undefined,
+          persisted: true,
+          persistedTo: persisted.persistedTo,
+          credentialPath: persisted.credentialPath,
+          envPath: persisted.envPath,
         };
       }
 
@@ -154,17 +175,56 @@ export async function login(opts: LoginOptions = {}): Promise<LoginResult> {
   }
 }
 
-function persistToken(projectDir: string | undefined, token: string): string | null {
-  if (!projectDir) return null;
-  const dir = path.resolve(projectDir);
-  const envPath = path.join(dir, '.env');
-  // The token is a secret — make sure `.env` is gitignored BEFORE it lands on
-  // disk (mirrors `configure`'s §8 guard so `login -p .` can't leave a
-  // committable token file behind even if the process dies between the two
-  // writes).
-  ensureEnvGitignored(dir);
-  writeEnvFile(envPath, { UNREAL_MCP_TOKEN: token, UNREAL_MCP_CONNECTION_MODE: 'Cloud' });
-  return envPath;
+interface TokenResponse {
+  access_token?: string;
+  refresh_token?: string;
+  /** Seconds until `access_token` expires (RFC 8628 / OAuth). */
+  expires_in?: number;
+}
+
+interface PersistOutcome {
+  persistedTo: PersistTarget;
+  credentialPath: string;
+  envPath?: string;
+}
+
+/**
+ * Persist the freshly-authorized credential. The default path writes the shared
+ * machine store (`~/.ai-game-dev/credentials.json`, DPAPI/0600) so the token
+ * NEVER lands in a committable project file; the `--path` override keeps the
+ * legacy project-local `.env` (gitignored) for per-project accounts.
+ */
+async function persistCredential(
+  opts: LoginOptions,
+  body: TokenResponse,
+  serverTarget: string,
+  now: () => number,
+): Promise<PersistOutcome> {
+  if (opts.projectDir) {
+    const dir = path.resolve(opts.projectDir);
+    const envPath = path.join(dir, '.env');
+    // The token is a secret — make sure `.env` is gitignored BEFORE it lands on
+    // disk (mirrors `configure`'s §8 guard so `login -p .` can't leave a
+    // committable token file behind even if the process dies between the two
+    // writes).
+    ensureEnvGitignored(dir);
+    writeEnvFile(envPath, { UNREAL_MCP_TOKEN: body.access_token, UNREAL_MCP_CONNECTION_MODE: 'Cloud' });
+    return { persistedTo: 'project-env', credentialPath: envPath, envPath };
+  }
+
+  const store = new MachineCredentialStore(opts.storeBaseDir);
+  const credentials: MachineCredentials = {
+    version: CREDENTIALS_VERSION,
+    accessToken: body.access_token,
+    refreshToken: body.refresh_token ?? undefined,
+    expiresAt:
+      typeof body.expires_in === 'number' && body.expires_in > 0
+        ? new Date(now() + body.expires_in * 1000).toISOString()
+        : undefined,
+    serverTarget,
+  };
+  await store.write(credentials);
+  return { persistedTo: 'machine-store', credentialPath: store.credentialsPath };
 }
 
 function fail(reason: string, message: string): LoginFailure {

--- a/cli/src/utils/machine-credentials.ts
+++ b/cli/src/utils/machine-credentials.ts
@@ -1,0 +1,205 @@
+// The shared machine credential store at `~/.ai-game-dev/credentials.json` — the
+// once-per-machine home for the ai-game.dev account credential (mcp-authorize
+// design 06 / 09, D12). Engines, CLIs, and the local server all read the SAME
+// store, so sign-in happens once per machine, never per project.
+//
+// This is the TypeScript peer of the shared C# `MachineCredentialStore`
+// (McpPlugin/src/AgentConfig/MachineCredentialStore.cs). The on-disk contract
+// MUST stay byte-compatible with it so the .NET sidecar can read what the CLI
+// writes and vice versa:
+//   • path        — `<home>/.ai-game-dev/credentials.json`.
+//   • JSON schema — camelCase `{ version, accessToken, refreshToken, expiresAt,
+//                   serverTarget, subject }`; null fields omitted; unknown fields
+//                   ignored on read (forwards-compatible).
+//   • at rest     — POSIX: plaintext with 0600 perms inside a 0700 directory.
+//                   Windows: DPAPI-encrypted with the current user's key
+//                   (`CryptProtectData`, CurrentUser scope, no entropy) so the
+//                   on-disk bytes are never plaintext.
+//
+// Credentials NEVER go into a project file / VCS (that is the whole point — the
+// `login --path` project-`.env` override is a separate, gitignored path).
+//
+// Library-safe: the store touches the filesystem (and, on Windows, spawns
+// PowerShell as a stateless DPAPI oracle) but callers own error shaping.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFile } from 'child_process';
+
+/** Directory name under the user home that holds the store. */
+export const STORE_DIR_NAME = '.ai-game-dev';
+
+/** File name of the secret credential document. */
+export const CREDENTIALS_FILE_NAME = 'credentials.json';
+
+/** Current schema version of the persisted credential document. */
+export const CREDENTIALS_VERSION = 1;
+
+/**
+ * The secret credential material persisted per machine. Mirrors the C#
+ * `MachineCredentials` DTO field-for-field (camelCase JSON on the wire).
+ */
+export interface MachineCredentials {
+  /** Schema version of the persisted document (currently {@link CREDENTIALS_VERSION}). */
+  version: number;
+  /** The current short-lived JWT access token (MCP audience). */
+  accessToken?: string;
+  /** The rotating refresh token used to mint a new access token before {@link expiresAt}. */
+  refreshToken?: string;
+  /** Absolute expiry of {@link accessToken} as an ISO-8601 string (C# `DateTimeOffset`). */
+  expiresAt?: string;
+  /** The server target the credential was issued for (hosted `https://ai-game.dev` or a local URL). */
+  serverTarget?: string;
+  /** The account id (`sub`) the credential resolves to. Audit/diagnostic only. */
+  subject?: string;
+}
+
+function isWindows(): boolean {
+  return process.platform === 'win32';
+}
+
+/**
+ * The shared machine credential store. `baseDir` defaults to `~/.ai-game-dev`;
+ * the override exists for tests and for the `--path` per-project store.
+ */
+export class MachineCredentialStore {
+  private readonly baseDir: string;
+
+  constructor(baseDir?: string) {
+    this.baseDir = baseDir ?? path.join(os.homedir(), STORE_DIR_NAME);
+  }
+
+  /** Absolute path of the store directory. */
+  get baseDirectory(): string {
+    return this.baseDir;
+  }
+
+  /** Absolute path of the secret credential file. */
+  get credentialsPath(): string {
+    return path.join(this.baseDir, CREDENTIALS_FILE_NAME);
+  }
+
+  /** True when a credential file exists in the store. */
+  exists(): boolean {
+    return fs.existsSync(this.credentialsPath);
+  }
+
+  /**
+   * Encrypt (Windows) / restrict (POSIX) and write `credentials` to the store,
+   * creating the store directory with owner-only permissions if needed.
+   */
+  async write(credentials: MachineCredentials): Promise<void> {
+    const json = serializeCredentials(credentials);
+    const plaintext = Buffer.from(json, 'utf-8');
+
+    fs.mkdirSync(this.baseDir, { recursive: true });
+    setOwnerOnly(this.baseDir, 0o700);
+
+    const bytes = isWindows() ? await dpapiProtect(plaintext) : plaintext;
+    fs.writeFileSync(this.credentialsPath, bytes);
+    setOwnerOnly(this.credentialsPath, 0o600);
+  }
+
+  /** Read and decrypt the stored credentials, or `null` when none are present. */
+  async read(): Promise<MachineCredentials | null> {
+    if (!fs.existsSync(this.credentialsPath)) return null;
+
+    const raw = fs.readFileSync(this.credentialsPath);
+    if (raw.length === 0) return null;
+
+    const plaintext = isWindows() ? await dpapiUnprotect(raw) : raw;
+    const json = plaintext.toString('utf-8');
+    if (json.trim().length === 0) return null;
+
+    return JSON.parse(json) as MachineCredentials;
+  }
+
+  /** Delete the stored credentials (sign-out). No-op when none exist. */
+  delete(): void {
+    if (fs.existsSync(this.credentialsPath)) {
+      fs.rmSync(this.credentialsPath, { force: true });
+    }
+  }
+}
+
+/**
+ * Serialize to the camelCase JSON shape the C# store reads. Null/undefined
+ * fields are omitted (matches `DefaultIgnoreCondition.WhenWritingNull`); the
+ * key order mirrors the C# DTO for a stable on-disk document.
+ */
+function serializeCredentials(c: MachineCredentials): string {
+  const obj: Record<string, unknown> = { version: c.version ?? CREDENTIALS_VERSION };
+  if (c.accessToken != null) obj.accessToken = c.accessToken;
+  if (c.refreshToken != null) obj.refreshToken = c.refreshToken;
+  if (c.expiresAt != null) obj.expiresAt = c.expiresAt;
+  if (c.serverTarget != null) obj.serverTarget = c.serverTarget;
+  if (c.subject != null) obj.subject = c.subject;
+  return JSON.stringify(obj, null, 2);
+}
+
+/** chmod best-effort; a no-op on Windows (ACL-based, DPAPI already protects). */
+function setOwnerOnly(target: string, mode: number): void {
+  if (isWindows()) return;
+  try {
+    fs.chmodSync(target, mode);
+  } catch {
+    /* best-effort — a filesystem that rejects chmod must not fail the write */
+  }
+}
+
+// ── Windows DPAPI oracle ───────────────────────────────────────────────────
+// Node has no native DPAPI, so shell out to PowerShell's ProtectedData (the thin
+// managed wrapper over CryptProtectData/CryptUnprotectData). `CurrentUser` scope
+// + null entropy makes the blob byte-compatible with the C# store's
+// `CryptProtectData(pOptionalEntropy = Zero)`. PowerShell is used as a stateless
+// crypto oracle only — all file I/O and directory perms stay in Node above.
+// Plaintext bytes go in base64 over stdin; the base64 result comes back on stdout.
+
+const DPAPI_PROTECT_PS = [
+  "$ErrorActionPreference='Stop'",
+  'Add-Type -AssemblyName System.Security',
+  '$b64=[Console]::In.ReadToEnd()',
+  '$bytes=[System.Convert]::FromBase64String($b64)',
+  '$out=[System.Security.Cryptography.ProtectedData]::Protect($bytes,$null,[System.Security.Cryptography.DataProtectionScope]::CurrentUser)',
+  '[Console]::Out.Write([System.Convert]::ToBase64String($out))',
+].join('\n');
+
+const DPAPI_UNPROTECT_PS = [
+  "$ErrorActionPreference='Stop'",
+  'Add-Type -AssemblyName System.Security',
+  '$b64=[Console]::In.ReadToEnd()',
+  '$bytes=[System.Convert]::FromBase64String($b64)',
+  '$out=[System.Security.Cryptography.ProtectedData]::Unprotect($bytes,$null,[System.Security.Cryptography.DataProtectionScope]::CurrentUser)',
+  '[Console]::Out.Write([System.Convert]::ToBase64String($out))',
+].join('\n');
+
+function runDpapi(script: string, input: Buffer): Promise<Buffer> {
+  return new Promise<Buffer>((resolve, reject) => {
+    const child = execFile(
+      'powershell',
+      ['-NoProfile', '-NonInteractive', '-Command', script],
+      { windowsHide: true, maxBuffer: 16 * 1024 * 1024 },
+      (err, stdout) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        try {
+          resolve(Buffer.from(String(stdout).trim(), 'base64'));
+        } catch (e) {
+          reject(e as Error);
+        }
+      },
+    );
+    child.stdin?.end(input.toString('base64'));
+  });
+}
+
+function dpapiProtect(plaintext: Buffer): Promise<Buffer> {
+  return runDpapi(DPAPI_PROTECT_PS, plaintext);
+}
+
+function dpapiUnprotect(protectedBytes: Buffer): Promise<Buffer> {
+  return runDpapi(DPAPI_UNPROTECT_PS, protectedBytes);
+}

--- a/cli/src/utils/machine-credentials.ts
+++ b/cli/src/utils/machine-credentials.ts
@@ -192,7 +192,17 @@ function runDpapi(script: string, input: Buffer): Promise<Buffer> {
         }
       },
     );
-    child.stdin?.end(input.toString('base64'));
+    // A spawn failure (e.g. powershell not on PATH) surfaces via the execFile
+    // callback's `err`; but writing to a broken/closed stdin ALSO emits an
+    // `'error'` on the stdin stream, which throws (crashes the process) unless
+    // handled. Route it to `reject` — harmless if the callback already settled
+    // the promise. (Matches the `child.on('error', reject)` spawn convention in
+    // unreal-build.ts / open.ts.)
+    const stdin = child.stdin;
+    if (stdin) {
+      stdin.on('error', reject);
+      stdin.end(input.toString('base64'));
+    }
   });
 }
 

--- a/cli/src/utils/port.ts
+++ b/cli/src/utils/port.ts
@@ -5,19 +5,72 @@ const MAX_PORT = 29999;
 const PORT_RANGE = MAX_PORT - MIN_PORT + 1;
 
 /**
+ * Characters where JS `String.prototype.toLowerCase()` diverges from C#
+ * `string.ToLowerInvariant()`. The shared `ProjectIdentity` reference hashes
+ * `ToLowerInvariant()` output, so a naive TS `toLowerCase()` port would compute
+ * a DIFFERENT hash for these code points and break cross-language parity. The
+ * golden vectors (`ProjectIdentity.GoldenVectors.json` § unicodeDivergence) pin
+ * the one that matters for path hashing: U+0130 (İ) — C# leaves it unchanged;
+ * JS expands it to `i` + U+0307 (COMBINING DOT ABOVE). Extend this map if a new
+ * divergence surfaces in the vectors.
+ */
+const TO_LOWER_INVARIANT_OVERRIDES: Readonly<Record<string, string>> = {
+  'İ': 'İ', // LATIN CAPITAL LETTER I WITH DOT ABOVE — unchanged under ToLowerInvariant
+};
+
+/**
+ * Lowercase a string the way C# `string.ToLowerInvariant()` does. Iterating by
+ * code point (not code unit) and lowercasing each independently reproduces the
+ * invariant SIMPLE (1:1) case mapping — closer to `ToLowerInvariant` than a
+ * whole-string `toLowerCase()`, which applies context-sensitive / expanding full
+ * case folding — with the documented divergent code points overridden. Pure.
+ */
+function toLowerInvariant(s: string): string {
+  let out = '';
+  for (const ch of s) {
+    const override = TO_LOWER_INVARIANT_OVERRIDES[ch];
+    out += override !== undefined ? override : ch.toLowerCase();
+  }
+  return out;
+}
+
+/**
+ * Trim trailing directory separators (`/` and `\`) so `/a/b` and `/a/b/` are the
+ * same project. Keeps at least one character (mirrors the C# reference, which
+ * loops while `end > 1`). Separators are NEVER converted — `C:\a` and `C:/a`
+ * intentionally hash differently. Pure.
+ */
+function trimTrailingSeparators(p: string): string {
+  let end = p.length;
+  while (end > 1 && (p[end - 1] === '/' || p[end - 1] === '\\')) end--;
+  return end === p.length ? p : p.slice(0, end);
+}
+
+/**
+ * The exact string that gets UTF-8/SHA-256 hashed: the project root with trailing
+ * separators trimmed, then `ToLowerInvariant`-lowercased. Exposed so tests and
+ * callers can reproduce the pre-hash string. Pure.
+ */
+export function normalizeProjectRoot(dir: string): string {
+  return toLowerInvariant(trimTrailingSeparators(dir));
+}
+
+/**
  * Generate a deterministic localhost port from a project directory.
  *
- * Mirrors the proven Unity/Godot scheme (`GeneratePortFromDirectory`):
- * SHA-256 of the lowercased directory path, first 4 bytes read as a
- * little-endian uint32, modulo the 20000–29999 range. The UnrealMCP
- * plugin (when it lands) will use the same hashing so the CLI can
- * reach a project's local MCP server without reading any config.
+ * The single canonical `ProjectIdentity` derivation shared with the .NET/Unity/
+ * Godot plugins (`McpPlugin/src/AgentConfig/ProjectIdentity.cs`), gated
+ * byte-for-byte by the committed golden vectors:
+ *   1. Trim trailing separators, then `ToLowerInvariant` the project root.
+ *   2. UTF-8 encode, then SHA-256 hash.
+ *   3. port = 20000 + (littleEndianUInt32(first 4 bytes) % 10000). Range 20000–29999.
  *
- * Pure / no I/O.
+ * No probing, no I/O — so the CLI reaches a project's local MCP server without
+ * reading any config, matching the port the plugin derives for the same path.
+ * Pure.
  */
 export function generatePortFromDirectory(dir: string): number {
-  const hash = createHash('sha256').update(dir.toLowerCase()).digest();
-  const int32 = hash.readInt32LE(0);
-  const uint32 = int32 >>> 0;
+  const hash = createHash('sha256').update(normalizeProjectRoot(dir), 'utf-8').digest();
+  const uint32 = hash.readUInt32LE(0);
   return MIN_PORT + (uint32 % PORT_RANGE);
 }

--- a/cli/tests/login.test.ts
+++ b/cli/tests/login.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { login } from '../src/lib/login.js';
 import { readEnvFile } from '../src/utils/env-file.js';
+import { MachineCredentialStore } from '../src/utils/machine-credentials.js';
 import { makeTempDir, rmTempDir, fakeResponse } from './helpers.js';
 
 const dirs: string[] = [];
@@ -15,7 +16,13 @@ function tmp(): string {
   return d;
 }
 
-function deviceFlowFetch(pendingCount: number): typeof fetch {
+interface SuccessBody {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+}
+
+function deviceFlowFetch(pendingCount: number, success: SuccessBody = { access_token: 'final-token' }): typeof fetch {
   let tokenCalls = 0;
   return (async (url: string) => {
     if (String(url).endsWith('/authorize')) {
@@ -35,13 +42,14 @@ function deviceFlowFetch(pendingCount: number): typeof fetch {
     if (tokenCalls <= pendingCount) {
       return fakeResponse({ ok: false, status: 400, body: JSON.stringify({ error: 'authorization_pending' }) });
     }
-    return fakeResponse({ ok: true, status: 200, body: JSON.stringify({ access_token: 'final-token' }) });
+    return fakeResponse({ ok: true, status: 200, body: JSON.stringify(success) });
   }) as unknown as typeof fetch;
 }
 
 describe('login (device flow)', () => {
   it('polls past authorization_pending and returns the token', async () => {
     const r = await login({
+      storeBaseDir: tmp(),
       fetchImpl: deviceFlowFetch(2),
       sleepImpl: async () => {},
       nowImpl: () => 0,
@@ -51,7 +59,35 @@ describe('login (device flow)', () => {
     if (r.kind === 'success') expect(r.token).toBe('final-token');
   });
 
-  it('persists the token into a project .env when projectDir is given', async () => {
+  it('persists to the shared machine store by default (not a project .env)', async () => {
+    const store = tmp();
+    const project = tmp();
+    const r = await login({
+      storeBaseDir: store,
+      fetchImpl: deviceFlowFetch(0, { access_token: 'jwt-1', refresh_token: 'refresh-1', expires_in: 3600 }),
+      sleepImpl: async () => {},
+      nowImpl: () => 1_000_000, // fixed clock for a deterministic expiresAt
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+
+    expect(r.persisted).toBe(true);
+    expect(r.persistedTo).toBe('machine-store');
+
+    const creds = await new MachineCredentialStore(store).read();
+    expect(creds).not.toBeNull();
+    expect(creds!.version).toBe(1);
+    expect(creds!.accessToken).toBe('jwt-1');
+    expect(creds!.refreshToken).toBe('refresh-1');
+    expect(creds!.serverTarget).toBe('https://ai-game.dev');
+    // expiresAt = now (1_000_000ms) + expires_in (3600s).
+    expect(creds!.expiresAt).toBe(new Date(1_000_000 + 3600 * 1000).toISOString());
+
+    // The token must NOT have leaked into any project file: no `.env` was written.
+    expect(fs.existsSync(path.join(project, '.env'))).toBe(false);
+  });
+
+  it('persists the token into a project .env when --path (projectDir) is given', async () => {
     const dir = tmp();
     const r = await login({
       projectDir: dir,
@@ -62,6 +98,7 @@ describe('login (device flow)', () => {
     expect(r.kind).toBe('success');
     if (r.kind !== 'success') return;
     expect(r.persisted).toBe(true);
+    expect(r.persistedTo).toBe('project-env');
     const env = readEnvFile(path.join(dir, '.env'));
     expect(env['UNREAL_MCP_TOKEN']).toBe('final-token');
     expect(env['UNREAL_MCP_CONNECTION_MODE']).toBe('Cloud');
@@ -82,7 +119,7 @@ describe('login (device flow)', () => {
       return fakeResponse({ ok: true, status: 200, body: JSON.stringify({ access_token: 'final-token' }) });
     }) as unknown as typeof fetch;
     const sleeps: number[] = [];
-    const r = await login({ fetchImpl, sleepImpl: async (ms) => { sleeps.push(ms); }, nowImpl: () => 0, timeoutMs: 100000 });
+    const r = await login({ storeBaseDir: tmp(), fetchImpl, sleepImpl: async (ms) => { sleeps.push(ms); }, nowImpl: () => 0, timeoutMs: 100000 });
     expect(r.kind).toBe('success');
     // One sleep per poll (at the top of the loop): 1000ms before the first
     // (slow_down) poll, then a PERSISTENTLY increased 6000ms before the retry —

--- a/cli/tests/machine-credentials.test.ts
+++ b/cli/tests/machine-credentials.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  MachineCredentialStore,
+  STORE_DIR_NAME,
+  CREDENTIALS_FILE_NAME,
+  type MachineCredentials,
+} from '../src/utils/machine-credentials.js';
+import { makeTempDir, rmTempDir } from './helpers.js';
+
+const isWindows = process.platform === 'win32';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+function sampleCreds(): MachineCredentials {
+  return {
+    version: 1,
+    accessToken: 'jwt-abc',
+    refreshToken: 'refresh-xyz',
+    expiresAt: '2026-07-14T12:00:00.000Z',
+    serverTarget: 'https://ai-game.dev',
+  };
+}
+
+describe('MachineCredentialStore', () => {
+  it('defaults the credential file to ~/.ai-game-dev/credentials.json', () => {
+    const store = new MachineCredentialStore();
+    expect(store.baseDirectory).toBe(path.join(os.homedir(), STORE_DIR_NAME));
+    expect(store.credentialsPath).toBe(path.join(os.homedir(), STORE_DIR_NAME, CREDENTIALS_FILE_NAME));
+    expect(CREDENTIALS_FILE_NAME).toBe('credentials.json');
+    expect(STORE_DIR_NAME).toBe('.ai-game-dev');
+  });
+
+  it('round-trips a credential through write() and read()', async () => {
+    const store = new MachineCredentialStore(tmp());
+    expect(store.exists()).toBe(false);
+    expect(await store.read()).toBeNull();
+
+    const creds = sampleCreds();
+    await store.write(creds);
+
+    expect(store.exists()).toBe(true);
+    expect(await store.read()).toEqual(creds);
+  });
+
+  it('omits null/undefined fields from the persisted document', async () => {
+    const store = new MachineCredentialStore(tmp());
+    await store.write({ version: 1, accessToken: 'only-jwt', serverTarget: 'https://ai-game.dev' });
+    const read = await store.read();
+    expect(read).toEqual({ version: 1, accessToken: 'only-jwt', serverTarget: 'https://ai-game.dev' });
+    expect(read).not.toHaveProperty('refreshToken');
+    expect(read).not.toHaveProperty('subject');
+  });
+
+  it('delete() removes the credential file (sign-out)', async () => {
+    const store = new MachineCredentialStore(tmp());
+    await store.write(sampleCreds());
+    expect(store.exists()).toBe(true);
+    store.delete();
+    expect(store.exists()).toBe(false);
+    expect(await store.read()).toBeNull();
+    store.delete(); // idempotent — no throw when absent
+  });
+
+  // POSIX: plaintext JSON at rest, but locked down to owner-only (0600 file / 0700 dir).
+  it.skipIf(isWindows)('writes plaintext camelCase JSON with 0600/0700 perms on POSIX', async () => {
+    const base = tmp();
+    const store = new MachineCredentialStore(base);
+    await store.write(sampleCreds());
+
+    const raw = fs.readFileSync(store.credentialsPath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.accessToken).toBe('jwt-abc');
+    expect(parsed.refreshToken).toBe('refresh-xyz');
+    expect(parsed.serverTarget).toBe('https://ai-game.dev');
+    expect(raw).toContain('"accessToken"'); // camelCase keys (matches the C# store)
+
+    expect(fs.statSync(store.credentialsPath).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(base).mode & 0o777).toBe(0o700);
+  });
+
+  // Windows: DPAPI-encrypted at rest — the secret must never sit in plaintext bytes.
+  it.skipIf(!isWindows)('DPAPI-encrypts the document at rest on Windows', async () => {
+    const store = new MachineCredentialStore(tmp());
+    await store.write(sampleCreds());
+
+    const rawBytes = fs.readFileSync(store.credentialsPath).toString('latin1');
+    expect(rawBytes).not.toContain('jwt-abc'); // token is not in the on-disk bytes
+    expect(rawBytes).not.toContain('refresh-xyz');
+    expect(rawBytes).not.toContain('accessToken');
+
+    // ...yet read() recovers it via CryptUnprotectData.
+    expect(await store.read()).toEqual(sampleCreds());
+  });
+});

--- a/cli/tests/port.test.ts
+++ b/cli/tests/port.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generatePortFromDirectory } from '../src/utils/port.js';
+import { generatePortFromDirectory, normalizeProjectRoot } from '../src/utils/port.js';
 
 describe('generatePortFromDirectory', () => {
   it('is deterministic and in the 20000-29999 range', () => {
@@ -16,5 +16,48 @@ describe('generatePortFromDirectory', () => {
 
   it('differs for different directories', () => {
     expect(generatePortFromDirectory('/a')).not.toBe(generatePortFromDirectory('/b'));
+  });
+
+  it('trims trailing separators so /a/b and /a/b/ are the same project', () => {
+    expect(generatePortFromDirectory('/a/b')).toBe(generatePortFromDirectory('/a/b/'));
+    expect(generatePortFromDirectory('/a/b')).toBe(generatePortFromDirectory('/a/b///'));
+  });
+
+  it('does NOT convert separators (backslash and forward-slash forms differ)', () => {
+    expect(generatePortFromDirectory('C:\\a')).not.toBe(generatePortFromDirectory('C:/a'));
+  });
+});
+
+// Cross-language parity with the shared C# ProjectIdentity reference
+// (McpPlugin/src/AgentConfig/ProjectIdentity.cs). The vectors are copied inline
+// from ProjectIdentity.GoldenVectors.json (no runtime dependency on that file);
+// the TS port MUST reproduce every `port` byte-for-byte.
+describe('generatePortFromDirectory — ProjectIdentity golden-vector parity', () => {
+  const VECTORS: ReadonlyArray<{ path: string; port: number; note: string }> = [
+    { path: '/home/user/my-game', port: 23940, note: 'POSIX typical project path' },
+    { path: '/home/user/my-game/', port: 23940, note: 'trailing slash trimmed → identical' },
+    { path: '/home/USER/My-Game', port: 23940, note: 'case-folded → identical' },
+    { path: 'C:\\Users\\user\\my-game', port: 29310, note: 'Windows backslash form' },
+    { path: 'C:\\Users\\user\\my-game\\', port: 29310, note: 'trailing backslash trimmed → identical' },
+    { path: 'C:/Users/user/my-game', port: 24298, note: 'forward-slash form DIFFERS (separators not normalized)' },
+    { path: '/home/İstanbul/game', port: 25303, note: 'U+0130 — ToLowerInvariant leaves it unchanged' },
+    { path: '/srv/games/space sim', port: 27816, note: 'path containing a space' },
+  ];
+
+  for (const v of VECTORS) {
+    it(`derives ${v.port} for ${JSON.stringify(v.path)} (${v.note})`, () => {
+      expect(generatePortFromDirectory(v.path)).toBe(v.port);
+    });
+  }
+
+  // The U+0130 vector is the whole point of ToLowerInvariant vs a naive JS
+  // toLowerCase(): a naive port lowercases İ → 'i' + U+0307 and computes port
+  // 27751. Assert we produce the canonical 25303, not the naive value.
+  it('special-cases U+0130 (İ) to match ToLowerInvariant, not naive toLowerCase()', () => {
+    expect(generatePortFromDirectory('/home/İstanbul/game')).toBe(25303);
+    expect(generatePortFromDirectory('/home/İstanbul/game')).not.toBe(27751);
+    // The naive path a bad port would hash: 'İ'.toLowerCase() === 'i̇'.
+    expect(normalizeProjectRoot('/home/İstanbul/game')).toContain('İ');
+    expect(normalizeProjectRoot('/home/İstanbul/game')).not.toContain('̇');
   });
 });


### PR DESCRIPTION
## Summary
- `unreal-mcp-cli login` now persists the ai-game.dev credential into the **shared machine credential store** (`~/.ai-game-dev/credentials.json`) by default instead of a project `.env` — sign-in once per machine, never a committable project file. Matches the bridge's McpPlugin 7.0 `MachineCredentialStore` on-disk contract (camelCase JSON schema, 0600/0700 on POSIX, DPAPI-encrypted on Windows via a PowerShell `ProtectedData`/CurrentUser oracle) so the .NET sidecar reads what the CLI writes. The `--path <dir>` override keeps the project-local `.env` (gitignored) for per-project accounts.
- `cli/src/utils/port.ts` is ported to the shared `ProjectIdentity` derivation (trim trailing separators, `ToLowerInvariant` with the U+0130 override, separators NOT converted), replacing the naive `toLowerCase()`-with-no-trim derivation — now byte-for-byte with the committed golden vectors.

First of two CLI PRs decomposing the mcp-authorize f2 CLI task (design 06/09, D12/D15). Out of scope here (CLI PR 2): `install-plugin --with-server`/`--enroll`, `configure --agent`, live 1A/1B e2e harness.

## Test plan
- [x] Target-specific local tests passed (Suite 6: `tsc` + `vitest run`, MCP env unset) — 357 passed, 0 failures.
- [x] New golden-vector parity test reproduces every `ProjectIdentity.GoldenVectors.json` port byte-for-byte (incl. the U+0130 `ToLowerInvariant` divergence, canonical 25303 not naive 27751).
- [x] Machine-store round-trip + at-rest tests (DPAPI-encrypted on Windows, plaintext + 0600/0700 on POSIX); login persists to the machine store by default and to the project `.env` under `--path`.

Closes #219