### PR TITLE
feat(cli): install-plugin --with-server/--enroll + configure --agent proxy (mcp-authorize f2)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpServerManagerSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpServerManagerSpec.cpp
@@ -175,7 +175,7 @@ void FUnrealMcpServerManagerSpec::Define()
 	{
 		It("is pinned to the lockstep value (kept in sync with cli/src/lib/server-version.ts)", [this]()
 		{
-			TestEqual(TEXT("pinned server version"), FString(FUnrealMcpServerManager::ServerVersion), FString(TEXT("8.0.3")));
+			TestEqual(TEXT("pinned server version"), FString(FUnrealMcpServerManager::ServerVersion), FString(TEXT("9.0.0")));
 		});
 	});
 

--- a/cli/src/commands/configure.ts
+++ b/cli/src/commands/configure.ts
@@ -1,11 +1,16 @@
 import { Command } from 'commander';
 import { configure } from '../lib/configure.js';
+import { configureAgent } from '../lib/configure-agent.js';
 import type { AuthOption, ConnectionMode, McpTransport } from '../lib/types.js';
 import * as ui from '../utils/ui.js';
 
 export const configureCommand = new Command('configure')
-  .description('Write UNREAL_MCP_* values into <project>/.env and gitignore .env (§8)')
+  .description('Configure MCP for a project. With --agent <id>, proxies to the managed gamedev-mcp-server configurator to write a pinned client config; otherwise writes UNREAL_MCP_* values into <project>/.env (§8).')
   .option('-p, --path <dir>', 'Unreal project directory (defaults to cwd)', process.cwd())
+  .option('--agent <id>', 'Proxy to `gamedev-mcp-server configure --agent <id>` to write a pinned MCP client config')
+  .option('--url <url>', 'Server URL for the --agent proxy (omit for the derived local host)')
+  .option('--server-version <v>', 'Server version to acquire for the --agent proxy (defaults to the pinned SERVER_VERSION)')
+  .option('--server-source <path-or-url>', 'Offline/CI escape hatch for the --agent proxy server binary (local zip/dir/binary or URL)')
   .option('--mode <mode>', 'Connection mode: Cloud | Custom')
   .option('--host <url>', 'Server host (UNREAL_MCP_HOST)')
   .option('--cloud-url <url>', 'Cloud URL (UNREAL_MCP_CLOUD_URL)')
@@ -18,6 +23,34 @@ export const configureCommand = new Command('configure')
   .option('--log-level <level>', 'Log level (UNREAL_MCP_LOG_LEVEL)')
   .option('--no-gitignore', 'Do not touch .gitignore')
   .action(async (opts) => {
+    // --agent routes to the shared C# configurator registry inside the managed
+    // gamedev-mcp-server binary (mcp-authorize design 06/09, D12) — writing a
+    // project-scoped, pinned client config. This is a distinct surface from the
+    // legacy `.env` writer below.
+    if (opts.agent !== undefined) {
+      const spinner = ui.startSpinner(`Configuring ${opts.agent} via gamedev-mcp-server...`);
+      const result = await configureAgent({
+        agentId: opts.agent,
+        projectDir: opts.path,
+        url: opts.url,
+        transport: opts.transport as McpTransport | undefined,
+        serverVersion: opts.serverVersion,
+        serverSource: opts.serverSource,
+        onProgress: (e) => {
+          if (e.phase === 'start' || e.phase === 'info') spinner.text = e.message;
+        },
+      });
+      if (result.kind === 'failure') {
+        spinner.error(result.error.message);
+        ui.printWarnings(result.warnings);
+        process.exitCode = 1;
+        return;
+      }
+      spinner.success(`Configured ${result.agentId} via ${result.serverPath}.`);
+      ui.printWarnings(result.warnings);
+      return;
+    }
+
     const result = await configure({
       projectDir: opts.path,
       connectionMode: opts.mode as ConnectionMode | undefined,

--- a/cli/src/commands/install-plugin.ts
+++ b/cli/src/commands/install-plugin.ts
@@ -2,28 +2,98 @@ import { Command } from 'commander';
 import { installPlugin } from '../lib/install-plugin.js';
 import * as ui from '../utils/ui.js';
 
+/**
+ * Read the enrollment code from stdin (for `--enroll-stdin`) so it never lands
+ * in argv / shell history (mcp-authorize design 06, D13). Reads to EOF, trims.
+ */
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data.trim()));
+    process.stdin.on('error', reject);
+    process.stdin.resume();
+  });
+}
+
 export const installPluginCommand = new Command('install-plugin')
-  .description('Install the UnrealMCP plugin into <project>/Plugins (copy or --junction). Defaults to the local repo source when present, otherwise downloads the matching GitHub release.')
+  .description('Install the UnrealMCP plugin into <project>/Plugins (copy or --junction). Defaults to the local repo source when present, otherwise downloads the matching GitHub release. Optionally bundles the local MCP server (--with-server) and/or redeems an agent enrollment code (--enroll).')
   .argument('[path]', 'Unreal project directory (defaults to cwd)')
   .option('--plugin-source <dir>', 'UnrealMCP plugin source dir (offline / CI / dev override)')
   .option('--junction', 'Create a dev junction instead of copying (Windows)')
-  .action(async (pathArg: string | undefined, opts: { pluginSource?: string; junction?: boolean }) => {
-    const projectDir = pathArg ?? process.cwd();
-    const spinner = ui.startSpinner('Installing UnrealMCP plugin...');
-    const result = await installPlugin({
-      projectDir,
-      pluginSourceDir: opts.pluginSource,
-      junction: opts.junction,
-      onProgress: (event) => {
-        spinner.text = event.message;
+  .option('--with-server', 'Also download the RID-matched gamedev-mcp-server binary (checksum-verified) into the managed dir')
+  .option('--server-version <v>', 'Server version to download with --with-server (defaults to the pinned SERVER_VERSION)')
+  .option('--server-source <path-or-url>', 'Offline/CI escape hatch for --with-server: a local zip/dir/binary or a URL')
+  .option('--enroll <code>', 'Redeem a D13 agent enrollment code → shared machine store + project marker + pin (no browser)')
+  .option('--enroll-stdin', 'Read the enrollment code from stdin instead of argv (keeps it out of shell history)')
+  .option('--base-url <url>', 'Auth base URL for --enroll (defaults to https://ai-game.dev)')
+  .action(
+    async (
+      pathArg: string | undefined,
+      opts: {
+        pluginSource?: string;
+        junction?: boolean;
+        withServer?: boolean;
+        serverVersion?: string;
+        serverSource?: string;
+        enroll?: string;
+        enrollStdin?: boolean;
+        baseUrl?: string;
       },
-    });
-    if (result.kind === 'failure') {
-      spinner.error(result.error.message);
+    ) => {
+      const projectDir = pathArg ?? process.cwd();
+
+      if (opts.enroll !== undefined && opts.enrollStdin) {
+        ui.error('Use either --enroll <code> or --enroll-stdin, not both.');
+        process.exitCode = 1;
+        return;
+      }
+
+      let enrollCode: string | undefined;
+      if (opts.enrollStdin) {
+        enrollCode = await readStdin();
+        if (enrollCode.length === 0) {
+          ui.error('--enroll-stdin was set but no enrollment code was received on stdin.');
+          process.exitCode = 1;
+          return;
+        }
+      } else if (opts.enroll !== undefined) {
+        enrollCode = opts.enroll;
+      }
+
+      const spinner = ui.startSpinner('Installing UnrealMCP plugin...');
+      const result = await installPlugin({
+        projectDir,
+        pluginSourceDir: opts.pluginSource,
+        junction: opts.junction,
+        withServer: opts.withServer,
+        serverVersion: opts.serverVersion,
+        serverSource: opts.serverSource,
+        enrollCode,
+        baseUrl: opts.baseUrl,
+        onProgress: (event) => {
+          spinner.text = event.message;
+        },
+      });
+      if (result.kind === 'failure') {
+        spinner.error(result.error.message);
+        ui.printWarnings(result.warnings);
+        process.exitCode = 1;
+        return;
+      }
+      spinner.success(`Installed plugin (${result.mode}) at ${result.installedPath}`);
+      if (result.serverPath) {
+        ui.info(`Server binary ready: ${result.serverPath}`);
+      }
+      if (result.enrolled) {
+        ui.info(`Enrolled — credential saved to the machine store; server target ${result.serverTarget} (pin ${result.pin}).`);
+        if (result.pinnedConfigFiles && result.pinnedConfigFiles.length > 0) {
+          ui.info(`Pinned existing agent config(s): ${result.pinnedConfigFiles.join(', ')}`);
+        }
+      }
       ui.printWarnings(result.warnings);
-      process.exitCode = 1;
-      return;
-    }
-    spinner.success(`Installed plugin (${result.mode}) at ${result.installedPath}`);
-    ui.printWarnings(result.warnings);
-  });
+    },
+  );

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -12,6 +12,8 @@
 
 // --- command logic ---------------------------------------------------------
 export { configure } from './lib/configure.js';
+export { configureAgent } from './lib/configure-agent.js';
+export { enrollPlugin } from './lib/enroll.js';
 export { openProject, buildOpenEnv } from './lib/open.js';
 export { close, selectEditorProcesses } from './lib/close.js';
 export { createProject, renderProjectTemplate, validateModuleName } from './lib/create-project.js';
@@ -102,7 +104,23 @@ export {
   UE_BUILDS_REGISTRY_KEY,
 } from './utils/engine-discovery.js';
 export { readUProject, readEngineAssociation, findUProjectFile } from './utils/project.js';
-export { generatePortFromDirectory } from './utils/port.js';
+export { generatePortFromDirectory, deriveProjectPin, PROJECT_PIN_LENGTH } from './utils/port.js';
+export {
+  readProjectMarker,
+  writeProjectMarker,
+  serializeProjectMarker,
+  upsertServerTarget,
+  projectMarkerPath,
+  PROJECT_MARKER_DIR,
+  PROJECT_MARKER_FILE,
+} from './utils/project-marker.js';
+export {
+  upsertProjectPin,
+  pinnedUrl,
+  originMatches,
+  applyPinToConfigText,
+  projectLocalAgentConfigPaths,
+} from './utils/pin-upsert.js';
 export { resolveConnection } from './utils/config.js';
 export {
   parseEnvContent,
@@ -198,8 +216,22 @@ export type {
   EngineDiscoverySource,
 } from './lib/engine.js';
 export type { UProjectInfo } from './utils/project.js';
+export type { ProjectMarker } from './utils/project-marker.js';
+export type { UpsertPinOptions, UpsertPinResult } from './utils/pin-upsert.js';
 export type { ResolvedConnection } from './utils/config.js';
 export type { LoginOptions, LoginResult } from './lib/login.js';
+export type {
+  EnrollOptions,
+  EnrollResult,
+  EnrollSuccess,
+  EnrollFailure,
+} from './lib/enroll.js';
+export type {
+  ConfigureAgentOptions,
+  ConfigureAgentResult,
+  ConfigureAgentSuccess,
+  ConfigureAgentFailure,
+} from './lib/configure-agent.js';
 export type { UpdateOptions, UpdateResult } from './lib/update.js';
 export type {
   CleanPluginOptions,

--- a/cli/src/lib/configure-agent.ts
+++ b/cli/src/lib/configure-agent.ts
@@ -1,0 +1,141 @@
+// `configure --agent <id>` — proxy the terminal to the managed
+// `gamedev-mcp-server configure` subcommand (mcp-authorize design 06/09, D12).
+//
+// The shared C# agent-configurator registry (16 clients) lives inside the
+// `gamedev-mcp-server` binary; exposing it from the terminal means agent-first
+// users write any client config with ONE command and never touch the editor UI.
+// This module is the thin proxy: it resolves the managed server binary (the same
+// §6 `download-server` resolver `setup-mcp` uses — the binary lives in the CLI's
+// managed dir under `Intermediate/UnrealMCP/server/<rid>/`, not on PATH), then
+// spawns `<binary> configure --agent <id> [--url <url>] --transport <t>
+// --project <projectDir>`, streaming its output and forwarding its exit code.
+//
+// Transport defaults to `stdio` — the offline-local installer flow this surface
+// serves (design 09 workflow 1B: `configure --agent <id>` writes the stdio
+// config with the derived `port=`/`project=` pin, `none` mode). Pass
+// `transport: 'http'` for the hosted/local-oauth shape. Credentials are never
+// written by the server's URL-only default (D11).
+//
+// Library-safe: never throws past the boundary. `downloadServerImpl` + `spawnImpl`
+// are injectable so a test asserts the resolved binary + arg vector without a real
+// server download or child process.
+
+import * as path from 'path';
+import { spawn } from 'child_process';
+import {
+  downloadServer,
+  resolveServerOverride,
+  SERVER_PATH_ENV_VAR,
+} from './download-server.js';
+import { asError } from '../utils/error.js';
+import { emitProgress } from './progress.js';
+import type { DownloadServerOptions, DownloadServerResult, McpTransport, ProgressCallback } from './types.js';
+
+export interface ConfigureAgentOptions {
+  /** Agent id to configure (e.g. `claude-code`). Forwarded to the server's `--agent`. */
+  agentId: string;
+  /** Project dir the config is pinned to (defaults to `process.cwd()`). */
+  projectDir?: string;
+  /** Explicit server URL (`--url`). Omitted → the server defaults to the local host. */
+  url?: string;
+  /** `stdio` (default — offline-local 1B flow) or `http` (hosted/local-oauth). */
+  transport?: McpTransport;
+  /** Server version to acquire when downloading the managed binary. Defaults to the pin. */
+  serverVersion?: string;
+  /** Offline/CI escape hatch forwarded to the download resolver (`--server-source`). */
+  serverSource?: string;
+  /** Env source for the `UNREAL_MCP_SERVER_PATH` override (test injection). */
+  env?: NodeJS.ProcessEnv;
+  /** Inject the server-binary acquisition (defaults to `downloadServer`). Test injection. */
+  downloadServerImpl?: (opts: DownloadServerOptions) => Promise<DownloadServerResult>;
+  /** Inject the child-process runner (defaults to spawning the server, stdio inherited). Test injection. */
+  spawnImpl?: (bin: string, args: string[]) => Promise<{ exitCode: number }>;
+  onProgress?: ProgressCallback;
+}
+
+export interface ConfigureAgentSuccess {
+  kind: 'success';
+  success: true;
+  agentId: string;
+  /** Absolute path of the managed server binary the config was written through. */
+  serverPath: string;
+  /** The full argument vector passed to the server binary. */
+  args: string[];
+  /** The server subcommand's exit code (0 on success). */
+  exitCode: number;
+  warnings: string[];
+}
+
+export interface ConfigureAgentFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  error: Error;
+}
+
+export type ConfigureAgentResult = ConfigureAgentSuccess | ConfigureAgentFailure;
+
+export async function configureAgent(opts: ConfigureAgentOptions): Promise<ConfigureAgentResult> {
+  const warnings: string[] = [];
+  try {
+    const agentId = (opts.agentId ?? '').trim();
+    if (agentId.length === 0) throw new Error('An --agent id is required.');
+
+    const projectDir = path.resolve(opts.projectDir ?? process.cwd());
+    const transport: McpTransport = opts.transport ?? 'stdio';
+    const env = opts.env ?? process.env;
+
+    // Resolve the managed server binary: the UNREAL_MCP_SERVER_PATH override wins
+    // (no download); otherwise download/refresh the pinned gamedev-mcp-server.
+    let serverPath = resolveServerOverride(env);
+    if (!serverPath) {
+      const download = opts.downloadServerImpl ?? downloadServer;
+      const dl = await download({
+        projectDir,
+        version: opts.serverVersion,
+        source: opts.serverSource,
+        env,
+        onProgress: opts.onProgress,
+      });
+      if (dl.kind !== 'success') {
+        throw new Error(
+          `Could not acquire the gamedev-mcp-server binary to proxy configure: ${dl.error.message}. ` +
+            `Provide one with ${SERVER_PATH_ENV_VAR}, --server-source, or once the download can succeed.`,
+        );
+      }
+      warnings.push(...dl.warnings);
+      serverPath = dl.serverPath;
+    }
+
+    const args = ['configure', '--agent', agentId];
+    if (opts.url && opts.url.trim().length > 0) args.push('--url', opts.url.trim());
+    args.push('--transport', transport);
+    args.push('--project', projectDir);
+
+    emitProgress(opts.onProgress, {
+      phase: 'start',
+      message: `Proxying to gamedev-mcp-server configure --agent ${agentId} (${transport})`,
+    });
+
+    const runner = opts.spawnImpl ?? defaultSpawn;
+    const { exitCode } = await runner(serverPath, args);
+
+    if (exitCode !== 0) {
+      throw new Error(`gamedev-mcp-server configure exited with code ${exitCode}.`);
+    }
+
+    emitProgress(opts.onProgress, { phase: 'done', message: `Configured ${agentId}.` });
+    return { kind: 'success', success: true, agentId, serverPath, args, exitCode, warnings };
+  } catch (err: unknown) {
+    return { kind: 'failure', success: false, warnings, error: asError(err) };
+  }
+}
+
+/** Spawn the server binary with stdio inherited so its config summary reaches the user. */
+function defaultSpawn(bin: string, args: string[]): Promise<{ exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(bin, args, { stdio: 'inherit' });
+    child.on('error', (err) => reject(new Error(`Failed to launch the server configurator: ${err.message}`)));
+    child.on('close', (code) => resolve({ exitCode: code ?? 0 }));
+  });
+}

--- a/cli/src/lib/download-server.ts
+++ b/cli/src/lib/download-server.ts
@@ -385,7 +385,7 @@ export async function downloadServer(opts: DownloadServerOptions): Promise<Downl
       return { kind: 'success', success: true, serverPath: exePath, source: 'cache', version, warnings };
     }
 
-    // 3. Download the release zip.
+    // 4. Download the release zip.
     const rid = ridForPlatform(osPlatform, arch);
     url = serverDownloadUrl(rid, version);
     emitProgress(opts.onProgress, {

--- a/cli/src/lib/download-server.ts
+++ b/cli/src/lib/download-server.ts
@@ -158,14 +158,178 @@ export function findExtractedBinary(stagingDir: string, executableName: string):
   return best;
 }
 
+/** True when `value` looks like an `http(s)://` URL. Pure. */
+function isHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value.trim());
+}
+
+/**
+ * Staging-extract a server zip's bytes into `installDir`: unzip everything to a
+ * throwaway dir, FIND the binary wherever the layout put it (root for the FLAT
+ * win zips, nested `<rid>/` for osx/linux), then replace `installDir` with the
+ * binary PLUS every sidecar file beside it. Returns the installed binary path.
+ * `sourceLabel` names the zip in error messages. Throws on a missing binary.
+ */
+function extractServerZip(
+  zipBytes: Uint8Array,
+  installDir: string,
+  exeName: string,
+  sourceLabel: string,
+  warnings: string[],
+): string {
+  const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), `${SERVER_BINARY_BASENAME}-extract-`));
+  try {
+    const entries = unzipSync(zipBytes);
+    for (const [entryName, data] of Object.entries(entries)) {
+      if (entryName.endsWith('/')) continue; // directory entry
+      const target = path.join(stagingDir, entryName);
+      // Zip-slip guard: never write outside the staging dir.
+      if (!path.resolve(target).startsWith(path.resolve(stagingDir) + path.sep)) {
+        warnings.push(`Skipped suspicious zip entry: ${entryName}`);
+        continue;
+      }
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, data);
+    }
+
+    const extractedBinary = findExtractedBinary(stagingDir, exeName);
+    if (!extractedBinary) {
+      throw new Error(`Server binary '${exeName}' not found inside ${sourceLabel}.`);
+    }
+
+    // Replace any stale install dir so a partial/old extract can't linger, then
+    // move the binary PLUS its sidecar files (appsettings.json, NLog.config, … —
+    // they MUST land next to the binary).
+    fs.rmSync(installDir, { recursive: true, force: true });
+    fs.mkdirSync(installDir, { recursive: true });
+    const sourceDir = path.dirname(extractedBinary);
+    for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      fs.renameSync(path.join(sourceDir, entry.name), path.join(installDir, entry.name));
+    }
+  } finally {
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  }
+
+  const exePath = path.join(installDir, exeName);
+  if (!fs.existsSync(exePath)) {
+    throw new Error(`Server binary not found after unpack at: ${exePath}`);
+  }
+  return exePath;
+}
+
+/**
+ * Install from an ALREADY-EXTRACTED local directory (or the directory holding a
+ * bare binary file): find the binary under `sourceDir`, then COPY it + its
+ * sidecar files into `installDir` (copy, never move — the user's source stays
+ * intact). Returns the installed binary path. Throws on a missing binary.
+ */
+function installServerFromDir(sourceDir: string, installDir: string, exeName: string): string {
+  const extractedBinary = findExtractedBinary(sourceDir, exeName);
+  if (!extractedBinary) {
+    throw new Error(`Server binary '${exeName}' not found under source '${sourceDir}'.`);
+  }
+  fs.rmSync(installDir, { recursive: true, force: true });
+  fs.mkdirSync(installDir, { recursive: true });
+  const dir = path.dirname(extractedBinary);
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    fs.copyFileSync(path.join(dir, entry.name), path.join(installDir, entry.name));
+  }
+  const exePath = path.join(installDir, exeName);
+  if (!fs.existsSync(exePath)) {
+    throw new Error(`Server binary not found after copy at: ${exePath}`);
+  }
+  return exePath;
+}
+
+/**
+ * Finalize a freshly-installed server binary: chmod on Unix + write the
+ * `version` marker beside it. Shared by the download and source paths.
+ */
+function finalizeServerInstall(
+  exePath: string,
+  installDir: string,
+  osPlatform: NodeJS.Platform,
+  version: string,
+  warnings: string[],
+): void {
+  if (osPlatform !== 'win32') {
+    try {
+      fs.chmodSync(exePath, 0o755);
+    } catch (err: unknown) {
+      warnings.push(`Could not mark the server binary executable: ${asError(err).message}`);
+    }
+  }
+  fs.writeFileSync(path.join(installDir, 'version'), version, 'utf-8');
+}
+
+/**
+ * Install the server from the explicit `--server-source` escape hatch (a local
+ * `.zip`, an already-extracted directory, a bare binary file, or an
+ * `http(s)://` URL to a `.zip`). This is a TRUSTED, user-provided artifact, so
+ * the release `SHA256SUMS` integrity gate is deliberately NOT applied (it can
+ * only verify the pinned GitHub release). Returns the resolved binary path.
+ */
+async function installFromSource(
+  source: string,
+  installDir: string,
+  exeName: string,
+  osPlatform: NodeJS.Platform,
+  version: string,
+  fetchImpl: typeof fetch,
+  onProgress: DownloadServerOptions['onProgress'],
+  warnings: string[],
+): Promise<string> {
+  const trimmed = source.trim();
+
+  if (isHttpUrl(trimmed)) {
+    emitProgress(onProgress, { phase: 'start', message: `Fetching server from --server-source URL: ${trimmed}` });
+    const response = await fetchImpl(trimmed);
+    if (!response.ok) {
+      throw new Error(`--server-source download failed: HTTP ${response.status} ${response.statusText} for ${trimmed}.`);
+    }
+    const zipBytes = new Uint8Array(await response.arrayBuffer());
+    const exePath = extractServerZip(zipBytes, installDir, exeName, `the --server-source URL (${trimmed})`, warnings);
+    finalizeServerInstall(exePath, installDir, osPlatform, version, warnings);
+    return exePath;
+  }
+
+  const abs = path.resolve(trimmed);
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(abs);
+  } catch {
+    throw new Error(`--server-source path does not exist: ${abs}`);
+  }
+
+  if (stat.isFile() && abs.toLowerCase().endsWith('.zip')) {
+    emitProgress(onProgress, { phase: 'start', message: `Extracting server from --server-source zip: ${abs}` });
+    const zipBytes = new Uint8Array(fs.readFileSync(abs));
+    const exePath = extractServerZip(zipBytes, installDir, exeName, `the --server-source zip (${abs})`, warnings);
+    finalizeServerInstall(exePath, installDir, osPlatform, version, warnings);
+    return exePath;
+  }
+
+  // A directory (already-extracted) OR a bare binary file: install from its dir.
+  emitProgress(onProgress, { phase: 'start', message: `Installing server from --server-source path: ${abs}` });
+  const sourceDir = stat.isDirectory() ? abs : path.dirname(abs);
+  const exePath = installServerFromDir(sourceDir, installDir, exeName);
+  finalizeServerInstall(exePath, installDir, osPlatform, version, warnings);
+  return exePath;
+}
+
 /**
  * Download + install the pinned `gamedev-mcp-server` binary when it is
  * missing or version-mismatched. Resolution order:
  *
  * 1. `UNREAL_MCP_SERVER_PATH` override → used as-is (no download, no check).
- * 2. Cached binary whose `version` marker equals the pin → reused.
- * 3. Otherwise: download the release zip, staging-extract, move the binary +
- *    its sidecar files into the install dir, chmod on Unix, write `version`.
+ * 2. `--server-source` escape hatch (local zip/dir/binary or URL) → installed
+ *    into the managed dir WITHOUT the SHA256SUMS gate (trusted user artifact).
+ * 3. Cached binary whose `version` marker equals the pin → reused.
+ * 4. Otherwise: download the release zip, VERIFY it against the release
+ *    `SHA256SUMS` (fail-closed), staging-extract, move the binary + its sidecar
+ *    files into the install dir, chmod on Unix, write `version`.
  *
  * Never throws past the boundary — failures return `{ kind: 'failure' }`.
  */
@@ -193,7 +357,30 @@ export async function downloadServer(opts: DownloadServerOptions): Promise<Downl
     const exeName = serverExecutableName(osPlatform);
     const exePath = path.join(installDir, exeName);
 
-    // 2. Cache hit — binary present AND version marker matches the pin.
+    // 2. Explicit `--server-source` escape hatch (offline / CI) — a trusted,
+    //    user-provided local zip/dir/binary or URL. Installed WITHOUT the
+    //    SHA256SUMS gate (that gate protects the DEFAULT GitHub download only).
+    if (opts.source && opts.source.trim().length > 0) {
+      const fetchImpl = opts.fetchImpl ?? fetch;
+      const resolved = await installFromSource(
+        opts.source,
+        installDir,
+        exeName,
+        osPlatform,
+        version,
+        fetchImpl,
+        opts.onProgress,
+        warnings,
+      );
+      emitProgress(opts.onProgress, {
+        phase: 'file-written',
+        message: `Server binary ready from --server-source: ${resolved} (version ${version})`,
+        filePath: resolved,
+      });
+      return { kind: 'success', success: true, serverPath: resolved, source: 'source', version, warnings };
+    }
+
+    // 3. Cache hit — binary present AND version marker matches the pin.
     if (!opts.force && fs.existsSync(exePath) && readVersionMarker(installDir) === version) {
       return { kind: 'success', success: true, serverPath: exePath, source: 'cache', version, warnings };
     }
@@ -249,51 +436,8 @@ export async function downloadServer(opts: DownloadServerOptions): Promise<Downl
 
     // Staging-dir extraction: unzip everything to a throwaway dir, find the
     // binary wherever the layout put it, then move its folder's files.
-    const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), `${SERVER_BINARY_BASENAME}-extract-`));
-    try {
-      const entries = unzipSync(zipBytes);
-      for (const [entryName, data] of Object.entries(entries)) {
-        if (entryName.endsWith('/')) continue; // directory entry
-        const target = path.join(stagingDir, entryName);
-        // Zip-slip guard: never write outside the staging dir.
-        if (!path.resolve(target).startsWith(path.resolve(stagingDir) + path.sep)) {
-          warnings.push(`Skipped suspicious zip entry: ${entryName}`);
-          continue;
-        }
-        fs.mkdirSync(path.dirname(target), { recursive: true });
-        fs.writeFileSync(target, data);
-      }
-
-      const extractedBinary = findExtractedBinary(stagingDir, exeName);
-      if (!extractedBinary) {
-        throw new Error(`Server binary '${exeName}' not found inside the downloaded zip (${url}).`);
-      }
-
-      // Replace any stale install dir so a partial/old extract can't linger,
-      // then move the binary PLUS its sidecar files (appsettings.json,
-      // NLog.config, server.json, … — they MUST land next to the binary).
-      fs.rmSync(installDir, { recursive: true, force: true });
-      fs.mkdirSync(installDir, { recursive: true });
-      const sourceDir = path.dirname(extractedBinary);
-      for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
-        if (!entry.isFile()) continue;
-        fs.renameSync(path.join(sourceDir, entry.name), path.join(installDir, entry.name));
-      }
-    } finally {
-      fs.rmSync(stagingDir, { recursive: true, force: true });
-    }
-
-    if (!fs.existsSync(exePath)) {
-      throw new Error(`Server binary not found after unpack at: ${exePath}`);
-    }
-    if (osPlatform !== 'win32') {
-      try {
-        fs.chmodSync(exePath, 0o755);
-      } catch (err: unknown) {
-        warnings.push(`Could not mark the server binary executable: ${asError(err).message}`);
-      }
-    }
-    fs.writeFileSync(path.join(installDir, 'version'), version, 'utf-8');
+    extractServerZip(zipBytes, installDir, exeName, `the downloaded zip (${url})`, warnings);
+    finalizeServerInstall(exePath, installDir, osPlatform, version, warnings);
 
     emitProgress(opts.onProgress, {
       phase: 'file-written',

--- a/cli/src/lib/enroll.ts
+++ b/cli/src/lib/enroll.ts
@@ -126,7 +126,18 @@ export async function enrollPlugin(opts: EnrollOptions): Promise<EnrollResult> {
       }
       const body = (await resp.json().catch(() => ({}))) as { error?: string; error_description?: string };
       const reason = body.error === 'invalid_grant' ? 'invalid_code' : body.error ?? `http-${resp.status}`;
-      return fail(reason, INVALID_CODE_MESSAGE);
+      // A 400 (or an explicit `invalid_grant`) is the AS's uniform spent/invalid/
+      // expired-code signal (no oracle). Any OTHER status (e.g. a transient 5xx) is
+      // a server-side failure, not a bad code — surfacing INVALID_CODE_MESSAGE there
+      // would wrongly tell the user to reissue a code that is actually fine.
+      if (resp.status === 400 || body.error === 'invalid_grant') {
+        return fail(reason, INVALID_CODE_MESSAGE);
+      }
+      return fail(
+        reason,
+        `The enrollment server returned HTTP ${resp.status}${resp.statusText ? ` ${resp.statusText}` : ''}. ` +
+          `This is a server-side error, not a bad code — try again shortly.`,
+      );
     }
 
     const body = (await resp.json()) as RedeemResponse;

--- a/cli/src/lib/enroll.ts
+++ b/cli/src/lib/enroll.ts
@@ -1,0 +1,188 @@
+// `enroll` — redeem a D13 agent-driven enrollment code for a plugin credential
+// with NO browser hop (mcp-authorize design 06/09, D13). The agent's
+// `enroll_engine_plugin` tool hands the user a `install-plugin --enroll <code>`
+// command; this redeems `<code>` against the cloud AS
+// `POST /api/auth/enroll/redeem` and, on success:
+//
+//   1. persists the returned mcp:plugin credential into the SHARED machine
+//      credential store (`~/.ai-game-dev/credentials.json`, D12) — the same
+//      once-per-machine store `login` writes, NOT a project `.env`;
+//   2. records the redeemed **server target** URL in the committable project
+//      marker `<project>/.ai-game-dev/project.json` (so the plugin boots against
+//      the right hub — hosted vs local);
+//   3. **upserts the D14 routing pin** into any existing project-local agent
+//      config entry pointed at that server (so a hosted server added manually in
+//      workflow-1A step 1 becomes pinned).
+//
+// The code is **burned server-side on the first redeem attempt** (single-use, 5
+// min TTL) — a spent/invalid/expired code yields the SAME uniform error (no
+// oracle), surfaced here as a clean, actionable message. Never mint or log a
+// real token. fetch + clock + store base dir are injectable for tests.
+// Library-safe: never throws past the boundary.
+
+import { MachineCredentialStore, type MachineCredentials, CREDENTIALS_VERSION } from '../utils/machine-credentials.js';
+import { upsertServerTarget } from '../utils/project-marker.js';
+import { deriveProjectPin } from '../utils/port.js';
+import { upsertProjectPin } from '../utils/pin-upsert.js';
+import { asError } from '../utils/error.js';
+import { fetchWithTimeout } from '../utils/http.js';
+import { emitProgress } from './progress.js';
+import type { ProgressCallback } from './types.js';
+import * as path from 'path';
+
+const DEFAULT_BASE_URL = 'https://ai-game.dev';
+const REDEEM_PATH = '/api/auth/enroll/redeem';
+/** Per-request deadline so a hung endpoint can't stall the flow forever. */
+const PER_REQUEST_TIMEOUT_MS = 30_000;
+
+export interface EnrollOptions {
+  /** The one-time enrollment code from the agent's `enroll_engine_plugin` tool. */
+  enrollCode: string;
+  /** The project to record the marker + pin into (the enrolled project). */
+  projectDir: string;
+  /** Auth base URL (defaults to `https://ai-game.dev`). Test injection. */
+  baseUrl?: string;
+  /** Override the machine credential store base dir (default `~/.ai-game-dev`). Test injection. */
+  storeBaseDir?: string;
+  fetchImpl?: typeof fetch;
+  nowImpl?: () => number;
+  onProgress?: ProgressCallback;
+}
+
+export interface EnrollSuccess {
+  kind: 'success';
+  success: true;
+  /** The redeemed mcp:plugin access token. */
+  token: string;
+  /** The server-target URL the code was minted for (hosted vs local hub). */
+  serverTarget: string;
+  /** Absolute path of the machine-store credential file the token was written to. */
+  credentialPath: string;
+  /** Absolute path of the project marker written (`.ai-game-dev/project.json`). */
+  markerPath: string;
+  /** The D14 routing pin derived for this project. */
+  pin: string;
+  /** Project-local agent config files whose server URL was pinned this run. */
+  pinnedConfigFiles: string[];
+  warnings: string[];
+}
+
+export interface EnrollFailure {
+  kind: 'failure';
+  success: false;
+  /** Coarse reason — `invalid_code`, `signing_unavailable`, `network-error`, `timeout`, … */
+  reason: string;
+  error: Error;
+}
+
+export type EnrollResult = EnrollSuccess | EnrollFailure;
+
+interface RedeemResponse {
+  access_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  refresh_token?: string;
+  scope?: string;
+  server_url?: string;
+}
+
+/** The single actionable message for a spent/invalid/expired code (server uniform error). */
+const INVALID_CODE_MESSAGE =
+  'Enrollment code is invalid, expired, or already used. Codes are single-use and burn on the first ' +
+  'attempt (5 min TTL) — ask the agent to run `enroll_engine_plugin` again for a fresh code.';
+
+export async function enrollPlugin(opts: EnrollOptions): Promise<EnrollResult> {
+  const warnings: string[] = [];
+  const baseUrl = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const now = opts.nowImpl ?? Date.now;
+
+  try {
+    const enrollCode = (opts.enrollCode ?? '').trim();
+    if (enrollCode.length === 0) return fail('missing_code', 'An enrollment code is required.');
+    if (!opts.projectDir || opts.projectDir.trim().length === 0) {
+      return fail('missing_project', 'A project directory is required to record the enrollment marker.');
+    }
+    const projectDir = path.resolve(opts.projectDir);
+
+    emitProgress(opts.onProgress, { phase: 'start', message: 'Redeeming enrollment code' });
+
+    const resp = await fetchWithTimeout(
+      fetchImpl,
+      `${baseUrl}${REDEEM_PATH}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enroll_code: enrollCode }),
+      },
+      { timeoutMs: PER_REQUEST_TIMEOUT_MS },
+    );
+
+    if (!resp.ok) {
+      // The AS returns a uniform `{ error, error_description }` for a spent /
+      // invalid / expired code (400), and 503 when signing is unavailable.
+      if (resp.status === 503) {
+        return fail('signing_unavailable', 'The server could not sign a plugin credential right now (503). Try again shortly.');
+      }
+      const body = (await resp.json().catch(() => ({}))) as { error?: string; error_description?: string };
+      const reason = body.error === 'invalid_grant' ? 'invalid_code' : body.error ?? `http-${resp.status}`;
+      return fail(reason, INVALID_CODE_MESSAGE);
+    }
+
+    const body = (await resp.json()) as RedeemResponse;
+    if (!body.access_token) return fail('token-malformed', 'Redeem response missing access_token.');
+    const serverTarget = (body.server_url ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+
+    // 1. Persist the plugin credential into the SHARED machine store (D12).
+    const store = new MachineCredentialStore(opts.storeBaseDir);
+    const credentials: MachineCredentials = {
+      version: CREDENTIALS_VERSION,
+      accessToken: body.access_token,
+      refreshToken: body.refresh_token ?? undefined,
+      expiresAt:
+        typeof body.expires_in === 'number' && body.expires_in > 0
+          ? new Date(now() + body.expires_in * 1000).toISOString()
+          : undefined,
+      serverTarget,
+    };
+    await store.write(credentials);
+    emitProgress(opts.onProgress, {
+      phase: 'info',
+      message: `Plugin credential saved to the shared machine store (${store.credentialsPath}).`,
+    });
+
+    // 2. Record the enrolled server target in the committable project marker.
+    const markerPath = upsertServerTarget(projectDir, serverTarget) ?? '';
+
+    // 3. Upsert the D14 routing pin into any existing project-local agent config.
+    const pin = deriveProjectPin(projectDir);
+    const { updatedFiles } = upsertProjectPin(projectDir, pin, { serverTarget });
+    if (updatedFiles.length > 0) {
+      emitProgress(opts.onProgress, {
+        phase: 'info',
+        message: `Pinned ${updatedFiles.length} existing agent config(s) to /p/${pin}.`,
+      });
+    }
+
+    emitProgress(opts.onProgress, { phase: 'done', message: 'Enrollment complete.' });
+    return {
+      kind: 'success',
+      success: true,
+      token: body.access_token,
+      serverTarget,
+      credentialPath: store.credentialsPath,
+      markerPath,
+      pin,
+      pinnedConfigFiles: updatedFiles,
+      warnings,
+    };
+  } catch (err) {
+    const error = asError(err);
+    const reason = error.name === 'AbortError' ? 'timeout' : 'network-error';
+    return { kind: 'failure', success: false, reason, error };
+  }
+}
+
+function fail(reason: string, message: string): EnrollFailure {
+  return { kind: 'failure', success: false, reason, error: new Error(message) };
+}

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -13,9 +13,12 @@ import { asError } from '../utils/error.js';
 import { isSymlink } from '../utils/fs.js';
 import { emitProgress } from './progress.js';
 import { resolvePluginSource } from './plugin-source.js';
+import { downloadServer } from './download-server.js';
+import { enrollPlugin } from './enroll.js';
 import type {
   InstallPluginOptions,
   InstallPluginResult,
+  InstallPluginSuccess,
   RemovePluginOptions,
   RemovePluginResult,
 } from './types.js';
@@ -154,7 +157,11 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     if (useJunction) {
       fs.symlinkSync(pluginSourceDir, installedPath, 'junction');
       emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin junctioned.' });
-      return { kind: 'success', success: true, installedPath, mode: 'junction', warnings };
+      return await postInstall(
+        { kind: 'success', success: true, installedPath, mode: 'junction', warnings },
+        opts,
+        projectDir,
+      );
     }
 
     // If the copy THROWS after the old install was rm'd and the bridge stashed,
@@ -205,7 +212,11 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     }
 
     emitProgress(opts.onProgress, { phase: 'done', message: 'Plugin copied.' });
-    return { kind: 'success', success: true, installedPath, mode: 'copy', warnings };
+    return await postInstall(
+      { kind: 'success', success: true, installedPath, mode: 'copy', warnings },
+      opts,
+      projectDir,
+    );
   } catch (err: unknown) {
     return {
       kind: 'failure',
@@ -216,6 +227,76 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
   } finally {
     cleanupSource?.();
   }
+}
+
+/**
+ * Run the post-plugin-install add-ons the `install-plugin` flags request, in
+ * order: `--with-server` (best-effort — a download failure degrades to a warning,
+ * the plugin is already in), then `--enroll` (a failure IS surfaced — the user
+ * explicitly asked to redeem a credential, and a bad/spent code must not read as
+ * success). `base` is the already-successful plugin install; its `warnings` array
+ * is mutated in place. Never throws.
+ */
+async function postInstall(
+  base: InstallPluginSuccess,
+  opts: InstallPluginOptions,
+  projectDir: string,
+): Promise<InstallPluginResult> {
+  // --with-server: acquire the RID-matched gamedev-mcp-server into the managed
+  // dir (SHA256SUMS-verified). Best-effort: a failure warns but keeps the install.
+  if (opts.withServer) {
+    const download = opts.downloadServerImpl ?? downloadServer;
+    const dl = await download({
+      projectDir,
+      version: opts.serverVersion,
+      source: opts.serverSource,
+      fetchImpl: opts.fetchImpl,
+      onProgress: opts.onProgress,
+    });
+    if (dl.kind === 'success') {
+      base.warnings.push(...dl.warnings);
+      base.serverPath = dl.serverPath;
+      base.serverVersion = dl.version;
+    } else {
+      base.warnings.push(
+        `--with-server: could not download the gamedev-mcp-server binary: ${dl.error.message}. ` +
+          `The plugin is installed; re-run once the download can succeed or use --server-source.`,
+      );
+    }
+  }
+
+  // --enroll: redeem the code → machine store + marker + pin. A failure is
+  // surfaced as an overall failure (the plugin/server are still installed).
+  if (opts.enrollCode !== undefined) {
+    const enroll = opts.enrollImpl ?? enrollPlugin;
+    const er = await enroll({
+      enrollCode: opts.enrollCode,
+      projectDir,
+      baseUrl: opts.baseUrl,
+      storeBaseDir: opts.storeBaseDir,
+      fetchImpl: opts.fetchImpl,
+      nowImpl: opts.nowImpl,
+      onProgress: opts.onProgress,
+    });
+    if (er.kind === 'success') {
+      base.enrolled = true;
+      base.serverTarget = er.serverTarget;
+      base.pin = er.pin;
+      base.pinnedConfigFiles = er.pinnedConfigFiles;
+      base.warnings.push(...er.warnings);
+    } else {
+      return {
+        kind: 'failure',
+        success: false,
+        warnings: base.warnings,
+        error: new Error(
+          `Plugin installed at ${base.installedPath}, but enrollment failed (${er.reason}): ${er.error.message}`,
+        ),
+      };
+    }
+  }
+
+  return base;
 }
 
 export async function removePlugin(opts: RemovePluginOptions): Promise<RemovePluginResult> {

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -16,6 +16,7 @@
 import type { ExtensionDescriptor } from '../utils/extensions-catalog.js';
 import type { InstallSourceKind } from '../utils/extension-source.js';
 import type { DismissOutcome, DismissPlatform, UnrealStartupDialogKey } from '../utils/startup-dialog-dismiss.js';
+import type { EnrollOptions, EnrollResult } from './enroll.js';
 
 export type ResultKind = 'success' | 'failure';
 
@@ -243,8 +244,34 @@ export interface InstallPluginOptions {
   pluginSourceDir?: string;
   /** Junction (dev) instead of copy. Windows only. Default `false`. */
   junction?: boolean;
-  /** Injectable fetch for tests (download path only). */
+  /**
+   * `--with-server`: after installing the plugin, download the RID-matched
+   * `gamedev-mcp-server` binary into the CLI-managed dir (checksum-verified via
+   * the existing SHA256SUMS flow), so an offline user needs no .NET SDK (D12).
+   */
+  withServer?: boolean;
+  /** `--server-version <v>`: server version to download for `--with-server`. Defaults to the pinned `SERVER_VERSION`. */
+  serverVersion?: string;
+  /** `--server-source <path-or-url>`: offline/CI escape hatch for the `--with-server` download (see `DownloadServerOptions.source`). */
+  serverSource?: string;
+  /**
+   * `--enroll <code>` / `--enroll-stdin`: redeem a D13 enrollment code for a
+   * plugin credential (→ shared machine store + project marker + pin upsert). No
+   * browser hop. The code is single-use and burns on the first attempt.
+   */
+  enrollCode?: string;
+  /** Auth base URL for `--enroll` (defaults to `https://ai-game.dev`). Test injection. */
+  baseUrl?: string;
+  /** Override the machine credential store base dir for `--enroll` (default `~/.ai-game-dev`). Test injection. */
+  storeBaseDir?: string;
+  /** Injectable fetch for tests (plugin download + server download + enroll). */
   fetchImpl?: typeof fetch;
+  /** Injectable clock for the enrollment credential's `expiresAt`. Test injection. */
+  nowImpl?: () => number;
+  /** Inject the `--with-server` acquisition (defaults to `downloadServer`). Test injection. */
+  downloadServerImpl?: (opts: DownloadServerOptions) => Promise<DownloadServerResult>;
+  /** Inject the `--enroll` redemption (defaults to `enrollPlugin`). Test injection. */
+  enrollImpl?: (opts: EnrollOptions) => Promise<EnrollResult>;
   onProgress?: ProgressCallback;
 }
 
@@ -254,6 +281,18 @@ export interface InstallPluginSuccess {
   /** Absolute path to `<project>/Plugins/UnrealMCP`. */
   installedPath: string;
   mode: 'copy' | 'junction';
+  /** `--with-server`: absolute path of the downloaded server binary, when acquired. */
+  serverPath?: string;
+  /** `--with-server`: installed server version, when acquired. */
+  serverVersion?: string | null;
+  /** `--enroll`: `true` when a credential was redeemed + persisted. */
+  enrolled?: boolean;
+  /** `--enroll`: the server-target URL the code was minted for. */
+  serverTarget?: string;
+  /** `--enroll`: the D14 routing pin derived for this project. */
+  pin?: string;
+  /** `--enroll`: project-local agent config files whose URL was pinned. */
+  pinnedConfigFiles?: string[];
   warnings: string[];
 }
 
@@ -398,6 +437,17 @@ export interface DownloadServerOptions {
   arch?: string;
   /** Server version to download. Defaults to the pinned `SERVER_VERSION`. */
   version?: string;
+  /**
+   * Offline / CI escape hatch (the `install-plugin --server-source` flag): a
+   * local path or URL supplying the server binary directly instead of the
+   * pinned GitHub release. Accepts a local `.zip`, an already-extracted
+   * directory, a bare binary file, or an `http(s)://` URL to a `.zip`. Because
+   * it is an EXPLICIT user-provided artifact, the release `SHA256SUMS` gate is
+   * skipped for this path (the gate protects the DEFAULT download only). Wins
+   * over the network download; the `UNREAL_MCP_SERVER_PATH` env override still
+   * wins over this.
+   */
+  source?: string;
   /** Env source for the `UNREAL_MCP_SERVER_PATH` override (test injection). */
   env?: NodeJS.ProcessEnv;
   /** Inject the HTTP client (defaults to global `fetch`). */
@@ -413,7 +463,7 @@ export interface DownloadServerSuccess {
   /** Absolute path to the resolved server binary. */
   serverPath: string;
   /** How the binary was resolved. */
-  source: 'override' | 'cache' | 'download';
+  source: 'override' | 'cache' | 'download' | 'source';
   /** Installed server version (`null` for an override — version unknown/unchecked). */
   version: string | null;
   warnings: string[];

--- a/cli/src/utils/pin-upsert.ts
+++ b/cli/src/utils/pin-upsert.ts
@@ -1,0 +1,182 @@
+// Upsert the D14 routing pin (`/p/<pin>`) into any EXISTING project-local agent
+// config entry that points at the enrolled ai-game.dev MCP server (mcp-authorize
+// design 06 — "the CLI … upserts the D14 pin into any existing project-local
+// agent config entry, so a hosted server added manually in step 1 of workflow 1A
+// becomes pinned, and the plugin boots pointed at the right hub").
+//
+// The classic 1A case: the user ran `claude mcp add --transport http
+// ai-game-developer https://ai-game.dev/mcp` (writing a project-local `.mcp.json`)
+// BEFORE enrolling. `install-plugin --enroll <code>` then rewrites that server's
+// URL to carry the `/p/<pin>` path segment so agent sessions launched in this
+// project folder route strictly to this project's engine (D14 strict pin routing).
+//
+// Scope (design 06, "Project-scoped configs only, D14"): only **project-local**
+// config files (those whose path is under the project root) are touched — the
+// golden path never rewrites a user-global config. The rewrite is:
+//   • format-preserving (a targeted string substitution on the URL token, never a
+//     whole-file reparse/reformat), so it works for JSON and TOML configs alike;
+//   • host-scoped (only URLs whose origin matches the enrolled `serverTarget` —
+//     or, when no target is known, ai-game.dev + loopback hosts — are rewritten);
+//   • idempotent (an already-pinned URL's stale `/p/<hex8>` segment is stripped
+//     and re-appended, so re-running never produces `/p/x/p/y`).
+//
+// Library-safe: never throws past the boundary; an unreadable/garbage config is
+// skipped, not fatal.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { agentRegistry } from './agents.js';
+
+/** Matches a trailing `/p/<8-hex>` routing-pin segment (trailing slash tolerated). */
+const TRAILING_PIN_RE = /\/p\/[0-9a-fA-F]{8}\/?$/;
+
+/**
+ * URL/serverUrl key → quoted value, for BOTH JSON (`"url": "…"`) and TOML
+ * (`url = "…"`). The optional `\1` backreference makes the key quotes match
+ * (present in JSON, absent in TOML); the value token excludes quotes/whitespace
+ * so it captures exactly one URL.
+ */
+const URL_FIELD_RE = /(["']?)(url|serverUrl)\1\s*[:=]\s*(["'])([^"'\s]+)\3/g;
+
+export interface UpsertPinOptions {
+  /**
+   * The enrolled server target URL. Only config URLs whose ORIGIN matches this
+   * target's origin are pinned. When omitted, ai-game.dev + loopback hosts match
+   * (a defensive default; the enroll flow always supplies the redeemed target).
+   */
+  serverTarget?: string;
+  /**
+   * Explicit list of config file paths to scan. Defaults to the PROJECT-LOCAL
+   * subset of the agent registry's config paths (those under the project root).
+   * Test injection.
+   */
+  configPaths?: string[];
+}
+
+export interface UpsertPinResult {
+  /** Absolute paths of the config files whose URL was rewritten this run. */
+  updatedFiles: string[];
+}
+
+/**
+ * The pinned form of `rawUrl`: any existing trailing `/p/<8hex>` segment stripped,
+ * then `/p/<pin>` appended to the path. Preserves scheme/host/port and any prefix
+ * path (e.g. hosted `…/mcp` stays, local origin gets a bare `/p/<pin>`). Pure.
+ * A non-absolute / unparsable URL is returned unchanged.
+ */
+export function pinnedUrl(rawUrl: string, pin: string): string {
+  let u: URL;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    return rawUrl;
+  }
+  let pathname = u.pathname.replace(TRAILING_PIN_RE, '').replace(/\/+$/, '');
+  u.pathname = `${pathname}/p/${pin}`;
+  // Drop a trailing slash `URL` may re-add for an empty search/hash.
+  return u.toString().replace(/\/$/, '');
+}
+
+/**
+ * True when `rawUrl`'s origin should be pinned for this enrollment. With a
+ * `serverTarget`, the origins (scheme+host+port, case-insensitive) must match.
+ * Without one, ai-game.dev (or a subdomain) and loopback hosts match. Pure.
+ */
+export function originMatches(rawUrl: string, serverTarget?: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (serverTarget && serverTarget.trim().length > 0) {
+    try {
+      return u.origin.toLowerCase() === new URL(serverTarget).origin.toLowerCase();
+    } catch {
+      return false;
+    }
+  }
+  const host = u.hostname.toLowerCase();
+  return (
+    host === 'ai-game.dev' ||
+    host.endsWith('.ai-game.dev') ||
+    host === 'localhost' ||
+    host === '127.0.0.1' ||
+    host === '[::1]'
+  );
+}
+
+/**
+ * Rewrite matching `url`/`serverUrl` string values in `text` to carry the pin,
+ * returning the new text plus whether anything changed. Format-preserving:
+ * substitutes only the URL token, leaving surrounding whitespace/formatting
+ * intact. Pure.
+ */
+export function applyPinToConfigText(
+  text: string,
+  pin: string,
+  serverTarget?: string,
+): { text: string; changed: boolean } {
+  let changed = false;
+  const out = text.replace(URL_FIELD_RE, (full, _q1, _key, quote, url) => {
+    if (!originMatches(url, serverTarget)) return full;
+    const pinned = pinnedUrl(url, pin);
+    if (pinned === url) return full;
+    changed = true;
+    return full.replace(`${quote}${url}${quote}`, `${quote}${pinned}${quote}`);
+  });
+  return { text: out, changed };
+}
+
+/**
+ * The default set of config files the enroll pin-upsert scans: every agent
+ * registry config path that resolves UNDER `projectDir` (project-local). Global
+ * / home-dir configs (Claude Desktop, Antigravity, Cline, Copilot CLI) are
+ * excluded by construction. Pure-ish (no I/O). De-duplicated.
+ */
+export function projectLocalAgentConfigPaths(projectDir: string): string[] {
+  const root = path.resolve(projectDir);
+  const withSep = root.endsWith(path.sep) ? root : root + path.sep;
+  const seen = new Set<string>();
+  for (const agent of agentRegistry) {
+    let configPath: string;
+    try {
+      configPath = path.resolve(agent.getConfigPath(root));
+    } catch {
+      continue;
+    }
+    if (configPath === root || configPath.startsWith(withSep)) {
+      seen.add(configPath);
+    }
+  }
+  return [...seen];
+}
+
+/**
+ * Upsert the `/p/<pin>` routing segment into every existing project-local agent
+ * config whose ai-game.dev/target-origin server URL is not already pinned to
+ * `pin`. Returns the files that changed. Never throws — an unreadable/garbage
+ * config is skipped.
+ */
+export function upsertProjectPin(projectDir: string, pin: string, opts: UpsertPinOptions = {}): UpsertPinResult {
+  const updatedFiles: string[] = [];
+  const paths = opts.configPaths ?? projectLocalAgentConfigPaths(projectDir);
+  for (const configPath of paths) {
+    let text: string;
+    try {
+      if (!fs.existsSync(configPath)) continue;
+      text = fs.readFileSync(configPath, 'utf-8');
+    } catch {
+      continue;
+    }
+    const { text: next, changed } = applyPinToConfigText(text, pin, opts.serverTarget);
+    if (!changed) continue;
+    try {
+      fs.writeFileSync(configPath, next);
+      updatedFiles.push(configPath);
+    } catch {
+      // Best-effort — a read-only config must not fail the enrollment.
+    }
+  }
+  return { updatedFiles };
+}

--- a/cli/src/utils/port.ts
+++ b/cli/src/utils/port.ts
@@ -74,3 +74,23 @@ export function generatePortFromDirectory(dir: string): number {
   const uint32 = hash.readUInt32LE(0);
   return MIN_PORT + (uint32 % PORT_RANGE);
 }
+
+/** Number of hex characters in the routing pin (first 4 bytes of the hash). */
+export const PROJECT_PIN_LENGTH = 8;
+
+/**
+ * The D14 routing **pin** for a project directory: the first 4 bytes of the
+ * SHA-256 of the normalized project root, rendered as 8 lowercase hex chars.
+ * The pin is NEVER affected by a port override — it is purely hash-derived.
+ *
+ * Byte-for-byte identical to the shared `ProjectIdentity.DerivePin`
+ * (`McpPlugin/src/AgentConfig/ProjectIdentity.cs`, `ToHex(hash, 4)`), gated by
+ * the same golden vectors that pin `generatePortFromDirectory`, so the pin the
+ * CLI writes into an agent config's `/p/<pin>` URL segment routes to the SAME
+ * project's engine the plugin reports in its hub instance-metadata handshake.
+ * Pure.
+ */
+export function deriveProjectPin(dir: string): string {
+  const hash = createHash('sha256').update(normalizeProjectRoot(dir), 'utf-8').digest();
+  return hash.subarray(0, PROJECT_PIN_LENGTH / 2).toString('hex');
+}

--- a/cli/src/utils/project-marker.ts
+++ b/cli/src/utils/project-marker.ts
@@ -1,0 +1,123 @@
+// The tool-neutral, committable per-project marker file
+// `<project>/.ai-game-dev/project.json` (mcp-authorize design 06, D14/D15).
+//
+// It records the enrolled `serverTarget` (hosted vs local) and the user's
+// optional explicit `portOverride`. ProjectIdentity resolution and every config
+// writer (engine UI, CLIs, `configure`) consult it, so an override or target can
+// never silently diverge between the plugin and a terminal-written config.
+//
+// This is the TypeScript peer of the shared C# `ProjectMarker`
+// (McpPlugin/src/AgentConfig/ProjectMarker.cs). The on-disk contract MUST stay
+// byte-compatible so the .NET sidecar / engine plugin reads what the CLI writes
+// and vice versa:
+//   • path        — `<project>/.ai-game-dev/project.json`.
+//   • JSON schema — camelCase `{ serverTarget?, portOverride? }`; null fields
+//                   omitted (matches `DefaultIgnoreCondition.WhenWritingNull`);
+//                   unknown fields ignored on read (forwards-compatible).
+//   • at rest     — non-secret, standard file permissions, 2-space-indented JSON.
+//
+// **Credentials are NEVER written here** — they live only in the machine
+// credential store (`utils/machine-credentials.ts`). This file is safe to commit.
+//
+// Library-safe: read tolerates a missing/blank/garbage marker (returns null);
+// callers own error shaping.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** Directory name (under the project root) that holds the marker. */
+export const PROJECT_MARKER_DIR = '.ai-game-dev';
+
+/** Marker file name inside {@link PROJECT_MARKER_DIR}. */
+export const PROJECT_MARKER_FILE = 'project.json';
+
+/**
+ * The committable marker document. Mirrors the C# `ProjectMarker` field-for-field
+ * (camelCase JSON on the wire). Both fields are optional.
+ */
+export interface ProjectMarker {
+  /** The enrolled server target URL (hosted `https://ai-game.dev` or a local URL). */
+  serverTarget?: string;
+  /** The user's explicit local-port override. When set it wins over the derived port. */
+  portOverride?: number;
+}
+
+/** Absolute path of the marker file for a given project root. Pure. */
+export function projectMarkerPath(projectDir: string): string {
+  return path.join(path.resolve(projectDir), PROJECT_MARKER_DIR, PROJECT_MARKER_FILE);
+}
+
+/**
+ * Read the marker for `projectDir`. Returns `null` when the marker file does not
+ * exist (a project that has never been enrolled / configured). A present-but-blank
+ * file yields an empty marker `{}`; a present-but-garbage file also yields `{}`
+ * (mirrors the C# `Read`, which never throws for a malformed marker). Never throws.
+ */
+export function readProjectMarker(projectDir: string): ProjectMarker | null {
+  const markerPath = projectMarkerPath(projectDir);
+  let raw: string;
+  try {
+    if (!fs.existsSync(markerPath)) return null;
+    raw = fs.readFileSync(markerPath, 'utf-8');
+  } catch {
+    return null;
+  }
+  // Strip a leading UTF-8 BOM if some other writer added one.
+  if (raw.charCodeAt(0) === 0xfeff) raw = raw.slice(1);
+  if (raw.trim().length === 0) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (parsed === null || typeof parsed !== 'object') return {};
+  const obj = parsed as Record<string, unknown>;
+  const marker: ProjectMarker = {};
+  if (typeof obj.serverTarget === 'string' && obj.serverTarget.trim().length > 0) {
+    marker.serverTarget = obj.serverTarget;
+  }
+  if (typeof obj.portOverride === 'number' && Number.isInteger(obj.portOverride)) {
+    marker.portOverride = obj.portOverride;
+  }
+  return marker;
+}
+
+/**
+ * Serialize a marker to the exact camelCase JSON shape the C# store reads:
+ * 2-space indent, null/undefined fields omitted, `serverTarget` before
+ * `portOverride` (mirrors the C# property order for a stable on-disk document).
+ * Pure.
+ */
+export function serializeProjectMarker(marker: ProjectMarker): string {
+  const obj: Record<string, unknown> = {};
+  if (marker.serverTarget != null && marker.serverTarget !== '') obj.serverTarget = marker.serverTarget;
+  if (marker.portOverride != null) obj.portOverride = marker.portOverride;
+  return JSON.stringify(obj, null, 2);
+}
+
+/**
+ * Write `marker` into `projectDir`, creating the `.ai-game-dev` directory if
+ * needed. Non-secret; standard file permissions. Returns the absolute path
+ * written.
+ */
+export function writeProjectMarker(projectDir: string, marker: ProjectMarker): string {
+  const markerPath = projectMarkerPath(projectDir);
+  fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+  fs.writeFileSync(markerPath, serializeProjectMarker(marker), 'utf-8');
+  return markerPath;
+}
+
+/**
+ * Read-modify-write the marker so `serverTarget` is recorded while any existing
+ * `portOverride` (the user's D15 choice) is preserved. Returns the absolute path
+ * written, or `null` when `serverTarget` is blank (nothing to record). The enroll
+ * flow calls this after a successful redeem so the plugin boots against the hub
+ * the code was minted for. Never throws past the boundary.
+ */
+export function upsertServerTarget(projectDir: string, serverTarget: string | undefined | null): string | null {
+  if (serverTarget == null || serverTarget.trim().length === 0) return null;
+  const existing = readProjectMarker(projectDir) ?? {};
+  existing.serverTarget = serverTarget.trim();
+  return writeProjectMarker(projectDir, existing);
+}

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -1,19 +1,41 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = path.resolve(__dirname, '..', 'bin', 'unreal-mcp-cli.js');
 
-function runCli(args: string[]): { stdout: string; exitCode: number } {
+function runCli(args: string[], input?: string): { stdout: string; exitCode: number } {
   try {
-    const stdout = execFileSync('node', [CLI_PATH, ...args], { encoding: 'utf-8', timeout: 20000 });
+    const stdout = execFileSync('node', [CLI_PATH, ...args], {
+      encoding: 'utf-8',
+      timeout: 20000,
+      input: input ?? '',
+    });
     return { stdout, exitCode: 0 };
   } catch (err: unknown) {
     const e = err as { stdout?: string; stderr?: string; status?: number };
     return { stdout: (e.stdout ?? '') + (e.stderr ?? ''), exitCode: e.status ?? 1 };
   }
+}
+
+const cliDirs: string[] = [];
+afterEach(() => {
+  while (cliDirs.length) {
+    try {
+      fs.rmSync(cliDirs.pop()!, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+function cliTmp(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'unreal-mcp-cli-int-'));
+  cliDirs.push(d);
+  return d;
 }
 
 const ALL_COMMANDS = [
@@ -72,4 +94,41 @@ describe('CLI integration', () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain('5.7');
   });
+
+  it('install-plugin --help lists the mcp-authorize flags', () => {
+    const { stdout, exitCode } = runCli(['install-plugin', '--help']);
+    expect(exitCode).toBe(0);
+    for (const flag of ['--with-server', '--server-version', '--server-source', '--enroll', '--enroll-stdin']) {
+      expect(stdout, `install-plugin --help should list ${flag}`).toContain(flag);
+    }
+  });
+
+  it('configure --help lists the --agent proxy flag', () => {
+    const { stdout, exitCode } = runCli(['configure', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--agent');
+  });
+
+  it('install-plugin rejects --enroll and --enroll-stdin together (before reading stdin)', () => {
+    const { stdout, exitCode } = runCli(['install-plugin', cliTmp(), '--enroll', 'x', '--enroll-stdin']);
+    expect(exitCode).toBe(1);
+    expect(stdout).toMatch(/either --enroll <code> or --enroll-stdin/i);
+  });
+
+  it('install-plugin --enroll-stdin reads the code from stdin (never argv) and attempts redemption', () => {
+    // A minimal local plugin source so the plugin install succeeds offline; enroll
+    // then redeems against an unreachable base-url → connection refused. The code
+    // is delivered ONLY on stdin, proving --enroll-stdin keeps it out of argv.
+    const project = cliTmp();
+    const source = cliTmp();
+    fs.writeFileSync(path.join(source, 'UnrealMCP.uplugin'), JSON.stringify({ VersionName: '0.1.0' }));
+    const { stdout, exitCode } = runCli(
+      ['install-plugin', project, '--plugin-source', source, '--enroll-stdin', '--base-url', 'http://127.0.0.1:9'],
+      'STDIN-ENROLL-CODE',
+    );
+    // Plugin materialized; enrollment attempted and failed on the refused connection.
+    expect(fs.existsSync(path.join(project, 'Plugins', 'UnrealMCP', 'UnrealMCP.uplugin'))).toBe(true);
+    expect(exitCode).toBe(1);
+    expect(stdout).toMatch(/enrollment failed/i);
+  }, 20000);
 });

--- a/cli/tests/configure-agent.test.ts
+++ b/cli/tests/configure-agent.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import { configureAgent } from '../src/lib/configure-agent.js';
+import { SERVER_PATH_ENV_VAR } from '../src/lib/download-server.js';
+import type { DownloadServerResult } from '../src/lib/types.js';
+
+function okDownload(serverPath: string): () => Promise<DownloadServerResult> {
+  return async () =>
+    ({ kind: 'success', success: true, serverPath, source: 'download', version: '9.0.0', warnings: [] }) as DownloadServerResult;
+}
+
+describe('configureAgent (proxy to gamedev-mcp-server configure)', () => {
+  it('spawns the managed server binary with the right arg vector (stdio default)', async () => {
+    const projectDir = path.resolve('/tmp/my-unreal-proj');
+    let spawned: { bin?: string; args?: string[] } = {};
+    const r = await configureAgent({
+      agentId: 'claude-code',
+      projectDir,
+      env: {},
+      downloadServerImpl: okDownload('/managed/gamedev-mcp-server.exe'),
+      spawnImpl: async (bin, args) => {
+        spawned = { bin, args };
+        return { exitCode: 0 };
+      },
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(spawned.bin).toBe('/managed/gamedev-mcp-server.exe');
+    expect(spawned.args).toEqual([
+      'configure',
+      '--agent',
+      'claude-code',
+      '--transport',
+      'stdio',
+      '--project',
+      projectDir,
+    ]);
+    expect(r.serverPath).toBe('/managed/gamedev-mcp-server.exe');
+  });
+
+  it('forwards --url and an explicit --transport http', async () => {
+    let args: string[] = [];
+    await configureAgent({
+      agentId: 'cursor',
+      projectDir: path.resolve('/tmp/p'),
+      url: 'https://ai-game.dev',
+      transport: 'http',
+      env: {},
+      downloadServerImpl: okDownload('/managed/bin'),
+      spawnImpl: async (_bin, a) => {
+        args = a;
+        return { exitCode: 0 };
+      },
+    });
+    expect(args).toContain('--url');
+    expect(args[args.indexOf('--url') + 1]).toBe('https://ai-game.dev');
+    expect(args[args.indexOf('--transport') + 1]).toBe('http');
+  });
+
+  it('prefers the UNREAL_MCP_SERVER_PATH override and does NOT download', async () => {
+    const overrideBin = makeExistingBinary();
+    let downloaded = false;
+    let usedBin = '';
+    const r = await configureAgent({
+      agentId: 'claude-code',
+      projectDir: path.resolve('/tmp/p'),
+      env: { [SERVER_PATH_ENV_VAR]: overrideBin },
+      downloadServerImpl: async () => {
+        downloaded = true;
+        return okDownload('/should/not/be/used')();
+      },
+      spawnImpl: async (bin) => {
+        usedBin = bin;
+        return { exitCode: 0 };
+      },
+    });
+    expect(r.kind).toBe('success');
+    expect(downloaded).toBe(false);
+    expect(usedBin).toBe(overrideBin);
+  });
+
+  it('fails when the server binary cannot be acquired', async () => {
+    const r = await configureAgent({
+      agentId: 'claude-code',
+      projectDir: path.resolve('/tmp/p'),
+      env: {},
+      downloadServerImpl: async () =>
+        ({ kind: 'failure', success: false, warnings: [], error: new Error('offline') }) as DownloadServerResult,
+      spawnImpl: async () => ({ exitCode: 0 }),
+    });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.error.message).toMatch(/could not acquire/i);
+  });
+
+  it('fails when the server configure subcommand exits non-zero', async () => {
+    const r = await configureAgent({
+      agentId: 'unknown-agent',
+      projectDir: path.resolve('/tmp/p'),
+      env: {},
+      downloadServerImpl: okDownload('/managed/bin'),
+      spawnImpl: async () => ({ exitCode: 2 }),
+    });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.error.message).toMatch(/exited with code 2/i);
+  });
+
+  it('rejects a blank agent id', async () => {
+    const r = await configureAgent({
+      agentId: '   ',
+      env: {},
+      downloadServerImpl: okDownload('/managed/bin'),
+      spawnImpl: async () => ({ exitCode: 0 }),
+    });
+    expect(r.kind).toBe('failure');
+  });
+});
+
+// A real existing file so `resolveServerOverride` accepts the override path.
+import * as fs from 'fs';
+import * as os from 'os';
+function makeExistingBinary(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'unreal-mcp-cfgagent-'));
+  const p = path.join(dir, 'gamedev-mcp-server.exe');
+  fs.writeFileSync(p, 'x');
+  return p;
+}

--- a/cli/tests/download-server.test.ts
+++ b/cli/tests/download-server.test.ts
@@ -362,3 +362,133 @@ describe('downloadServer', () => {
     expect(fs.existsSync(r.serverPath)).toBe(true);
   });
 });
+
+// --- --server-source escape hatch (offline / CI) ----------------------------
+
+/** A fetch that FAILS the test if called — asserts the source path never hits the network. */
+function fetchNever(): typeof fetch {
+  return (async () => {
+    throw new Error('fetch must not be called for a local --server-source');
+  }) as typeof fetch;
+}
+
+describe('downloadServer --server-source', () => {
+  it('installs from a local .zip into the managed dir WITHOUT the SHA256SUMS gate', async () => {
+    const proj = tmp();
+    const src = tmp();
+    const zipPath = path.join(src, 'server.zip');
+    fs.writeFileSync(zipPath, flatWinZip());
+
+    const r = await downloadServer({
+      projectDir: proj,
+      os: 'win32',
+      arch: 'x64',
+      env: {},
+      source: zipPath,
+      fetchImpl: fetchNever(), // no network — no SHA256SUMS fetch, no release download
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.source).toBe('source');
+    const installDir = serverInstallDir(proj, 'win32', 'x64');
+    expect(r.serverPath).toBe(path.join(installDir, 'gamedev-mcp-server.exe'));
+    expect(fs.existsSync(r.serverPath)).toBe(true);
+    // Sidecars moved beside the binary, and the version marker written.
+    expect(fs.existsSync(path.join(installDir, 'appsettings.json'))).toBe(true);
+    expect(readVersionMarker(installDir)).toBe(SERVER_VERSION);
+  });
+
+  it('installs from an already-extracted directory (copy, source left intact)', async () => {
+    const proj = tmp();
+    const src = tmp();
+    fs.writeFileSync(path.join(src, 'gamedev-mcp-server.exe'), 'exe-bytes');
+    fs.writeFileSync(path.join(src, 'appsettings.json'), '{}');
+
+    const r = await downloadServer({
+      projectDir: proj,
+      os: 'win32',
+      arch: 'x64',
+      env: {},
+      source: src,
+      fetchImpl: fetchNever(),
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.source).toBe('source');
+    expect(fs.existsSync(r.serverPath)).toBe(true);
+    // The source directory is preserved (copy, not move).
+    expect(fs.existsSync(path.join(src, 'gamedev-mcp-server.exe'))).toBe(true);
+  });
+
+  it('installs from a bare binary file path', async () => {
+    const proj = tmp();
+    const src = tmp();
+    const bin = path.join(src, 'gamedev-mcp-server.exe');
+    fs.writeFileSync(bin, 'exe-bytes');
+
+    const r = await downloadServer({ projectDir: proj, os: 'win32', arch: 'x64', env: {}, source: bin, fetchImpl: fetchNever() });
+    expect(r.kind).toBe('success');
+    if (r.kind === 'success') expect(r.source).toBe('source');
+  });
+
+  it('downloads from a --server-source URL WITHOUT fetching SHA256SUMS', async () => {
+    const proj = tmp();
+    const zip = flatWinZip();
+    const calls: string[] = [];
+    const fetchImpl = (async (url: unknown) => {
+      calls.push(String(url));
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        arrayBuffer: async () => zip.buffer.slice(zip.byteOffset, zip.byteOffset + zip.byteLength),
+      } as unknown as Response;
+    }) as typeof fetch;
+
+    const r = await downloadServer({
+      projectDir: proj,
+      os: 'win32',
+      arch: 'x64',
+      env: {},
+      source: 'https://example.com/custom-server.zip',
+      fetchImpl,
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind === 'success') expect(r.source).toBe('source');
+    // Exactly one fetch — the source URL. No SHA256SUMS request.
+    expect(calls).toEqual(['https://example.com/custom-server.zip']);
+    expect(calls.some((u) => u.endsWith('SHA256SUMS'))).toBe(false);
+  });
+
+  it('fails cleanly for a non-existent --server-source path', async () => {
+    const r = await downloadServer({
+      projectDir: tmp(),
+      os: 'win32',
+      arch: 'x64',
+      env: {},
+      source: path.join(tmp(), 'does-not-exist.zip'),
+      fetchImpl: fetchNever(),
+    });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.error.message).toMatch(/does not exist/i);
+  });
+
+  it('the UNREAL_MCP_SERVER_PATH override still wins over --server-source', async () => {
+    const proj = tmp();
+    const overrideBin = path.join(tmp(), 'gamedev-mcp-server.exe');
+    fs.writeFileSync(overrideBin, 'x');
+    const r = await downloadServer({
+      projectDir: proj,
+      os: 'win32',
+      arch: 'x64',
+      env: { [SERVER_PATH_ENV_VAR]: overrideBin },
+      source: path.join(tmp(), 'ignored.zip'),
+      fetchImpl: fetchNever(),
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind === 'success') {
+      expect(r.source).toBe('override');
+      expect(r.serverPath).toBe(overrideBin);
+    }
+  });
+});

--- a/cli/tests/enroll.test.ts
+++ b/cli/tests/enroll.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { enrollPlugin } from '../src/lib/enroll.js';
+import { MachineCredentialStore } from '../src/utils/machine-credentials.js';
+import { readProjectMarker } from '../src/utils/project-marker.js';
+import { deriveProjectPin } from '../src/utils/port.js';
+import { makeTempDir, rmTempDir, fakeResponse } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+interface RedeemBody {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  scope?: string;
+  server_url?: string;
+}
+
+/** A fetch that records the redeem request and returns a fixed response. */
+function redeemFetch(
+  response: { ok: boolean; status: number; body: string },
+  captured: { url?: string; method?: string; body?: unknown } = {},
+): typeof fetch {
+  return (async (url: string, init: RequestInit) => {
+    captured.url = String(url);
+    captured.method = init?.method;
+    captured.body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    return fakeResponse(response);
+  }) as unknown as typeof fetch;
+}
+
+function ok(body: RedeemBody): { ok: true; status: 200; body: string } {
+  return { ok: true, status: 200, body: JSON.stringify(body) };
+}
+
+describe('enrollPlugin', () => {
+  it('redeems and persists credential to the shared machine store + writes the marker + pin', async () => {
+    const store = tmp();
+    const project = tmp();
+    // A pre-existing manually-added Claude Code config (workflow 1A step 1).
+    fs.writeFileSync(
+      path.join(project, '.mcp.json'),
+      JSON.stringify({ mcpServers: { 'ai-game-developer': { type: 'http', url: 'https://ai-game.dev/mcp' } } }, null, 2),
+    );
+
+    const captured: { url?: string; method?: string; body?: unknown } = {};
+    const r = await enrollPlugin({
+      enrollCode: 'ABCD-1234',
+      projectDir: project,
+      storeBaseDir: store,
+      nowImpl: () => 1_000_000,
+      fetchImpl: redeemFetch(
+        ok({ access_token: 'plugin-jwt', refresh_token: 'refresh-1', expires_in: 3600, scope: 'mcp:plugin', server_url: 'https://ai-game.dev' }),
+        captured,
+      ),
+    });
+
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+
+    // Request shape: POST /api/auth/enroll/redeem with { enroll_code }.
+    expect(captured.url).toBe('https://ai-game.dev/api/auth/enroll/redeem');
+    expect(captured.method).toBe('POST');
+    expect(captured.body).toEqual({ enroll_code: 'ABCD-1234' });
+
+    // Credential landed in the machine store (NOT a project .env).
+    const stored = await new MachineCredentialStore(store).read();
+    expect(stored?.accessToken).toBe('plugin-jwt');
+    expect(stored?.refreshToken).toBe('refresh-1');
+    expect(stored?.serverTarget).toBe('https://ai-game.dev');
+    expect(stored?.expiresAt).toBe(new Date(1_000_000 + 3600 * 1000).toISOString());
+    expect(fs.existsSync(path.join(project, '.env'))).toBe(false);
+
+    // Marker recorded the server target.
+    expect(readProjectMarker(project)).toEqual({ serverTarget: 'https://ai-game.dev' });
+
+    // Pin upserted into the existing project-local config.
+    const pin = deriveProjectPin(project);
+    expect(r.pin).toBe(pin);
+    expect(r.pinnedConfigFiles).toContain(path.join(project, '.mcp.json'));
+    const parsed = JSON.parse(fs.readFileSync(path.join(project, '.mcp.json'), 'utf-8'));
+    expect(parsed.mcpServers['ai-game-developer'].url).toBe(`https://ai-game.dev/mcp/p/${pin}`);
+  });
+
+  it('records a LOCAL server target when the code was minted for a localhost RS', async () => {
+    const store = tmp();
+    const project = tmp();
+    const r = await enrollPlugin({
+      enrollCode: 'code',
+      projectDir: project,
+      storeBaseDir: store,
+      fetchImpl: redeemFetch(ok({ access_token: 't', server_url: 'http://localhost:24567' })),
+    });
+    expect(r.kind).toBe('success');
+    expect(readProjectMarker(project)).toEqual({ serverTarget: 'http://localhost:24567' });
+  });
+
+  it('surfaces a clean, uniform error for a spent/invalid code (no oracle)', async () => {
+    const store = tmp();
+    const project = tmp();
+    const r = await enrollPlugin({
+      enrollCode: 'spent',
+      projectDir: project,
+      storeBaseDir: store,
+      fetchImpl: redeemFetch({
+        ok: false,
+        status: 400,
+        body: JSON.stringify({ error: 'invalid_grant', error_description: 'invalid code' }),
+      }),
+    });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') {
+      expect(r.reason).toBe('invalid_code');
+      expect(r.error.message).toMatch(/single-use|invalid|expired/i);
+    }
+    // Nothing was persisted on failure.
+    expect(new MachineCredentialStore(store).exists()).toBe(false);
+    expect(readProjectMarker(project)).toBeNull();
+  });
+
+  it('surfaces a distinct signing-unavailable error on 503', async () => {
+    const r = await enrollPlugin({
+      enrollCode: 'code',
+      projectDir: tmp(),
+      storeBaseDir: tmp(),
+      fetchImpl: redeemFetch({ ok: false, status: 503, body: '{}' }),
+    });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.reason).toBe('signing_unavailable');
+  });
+
+  it('rejects a blank enrollment code without hitting the network', async () => {
+    let called = false;
+    const r = await enrollPlugin({
+      enrollCode: '   ',
+      projectDir: tmp(),
+      storeBaseDir: tmp(),
+      fetchImpl: (async () => {
+        called = true;
+        return fakeResponse({ ok: true, status: 200, body: '{}' });
+      }) as unknown as typeof fetch,
+    });
+    expect(r.kind).toBe('failure');
+    expect(called).toBe(false);
+  });
+});

--- a/cli/tests/install-plugin.test.ts
+++ b/cli/tests/install-plugin.test.ts
@@ -207,3 +207,111 @@ describe('removePlugin', () => {
     if (r.kind === 'success') expect(r.removed).toBe(false);
   });
 });
+
+describe('installPlugin --with-server', () => {
+  it('downloads the server after the plugin install and records its path', async () => {
+    const project = tmp();
+    const source = makePluginSource();
+    let called: unknown;
+    const r = await installPlugin({
+      projectDir: project,
+      pluginSourceDir: source,
+      withServer: true,
+      serverVersion: '9.0.0',
+      downloadServerImpl: async (opts) => {
+        called = opts;
+        return { kind: 'success', success: true, serverPath: '/managed/gamedev-mcp-server.exe', source: 'download', version: '9.0.0', warnings: [] };
+      },
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(r.serverPath).toBe('/managed/gamedev-mcp-server.exe');
+    expect(r.serverVersion).toBe('9.0.0');
+    expect((called as { projectDir: string }).projectDir).toBe(project);
+    expect((called as { version?: string }).version).toBe('9.0.0');
+  });
+
+  it('forwards --server-source to the download resolver', async () => {
+    const project = tmp();
+    const source = makePluginSource();
+    let seenSource: string | undefined;
+    await installPlugin({
+      projectDir: project,
+      pluginSourceDir: source,
+      withServer: true,
+      serverSource: '/local/server.zip',
+      downloadServerImpl: async (opts) => {
+        seenSource = opts.source;
+        return { kind: 'success', success: true, serverPath: '/x', source: 'source', version: '9.0.0', warnings: [] };
+      },
+    });
+    expect(seenSource).toBe('/local/server.zip');
+  });
+
+  it('degrades a server-download failure to a warning (plugin still installed)', async () => {
+    const project = tmp();
+    const source = makePluginSource();
+    const r = await installPlugin({
+      projectDir: project,
+      pluginSourceDir: source,
+      withServer: true,
+      downloadServerImpl: async () => ({ kind: 'failure', success: false, warnings: [], error: new Error('offline') }),
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind === 'success') {
+      expect(r.serverPath).toBeUndefined();
+      expect(r.warnings.join(' ')).toMatch(/--with-server/);
+    }
+  });
+});
+
+describe('installPlugin --enroll', () => {
+  it('redeems the code after the plugin install and records enrollment fields', async () => {
+    const project = tmp();
+    const source = makePluginSource();
+    let seenCode: string | undefined;
+    const r = await installPlugin({
+      projectDir: project,
+      pluginSourceDir: source,
+      enrollCode: 'ABCD-1234',
+      enrollImpl: async (opts) => {
+        seenCode = opts.enrollCode;
+        return {
+          kind: 'success',
+          success: true,
+          token: 't',
+          serverTarget: 'https://ai-game.dev',
+          credentialPath: '/store/credentials.json',
+          markerPath: path.join(opts.projectDir, '.ai-game-dev', 'project.json'),
+          pin: 'abcd1234',
+          pinnedConfigFiles: [path.join(opts.projectDir, '.mcp.json')],
+          warnings: [],
+        };
+      },
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    expect(seenCode).toBe('ABCD-1234');
+    expect(r.enrolled).toBe(true);
+    expect(r.serverTarget).toBe('https://ai-game.dev');
+    expect(r.pin).toBe('abcd1234');
+  });
+
+  it('surfaces an enroll failure as an overall failure (noting the plugin was installed)', async () => {
+    const project = tmp();
+    const source = makePluginSource();
+    const r = await installPlugin({
+      projectDir: project,
+      pluginSourceDir: source,
+      enrollCode: 'spent',
+      enrollImpl: async () => ({ kind: 'failure', success: false, reason: 'invalid_code', error: new Error('bad code') }),
+    });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') {
+      expect(r.error.message).toMatch(/Plugin installed/);
+      expect(r.error.message).toMatch(/enrollment failed/i);
+    }
+    // The plugin was still materialized on disk.
+    expect(fs.existsSync(path.join(project, 'Plugins', 'UnrealMCP', 'UnrealMCP.uplugin'))).toBe(true);
+  });
+});

--- a/cli/tests/pin-upsert.test.ts
+++ b/cli/tests/pin-upsert.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  pinnedUrl,
+  originMatches,
+  applyPinToConfigText,
+  projectLocalAgentConfigPaths,
+  upsertProjectPin,
+} from '../src/utils/pin-upsert.js';
+
+const PIN = 'deadbeef';
+
+describe('pinnedUrl', () => {
+  it('appends /p/<pin> after a hosted /mcp path', () => {
+    expect(pinnedUrl('https://ai-game.dev/mcp', PIN)).toBe('https://ai-game.dev/mcp/p/deadbeef');
+  });
+
+  it('appends /p/<pin> to a bare local origin', () => {
+    expect(pinnedUrl('http://localhost:24567', PIN)).toBe('http://localhost:24567/p/deadbeef');
+  });
+
+  it('is idempotent — replaces an existing stale pin segment, never nests', () => {
+    const once = pinnedUrl('https://ai-game.dev/mcp', PIN);
+    expect(pinnedUrl(once, PIN)).toBe(once);
+    expect(pinnedUrl('https://ai-game.dev/mcp/p/00112233', PIN)).toBe('https://ai-game.dev/mcp/p/deadbeef');
+  });
+
+  it('leaves a non-URL string unchanged', () => {
+    expect(pinnedUrl('not a url', PIN)).toBe('not a url');
+  });
+});
+
+describe('originMatches', () => {
+  it('matches by origin when a serverTarget is given', () => {
+    expect(originMatches('https://ai-game.dev/mcp', 'https://ai-game.dev')).toBe(true);
+    expect(originMatches('https://evil.example/mcp', 'https://ai-game.dev')).toBe(false);
+    expect(originMatches('http://localhost:8080/mcp', 'http://localhost:8080')).toBe(true);
+    expect(originMatches('http://localhost:9999/mcp', 'http://localhost:8080')).toBe(false);
+  });
+
+  it('falls back to ai-game.dev + loopback hosts when no target', () => {
+    expect(originMatches('https://ai-game.dev/mcp')).toBe(true);
+    expect(originMatches('http://localhost:1234')).toBe(true);
+    expect(originMatches('https://example.com/mcp')).toBe(false);
+  });
+});
+
+describe('applyPinToConfigText', () => {
+  it('rewrites a JSON url value, preserving formatting', () => {
+    const src = '{\n  "mcpServers": {\n    "ai-game-developer": {\n      "type": "http",\n      "url": "https://ai-game.dev/mcp"\n    }\n  }\n}';
+    const { text, changed } = applyPinToConfigText(src, PIN, 'https://ai-game.dev');
+    expect(changed).toBe(true);
+    expect(text).toContain('"url": "https://ai-game.dev/mcp/p/deadbeef"');
+    // Formatting untouched apart from the URL token.
+    expect(text).toContain('"type": "http"');
+  });
+
+  it('rewrites a TOML url value', () => {
+    const src = '[mcp_servers.unreal-mcp]\nenabled = true\nurl = "https://ai-game.dev/mcp"\n';
+    const { text, changed } = applyPinToConfigText(src, PIN, 'https://ai-game.dev');
+    expect(changed).toBe(true);
+    expect(text).toContain('url = "https://ai-game.dev/mcp/p/deadbeef"');
+  });
+
+  it('rewrites the Antigravity serverUrl key', () => {
+    const src = '{ "mcpServers": { "x": { "serverUrl": "https://ai-game.dev/mcp" } } }';
+    const { text, changed } = applyPinToConfigText(src, PIN, 'https://ai-game.dev');
+    expect(changed).toBe(true);
+    expect(text).toContain('"serverUrl": "https://ai-game.dev/mcp/p/deadbeef"');
+  });
+
+  it('does NOT rewrite a non-matching origin', () => {
+    const src = '{ "mcpServers": { "other": { "url": "https://other.example/mcp" } } }';
+    const { text, changed } = applyPinToConfigText(src, PIN, 'https://ai-game.dev');
+    expect(changed).toBe(false);
+    expect(text).toBe(src);
+  });
+
+  it('is a no-op when already pinned', () => {
+    const src = '{ "url": "https://ai-game.dev/mcp/p/deadbeef" }';
+    const { changed } = applyPinToConfigText(src, PIN, 'https://ai-game.dev');
+    expect(changed).toBe(false);
+  });
+});
+
+describe('projectLocalAgentConfigPaths', () => {
+  it('returns only paths under the project root (no global/home configs)', () => {
+    const projectDir = path.resolve('/tmp/some-unreal-project');
+    const paths = projectLocalAgentConfigPaths(projectDir);
+    expect(paths.length).toBeGreaterThan(0);
+    for (const p of paths) {
+      expect(p.startsWith(projectDir)).toBe(true);
+    }
+    // A known project-local config (Claude Code .mcp.json) is included; a known
+    // global one (Claude Desktop) is not.
+    expect(paths).toContain(path.join(projectDir, '.mcp.json'));
+    expect(paths.some((p) => p.includes('claude_desktop_config.json'))).toBe(false);
+  });
+});
+
+describe('upsertProjectPin (filesystem)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'unreal-mcp-pin-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('pins a manually-added Claude Code .mcp.json server URL', () => {
+    const mcpJson = path.join(dir, '.mcp.json');
+    fs.writeFileSync(
+      mcpJson,
+      JSON.stringify({ mcpServers: { 'ai-game-developer': { type: 'http', url: 'https://ai-game.dev/mcp' } } }, null, 2),
+    );
+    const result = upsertProjectPin(dir, PIN, { serverTarget: 'https://ai-game.dev' });
+    expect(result.updatedFiles).toEqual([mcpJson]);
+    const parsed = JSON.parse(fs.readFileSync(mcpJson, 'utf-8'));
+    expect(parsed.mcpServers['ai-game-developer'].url).toBe('https://ai-game.dev/mcp/p/deadbeef');
+  });
+
+  it('skips configs with no matching server and reports no updates', () => {
+    const mcpJson = path.join(dir, '.mcp.json');
+    fs.writeFileSync(mcpJson, JSON.stringify({ mcpServers: { other: { url: 'https://other.example/mcp' } } }));
+    const result = upsertProjectPin(dir, PIN, { serverTarget: 'https://ai-game.dev' });
+    expect(result.updatedFiles).toEqual([]);
+  });
+
+  it('is idempotent across re-runs', () => {
+    const configPath = path.join(dir, 'mcp.json');
+    fs.writeFileSync(configPath, JSON.stringify({ mcpServers: { x: { url: 'https://ai-game.dev/mcp' } } }));
+    upsertProjectPin(dir, PIN, { serverTarget: 'https://ai-game.dev', configPaths: [configPath] });
+    const second = upsertProjectPin(dir, PIN, { serverTarget: 'https://ai-game.dev', configPaths: [configPath] });
+    expect(second.updatedFiles).toEqual([]);
+  });
+});

--- a/cli/tests/port.test.ts
+++ b/cli/tests/port.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generatePortFromDirectory, normalizeProjectRoot } from '../src/utils/port.js';
+import { generatePortFromDirectory, normalizeProjectRoot, deriveProjectPin } from '../src/utils/port.js';
 
 describe('generatePortFromDirectory', () => {
   it('is deterministic and in the 20000-29999 range', () => {
@@ -59,5 +59,32 @@ describe('generatePortFromDirectory — ProjectIdentity golden-vector parity', (
     // The naive path a bad port would hash: 'İ'.toLowerCase() === 'i̇'.
     expect(normalizeProjectRoot('/home/İstanbul/game')).toContain('İ');
     expect(normalizeProjectRoot('/home/İstanbul/game')).not.toContain('̇');
+  });
+});
+
+// The D14 routing pin shares the ProjectIdentity derivation with the port, so it
+// is gated by the SAME golden vectors (ProjectIdentity.GoldenVectors.json `pin`
+// field). `deriveProjectPin` MUST reproduce every `pin` byte-for-byte.
+describe('deriveProjectPin — ProjectIdentity golden-vector parity', () => {
+  const VECTORS: ReadonlyArray<{ path: string; pin: string; note: string }> = [
+    { path: '/home/user/my-game', pin: '34ea75f2', note: 'POSIX typical project path' },
+    { path: '/home/user/my-game/', pin: '34ea75f2', note: 'trailing slash trimmed → identical' },
+    { path: '/home/USER/My-Game', pin: '34ea75f2', note: 'case-folded → identical' },
+    { path: 'C:\\Users\\user\\my-game', pin: '8ef72cf7', note: 'Windows backslash form' },
+    { path: 'C:\\Users\\user\\my-game\\', pin: '8ef72cf7', note: 'trailing backslash trimmed → identical' },
+    { path: 'C:/Users/user/my-game', pin: '5a87324e', note: 'forward-slash form DIFFERS (separators not normalized)' },
+    { path: '/home/İstanbul/game', pin: '672d80a7', note: 'U+0130 — ToLowerInvariant leaves it unchanged' },
+    { path: '/srv/games/space sim', pin: '08c6cbb6', note: 'path containing a space' },
+  ];
+
+  for (const v of VECTORS) {
+    it(`derives ${v.pin} for ${JSON.stringify(v.path)} (${v.note})`, () => {
+      expect(deriveProjectPin(v.path)).toBe(v.pin);
+    });
+  }
+
+  it('is 8 lowercase hex chars and independent of any port override', () => {
+    const pin = deriveProjectPin('/home/user/my-game');
+    expect(pin).toMatch(/^[0-9a-f]{8}$/);
   });
 });

--- a/cli/tests/project-marker.test.ts
+++ b/cli/tests/project-marker.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  readProjectMarker,
+  writeProjectMarker,
+  serializeProjectMarker,
+  upsertServerTarget,
+  projectMarkerPath,
+  PROJECT_MARKER_DIR,
+  PROJECT_MARKER_FILE,
+} from '../src/utils/project-marker.js';
+
+describe('project-marker', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'unreal-mcp-marker-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reads null when no marker exists', () => {
+    expect(readProjectMarker(dir)).toBeNull();
+  });
+
+  it('writes camelCase, 2-space-indented JSON at .ai-game-dev/project.json (C# byte-compat)', () => {
+    const written = writeProjectMarker(dir, { serverTarget: 'https://ai-game.dev', portOverride: 24567 });
+    expect(written).toBe(path.join(dir, PROJECT_MARKER_DIR, PROJECT_MARKER_FILE));
+    const raw = fs.readFileSync(written, 'utf-8');
+    expect(raw).toBe('{\n  "serverTarget": "https://ai-game.dev",\n  "portOverride": 24567\n}');
+  });
+
+  it('omits null/blank fields on serialize', () => {
+    expect(serializeProjectMarker({ serverTarget: 'https://ai-game.dev' })).toBe(
+      '{\n  "serverTarget": "https://ai-game.dev"\n}',
+    );
+    expect(serializeProjectMarker({})).toBe('{}');
+    expect(serializeProjectMarker({ serverTarget: '' })).toBe('{}');
+  });
+
+  it('round-trips serverTarget + portOverride', () => {
+    writeProjectMarker(dir, { serverTarget: 'http://localhost:24567', portOverride: 24567 });
+    const marker = readProjectMarker(dir);
+    expect(marker).toEqual({ serverTarget: 'http://localhost:24567', portOverride: 24567 });
+  });
+
+  it('tolerates a blank marker file (→ {}) and a garbage marker (→ {})', () => {
+    const p = projectMarkerPath(dir);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, '   ');
+    expect(readProjectMarker(dir)).toEqual({});
+    fs.writeFileSync(p, 'not json {{{');
+    expect(readProjectMarker(dir)).toEqual({});
+  });
+
+  it('ignores unknown fields on read (forwards-compatible)', () => {
+    const p = projectMarkerPath(dir);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, JSON.stringify({ serverTarget: 'https://ai-game.dev', futureField: 42 }));
+    expect(readProjectMarker(dir)).toEqual({ serverTarget: 'https://ai-game.dev' });
+  });
+
+  it('tolerates a UTF-8 BOM', () => {
+    const p = projectMarkerPath(dir);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, '﻿' + JSON.stringify({ serverTarget: 'https://ai-game.dev' }));
+    expect(readProjectMarker(dir)).toEqual({ serverTarget: 'https://ai-game.dev' });
+  });
+
+  describe('upsertServerTarget', () => {
+    it('records the server target, preserving an existing portOverride', () => {
+      writeProjectMarker(dir, { portOverride: 25001 });
+      const written = upsertServerTarget(dir, 'https://ai-game.dev');
+      expect(written).toBe(projectMarkerPath(dir));
+      expect(readProjectMarker(dir)).toEqual({ serverTarget: 'https://ai-game.dev', portOverride: 25001 });
+    });
+
+    it('creates the marker when none exists', () => {
+      upsertServerTarget(dir, 'http://localhost:8080');
+      expect(readProjectMarker(dir)).toEqual({ serverTarget: 'http://localhost:8080' });
+    });
+
+    it('is a no-op for a blank/undefined target', () => {
+      expect(upsertServerTarget(dir, '')).toBeNull();
+      expect(upsertServerTarget(dir, undefined)).toBeNull();
+      expect(readProjectMarker(dir)).toBeNull();
+    });
+
+    it('trims the target before writing', () => {
+      upsertServerTarget(dir, '  https://ai-game.dev  ');
+      expect(readProjectMarker(dir)).toEqual({ serverTarget: 'https://ai-game.dev' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **`install-plugin --with-server`** — download the RID-matched `gamedev-mcp-server` binary into the CLI-managed dir, SHA256SUMS-verified (fail-closed) via the existing flow; `--server-version <v>` (default `SERVER_VERSION` = 9.0.0) + `--server-source <path-or-url>` offline/CI escape hatch.
- **`install-plugin --enroll <code>` / `--enroll-stdin`** — redeem against the cloud AS `POST /api/auth/enroll/redeem`; persist the credential to the SHARED machine store; write the committable project marker `.ai-game-dev/project.json` (byte-compatible with the C# `ProjectMarker`) with the server target; upsert the D14 routing pin into existing project-local agent configs. `--enroll-stdin` keeps the code out of argv/shell history.
- **`configure --agent <id>`** — proxy to the managed server binary's `configure` subcommand (shared C# configurator registry).
- `port.ts` gains `deriveProjectPin` (first 4 bytes of the ProjectIdentity SHA256), gated by the same golden vectors as the port.

Final Unreal CLI PR of the mcp-authorize **f2** task (design refs `06-engine-plugins`, `09-user-workflows`). CLI-PR1 (login → machine store) landed in #220; the plugin+sidecar (f1) is on `main`.

No CLI version bump / no `npm publish` — the `unreal-mcp-cli` rides the plugin release.

## Test plan
- [x] `cli/` vitest green (full suite; new: enroll, project-marker, pin-upsert, configure-agent, download-server `--server-source`, `deriveProjectPin` golden parity, install-plugin wiring, `--enroll-stdin` stdin-only integration).
- [x] RID-detect + SHA256 fail-closed covered; golden-vector parity (`port.ts`) stays green.
- [x] `tsc` clean.

Closes #222