### PR TITLE
fix(cli): setup-mcp writes credential-free URL-only config for OAuth clients

### DIFF
--- a/cli/src/lib/setup-mcp.ts
+++ b/cli/src/lib/setup-mcp.ts
@@ -39,6 +39,34 @@ export function listAgentIds(): string[] {
   return getAgentIds();
 }
 
+/**
+ * Decide whether `setup-mcp` should write a static `Authorization: Bearer` header
+ * into an http client config. Pure — exported for unit tests.
+ *
+ * Design decision D11 / Flow A: an OAuth-capable interactive client (Claude Code,
+ * Cursor, Codex, Copilot, …) must receive a CREDENTIAL-FREE, URL-only config so it
+ * performs its own native RFC 9728 OAuth against the endpoint. A static Bearer
+ * header (a) is rejected by the hosted OAuth server (401) and (b) SUPPRESSES the
+ * client's own OAuth handshake ("OAuth fallback is disabled when headers.
+ * Authorization is set"). So a header is written ONLY when a credential is present
+ * AND either the client is NOT OAuth-capable (`supportsOAuth:false`) OR the caller
+ * EXPLICITLY opted into a PAT (passed `--token`) — Flow C, the recommended path for
+ * headless CI / self-hosted required-auth against a non-OAuth endpoint. An ambient
+ * token (resolved from the project `.env` / process env) never forces a header onto
+ * an OAuth-capable client. Mirrors the shared b6 C# configurators / `configure --agent`.
+ */
+export function shouldWriteAuthHeader(args: {
+  /** The resolved credential (`''` when none). */
+  token: string;
+  /** The agent's OAuth capability (`AgentDefinition.supportsOAuth`). */
+  supportsOAuth: boolean;
+  /** `true` when the user EXPLICITLY supplied a token (PAT opt-in), not an ambient one. */
+  explicitPatOptIn: boolean;
+}): boolean {
+  if (args.token.length === 0) return false;
+  return !args.supportsOAuth || args.explicitPatOptIn;
+}
+
 export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
   const warnings: string[] = [];
   const nextSteps: string[] = [];
@@ -96,7 +124,18 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
       // this avoids the historical `/mcp` double-append.
       const httpUrl = appendMcp(conn.url);
       const token = conn.token ?? '';
-      props = agent.getHttpProps(httpUrl, token, token.length > 0);
+      // D11 / Flow A: OAuth-capable clients get a CREDENTIAL-FREE, URL-only config
+      // so they run their own native OAuth; a static Bearer header is emitted only
+      // for a non-OAuth client (`supportsOAuth:false`) or an EXPLICIT PAT opt-in
+      // (the caller passed `--token`) — Flow C. An ambient token (from the project
+      // `.env` / process env) never forces a header. See `shouldWriteAuthHeader`.
+      const explicitPatOptIn = (opts.token ?? '').trim().length > 0;
+      const writeAuthHeader = shouldWriteAuthHeader({
+        token,
+        supportsOAuth: agent.supportsOAuth,
+        explicitPatOptIn,
+      });
+      props = agent.getHttpProps(httpUrl, token, writeAuthHeader);
       removeKeys = agent.httpRemoveKeys;
     }
 

--- a/cli/src/utils/agents.ts
+++ b/cli/src/utils/agents.ts
@@ -40,6 +40,18 @@ export interface AgentDefinition {
   configPathDisplay: string;
   /** Config-file serialization format. `toml` is the Codex branch. */
   configFormat: 'json' | 'toml';
+  /**
+   * Whether this client performs its OWN native RFC 9728 OAuth against an
+   * OAuth-protected MCP endpoint (design decision D11 / Flow A). `true` for every
+   * interactive client — the b6 configurator default. When `true`, `setup-mcp`
+   * writes a CREDENTIAL-FREE, URL-only http config (no `Authorization` header) so
+   * the client runs its own OAuth handshake: a static Bearer header is both
+   * rejected by the hosted OAuth server (401) AND suppresses the client's own
+   * flow ("OAuth fallback is disabled when headers.Authorization is set"). A
+   * static header is emitted only for a `supportsOAuth:false` client OR an
+   * explicit PAT opt-in (Flow C) — see `lib/setup-mcp.ts` `shouldWriteAuthHeader`.
+   */
+  supportsOAuth: boolean;
   bodyPath: string;
   /** Resolve the absolute config-file path for a given project root. */
   getConfigPath(projectPath: string): string;
@@ -99,6 +111,17 @@ function stdioArgs(port: number, auth: string, token: string): string[] {
   ];
 }
 
+/**
+ * Build the `{ Authorization: Bearer <token> }` header object for an http server
+ * entry, or `undefined` to omit it entirely.
+ *
+ * `authRequired` is the FINAL "write a static Bearer header?" decision, computed
+ * by the caller (`lib/setup-mcp.ts` `shouldWriteAuthHeader`) from the agent's
+ * `supportsOAuth` capability + whether the user explicitly opted into a PAT.
+ * OAuth-capable clients (Flow A) receive a credential-free, URL-only config, so
+ * the caller passes `false` for them unless a PAT was explicitly supplied — the
+ * static Bearer header is the PAT / non-OAuth fallback only (Flow C).
+ */
 function authHeaders(
   token: string,
   authRequired: boolean,
@@ -123,6 +146,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
     skillsPath: '.claude/skills',
     configPathDisplay: '.mcp.json',
     configFormat: 'json',
+    supportsOAuth: true,
     bodyPath: 'mcpServers',
     getConfigPath: (p) => path.join(p, '.mcp.json'),
     getStdioProps: (serverPath, port, auth, token) => ({
@@ -135,7 +159,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
       ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
     }),
     stdioRemoveKeys: ['type', 'url'],
-    httpRemoveKeys: ['command', 'args'],
+    httpRemoveKeys: ['command', 'args', 'headers'],
   },
 
   // ── Claude Desktop ───────────────────────────────────────────
@@ -145,6 +169,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
     skillsPath: null,
     configPathDisplay: '~/Claude/claude_desktop_config.json',
     configFormat: 'json',
+    supportsOAuth: true,
     bodyPath: 'mcpServers',
     getConfigPath: () => {
       if (isWindows()) {
@@ -166,7 +191,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
       ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
     }),
     stdioRemoveKeys: ['url'],
-    httpRemoveKeys: ['command', 'args'],
+    httpRemoveKeys: ['command', 'args', 'headers'],
   },
 
   // ── Cursor ───────────────────────────────────────────────────
@@ -176,6 +201,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
     skillsPath: '.cursor/skills',
     configPathDisplay: '.cursor/mcp.json',
     configFormat: 'json',
+    supportsOAuth: true,
     bodyPath: 'mcpServers',
     getConfigPath: (p) => path.join(p, '.cursor', 'mcp.json'),
     getStdioProps: (serverPath, port, auth, token) => ({
@@ -189,7 +215,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
       ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
     }),
     stdioRemoveKeys: ['url'],
-    httpRemoveKeys: ['command', 'args'],
+    httpRemoveKeys: ['command', 'args', 'headers'],
   },
 
   // ── VS Code (Copilot) ────────────────────────────────────────
@@ -199,6 +225,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
     skillsPath: '.github/skills',
     configPathDisplay: '.vscode/mcp.json',
     configFormat: 'json',
+    supportsOAuth: true,
     bodyPath: 'servers',
     getConfigPath: (p) => path.join(p, '.vscode', 'mcp.json'),
     getStdioProps: (serverPath, port, auth, token) => ({
@@ -212,7 +239,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
       ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
     }),
     stdioRemoveKeys: ['url'],
-    httpRemoveKeys: ['command', 'args'],
+    httpRemoveKeys: ['command', 'args', 'headers'],
   },
 
   // ── Visual Studio (Copilot) ──────────────────────────────────
@@ -222,6 +249,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
     skillsPath: '.github/skills',
     configPathDisplay: '.vs/mcp.json',
     configFormat: 'json',
+    supportsOAuth: true,
     bodyPath: 'servers',
     getConfigPath: (p) => path.join(p, '.vs', 'mcp.json'),
     getStdioProps: (serverPath, port, auth, token) => ({
@@ -235,7 +263,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
       ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
     }),
     stdioRemoveKeys: ['url'],
-    httpRemoveKeys: ['command', 'args'],
+    httpRemoveKeys: ['command', 'args', 'headers'],
   },
 
   // ── Rider (Junie) ───────────────────────────────────────────
@@ -245,6 +273,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
     skillsPath: '.junie/skills',
     configPathDisplay: '.junie/mcp/mcp.json',
     configFormat: 'json',
+    supportsOAuth: true,
     bodyPath: 'mcpServers',
     getConfigPath: (p) => path.join(p, '.junie', 'mcp', 'mcp.json'),
     getStdioProps: (serverPath, port, auth, token) => ({
@@ -260,7 +289,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
       ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
     }),
     stdioRemoveKeys: ['disabled', 'url'],
-    httpRemoveKeys: ['disabled', 'command', 'args'],
+    httpRemoveKeys: ['disabled', 'command', 'args', 'headers'],
   },
 
   // ── GitHub Copilot CLI ──────────────────────────────────────
@@ -270,6 +299,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
     skillsPath: '.github/skills',
     configPathDisplay: '~/.copilot/mcp-config.json',
     configFormat: 'json',
+    supportsOAuth: true,
     bodyPath: 'mcpServers',
     getConfigPath: () => path.join(home(), '.copilot', 'mcp-config.json'),
     getStdioProps: (serverPath, port, auth, token) => ({
@@ -284,7 +314,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
       ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
     }),
     stdioRemoveKeys: ['url', 'type'],
-    httpRemoveKeys: ['command', 'args'],
+    httpRemoveKeys: ['command', 'args', 'headers'],
   },
 
   // ── Gemini ──────────────────────────────────────────────────
@@ -294,6 +324,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
     skillsPath: '.gemini/skills',
     configPathDisplay: '.gemini/settings.json',
     configFormat: 'json',
+    supportsOAuth: true,
     bodyPath: 'mcpServers',
     getConfigPath: (p) => path.join(p, '.gemini', 'settings.json'),
     getStdioProps: (serverPath, port, auth, token) => ({
@@ -307,7 +338,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
       ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
     }),
     stdioRemoveKeys: ['url'],
-    httpRemoveKeys: ['command', 'args'],
+    httpRemoveKeys: ['command', 'args', 'headers'],
   },
 
   // ── Antigravity ─────────────────────────────────────────────
@@ -317,6 +348,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
     skillsPath: '.agent/skills',
     configPathDisplay: '~/.gemini/config/mcp_config.json',
     configFormat: 'json',
+    supportsOAuth: true,
     bodyPath: 'mcpServers',
     getConfigPath: () => path.join(home(), '.gemini', 'config', 'mcp_config.json'),
     // Antigravity uses a `serverUrl` key (not `url`) and a `disabled` flag.
@@ -340,6 +372,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
     skillsPath: '.cline/skills',
     configPathDisplay: '~/Code/globalStorage/.../cline_mcp_settings.json',
     configFormat: 'json',
+    supportsOAuth: true,
     bodyPath: 'mcpServers',
     getConfigPath: () => {
       if (isWindows()) {
@@ -369,7 +402,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
       ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
     }),
     stdioRemoveKeys: ['url'],
-    httpRemoveKeys: ['command', 'args'],
+    httpRemoveKeys: ['command', 'args', 'headers'],
   },
 
   // ── Open Code ───────────────────────────────────────────────
@@ -379,6 +412,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
     skillsPath: '.opencode/skills',
     configPathDisplay: 'opencode.json',
     configFormat: 'json',
+    supportsOAuth: true,
     bodyPath: 'mcp',
     getConfigPath: (p) => path.join(p, 'opencode.json'),
     getStdioProps: (serverPath, port, auth, token) => ({
@@ -393,7 +427,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
       ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
     }),
     stdioRemoveKeys: ['url', 'args'],
-    httpRemoveKeys: ['command', 'args'],
+    httpRemoveKeys: ['command', 'args', 'headers'],
   },
 
   // ── Codex (TOML config) ─────────────────────────────────────
@@ -403,6 +437,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
     skillsPath: '.agents/skills',
     configPathDisplay: '.codex/config.toml',
     configFormat: 'toml',
+    supportsOAuth: true,
     bodyPath: 'mcp_servers',
     getConfigPath: (p) => path.join(p, '.codex', 'config.toml'),
     // Codex's stdio arg vector omits the bearer token (it is not accepted on
@@ -430,6 +465,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
     skillsPath: '.kilocode/skills',
     configPathDisplay: '.kilocode/mcp.json',
     configFormat: 'json',
+    supportsOAuth: true,
     bodyPath: 'mcpServers',
     getConfigPath: (p) => path.join(p, '.kilocode', 'mcp.json'),
     getStdioProps: (serverPath, port, auth, token) => ({
@@ -445,7 +481,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
       ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
     }),
     stdioRemoveKeys: ['url'],
-    httpRemoveKeys: ['command', 'args'],
+    httpRemoveKeys: ['command', 'args', 'headers'],
   },
 
   // ── Custom (generic mcpServers entry written to a caller path) ─
@@ -455,6 +491,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
     skillsPath: null,
     configPathDisplay: 'mcp.json',
     configFormat: 'json',
+    supportsOAuth: true,
     bodyPath: 'mcpServers',
     getConfigPath: (p) => path.join(p, 'mcp.json'),
     getStdioProps: (serverPath, port, auth, token) => ({
@@ -468,7 +505,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
       ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
     }),
     stdioRemoveKeys: ['url'],
-    httpRemoveKeys: ['command', 'args'],
+    httpRemoveKeys: ['command', 'args', 'headers'],
   },
 ] as const;
 

--- a/cli/tests/setup-mcp.test.ts
+++ b/cli/tests/setup-mcp.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
-import { setupMcp, listAgentIds } from '../src/lib/setup-mcp.js';
+import { setupMcp, listAgentIds, shouldWriteAuthHeader } from '../src/lib/setup-mcp.js';
 import { agentRegistry, getAgentById, getAgentIds, MCP_SERVER_NAME } from '../src/utils/agents.js';
 import { makeTempDir, rmTempDir } from './helpers.js';
 
@@ -58,6 +58,13 @@ describe('agent roster', () => {
       expect(['json', 'toml']).toContain(a.configFormat);
       expect(typeof a.bodyPath).toBe('string');
       expect(a.bodyPath.length).toBeGreaterThan(0);
+      expect(typeof a.supportsOAuth).toBe('boolean');
+    }
+  });
+
+  it('every agent is OAuth-capable (supportsOAuth true — b6 / D11 default)', () => {
+    for (const a of agentRegistry) {
+      expect(a.supportsOAuth).toBe(true);
     }
   });
 
@@ -138,7 +145,7 @@ describe('setupMcp — http transport', () => {
     expect(written.mcpServers['unreal-mcp'].type).toBe('http');
   });
 
-  it('adds a bearer header when a token is supplied', async () => {
+  it('adds a bearer header when a token is EXPLICITLY supplied (PAT opt-in / Flow C)', async () => {
     const dir = tmp();
     const r = await setupMcp({ agentId: 'claude-code', projectDir: dir, transport: 'http', url: 'http://h', token: 'tok' });
     expect(r.kind).toBe('success');
@@ -187,6 +194,88 @@ describe('setupMcp — http transport', () => {
     expect(fs.existsSync(r.configPath)).toBe(false);
     expect(r.snippet).toContain('unreal-mcp');
     expect(r.snippet).toContain('http://h/mcp');
+  });
+});
+
+describe('setupMcp — D11 credential-free OAuth config (http)', () => {
+  // The flagship fix: OAuth-capable interactive clients must get a URL-only
+  // `{type,url}` config with NO Authorization header, so the client performs its
+  // own native RFC 9728 OAuth. A static Bearer header both 401s against the hosted
+  // AS and suppresses the client's OAuth handshake.
+  for (const agentId of ['claude-code', 'cursor', 'vscode-copilot']) {
+    it(`writes URL-only ${agentId} config (no Authorization header) with no token`, async () => {
+      const dir = tmp();
+      const r = await setupMcp({ agentId, projectDir: dir, transport: 'http', url: 'https://ai-game.dev' });
+      expect(r.kind).toBe('success');
+      if (r.kind !== 'success') return;
+      const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
+      const body = getAgentById(agentId)!.bodyPath;
+      const entry = written[body]['unreal-mcp'];
+      expect(entry.type).toBe('http');
+      expect(entry.url).toBe('https://ai-game.dev/mcp');
+      expect(entry.headers).toBeUndefined();
+    });
+  }
+
+  it('writes URL-only codex (TOML) config with no Authorization', async () => {
+    const dir = tmp();
+    const r = await setupMcp({ agentId: 'codex', projectDir: dir, transport: 'http', url: 'https://ai-game.dev' });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    const content = fs.readFileSync(r.configPath, 'utf-8');
+    expect(content).toContain('url = "https://ai-game.dev/mcp"');
+    expect(content.toLowerCase()).not.toContain('authorization');
+  });
+
+  it('an AMBIENT token (project .env) does NOT inject a header for an OAuth client (the bug)', async () => {
+    const dir = tmp();
+    // Simulate a project whose .env carries a token — the exact pre-fix condition
+    // that used to inject a static Bearer header and break the client's OAuth.
+    fs.writeFileSync(
+      path.join(dir, '.env'),
+      'UNREAL_MCP_HOST=https://ai-game.dev\nUNREAL_MCP_TOKEN=ambient-pat\n',
+      'utf-8',
+    );
+    const r = await setupMcp({ agentId: 'claude-code', projectDir: dir, transport: 'http' });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    const entry = JSON.parse(fs.readFileSync(r.configPath, 'utf-8')).mcpServers['unreal-mcp'];
+    expect(entry.url).toBe('https://ai-game.dev/mcp');
+    expect(entry.headers).toBeUndefined();
+  });
+
+  it('a re-run over a config that still has a stale Authorization header strips it', async () => {
+    const dir = tmp();
+    // Pre-fix state left on disk by an older buggy run: a lingering Bearer header.
+    fs.writeFileSync(
+      path.join(dir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: { 'unreal-mcp': { type: 'http', url: 'https://ai-game.dev/mcp', headers: { Authorization: 'Bearer stale' } } },
+      }),
+      'utf-8',
+    );
+    const r = await setupMcp({ agentId: 'claude-code', projectDir: dir, transport: 'http', url: 'https://ai-game.dev' });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    const entry = JSON.parse(fs.readFileSync(r.configPath, 'utf-8')).mcpServers['unreal-mcp'];
+    expect(entry.url).toBe('https://ai-game.dev/mcp');
+    expect(entry.headers).toBeUndefined();
+  });
+});
+
+describe('shouldWriteAuthHeader (pure decision)', () => {
+  it('OAuth-capable client with an ambient token → no header (URL-only)', () => {
+    expect(shouldWriteAuthHeader({ token: 'ambient', supportsOAuth: true, explicitPatOptIn: false })).toBe(false);
+  });
+  it('OAuth-capable client with an EXPLICIT PAT opt-in → header (Flow C)', () => {
+    expect(shouldWriteAuthHeader({ token: 'pat', supportsOAuth: true, explicitPatOptIn: true })).toBe(true);
+  });
+  it('non-OAuth client with a token → header (fallback), even without explicit opt-in', () => {
+    expect(shouldWriteAuthHeader({ token: 'tok', supportsOAuth: false, explicitPatOptIn: false })).toBe(true);
+  });
+  it('no token → never a header, regardless of the other flags', () => {
+    expect(shouldWriteAuthHeader({ token: '', supportsOAuth: false, explicitPatOptIn: true })).toBe(false);
+    expect(shouldWriteAuthHeader({ token: '', supportsOAuth: true, explicitPatOptIn: false })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- `setup-mcp` no longer injects a static `Authorization: Bearer` header for OAuth-capable interactive clients (Claude Code, Cursor, Codex, Copilot). They now get a credential-free, URL-only `{type,url}` http config so the client performs its own native RFC 9728 OAuth against the hosted endpoint (Flow A). The old static header 401'd against the hosted AS and suppressed the client's OAuth handshake.
- Added a `supportsOAuth` capability to the agent registry (default true, per the b6 configurators / D11) and centralized the decision in a pure, unit-tested `shouldWriteAuthHeader`.
- A static Bearer header is still written for a `supportsOAuth:false` client OR an explicit PAT opt-in (`--token`) — Flow C. An ambient `.env`/env token no longer forces a header.
- Added `headers` to the http `removeKeys` so a re-config strips a stale header left by the old behavior.

Scope: `cli/` config generation only — no plugin/bridge/editor changes. Mirrors the shared b6 C# configurators / this CLI's `configure --agent` path.

## Test plan
- [x] Target-specific local tests passed (cli Suite 6: `tsc` + `vitest run`, 429 passed / 0 failed; 11 new setup-mcp tests including URL-only for claude-code/cursor/codex/copilot, ambient-token regression, stale-header strip, and the `shouldWriteAuthHeader` truth table).
- [x] Drove the real CLI: `setup-mcp claude-code --url https://ai-game.dev` → `{type,url}` with no headers; `--token agd_pat_demo` → header written.

Closes #227