### PR TITLE
chore(deps): re-pin McpPlugin 7.0.0-preview.1 -> 7.0.0 stable

### DIFF
--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -51,7 +51,7 @@
 
   <!--
     Reused NuGet pins — normally owned by the upstream release pipelines and kept in lockstep
-    with Godot-MCP (Godot-MCP.csproj). Current: McpPlugin 7.0.0-preview.1 + ReflectorNet 5.3.2.
+    with Godot-MCP (Godot-MCP.csproj). Current: McpPlugin 7.0.0 + ReflectorNet 5.3.2.
     The MCP/reflection stack is NOT forked. Historical context: the 6.8.0 bump consumed the new
     shared engine-agnostic com.IvanMurzak.McpPlugin.AgentConfig module (the AI-agent configurators
     + the AgentConfiguratorDescription UI-DTO) so the sidecar hosts the AI-agent configuration
@@ -65,18 +65,18 @@
     Sections passthrough in AgentConfigService.Describe. 6.11.0 was a minor bump keeping ReflectorNet
     5.3.1.
     ⚠ DEVIATION (mcp-authorize f1, PR 1/~6 — maintainer-authorized dependency-freshness bump, per the
-    PIPELINE.md "Freshness-bump carve-out"): 6.11.0 -> 7.0.0-preview.1 is the breaking-major adoption
+    PIPELINE.md "Freshness-bump carve-out"): 6.11.0 -> 7.0.0 is the breaking-major adoption
     of the mcp-authorize connection layer. In 7.0 ConnectionConfig's static bearer becomes a credential
     PROVIDER (the migrated call sites live in Host/SidecarHost.cs); this PR migrates the existing
     static-token flow onto that new API shape, behavior-preserving, with NO new auth features (RFC 8628
-    device flow, machine credential store, etc. land in later PRs). 7.0.0-preview.1
+    device flow, machine credential store, etc. land in later PRs). 7.0.0
     transitively requires ReflectorNet >= 5.3.2, so its explicit pin advances 5.3.1 -> 5.3.2 in the
     same bump (NU1605 downgrade otherwise). Both versions are published on nuget.org. The Godot-MCP
     lockstep is temporarily broken until the sibling Godot adoption PR lands.
   -->
   <ItemGroup>
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.2" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.0.0-preview.1" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.0.0" />
   </ItemGroup>
 
   <!-- The xUnit suite exercises a couple of internal helpers (e.g. ProxyTool.CalculateTokenCount). -->


### PR DESCRIPTION
Re-pin the bridge (.NET sidecar) `com.IvanMurzak.Unreal.MCP.Bridge.csproj` from McpPlugin `7.0.0-preview.1` to the now-published **stable `7.0.0`** (Phase-4 prep before the Unreal release). No code behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)