### PR TITLE
feat: local self-hosted auth none/oauth/token + sidecar launch-arg consolidation (mcp-authorize g5/g6)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
@@ -76,17 +76,21 @@ namespace
 		return false;
 	}
 
-	// The auth-option string the dev-control surface speaks ("none"/"required") — matches the §7 segmented control.
+	// The auth-option string the dev-control surface speaks ("none"/"oauth"/"token") — matches the §7 segmented control.
 	const TCHAR* DevControlAuthOptionLabel(EUnrealMcpAuthOption Option)
 	{
-		return Option == EUnrealMcpAuthOption::Required ? TEXT("required") : TEXT("none");
+		return FUnrealMcpConfig::AuthOptionToString(Option);
 	}
 
-	// Parse a "none"/"required" auth-option string (case-insensitive). Returns true + the option on a match.
+	// Parse a "none"/"oauth"/"token" auth-option string (case-insensitive; legacy "required" maps to token via the
+	// shared migration). Returns true + the option on a match.
 	bool DevControlParseAuthOption(const FString& Raw, EUnrealMcpAuthOption& OutOption)
 	{
-		if (Raw.Equals(TEXT("none"), ESearchCase::IgnoreCase))     { OutOption = EUnrealMcpAuthOption::None;     return true; }
-		if (Raw.Equals(TEXT("required"), ESearchCase::IgnoreCase)) { OutOption = EUnrealMcpAuthOption::Required; return true; }
+		if (Raw.Equals(TEXT("none"), ESearchCase::IgnoreCase))  { OutOption = EUnrealMcpAuthOption::None;  return true; }
+		if (Raw.Equals(TEXT("oauth"), ESearchCase::IgnoreCase)) { OutOption = EUnrealMcpAuthOption::Oauth; return true; }
+		if (Raw.Equals(TEXT("token"), ESearchCase::IgnoreCase)) { OutOption = EUnrealMcpAuthOption::Token; return true; }
+		// Legacy back-compat: an old dev-control client still sending "required" maps to token (the g5 migration).
+		if (Raw.Equals(TEXT("required"), ESearchCase::IgnoreCase)) { OutOption = EUnrealMcpAuthOption::Token; return true; }
 		return false;
 	}
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
@@ -31,7 +31,7 @@
 
 // Single source of the consumed shared-server version. Kept in lockstep with cli/src/lib/server-version.ts
 // (SERVER_VERSION) and Unity's McpServerManager.ServerVersion — the three plugins consume the SAME server.
-const TCHAR* FUnrealMcpServerManager::ServerVersion = TEXT("9.0.0");
+const TCHAR* FUnrealMcpServerManager::ServerVersion = TEXT("9.1.0");
 const TCHAR* FUnrealMcpServerManager::ServerPathEnvVar = TEXT("UNREAL_MCP_SERVER_PATH");
 
 namespace
@@ -150,17 +150,6 @@ int32 FUnrealMcpServerManager::ParsePortFromHost(const FString& HostUrl, int32 D
 	if (bHadScheme)
 		return bHttps ? 443 : 80;
 	return DefaultPort;
-}
-
-FString FUnrealMcpServerManager::BuildLaunchArgs(int32 Port, int32 PluginTimeoutMs, bool bAuthRequired, const FString& Token)
-{
-	// Unity BuildArguments parity. client-transport is ALWAYS streamableHttp for a launched local server.
-	FString Args = FString::Printf(
-		TEXT("port=%d plugin-timeout=%d client-transport=streamableHttp authorization=%s"),
-		Port, PluginTimeoutMs, bAuthRequired ? TEXT("required") : TEXT("none"));
-	if (bAuthRequired && !Token.IsEmpty())
-		Args += FString::Printf(TEXT(" token=%s"), *Token);
-	return Args;
 }
 
 bool FUnrealMcpServerManager::IsLaunchAllowed(bool bIsCustomMode, bool bIsHttpTransport)
@@ -568,7 +557,7 @@ void FUnrealMcpServerManager::BindProcessToKillOnCloseJob(void* ProcessHandle)
 #endif
 }
 
-bool FUnrealMcpServerManager::Start(int32 Port, int32 PluginTimeoutMs, bool bAuthRequired, const FString& Token)
+bool FUnrealMcpServerManager::Start(int32 Port, const FString& InLaunchArgs)
 {
 	if (IsRunning() || bStarting)
 	{
@@ -578,7 +567,9 @@ bool FUnrealMcpServerManager::Start(int32 Port, int32 PluginTimeoutMs, bool bAut
 
 	bStarting = true;
 	ListenPort = Port;
-	LaunchArgs = BuildLaunchArgs(Port, PluginTimeoutMs, bAuthRequired, Token);
+	// mcp-authorize g5/g6: LaunchArgs are pre-composed by the .NET sidecar's shared ServerLaunchArguments builder
+	// and passed in — this manager never assembles the none/oauth/token arg string.
+	LaunchArgs = InLaunchArgs;
 
 	// Resolve the binary (override → cache); download on a miss.
 	BinaryPath = ResolveBinaryPath();
@@ -615,7 +606,7 @@ bool FUnrealMcpServerManager::Start(int32 Port, int32 PluginTimeoutMs, bool bAut
 	return true;
 }
 
-bool FUnrealMcpServerManager::ReattachIfRunning(int32 Port, int32 PluginTimeoutMs, bool bAuthRequired, const FString& Token)
+bool FUnrealMcpServerManager::ReattachIfRunning(int32 Port, const FString& InLaunchArgs)
 {
 	const int32 SavedPid = ReadPidFile();
 	if (SavedPid <= 0 || !IsServerProcessAlive(SavedPid))
@@ -633,7 +624,7 @@ bool FUnrealMcpServerManager::ReattachIfRunning(int32 Port, int32 PluginTimeoutM
 	}
 
 	ListenPort = Port;
-	LaunchArgs = BuildLaunchArgs(Port, PluginTimeoutMs, bAuthRequired, Token);
+	LaunchArgs = InLaunchArgs; // pre-composed by the sidecar (g5/g6) — used by the watchdog's respawn closure.
 	BinaryPath = ResolveBinaryPath();
 	{
 		FScopeLock Lock(&ProcessMutex);

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.h
@@ -40,15 +40,18 @@ public:
 	UNREALMCPEDITOR_API ~FUnrealMcpServerManager();
 
 	/**
-	 * Launch + supervise the local server on @p Port with the given launch parameters (auth/token). Resolves
-	 * the binary (override → cache → download), kills any orphaned `gamedev-mcp-server` already holding @p Port,
-	 * spawns the process, then arms the crash-restart watchdog (which detects an early exit and re-launches with
-	 * backoff). Returns true when the process was spawned (supervision proceeds asynchronously). Idempotent:
-	 * a call while already running/starting is a no-op that returns true. Game-thread only.
+	 * Launch + supervise the local server on @p Port with the pre-composed @p LaunchArgs. Resolves the binary
+	 * (override → cache → download), kills any orphaned `gamedev-mcp-server` already holding @p Port, spawns the
+	 * process, then arms the crash-restart watchdog (which detects an early exit and re-launches with backoff).
+	 * Returns true when the process was spawned (supervision proceeds asynchronously). Idempotent: a call while
+	 * already running/starting is a no-op that returns true. Game-thread only.
 	 *
-	 * @p bAuthRequired / @p Token shape the `authorization` + `token` launch args exactly like Unity's BuildArguments.
+	 * mcp-authorize g5/g6 consolidation: @p LaunchArgs is composed by the .NET sidecar's SHARED
+	 * ServerLaunchArguments builder (none/oauth/token) and delivered over IPC — this manager NEVER assembles the
+	 * arg string itself. The caller (FUnrealMcpEditorCoordinator) requests it via SendServerLaunchArgsRequest and
+	 * calls Start in the async result callback, so the args are always the freshly-resolved auth mode.
 	 */
-	bool Start(int32 Port, int32 PluginTimeoutMs, bool bAuthRequired, const FString& Token);
+	bool Start(int32 Port, const FString& LaunchArgs);
 
 	/**
 	 * Stop the supervised server. Stops the watchdog first (so a relaunch cannot undo the kill), then sends the
@@ -69,7 +72,7 @@ public:
 	 * still names a live `gamedev-mcp-server`, adopt it (so a later Stop tears it down) and re-arm the watchdog;
 	 * otherwise clear the stale marker. Returns true when an existing process was adopted. Game-thread only.
 	 */
-	bool ReattachIfRunning(int32 Port, int32 PluginTimeoutMs, bool bAuthRequired, const FString& Token);
+	bool ReattachIfRunning(int32 Port, const FString& LaunchArgs);
 
 	// --- Pure / static helpers (the spec-friendly heart — no live process, injectable filesystem). ---
 
@@ -103,15 +106,6 @@ public:
 	 * server listens on, so both are derived from the SAME Custom host the UI shows (mirrors Unity's Port).
 	 */
 	static UNREALMCPEDITOR_API int32 ParsePortFromHost(const FString& HostUrl, int32 DefaultPort = 8080);
-
-	/**
-	 * Compose the server launch args (Unity BuildArguments parity, the order the server's CLI parser expects):
-	 *   port=<port> plugin-timeout=<ms> client-transport=streamableHttp authorization=<none|required> [token=<t>]
-	 * The token arg is appended ONLY when @p bAuthRequired AND @p Token is non-empty. Pure — exercised by a spec.
-	 * The transport is ALWAYS streamableHttp for a launched local server (the agent's stdio/http choice is about
-	 * how the AGENT reaches the server, not how the server is hosted) — matching Unity's hard-coded launch transport.
-	 */
-	static UNREALMCPEDITOR_API FString BuildLaunchArgs(int32 Port, int32 PluginTimeoutMs, bool bAuthRequired, const FString& Token);
 
 	/**
 	 * Whether the local server may be launched for the given mode + transport. ONLY Custom mode + http transport

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentWidgets.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpAgentWidgets.h
@@ -156,7 +156,7 @@ namespace UnrealMcpAgentWidgets
  * Provided:
  *   - StyledCard       → the rounded rgba(20,40,69,0.2) frame-group container (Unity .frame-group).
  *   - SectionHeader    → a 20px-bold section title (Unity .header).
- *   - SegmentedControl → the tab-like Custom/Cloud · stdio/http · none/required toggle (Unity .segmented-control).
+ *   - SegmentedControl → the tab-like Custom/Cloud · stdio/http · none/oauth/token toggle (Unity .segmented-control).
  *   - StatusDot        → a 14px online/offline/ring connection dot (Unity .status-indicator-circle*).
  *   - PrimaryButton / AlertButton / SecondaryButton / GoldenButton → the styled buttons (Unity .btn-*).
  *   - IconButton       → a button with a leading icon brush + label (Unity .btn-with-icon).

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -47,8 +47,10 @@ namespace
 	constexpr int32 TagCloud  = 1;
 	constexpr int32 TagStdio  = 0;
 	constexpr int32 TagHttp   = 1;
-	constexpr int32 TagNone   = 0;
-	constexpr int32 TagRequired = 1;
+	// Auth segment (mcp-authorize g5/g6): the 3-way none / oauth / token local-server auth mode.
+	constexpr int32 TagNone  = 0;
+	constexpr int32 TagOauth = 1;
+	constexpr int32 TagToken = 2;
 
 	// The Log Level options in Unity's LogLevel.cs order (Runtime/Utils/LogLevel.cs): Trace, Debug, Info,
 	// Warning, Error, Exception, None. Rendered 1:1 in the §7 Log Level dropdown (issue #80 item 1).
@@ -797,7 +799,7 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildTransportSelector()
 TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCustomAuthSelector()
 {
 	return SNew(SVerticalBox)
-		// Authorization Token (none / required) row — label fills, segmented right-aligned to the shared edge.
+		// Authorization (none / oauth / token) row — label fills, segmented right-aligned to the shared edge.
 		+ SVerticalBox::Slot().AutoHeight()
 		[
 			SNew(SHorizontalBox)
@@ -805,30 +807,45 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCustomAuthSelector()
 			[
 				SNew(STextBlock)
 				.TextStyle(&FUnrealMcpStyle::Get().GetWidgetStyle<FTextBlockStyle>("UnrealMcp.Text.Description"))
-				.Text(LOCTEXT("AuthTokenLabel", "Authorization Token"))
+				.Text(LOCTEXT("AuthTokenLabel", "Authorization"))
 			]
 			+ SHorizontalBox::Slot().AutoWidth().HAlign(HAlign_Right).VAlign(VAlign_Center)
 			[
 				SNew(SBox).MinDesiredWidth(RightControlColumnWidth).HAlign(HAlign_Right)
 				[
 					UnrealMcpStyleWidgets::SegmentedControl(
-						{ { LOCTEXT("AuthNone", "none"), TagNone }, { LOCTEXT("AuthRequired", "required"), TagRequired } },
-						[this]() { return (IsViewModelValid() && ViewModel->GetAuthOption() == EUnrealMcpAuthOption::Required) ? TagRequired : TagNone; },
+						{ { LOCTEXT("AuthNone", "none"), TagNone }, { LOCTEXT("AuthOauth", "oauth"), TagOauth }, { LOCTEXT("AuthToken", "token"), TagToken } },
+						[this]() -> int32
+						{
+							if (!IsViewModelValid())
+								return TagNone;
+							switch (ViewModel->GetAuthOption())
+							{
+								case EUnrealMcpAuthOption::Oauth: return TagOauth;
+								case EUnrealMcpAuthOption::Token: return TagToken;
+								default:                          return TagNone;
+							}
+						},
 						[this](int32 SegTag)
 						{
-							if (IsViewModelValid())
-								ViewModel->SetAuthOption(SegTag == TagRequired ? EUnrealMcpAuthOption::Required : EUnrealMcpAuthOption::None);
+							if (!IsViewModelValid())
+								return;
+							const EUnrealMcpAuthOption Option =
+								SegTag == TagOauth ? EUnrealMcpAuthOption::Oauth :
+								SegTag == TagToken ? EUnrealMcpAuthOption::Token :
+								EUnrealMcpAuthOption::None;
+							ViewModel->SetAuthOption(Option);
 						})
 				]
 			]
 		]
-		// Masked token field + New — only when auth is required.
+		// Masked token field + New — only in Token mode (Oauth authorizes natively; None is anonymous).
 		+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
 		[
 			SNew(SHorizontalBox)
 			.Visibility_Lambda([this]()
 			{
-				return (IsViewModelValid() && ViewModel->GetAuthOption() == EUnrealMcpAuthOption::Required)
+				return (IsViewModelValid() && ViewModel->GetAuthOption() == EUnrealMcpAuthOption::Token)
 					? EVisibility::Visible : EVisibility::Collapsed;
 			})
 			+ SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center)

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAgentConfigModels.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpAgentConfigModels.cpp
@@ -18,18 +18,19 @@ FAiAgentConnectionInfo FAiAgentConnectionInfo::FromPluginConfig(const FUnrealMcp
 	const FString BaseUrl = bCloud ? Config.ResolveCloudBaseUrl() : Config.ResolveCustomHost();
 	Info.HttpUrl = BaseUrl + TEXT("/mcp");
 
-	// Auth: Cloud always requires it (the cloud enforces it); Custom follows AuthOption. The token is the
-	// mode-resolved effective bearer (Cloud→cloudToken, Custom+Required→token, else empty).
-	Info.bAuthRequired = bCloud || Config.AuthOption == EUnrealMcpAuthOption::Required;
+	// Auth (mcp-authorize g5/g6): Cloud always requires it (the cloud enforces it); Custom requires it in Oauth
+	// AND Token modes (None is anonymous/loopback). The token is the mode-resolved effective bearer
+	// (Cloud→cloudToken, Custom+Token→token, else empty — Oauth/None carry no static bearer).
+	Info.bAuthRequired = bCloud
+		|| Config.AuthOption == EUnrealMcpAuthOption::Oauth
+		|| Config.AuthOption == EUnrealMcpAuthOption::Token;
 	Info.Token = Config.ResolveEffectiveToken();
 
-	// mcp-authorize PR 5 (design 06, Flow C): the "Advanced: use access token" escape hatch. The DEFAULT path is
-	// native MCP OAuth (URL-only, no bearer) — with the device-flow machine credential store (PR 2) the token is no
-	// longer required input. Only an explicit Custom-mode Required-auth WITH a non-empty token opts into the legacy
-	// Bearer shape for clients that cannot do MCP OAuth. Cloud is ALWAYS native OAuth (its auth is server-enforced,
-	// never a user-pasted PAT), so it never triggers the escape hatch.
+	// The "write Authorization: Bearer <secret>" credential mode maps ONLY to Custom Token mode with a non-empty
+	// secret (g5/g6 DoD: "token → URL + Authorization: Bearer <local-secret>"). Cloud + Oauth are native MCP OAuth
+	// (URL-only config, the client authorizes itself); None is anonymous. So only Token opts into the Bearer shape.
 	Info.bUseAccessToken = !bCloud
-		&& Config.AuthOption == EUnrealMcpAuthOption::Required
+		&& Config.AuthOption == EUnrealMcpAuthOption::Token
 		&& !Info.Token.IsEmpty();
 
 	return Info;

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -40,7 +40,10 @@ void FUnrealMcpEditorViewModel::SetConnectionMode(EUnrealMcpConnectionMode InMod
 	if (InMode == EUnrealMcpConnectionMode::Cloud)
 	{
 		Config.SetTransportMethod(EUnrealMcpTransportMethod::Http);
-		Config.AuthOption = EUnrealMcpAuthOption::Required;
+		// Cloud auth is account-gated native OAuth (the cloud enforces it) — map to Oauth (the g5/g6 successor of
+		// the retired Required). The value is largely presentational in Cloud (bCloud independently drives
+		// bAuthRequired), but keeping it Oauth keeps the persisted intent coherent for a later switch back to Custom.
+		Config.AuthOption = EUnrealMcpAuthOption::Oauth;
 	}
 	// Bug #116: a mode switch RETARGETS the connection (Cloud↔Custom dial a different server). If we were showing
 	// Connected/Degraded against the now-abandoned target, the dot must drop off green THE MOMENT the mode flips —
@@ -158,8 +161,9 @@ void FUnrealMcpEditorViewModel::SetCustomToken(const FString& InToken)
 void FUnrealMcpEditorViewModel::GenerateCustomToken()
 {
 	Config.CustomToken = FUnrealMcpSidecarManager::GenerateToken();
-	// Generating a token only makes sense when auth is actually required — flip it so the new token is used.
-	Config.AuthOption = EUnrealMcpAuthOption::Required;
+	// Generating a local secret only makes sense in Token mode (the offline shared-secret path) — flip to Token
+	// so the new secret is launched (`auth=token token=<secret>`) and written as the client's Bearer credential.
+	Config.AuthOption = EUnrealMcpAuthOption::Token;
 	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] generated a new Custom-mode token (%s)."),
 		*FUnrealMcpConfig::MaskSecret(Config.CustomToken));
 	PersistAndPush();

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.cpp
@@ -249,6 +249,8 @@ void FUnrealMcpEditorCoordinator::Startup()
 	{
 		if (!ServerPtr)
 			return false;
+		if (ServerPtr->IsRunning())
+			return true; // already up — idempotent, no arg round-trip needed.
 		const int32 ServerPort = CoordinatorForStart->DerivedLocalServerPort;
 		if (ServerPort <= 0)
 		{
@@ -257,10 +259,13 @@ void FUnrealMcpEditorCoordinator::Startup()
 				TEXT("from the sidecar. Wait for the bridge to connect, then try again."));
 			return false;
 		}
+		// mcp-authorize g5/g6 consolidation: the launch-arg string is composed by the .NET sidecar's SHARED
+		// ServerLaunchArguments builder (none/oauth/token) — this C++ side never assembles it. Request the args over
+		// IPC; ApplyServerLaunchArgsResult runs Start with the returned string. Returns true = start INITIATED (the
+		// server-running sink polls IsRunning to reflect the actual state once the async Start completes).
 		const FUnrealMcpConfig Live = FUnrealMcpConfig::LoadAndResolve();
-		return ServerPtr->Start(
-			ServerPort, /*PluginTimeoutMs*/ 10000,
-			Live.AuthOption == EUnrealMcpAuthOption::Required, Live.ResolveEffectiveToken());
+		CoordinatorForStart->RequestServerLaunchArgs(ServerPort, /*PluginTimeoutMs*/ 10000, Live, /*bReattach*/ false);
+		return true;
 	};
 	ViewModel->OnStopLocalServer = [ServerPtr]()
 	{
@@ -312,6 +317,9 @@ void FUnrealMcpEditorCoordinator::Startup()
 				else if (Type == TEXT("project-config-result"))
 					// mcp-authorize PR 4: cache the sidecar-derived local-server port (and reattach a survivor on it).
 					CoordinatorPtr->ApplyProjectConfigResult(Message);
+				else if (Type == TEXT("server-launch-args-result"))
+					// mcp-authorize g5/g6: the sidecar composed the launch args — run the pending Start/reattach.
+					CoordinatorPtr->ApplyServerLaunchArgsResult(Message);
 			});
 		});
 
@@ -544,6 +552,11 @@ void FUnrealMcpEditorCoordinator::ApplyProjectConfigResult(const TSharedPtr<FJso
 	Message->TryGetBoolField(TEXT("portIsOverridden"), bPortIsOverridden);
 
 	DerivedLocalServerPort = DerivedPort;
+	// mcp-authorize g5/g6: cache the routing pin too — the oauth-mode launch args need public-url = the pinned
+	// loopback URL (http://localhost:<port>/mcp/p/<pin>) forwarded to the sidecar's shared builder.
+	FString Pin;
+	if (Message->TryGetStringField(TEXT("pin"), Pin))
+		DerivedLocalServerPin = Pin;
 	UE_LOG(LogUnrealMcp, Log, TEXT("[Unreal-MCP] resolved derived local-server port %d%s from the sidecar."),
 		DerivedPort, bPortIsOverridden ? TEXT(" [user override]") : TEXT(""));
 
@@ -556,11 +569,86 @@ void FUnrealMcpEditorCoordinator::ApplyProjectConfigResult(const TSharedPtr<FJso
 			Live.ConnectionMode == EUnrealMcpConnectionMode::Custom,
 			Live.ResolveEffectiveTransport() == EUnrealMcpTransportMethod::Http))
 	{
-		ServerManager->ReattachIfRunning(
-			DerivedPort, /*PluginTimeoutMs*/ 10000,
-			Live.AuthOption == EUnrealMcpAuthOption::Required, Live.ResolveEffectiveToken());
+		// g5/g6 consolidation: the reattach's launch args (used by the watchdog respawn) are also sidecar-composed —
+		// request them; ApplyServerLaunchArgsResult calls ReattachIfRunning with the returned string.
+		RequestServerLaunchArgs(DerivedPort, /*PluginTimeoutMs*/ 10000, Live, /*bReattach*/ true);
 	}
 	bLocalServerReattachAttempted = true;
+}
+
+void FUnrealMcpEditorCoordinator::RequestServerLaunchArgs(int32 Port, int32 PluginTimeoutMs, const FUnrealMcpConfig& Live, bool bReattach)
+{
+	// mcp-authorize g5/g6 consolidation. Game thread. Forward the resolved connection facts to the sidecar's SHARED
+	// ServerLaunchArguments builder; the C++ side NEVER assembles the arg string. The token/issuer/public-url are the
+	// mode-specific credentials the builder needs (fail-closed there on a missing one → ApplyServerLaunchArgsResult logs).
+	if (!BridgeServer.IsValid())
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] cannot request launch args: no bridge server."));
+		return;
+	}
+
+	const FString AuthMode = FUnrealMcpConfig::AuthOptionToString(Live.AuthOption);
+	const FString Token = Live.ResolveEffectiveToken(); // non-empty only in Token mode
+	FString AuthIssuer;
+	FString PublicUrl;
+	if (Live.AuthOption == EUnrealMcpAuthOption::Oauth)
+	{
+		// Loopback OAuth (design Part A): issuer = the resolved cloud base (the AS that mints loopback-audience
+		// tokens); public-url = the exact pinned loopback URL the client dials. Both must be present or the shared
+		// builder fails closed (never a silent auth=none downgrade).
+		AuthIssuer = Live.ResolveCloudBaseUrl();
+		if (!DerivedLocalServerPin.IsEmpty())
+			PublicUrl = FString::Printf(TEXT("http://localhost:%d/mcp/p/%s"), Port, *DerivedLocalServerPin);
+	}
+
+	const FString RequestId = FGuid::NewGuid().ToString();
+	PendingServerLaunches.Add(RequestId, FPendingServerLaunch{ Port, bReattach });
+	if (!BridgeServer->SendServerLaunchArgsRequest(RequestId, Port, PluginTimeoutMs, AuthMode, Token, AuthIssuer, PublicUrl))
+	{
+		PendingServerLaunches.Remove(RequestId);
+		UE_LOG(LogUnrealMcp, Warning,
+			TEXT("[Unreal-MCP] could not send the server-launch-args request (sidecar not connected); ")
+			TEXT("start again once the bridge is connected."));
+	}
+}
+
+void FUnrealMcpEditorCoordinator::ApplyServerLaunchArgsResult(const TSharedPtr<FJsonObject>& Message)
+{
+	// mcp-authorize g5/g6 consolidation. Game thread (the bridge status sink marshals onto it). Pop the pending
+	// Start/reattach for this requestId and run it with the sidecar-composed launch args. A malformed / not-ok /
+	// unknown-requestId result is a no-op (the token is never in this message — the sidecar never echoes it).
+	if (!Message.IsValid() || !ServerManager.IsValid())
+		return;
+
+	FString RequestId;
+	if (!Message->TryGetStringField(TEXT("requestId"), RequestId) || RequestId.IsEmpty())
+		return;
+
+	FPendingServerLaunch Pending;
+	if (!PendingServerLaunches.RemoveAndCopyValue(RequestId, Pending))
+		return; // unknown / already-handled requestId
+
+	bool bOk = false;
+	Message->TryGetBoolField(TEXT("ok"), bOk);
+	if (!bOk)
+	{
+		FString Error;
+		Message->TryGetStringField(TEXT("error"), Error);
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] server-launch-args-result not ok: %s"), *Error);
+		return;
+	}
+
+	FString Args;
+	if (!Message->TryGetStringField(TEXT("args"), Args) || Args.IsEmpty())
+	{
+		UE_LOG(LogUnrealMcp, Warning, TEXT("[Unreal-MCP] server-launch-args-result carried no args; not starting."));
+		return;
+	}
+
+	if (Pending.bReattach)
+		ServerManager->ReattachIfRunning(Pending.Port, Args);
+	else
+		ServerManager->Start(Pending.Port, Args);
 }
 
 void FUnrealMcpEditorCoordinator::Shutdown()

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UnrealMcpEditorCoordinator.h
@@ -50,6 +50,14 @@ public:
 	 */
 	void ApplyProjectConfigResult(const TSharedPtr<class FJsonObject>& Message);
 
+	/**
+	 * Handle a sidecar `server-launch-args-result` (mcp-authorize g5/g6 consolidation): the SHARED
+	 * ServerLaunchArguments builder composed the local-server launch-arg string, so now execute the pending
+	 * Start / reattach for the correlated requestId. Runs on the game thread (the bridge status sink marshals onto
+	 * it). A no-op on an `ok == false` / unknown-requestId result. Public so the wiring lambda routes to it.
+	 */
+	void ApplyServerLaunchArgsResult(const TSharedPtr<class FJsonObject>& Message);
+
 	FUnrealMcpToolRegistry* GetRegistry() const { return Registry.Get(); }
 	FUnrealMcpBridgeServer* GetBridgeServer() const { return BridgeServer.Get(); }
 	FUnrealMcpExtensionManager* GetExtensionManager() const { return ExtensionManager.Get(); }
@@ -92,9 +100,24 @@ private:
 	// the local `gamedev-mcp-server` start. Game-thread only (written from the game-thread-marshalled bridge
 	// status sink, read by the OnStartLocalServer sink), so no lock is needed.
 	int32 DerivedLocalServerPort = -1;
+	// mcp-authorize g5/g6: the sidecar-derived routing pin (first 8 hex of the ProjectIdentity SHA-256), cached
+	// alongside the port from the same `project-config-result`. Used to compose the oauth-mode `public-url`
+	// (http://localhost:<port>/mcp/p/<pin>) forwarded to the sidecar's launch-arg builder. Empty until the first result.
+	FString DerivedLocalServerPin;
 	// Guards the one-time survivor reattach: the reattach that used to run in Startup now runs when the first
 	// derived port arrives (the port is unknown until the sidecar handshakes) and must not repeat on a reconnect.
 	bool bLocalServerReattachAttempted = false;
+
+	// mcp-authorize g5/g6 consolidation: in-flight `server-launch-args` requests keyed by requestId. The
+	// OnStartLocalServer sink (and the one-time reattach) send an IPC request for the composed launch args and
+	// record the {port, bReattach} here; ApplyServerLaunchArgsResult pops the entry and runs Start/Reattach with the
+	// returned string. Game-thread only (both the send and the marshalled result run there) — no lock needed.
+	struct FPendingServerLaunch { int32 Port = -1; bool bReattach = false; };
+	TMap<FString, FPendingServerLaunch> PendingServerLaunches;
+
+	// Compose + send a `server-launch-args` IPC request for @p Live's resolved auth mode and, on the async result,
+	// Start (or, when @p bReattach, ReattachIfRunning) the local server on @p Port with the sidecar-built args.
+	void RequestServerLaunchArgs(int32 Port, int32 PluginTimeoutMs, const class FUnrealMcpConfig& Live, bool bReattach);
 
 	FDelegateHandle PreExitHandle;
 	bool bStarted = false;

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfigModelsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfigModelsSpec.cpp
@@ -261,9 +261,9 @@ void FUnrealMcpAgentConfigModelsSpec::Define()
 			TestTrue("httpUrl ends with /mcp", Info.HttpUrl.EndsWith(TEXT("/mcp")));
 		});
 
-		// mcp-authorize PR 5 (design 06, Flow C): bUseAccessToken drives the "Advanced: use access token" escape hatch.
-		// It is true ONLY for a Custom-mode Required-auth WITH a non-empty token — the default path (and Cloud, whose
-		// auth is server-enforced native OAuth, never a user PAT) stays on the credential-free OAuth path.
+		// mcp-authorize g5/g6: bUseAccessToken (the "write Authorization: Bearer <secret>" credential mode) is true
+		// ONLY for Custom-mode Token-auth WITH a non-empty secret. None (anonymous), Oauth (native OAuth — the client
+		// authorizes itself), and Cloud (server-enforced OAuth, never a user PAT) all stay on the credential-free path.
 		It("does not opt into the access-token escape hatch on the default Custom path", [this]()
 		{
 			FUnrealMcpConfig Config;
@@ -274,23 +274,35 @@ void FUnrealMcpAgentConfigModelsSpec::Define()
 			TestFalse("no escape hatch on default path", Info.bUseAccessToken);
 		});
 
-		It("opts into the access-token escape hatch for Custom + Required + a token", [this]()
+		It("does not opt into the access-token escape hatch in Oauth mode (native OAuth, URL-only)", [this]()
 		{
 			FUnrealMcpConfig Config;
 			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
 			Config.CustomHost = TEXT("http://localhost:8080");
-			Config.AuthOption = EUnrealMcpAuthOption::Required;
+			Config.AuthOption = EUnrealMcpAuthOption::Oauth;
+			Config.CustomToken = TEXT("pat-secret-value"); // stored but NOT written as a bearer in Oauth mode
+			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, FString(), 31234);
+			TestTrue("oauth requires auth", Info.bAuthRequired);
+			TestFalse("no bearer written in oauth mode", Info.bUseAccessToken);
+		});
+
+		It("opts into the access-token escape hatch for Custom + Token + a secret", [this]()
+		{
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.CustomHost = TEXT("http://localhost:8080");
+			Config.AuthOption = EUnrealMcpAuthOption::Token;
 			Config.CustomToken = TEXT("pat-secret-value");
 			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, FString(), 31234);
 			TestTrue("escape hatch active", Info.bUseAccessToken);
 			TestEqual("token forwarded", Info.Token, FString(TEXT("pat-secret-value")));
 		});
 
-		It("does not opt in for Custom + Required but an EMPTY token", [this]()
+		It("does not opt in for Custom + Token but an EMPTY secret", [this]()
 		{
 			FUnrealMcpConfig Config;
 			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
-			Config.AuthOption = EUnrealMcpAuthOption::Required;
+			Config.AuthOption = EUnrealMcpAuthOption::Token;
 			Config.CustomToken = FString();
 			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, FString(), 31234);
 			TestFalse("no token → no escape hatch", Info.bUseAccessToken);

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConfigSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConfigSpec.cpp
@@ -182,7 +182,7 @@ void FUnrealMcpConfigSpec::Define()
 
 	Describe("token routing + effective config", [this]()
 	{
-		It("Custom + None sends no bearer; Custom + Required sends the custom token", [this]()
+		It("Custom + None/Oauth send no bearer; Custom + Token sends the custom token", [this]()
 		{
 			FUnrealMcpConfig Config;
 			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
@@ -196,8 +196,49 @@ void FUnrealMcpConfigSpec::Define()
 			TestEqual(TEXT("custom token stored"), Config.CustomToken, FString(TEXT("the-custom-token")));
 			TestTrue(TEXT("effective token empty under None"), Config.ResolveEffectiveToken().IsEmpty());
 
-			Config.AuthOption = EUnrealMcpAuthOption::Required;
-			TestEqual(TEXT("effective token under Required"), Config.ResolveEffectiveToken(), FString(TEXT("the-custom-token")));
+			// Oauth mode is native OAuth (the client authorizes itself) — still NO static bearer on the wire.
+			Config.AuthOption = EUnrealMcpAuthOption::Oauth;
+			TestTrue(TEXT("effective token empty under Oauth"), Config.ResolveEffectiveToken().IsEmpty());
+
+			// Only Token mode (the offline shared secret) puts the custom token on the wire.
+			Config.AuthOption = EUnrealMcpAuthOption::Token;
+			TestEqual(TEXT("effective token under Token"), Config.ResolveEffectiveToken(), FString(TEXT("the-custom-token")));
+		});
+
+		It("migrates a persisted legacy authOption \"Required\" to Token (g5/g6)", [this]()
+		{
+			// A config saved by a pre-g5 plugin carries authOption:"Required". On load it must migrate to Token so the
+			// user keeps a working (offline-secret) local server instead of emitting the retired `required` value that
+			// crashes the 9.x server. And re-serializing must persist the migrated "Token" (the migration sticks).
+			TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+			Json->SetStringField(TEXT("connectionMode"), TEXT("Custom"));
+			Json->SetStringField(TEXT("authOption"), TEXT("Required"));
+			Json->SetStringField(TEXT("token"), TEXT("legacy-secret"));
+
+			const FUnrealMcpConfig Config = FromDiskJson(Json);
+			TestEqual(TEXT("legacy Required migrated to Token"),
+				static_cast<int32>(Config.AuthOption), static_cast<int32>(EUnrealMcpAuthOption::Token));
+			TestEqual(TEXT("Token mode still sends the stored secret"), Config.ResolveEffectiveToken(), FString(TEXT("legacy-secret")));
+
+			const TSharedPtr<FJsonObject> Reserialized = Config.ToJson();
+			FString Persisted;
+			TestTrue(TEXT("authOption persisted"), Reserialized->TryGetStringField(TEXT("authOption"), Persisted));
+			TestEqual(TEXT("re-serializes as Token, not Required"), Persisted, FString(TEXT("Token")));
+		});
+
+		It("round-trips a persisted Oauth authOption", [this]()
+		{
+			TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+			Json->SetStringField(TEXT("connectionMode"), TEXT("Custom"));
+			Json->SetStringField(TEXT("authOption"), TEXT("Oauth"));
+
+			const FUnrealMcpConfig Config = FromDiskJson(Json);
+			TestEqual(TEXT("Oauth parsed"), static_cast<int32>(Config.AuthOption), static_cast<int32>(EUnrealMcpAuthOption::Oauth));
+			// Oauth is native OAuth — no static bearer on the wire even if a token were stored.
+			TestTrue(TEXT("Oauth sends no bearer"), Config.ResolveEffectiveToken().IsEmpty());
+			FString Persisted;
+			Config.ToJson()->TryGetStringField(TEXT("authOption"), Persisted);
+			TestEqual(TEXT("re-serializes as Oauth"), Persisted, FString(TEXT("Oauth")));
 		});
 
 		It("routes the token to the cloud field in Cloud mode", [this]()

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDevControlSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDevControlSpec.cpp
@@ -136,7 +136,7 @@ void FUnrealMcpDevControlSpec::Define()
 			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
 			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
 			VM->SetTransportMethod(EUnrealMcpTransportMethod::Stdio);
-			VM->SetAuthOption(EUnrealMcpAuthOption::Required);
+			VM->SetAuthOption(EUnrealMcpAuthOption::Token);
 			VM->SetCustomToken(TEXT("super-secret-bearer-1234567890"));
 
 			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
@@ -147,7 +147,7 @@ void FUnrealMcpDevControlSpec::Define()
 			TestEqual("transport", Result->GetStringField(TEXT("transport")), FString(TEXT("stdio")));
 			TestTrue("transport selectable in Custom", Result->GetBoolField(TEXT("transportSelectable")));
 			// Auth option + token presence; the raw token is NEVER reported (§8) — only the masked form.
-			TestEqual("authOption", Result->GetStringField(TEXT("authOption")), FString(TEXT("required")));
+			TestEqual("authOption", Result->GetStringField(TEXT("authOption")), FString(TEXT("token")));
 			TestTrue("hasCustomToken", Result->GetBoolField(TEXT("hasCustomToken")));
 			const FString MaskedInState = Result->GetStringField(TEXT("customTokenMasked"));
 			TestFalse("masked token is not the raw value", MaskedInState.Equals(TEXT("super-secret-bearer-1234567890")));
@@ -556,11 +556,27 @@ void FUnrealMcpDevControlSpec::Define()
 
 			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
 			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
-				TEXT("POST"), TEXT("/control/auth-option"), DevCtlBody(TEXT("{\"option\":\"required\"}")), &VM.Get(), Result);
+				TEXT("POST"), TEXT("/control/auth-option"), DevCtlBody(TEXT("{\"option\":\"token\"}")), &VM.Get(), Result);
 
 			TestEqual("status", Status, 200);
-			TestEqual("auth option", VM->GetAuthOption(), EUnrealMcpAuthOption::Required);
-			TestEqual("echoed auth option", Result->GetStringField(TEXT("authOption")), FString(TEXT("required")));
+			TestEqual("auth option", VM->GetAuthOption(), EUnrealMcpAuthOption::Token);
+			TestEqual("echoed auth option", Result->GetStringField(TEXT("authOption")), FString(TEXT("token")));
+		});
+
+		It("migrates a legacy 'required' auth-option to token", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+
+			TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+			const int32 Status = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/control/auth-option"), DevCtlBody(TEXT("{\"option\":\"required\"}")), &VM.Get(), Result);
+
+			// g5/g6 back-compat: an old dev-control client sending "required" is migrated to Token, echoed as "token".
+			TestEqual("status", Status, 200);
+			TestEqual("legacy required migrates to token", VM->GetAuthOption(), EUnrealMcpAuthOption::Token);
+			TestEqual("echoed auth option", Result->GetStringField(TEXT("authOption")), FString(TEXT("token")));
 		});
 
 		It("rejects an invalid auth-option with 400", [this]()

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
@@ -283,7 +283,7 @@ void FUnrealMcpEditorViewModelSpec::Define()
 
 			VM->GenerateCustomToken();
 			TestFalse("token generated", VM->GetCustomToken().IsEmpty());
-			TestEqual("generating flips auth to Required", static_cast<int32>(VM->GetAuthOption()), static_cast<int32>(EUnrealMcpAuthOption::Required));
+			TestEqual("generating flips auth to Token", static_cast<int32>(VM->GetAuthOption()), static_cast<int32>(EUnrealMcpAuthOption::Token));
 			TestTrue("persisted at least once", Rec->PersistCount >= 1);
 		});
 	});
@@ -315,7 +315,7 @@ void FUnrealMcpEditorViewModelSpec::Define()
 			TestEqual("no-op host change did not notify", Notifications, 2);
 
 			// Auth option change toggles whether the snippet carries a bearer.
-			VM->SetAuthOption(EUnrealMcpAuthOption::Required);
+			VM->SetAuthOption(EUnrealMcpAuthOption::Token);
 			TestEqual("auth change notified", Notifications, 3);
 
 			// Token change is injected into the snippet/Configure output.
@@ -660,7 +660,7 @@ void FUnrealMcpEditorViewModelSpec::Define()
 			VM->OnConnectionSettingsChanged.Remove(Handle);
 		});
 
-		It("Cloud locks the transport to Http and forces auth Required (mirrors Unity)", [this]()
+		It("Cloud locks the transport to Http and forces auth Oauth (mirrors Unity)", [this]()
 		{
 			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
 			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
@@ -673,7 +673,8 @@ void FUnrealMcpEditorViewModelSpec::Define()
 			VM->SetConnectionMode(EUnrealMcpConnectionMode::Cloud);
 			TestFalse("transport not selectable in Cloud", VM->IsTransportSelectable());
 			TestEqual("Cloud effective transport is Http", static_cast<int32>(VM->GetEffectiveTransport()), static_cast<int32>(EUnrealMcpTransportMethod::Http));
-			TestEqual("Cloud forces auth Required", static_cast<int32>(VM->GetAuthOption()), static_cast<int32>(EUnrealMcpAuthOption::Required));
+			// Cloud is account-gated native OAuth — the g5/g6 successor of the retired Required.
+			TestEqual("Cloud forces auth Oauth", static_cast<int32>(VM->GetAuthOption()), static_cast<int32>(EUnrealMcpAuthOption::Oauth));
 
 			// A stray SetTransportMethod in Cloud is ignored (selector is locked).
 			VM->SetTransportMethod(EUnrealMcpTransportMethod::Stdio);

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpServerManagerSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpServerManagerSpec.cpp
@@ -129,36 +129,11 @@ void FUnrealMcpServerManagerSpec::Define()
 		});
 	});
 
-	Describe("BuildLaunchArgs", [this]()
-	{
-		It("composes Unity-parity args with streamableHttp and authorization=none (no token)", [this]()
-		{
-			const FString Args = FUnrealMcpServerManager::BuildLaunchArgs(8080, 10000, /*bAuthRequired*/ false, TEXT(""));
-			TestEqual(TEXT("none-auth args"), Args,
-				FString(TEXT("port=8080 plugin-timeout=10000 client-transport=streamableHttp authorization=none")));
-			TestFalse(TEXT("no token arg when auth is none"), Args.Contains(TEXT("token=")));
-		});
-
-		It("appends token= only when auth is required AND a token is present", [this]()
-		{
-			const FString WithToken = FUnrealMcpServerManager::BuildLaunchArgs(9000, 5000, /*bAuthRequired*/ true, TEXT("secret123"));
-			TestTrue(TEXT("required+token has authorization=required"), WithToken.Contains(TEXT("authorization=required")));
-			TestTrue(TEXT("required+token has token=secret123"), WithToken.Contains(TEXT("token=secret123")));
-
-			// Required but no token -> no token arg (matches Unity BuildArguments).
-			const FString NoToken = FUnrealMcpServerManager::BuildLaunchArgs(9000, 5000, /*bAuthRequired*/ true, TEXT(""));
-			TestTrue(TEXT("required+empty-token still authorization=required"), NoToken.Contains(TEXT("authorization=required")));
-			TestFalse(TEXT("required+empty-token has no token arg"), NoToken.Contains(TEXT("token=")));
-		});
-
-		It("always launches with client-transport=streamableHttp", [this]()
-		{
-			// The agent's stdio/http selection is about how the AGENT reaches the server; the launched server
-			// is always hosted over streamableHttp (Unity parity).
-			TestTrue(TEXT("transport is streamableHttp"),
-				FUnrealMcpServerManager::BuildLaunchArgs(1, 1, false, TEXT("")).Contains(TEXT("client-transport=streamableHttp")));
-		});
-	});
+	// NOTE (mcp-authorize g5/g6 consolidation): the launch-arg composition no longer lives in C++. The former
+	// FUnrealMcpServerManager::BuildLaunchArgs was DELETED — FUnrealMcpServerManager::Start now takes a pre-composed
+	// arg string, and the sidecar's SHARED com.IvanMurzak.McpPlugin.ServerLaunch.ServerLaunchArguments builder
+	// (none/oauth/token) composes it (covered by the bridge xUnit SidecarHostServerLaunchArgsTests). There is no C++
+	// arg-building logic left to spec here.
 
 	Describe("IsLaunchAllowed", [this]()
 	{
@@ -175,7 +150,7 @@ void FUnrealMcpServerManagerSpec::Define()
 	{
 		It("is pinned to the lockstep value (kept in sync with cli/src/lib/server-version.ts)", [this]()
 		{
-			TestEqual(TEXT("pinned server version"), FString(FUnrealMcpServerManager::ServerVersion), FString(TEXT("9.0.0")));
+			TestEqual(TEXT("pinned server version"), FString(FUnrealMcpServerManager::ServerVersion), FString(TEXT("9.1.0")));
 		});
 	});
 

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.cpp
@@ -57,6 +57,11 @@ namespace
 	// port, serverTarget} via the shared C# ProjectIdentity + project marker (no C++ derivation duplication).
 	const FString TypeProjectConfig = TEXT("project-config");
 	const FString TypeProjectConfigResult = TEXT("project-config-result");
+	// mcp-authorize g5/g6 consolidation: the plugin → sidecar `server-launch-args` request and the sidecar →
+	// plugin `server-launch-args-result`. The sidecar composes the local-server launch-arg string via the SHARED
+	// ServerLaunchArguments builder (none/oauth/token) so the C++ side holds no duplicate arg logic.
+	const FString TypeServerLaunchArgs = TEXT("server-launch-args");
+	const FString TypeServerLaunchArgsResult = TEXT("server-launch-args-result");
 	const FString TypePing = TEXT("ping");
 	const FString TypePong = TEXT("pong");
 	const FString TypeShutdown = TEXT("shutdown");
@@ -379,10 +384,11 @@ void FUnrealMcpBridgeServer::HandleLine(const FString& Line, int32 Generation)
 	{
 		// liveness already refreshed in Run()
 	}
-	else if (Type == TypeStatus || Type == TypeDeviceAuth || Type == TypeAgentConfigResult || Type == TypeProjectConfigResult)
+	else if (Type == TypeStatus || Type == TypeDeviceAuth || Type == TypeAgentConfigResult || Type == TypeProjectConfigResult || Type == TypeServerLaunchArgsResult)
 	{
-		// §1.3 / §7 / mcp-authorize PR 4: the live UI + control feed (connection status, device-auth, the AI-agent
-		// configurator results, AND the resolved project-config result carrying the derived local-server port).
+		// §1.3 / §7 / mcp-authorize PR 4 + g5/g6: the live UI + control feed (connection status, device-auth, the
+		// AI-agent configurator results, the resolved project-config result carrying the derived local-server port,
+		// AND the composed server-launch-args result the local-server start awaits).
 		// Hand it to the registered sink (the view-model) WITHOUT touching any Slate/engine state here — the
 		// sink marshals onto the game thread (M9b) and routes by type. Copy the sink out under the lock so a
 		// concurrent window-close clear never invalidates the TFunction mid-call.
@@ -1108,6 +1114,33 @@ bool FUnrealMcpBridgeServer::SendProjectConfigRequest(const FString& RequestId, 
 	Message->SetStringField(TEXT("type"), TypeProjectConfig);
 	Message->SetStringField(TEXT("requestId"), RequestId);
 	Message->SetStringField(TEXT("projectPath"), InProjectPath);
+	return SendMessage(Message);
+}
+
+bool FUnrealMcpBridgeServer::SendServerLaunchArgsRequest(
+	const FString& RequestId, int32 InPort, int32 InPluginTimeoutMs, const FString& InAuthMode,
+	const FString& InToken, const FString& InAuthIssuer, const FString& InPublicUrl)
+{
+	// mcp-authorize g5/g6 consolidation: ask the sidecar to COMPOSE the local-server launch-arg string via the
+	// shared ServerLaunchArguments builder. The C++ side forwards the resolved connection facts and never assembles
+	// the none/oauth/token arg string itself. The result arrives as a `server-launch-args-result` routed through the
+	// status sink. The token travels only over this loopback IPC (never argv, never logged) — same as the §1.4 model.
+	// (Params are In-prefixed so InToken does not shadow the FUnrealMcpBridgeServer::Token member — C4458 under /WX.)
+	if (!bClientConnected || !bHandshakeOk)
+		return false;
+
+	TSharedPtr<FJsonObject> Message = MakeShared<FJsonObject>();
+	Message->SetStringField(TEXT("type"), TypeServerLaunchArgs);
+	Message->SetStringField(TEXT("requestId"), RequestId);
+	Message->SetNumberField(TEXT("port"), InPort);
+	Message->SetNumberField(TEXT("pluginTimeoutMs"), InPluginTimeoutMs);
+	Message->SetStringField(TEXT("authMode"), InAuthMode);
+	if (!InToken.IsEmpty())
+		Message->SetStringField(TEXT("token"), InToken);
+	if (!InAuthIssuer.IsEmpty())
+		Message->SetStringField(TEXT("authIssuer"), InAuthIssuer);
+	if (!InPublicUrl.IsEmpty())
+		Message->SetStringField(TEXT("publicUrl"), InPublicUrl);
 	return SendMessage(Message);
 }
 

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Bridge/UnrealMcpBridgeServer.h
@@ -120,6 +120,20 @@ public:
 	bool SendProjectConfigRequest(const FString& RequestId, const FString& InProjectPath);
 
 	/**
+	 * Send a mcp-authorize g5/g6 `server-launch-args` request to the connected sidecar, which COMPOSES the local
+	 * gamedev-mcp-server launch-arg string via the SHARED com.IvanMurzak.McpPlugin.ServerLaunch.ServerLaunchArguments
+	 * builder (none/oauth/token) and answers with a `server-launch-args-result` routed back through the status sink.
+	 * This is the g6 consolidation: the C++ FUnrealMcpServerManager delegates arg-building rather than duplicating the
+	 * shared logic. @p RequestId correlates the response; @p AuthMode is the lowercase mode ("none"/"oauth"/"token");
+	 * @p Token (token mode) / @p AuthIssuer + @p PublicUrl (oauth mode) are the mode-specific credentials (@p Token
+	 * travels only over this loopback IPC, never argv, never logged). Thread-safe; no-op (returns false) when no
+	 * sidecar is connected/handshaken.
+	 */
+	bool SendServerLaunchArgsRequest(
+		const FString& RequestId, int32 InPort, int32 InPluginTimeoutMs, const FString& InAuthMode,
+		const FString& InToken, const FString& InAuthIssuer, const FString& InPublicUrl);
+
+	/**
 	 * Register a sink for the inbound sidecar→plugin `status` and `device-auth` feed (§1.3 / §7). The sink
 	 * is invoked ON THE IPC READER THREAD with the message type and parsed object — the caller (the §7
 	 * view-model) MUST marshal onto the game thread (AsyncTask(GameThread)) before touching any Slate state

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Config/UnrealMcpConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Config/UnrealMcpConfig.cpp
@@ -72,6 +72,19 @@ namespace
 			Out.LeftChopInline(1);
 		return Out;
 	}
+
+	// The persisted (config-file) PascalCase form of the auth option. Kept distinct from the lowercase
+	// launch/wire form (FUnrealMcpConfig::AuthOptionToString) — the JSON store has always used PascalCase
+	// ("None"/"Required"); the g5/g6 migration extends it to "None"/"Oauth"/"Token".
+	const TCHAR* AuthOptionToPersistString(EUnrealMcpAuthOption Option)
+	{
+		switch (Option)
+		{
+			case EUnrealMcpAuthOption::Oauth: return TEXT("Oauth");
+			case EUnrealMcpAuthOption::Token: return TEXT("Token");
+			default:                          return TEXT("None");
+		}
+	}
 }
 
 FUnrealMcpConfig::FUnrealMcpConfig()
@@ -327,7 +340,7 @@ TSharedPtr<FJsonObject> FUnrealMcpConfig::ToJson() const
 	Obj->SetStringField(KeyToken, CustomToken);
 	Obj->SetStringField(KeyCloudToken, CloudToken);
 	Obj->SetStringField(KeyCloudUrl, CloudUrl);
-	Obj->SetStringField(KeyAuthOption, AuthOption == EUnrealMcpAuthOption::Required ? TEXT("Required") : TEXT("None"));
+	Obj->SetStringField(KeyAuthOption, AuthOptionToPersistString(AuthOption));
 	Obj->SetBoolField(KeyKeepConnected, bKeepConnected);
 	Obj->SetStringField(KeyLogLevel, LogLevel);
 	Obj->SetStringField(KeyTransport, Transport);
@@ -440,9 +453,10 @@ FString FUnrealMcpConfig::ResolveEffectiveToken() const
 	if (ConnectionMode == EUnrealMcpConnectionMode::Cloud)
 		return CloudToken;
 
-	// Custom mode: an anonymous (None) connection sends NO bearer, regardless of any stored token — so
-	// flipping auth back to None drops the token from the wire without discarding the user's stored value.
-	return AuthOption == EUnrealMcpAuthOption::Required ? CustomToken : FString();
+	// Custom mode: only Token mode sends a bearer. None (anonymous/loopback) and Oauth (native OAuth — the
+	// client authorizes itself, no static bearer) send NOTHING, regardless of any stored token — so flipping
+	// auth away from Token drops the token from the wire without discarding the user's stored value.
+	return AuthOption == EUnrealMcpAuthOption::Token ? CustomToken : FString();
 }
 
 TSharedPtr<FJsonObject> FUnrealMcpConfig::BuildEffectiveConnectionConfig() const
@@ -604,12 +618,34 @@ bool FUnrealMcpConfig::TryParseAuthOption(const FString& Raw, EUnrealMcpAuthOpti
 		OutOption = EUnrealMcpAuthOption::None;
 		return true;
 	}
+	if (Normalized.Equals(TEXT("Oauth"), ESearchCase::IgnoreCase))
+	{
+		OutOption = EUnrealMcpAuthOption::Oauth;
+		return true;
+	}
+	if (Normalized.Equals(TEXT("Token"), ESearchCase::IgnoreCase))
+	{
+		OutOption = EUnrealMcpAuthOption::Token;
+		return true;
+	}
+	// Migration (mcp-authorize g5): the retired legacy `Required` (shared-secret bearer) maps to Token, so an
+	// existing persisted config / .env keeps working instead of crashing the 9.x server with `authorization=required`.
 	if (Normalized.Equals(TEXT("Required"), ESearchCase::IgnoreCase))
 	{
-		OutOption = EUnrealMcpAuthOption::Required;
+		OutOption = EUnrealMcpAuthOption::Token;
 		return true;
 	}
 	return false;
+}
+
+const TCHAR* FUnrealMcpConfig::AuthOptionToString(EUnrealMcpAuthOption Option)
+{
+	switch (Option)
+	{
+		case EUnrealMcpAuthOption::Oauth: return TEXT("oauth");
+		case EUnrealMcpAuthOption::Token: return TEXT("token");
+		default:                          return TEXT("none");
+	}
 }
 
 bool FUnrealMcpConfig::TryParseBool(const FString& Raw, bool& OutValue)

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Config/UnrealMcpConfig.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Config/UnrealMcpConfig.h
@@ -16,15 +16,20 @@ enum class EUnrealMcpConnectionMode : uint8
 };
 
 /**
- * Whether a Custom-mode connection sends a bearer token (§8). Only meaningful in
- * EUnrealMcpConnectionMode::Custom — Cloud-mode auth is the device-code flow (a later UI task).
+ * The Custom-mode local-server auth mode (mcp-authorize g5/g6, §8). Only meaningful in
+ * EUnrealMcpConnectionMode::Custom — Cloud-mode auth is the device-code flow. Mirrors the shared
+ * Consts.MCP.Server.AuthOption { none, oauth, token } the McpPlugin launch-arg builder consumes.
+ * The retired legacy `Required` value is migrated to Token on load (TryParseAuthOption accepts the
+ * old "Required" string and maps it to Token so an existing config keeps working).
  */
 enum class EUnrealMcpAuthOption : uint8
 {
-	/** No bearer token is sent (the Custom server accepts anonymous connections). */
+	/** Anonymous / loopback trust — no credential (server launched `auth=none`). The crash-safe default. */
 	None,
-	/** A bearer token is sent (the Custom server requires authorization). */
-	Required
+	/** Account-gated OAuth 2.1 — server launched `auth=oauth` with `auth-issuer` + `public-url`; client authorizes natively (URL-only config). */
+	Oauth,
+	/** Offline shared secret — server launched `auth=token token=<secret>`; client config carries `Authorization: Bearer <secret>`. */
+	Token
 };
 
 /**
@@ -195,6 +200,14 @@ public:
 	static UNREALMCPRUNTIME_API EUnrealMcpTransportMethod ParseTransport(const FString& Raw);
 	/** The canonical lowercase string ("stdio"/"http") for a transport enum (the persisted form). */
 	static UNREALMCPRUNTIME_API const TCHAR* TransportToString(EUnrealMcpTransportMethod Method);
+
+	/**
+	 * The canonical lowercase auth-mode string ("none"/"oauth"/"token") — the value the shared McpPlugin
+	 * ServerLaunchArguments builder + the gamedev-mcp-server CLI consume (the `auth=<mode>` launch arg), and
+	 * the value the g6 consolidation forwards over IPC to the sidecar. The C++ side NEVER assembles the launch
+	 * arg string itself (the sidecar's shared builder owns that); this is only the mode token.
+	 */
+	static UNREALMCPRUNTIME_API const TCHAR* AuthOptionToString(EUnrealMcpAuthOption Option);
 
 	/** The resolved cloud base URL (CloudUrl override or DefaultCloudBaseUrl), trailing slash trimmed. */
 	UNREALMCPRUNTIME_API FString ResolveCloudBaseUrl() const;

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/UnrealMcpRuntimeSubsystem.cpp
@@ -241,8 +241,10 @@ bool UUnrealMcpRuntimeSubsystem::Connect(const FString& Host, const FString& Tok
 		Config.CustomHost = Host;
 		if (!Token.IsEmpty())
 		{
+			// A runtime Connect() with an explicit static bearer is Token mode (mcp-authorize g5/g6 — the successor
+			// of the retired Required; the resolved effective token then travels on the §1.3 config push).
 			Config.CustomToken = Token;
-			Config.AuthOption = EUnrealMcpAuthOption::Required;
+			Config.AuthOption = EUnrealMcpAuthOption::Token;
 		}
 	}
 	else

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -859,7 +859,13 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         {
             var request = node.Deserialize<ServerLaunchArgsRequestMessage>(IpcProtocol.JsonOptions) ?? new ServerLaunchArgsRequestMessage();
 
-            if (!Enum.TryParse<Consts.MCP.Server.AuthOption>(request.AuthMode, ignoreCase: true, out var authOption)
+            // Accept only the enum NAMES (none|oauth|token). Enum.TryParse ALSO accepts numeric strings — e.g. "0"
+            // parses to the underlying enum value (none), which would let an unexpected numeric authMode silently spawn
+            // an anonymous server: the exact silent auth=none downgrade the g5/g6 design forbids. Reject any numeric
+            // form and fail closed (the plugin's FUnrealMcpConfig::AuthOptionToString only ever emits the names).
+            var rawAuthMode = request.AuthMode ?? string.Empty;
+            if (long.TryParse(rawAuthMode, out _)
+                || !Enum.TryParse<Consts.MCP.Server.AuthOption>(rawAuthMode, ignoreCase: true, out var authOption)
                 || (authOption != Consts.MCP.Server.AuthOption.none
                     && authOption != Consts.MCP.Server.AuthOption.oauth
                     && authOption != Consts.MCP.Server.AuthOption.token))

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -19,6 +19,7 @@ using System.Text.Json.Nodes;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.ServerLaunch;
 using com.IvanMurzak.ReflectorNet;
 using com.IvanMurzak.Unreal.MCP.Bridge.AgentConfig;
 using com.IvanMurzak.Unreal.MCP.Bridge.Auth;
@@ -423,6 +424,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _ipc.AuthMessageReceived += HandleAuthMessage;
             _ipc.AgentConfigRequestReceived += HandleAgentConfigRequest;
             _ipc.ProjectConfigRequestReceived += HandleProjectConfigRequest;
+            _ipc.ServerLaunchArgsRequestReceived += HandleServerLaunchArgsRequest;
 
             _logger?.LogInformation("Sidecar host built (version {Version}); awaiting IPC handshake.", _sidecarVersion);
         }
@@ -802,6 +804,101 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 PortIsOverridden = resolved.PortIsOverridden,
                 ServerTarget = resolved.ServerTarget,
             };
+        }
+
+        /// <summary>
+        /// Serve a mcp-authorize g5/g6 <c>server-launch-args</c> request: compose the LOCAL gamedev-mcp-server
+        /// launch-arg string via the SHARED <see cref="ServerLaunchArguments"/> builder (none/oauth/token) so the C++
+        /// <c>FUnrealMcpServerManager</c> never duplicates the arg logic, and send the terminal
+        /// <c>server-launch-args-result</c> back to the plugin. Never throws — a malformed request or a builder
+        /// <c>ArgumentException</c> (e.g. token mode with no secret) becomes an <c>ok == false</c> result (or, when even
+        /// the requestId cannot be recovered, a logged drop) so it cannot tear down the read loop. Public so the bridge
+        /// xUnit suite can drive the dispatch without a live socket.
+        /// </summary>
+        public void HandleServerLaunchArgsRequest(string type, JsonObject node)
+        {
+            _ = Task.Run(async () =>
+            {
+                ServerLaunchArgsResultMessage result;
+                try
+                {
+                    result = BuildServerLaunchArgsResult(node);
+                }
+                catch (Exception ex)
+                {
+                    // Recover the requestId defensively — this runs in a fire-and-forget Task.Run and must never throw.
+                    string? requestId = null;
+                    if (node["requestId"] is JsonValue requestIdValue)
+                        requestIdValue.TryGetValue(out requestId);
+                    if (string.IsNullOrEmpty(requestId))
+                    {
+                        _logger?.LogWarning("Dropped malformed server-launch-args '{Type}' request: {Message}", type, ex.Message);
+                        return;
+                    }
+                    result = new ServerLaunchArgsResultMessage
+                    {
+                        RequestId = requestId!,
+                        Ok = false,
+                        Error = $"Sidecar failed to compose launch args: {ex.Message}",
+                    };
+                }
+                await _ipc.SendToPluginAsync(result, CancellationToken.None).ConfigureAwait(false);
+            });
+        }
+
+        /// <summary>
+        /// Compose a <c>server-launch-args</c> request into its terminal result by calling the SHARED
+        /// <see cref="ServerLaunchArguments.BuildCommandLine"/> — the SAME builder Unity/Godot call in-process — with the
+        /// plugin-resolved connection facts. The auth mode maps to <see cref="Consts.MCP.Server.AuthOption"/>
+        /// (none/oauth/token; anything unrecognized fails closed as an error, never a silent downgrade). The builder is
+        /// fail-closed: token mode needs a non-empty token; oauth mode needs both issuer and public-url — a missing
+        /// credential throws <see cref="ArgumentException"/>, surfaced as <c>ok == false</c>. Internal so the bridge
+        /// xUnit suite asserts the composed args without the IPC send. Never logs the token.
+        /// </summary>
+        internal ServerLaunchArgsResultMessage BuildServerLaunchArgsResult(JsonObject node)
+        {
+            var request = node.Deserialize<ServerLaunchArgsRequestMessage>(IpcProtocol.JsonOptions) ?? new ServerLaunchArgsRequestMessage();
+
+            if (!Enum.TryParse<Consts.MCP.Server.AuthOption>(request.AuthMode, ignoreCase: true, out var authOption)
+                || (authOption != Consts.MCP.Server.AuthOption.none
+                    && authOption != Consts.MCP.Server.AuthOption.oauth
+                    && authOption != Consts.MCP.Server.AuthOption.token))
+            {
+                return new ServerLaunchArgsResultMessage
+                {
+                    RequestId = request.RequestId,
+                    Ok = false,
+                    Error = $"Unsupported auth mode '{request.AuthMode}' (expected none|oauth|token).",
+                };
+            }
+
+            try
+            {
+                var args = ServerLaunchArguments.BuildCommandLine(
+                    request.Port,
+                    request.PluginTimeoutMs,
+                    Consts.MCP.Server.TransportMethod.streamableHttp,
+                    authOption,
+                    token: request.Token,
+                    authIssuer: request.AuthIssuer,
+                    publicUrl: request.PublicUrl);
+                return new ServerLaunchArgsResultMessage
+                {
+                    RequestId = request.RequestId,
+                    Ok = true,
+                    Args = args,
+                };
+            }
+            catch (ArgumentException ex)
+            {
+                // Fail-closed: a mode's missing credential (token/issuer/public-url). Never echo the token.
+                return new ServerLaunchArgsResultMessage
+                {
+                    RequestId = request.RequestId,
+                    Ok = false,
+                    Error = ex.Message,
+                };
+            }
         }
 
         private void StartDeviceAuth()

--- a/bridge/src/Ipc/IpcClient.cs
+++ b/bridge/src/Ipc/IpcClient.cs
@@ -122,6 +122,15 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         /// </summary>
         public event Action<string, JsonObject>? ProjectConfigRequestReceived;
 
+        /// <summary>
+        /// Raised when the plugin sends a mcp-authorize g5/g6 <c>server-launch-args</c> request: the C++
+        /// <c>FUnrealMcpServerManager</c> asking the sidecar to compose the local-server launch-arg string via the
+        /// SHARED <c>ServerLaunchArguments</c> builder (none/oauth/token), so the C++ side holds no duplicate arg
+        /// logic. The arguments are the request <c>type</c> and the raw parsed JSON object; the host composes it and
+        /// answers with a <c>server-launch-args-result</c> via <see cref="SendToPluginAsync"/> (off the reader thread).
+        /// </summary>
+        public event Action<string, JsonObject>? ServerLaunchArgsRequestReceived;
+
         public IpcClient(string host, int port, string token, string sidecarVersion, ILogger? logger = null)
         {
             _host = host;
@@ -381,6 +390,13 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
                     // `project-config-result` (off the reader thread).
                     if (node is JsonObject projectConfigObj)
                         ProjectConfigRequestReceived?.Invoke(type, projectConfigObj);
+                    break;
+                case IpcProtocol.Type.ServerLaunchArgs:
+                    // mcp-authorize g5/g6: the plugin asks the sidecar to compose the local-server launch-arg
+                    // string via the shared ServerLaunchArguments builder (none/oauth/token). The host answers
+                    // with a `server-launch-args-result` (off the reader thread).
+                    if (node is JsonObject launchArgsObj)
+                        ServerLaunchArgsRequestReceived?.Invoke(type, launchArgsObj);
                     break;
                 case IpcProtocol.Type.Status:
                 case IpcProtocol.Type.Log:

--- a/bridge/src/Ipc/IpcProtocol.cs
+++ b/bridge/src/Ipc/IpcProtocol.cs
@@ -99,6 +99,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
             // design 04/06) — {pin, derived local-server port, portIsOverridden, serverTarget}. The terminal
             // answer to a plugin `project-config` request, correlated by requestId.
             public const string ProjectConfigResult = "project-config-result";
+            // sidecar → plugin: the composed local-server launch-arg string (mcp-authorize g5/g6 consolidation).
+            // The terminal answer to a plugin `server-launch-args` request: the sidecar calls the SHARED
+            // com.IvanMurzak.McpPlugin.ServerLaunch.ServerLaunchArguments builder (none/oauth/token) so the C++
+            // editor never duplicates the arg-building logic. Correlated by requestId.
+            public const string ServerLaunchArgsResult = "server-launch-args-result";
 
             // sidecar → plugin: fetch one prompt's rendered messages / read one resource's content (v2, §A.1).
             // Both round-trip through PendingCallRegistry by requestId, exactly like a tool-call, and reuse the
@@ -135,6 +140,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
             // sidecar computes {pin, derived local-server port, serverTarget} from McpPlugin's ProjectIdentity +
             // the project marker and answers with a `project-config-result`. Carries the project root to resolve from.
             public const string ProjectConfig = "project-config";
+            // plugin → sidecar: compose the LOCAL gamedev-mcp-server launch-arg string (mcp-authorize g5/g6
+            // consolidation). The C++ FUnrealMcpServerManager can't call the C# McpPlugin builder directly, so it
+            // delegates: it forwards {port, timeoutMs, authMode, token, authIssuer, publicUrl} and the sidecar calls
+            // the SHARED com.IvanMurzak.McpPlugin.ServerLaunch.ServerLaunchArguments.BuildCommandLine(...), answering
+            // with a `server-launch-args-result`. No C++ duplicate of the none/oauth/token arg logic.
+            public const string ServerLaunchArgs = "server-launch-args";
 
             // either direction
             public const string Ping = "ping";

--- a/bridge/src/Ipc/ServerLaunchArgsMessages.cs
+++ b/bridge/src/Ipc/ServerLaunchArgsMessages.cs
@@ -1,0 +1,63 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
+{
+    /// <summary>
+    /// IPC message payloads for the mcp-authorize g5/g6 <b>local-server launch-arg</b> consolidation. Unity and
+    /// Godot host McpPlugin in-process and call <c>ServerLaunchArguments.BuildCommandLine(...)</c> directly; the
+    /// Unreal C++ editor cannot call the C# builder, so <c>FUnrealMcpServerManager</c> DELEGATES: it forwards the
+    /// resolved connection facts and the sidecar calls the SHARED
+    /// <c>com.IvanMurzak.McpPlugin.ServerLaunch.ServerLaunchArguments</c> builder (none/oauth/token), answering with
+    /// a <see cref="ServerLaunchArgsResultMessage"/>. This is why the C++ side holds NO duplicate of the arg logic.
+    ///
+    /// The plugin sends a <see cref="ServerLaunchArgsRequestMessage"/> carrying the auth mode + the mode-specific
+    /// credentials (token for <c>token</c>; issuer + public-url for <c>oauth</c>); the sidecar composes the argv
+    /// string and returns it verbatim for <c>FPlatformProcess::CreateProc</c>.
+    /// </summary>
+
+    /// <summary>plugin → sidecar: compose the local-server launch-arg string for the given connection facts.</summary>
+    public sealed class ServerLaunchArgsRequestMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.ServerLaunchArgs;
+        [JsonPropertyName("requestId")] public string RequestId { get; set; } = string.Empty;
+        /// <summary>The derived per-project local-server port the server listens on (the port the plugin already resolved via project-config).</summary>
+        [JsonPropertyName("port")] public int Port { get; set; }
+        /// <summary>Plugin timeout in milliseconds (the server's <c>plugin-timeout</c> launch arg).</summary>
+        [JsonPropertyName("pluginTimeoutMs")] public int PluginTimeoutMs { get; set; } = IpcProtocol.DefaultToolTimeoutMs;
+        /// <summary>The auth mode, lowercase: <c>none</c> / <c>oauth</c> / <c>token</c> (the shared AuthOption enum names). Unknown → none (crash-safe loopback default).</summary>
+        [JsonPropertyName("authMode")] public string AuthMode { get; set; } = "none";
+        /// <summary>The offline shared secret for <c>token</c> mode (NEVER logged). Ignored in none/oauth.</summary>
+        [JsonPropertyName("token")] public string? Token { get; set; }
+        /// <summary>The OAuth issuer base URL for <c>oauth</c> mode (e.g. https://ai-game.dev). Ignored in none/token.</summary>
+        [JsonPropertyName("authIssuer")] public string? AuthIssuer { get; set; }
+        /// <summary>The exact loopback resource URL for <c>oauth</c> mode (http://localhost:&lt;port&gt;/mcp/p/&lt;pin&gt;). Ignored in none/token.</summary>
+        [JsonPropertyName("publicUrl")] public string? PublicUrl { get; set; }
+    }
+
+    /// <summary>
+    /// sidecar → plugin: the composed launch-arg string (or a failure reason). Correlated to the request by
+    /// <see cref="RequestId"/>. On <see cref="Ok"/> the <see cref="Args"/> string is the exact argv the plugin passes
+    /// to <c>FPlatformProcess::CreateProc</c>; otherwise <see cref="Error"/> carries a short human reason (never a secret —
+    /// the token is never echoed back).
+    /// </summary>
+    public sealed class ServerLaunchArgsResultMessage
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.ServerLaunchArgsResult;
+        [JsonPropertyName("requestId")] public string RequestId { get; set; } = string.Empty;
+        [JsonPropertyName("ok")] public bool Ok { get; set; }
+        /// <summary>A short human-readable failure reason on <c>ok == false</c> (never a secret).</summary>
+        [JsonPropertyName("error")] public string? Error { get; set; }
+        /// <summary>The composed launch-arg string on <c>ok == true</c> (e.g. <c>port=20123 plugin-timeout=10000 client-transport=streamableHttp auth=token token=…</c>).</summary>
+        [JsonPropertyName("args")] public string? Args { get; set; }
+    }
+}

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -73,10 +73,16 @@
     transitively requires ReflectorNet >= 5.3.2, so its explicit pin advances 5.3.1 -> 5.3.2 in the
     same bump (NU1605 downgrade otherwise). Both versions are published on nuget.org. The Godot-MCP
     lockstep is temporarily broken until the sibling Godot adoption PR lands.
+    ⚠ DEVIATION (mcp-authorize g5/g6, maintainer-authorized dependency-freshness bump, per the
+    PIPELINE.md "Freshness-bump carve-out"): 7.0.0 -> 7.1.0 is the additive minor that publishes the
+    shared com.IvanMurzak.McpPlugin.ServerLaunch.ServerLaunchArguments builder (the new none/oauth/token
+    launch-arg logic) + the Consts.MCP.Server.AuthOption { none, oauth, token } enum the g6 consolidation
+    delegates to (the sidecar calls ServerLaunchArguments.BuildCommandLine so the C++ editor no longer
+    duplicates arg-building). Published on nuget.org; ReflectorNet stays 5.3.2 (7.1.0 keeps that floor).
   -->
   <ItemGroup>
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.2" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.0.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.1.0" />
   </ItemGroup>
 
   <!-- The xUnit suite exercises a couple of internal helpers (e.g. ProxyTool.CalculateTokenCount). -->

--- a/bridge/tests/SidecarHostServerLaunchArgsTests.cs
+++ b/bridge/tests/SidecarHostServerLaunchArgsTests.cs
@@ -1,0 +1,160 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using com.IvanMurzak.Unreal.MCP.Bridge.Host;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>
+    /// Proves the mcp-authorize g5/g6 <c>server-launch-args</c> consolidation: the sidecar composes the LOCAL
+    /// gamedev-mcp-server launch-arg string via the SHARED
+    /// <c>com.IvanMurzak.McpPlugin.ServerLaunch.ServerLaunchArguments</c> builder (none/oauth/token) so the C++
+    /// <c>FUnrealMcpServerManager</c> holds no duplicate arg logic. Drives <see cref="SidecarHost.BuildServerLaunchArgsResult"/>
+    /// directly (no live socket), asserting the target-state <c>auth=&lt;mode&gt;</c> key and the fail-closed
+    /// missing-credential handling.
+    /// </summary>
+    public class SidecarHostServerLaunchArgsTests
+    {
+        private static SidecarHost BuildHost()
+        {
+            var ipc = new IpcClient("127.0.0.1", 39995, token: "test-token", sidecarVersion: "0.1.0");
+            var host = new SidecarHost(ipc, "0.1.0");
+            host.Build();
+            return host;
+        }
+
+        private static JsonObject Request(string requestId, string authMode, int port = 20123, int timeoutMs = 10000,
+            string? token = null, string? authIssuer = null, string? publicUrl = null)
+        {
+            var node = new JsonObject
+            {
+                ["type"] = IpcProtocol.Type.ServerLaunchArgs,
+                ["requestId"] = requestId,
+                ["port"] = port,
+                ["pluginTimeoutMs"] = timeoutMs,
+                ["authMode"] = authMode,
+            };
+            if (token != null) node["token"] = token;
+            if (authIssuer != null) node["authIssuer"] = authIssuer;
+            if (publicUrl != null) node["publicUrl"] = publicUrl;
+            return node;
+        }
+
+        [Fact]
+        public void ServerLaunchArgsMessages_RoundTripOverTheWire()
+        {
+            var request = new ServerLaunchArgsRequestMessage
+            {
+                RequestId = "req-1", Port = 20123, PluginTimeoutMs = 10000, AuthMode = "token", Token = "secret123",
+            };
+            var reqJson = JsonSerializer.Serialize(request, IpcProtocol.JsonOptions);
+            var reqBack = JsonSerializer.Deserialize<ServerLaunchArgsRequestMessage>(reqJson, IpcProtocol.JsonOptions)!;
+            Assert.Equal(IpcProtocol.Type.ServerLaunchArgs, reqBack.Type);
+            Assert.Equal("req-1", reqBack.RequestId);
+            Assert.Equal(20123, reqBack.Port);
+            Assert.Equal("token", reqBack.AuthMode);
+            Assert.Equal("secret123", reqBack.Token);
+
+            var result = new ServerLaunchArgsResultMessage { RequestId = "req-1", Ok = true, Args = "port=20123 auth=token token=secret123" };
+            var resJson = JsonSerializer.Serialize(result, IpcProtocol.JsonOptions);
+            var resBack = JsonSerializer.Deserialize<ServerLaunchArgsResultMessage>(resJson, IpcProtocol.JsonOptions)!;
+            Assert.Equal(IpcProtocol.Type.ServerLaunchArgsResult, resBack.Type);
+            Assert.True(resBack.Ok);
+            Assert.Equal("port=20123 auth=token token=secret123", resBack.Args);
+        }
+
+        [Fact]
+        public void BuildServerLaunchArgsResult_NoneMode_ComposesAnonymousArgs()
+        {
+            using var host = BuildHost();
+
+            var result = host.BuildServerLaunchArgsResult(Request("r-1", "none"));
+
+            Assert.True(result.Ok);
+            Assert.Equal("r-1", result.RequestId);
+            Assert.NotNull(result.Args);
+            Assert.Contains("port=20123", result.Args!);
+            Assert.Contains("plugin-timeout=10000", result.Args!);
+            Assert.Contains("client-transport=streamableHttp", result.Args!);
+            Assert.Contains("auth=none", result.Args!);              // target-state key (not legacy `authorization=`)
+            Assert.DoesNotContain("token=", result.Args!);
+            Assert.DoesNotContain("authorization=", result.Args!);
+        }
+
+        [Fact]
+        public void BuildServerLaunchArgsResult_TokenMode_AppendsTokenArg()
+        {
+            using var host = BuildHost();
+
+            var result = host.BuildServerLaunchArgsResult(Request("r-2", "token", token: "secret123"));
+
+            Assert.True(result.Ok);
+            Assert.Contains("auth=token", result.Args!);
+            Assert.Contains("token=secret123", result.Args!);
+        }
+
+        [Fact]
+        public void BuildServerLaunchArgsResult_OauthMode_AppendsIssuerAndPublicUrl()
+        {
+            using var host = BuildHost();
+
+            var result = host.BuildServerLaunchArgsResult(Request(
+                "r-3", "oauth", authIssuer: "https://ai-game.dev", publicUrl: "http://localhost:20123/mcp/p/34ea75f2"));
+
+            Assert.True(result.Ok);
+            Assert.Contains("auth=oauth", result.Args!);
+            Assert.Contains("auth-issuer=https://ai-game.dev", result.Args!);
+            Assert.Contains("public-url=http://localhost:20123/mcp/p/34ea75f2", result.Args!);
+        }
+
+        [Fact]
+        public void BuildServerLaunchArgsResult_TokenModeMissingSecret_FailsClosed()
+        {
+            using var host = BuildHost();
+
+            var result = host.BuildServerLaunchArgsResult(Request("r-4", "token", token: null));
+
+            Assert.False(result.Ok);
+            Assert.Equal("r-4", result.RequestId);
+            Assert.False(string.IsNullOrEmpty(result.Error));
+            Assert.Null(result.Args);
+        }
+
+        [Fact]
+        public void BuildServerLaunchArgsResult_OauthModeMissingPublicUrl_FailsClosed()
+        {
+            using var host = BuildHost();
+
+            var result = host.BuildServerLaunchArgsResult(Request("r-5", "oauth", authIssuer: "https://ai-game.dev"));
+
+            Assert.False(result.Ok);
+            Assert.False(string.IsNullOrEmpty(result.Error));
+            Assert.Null(result.Args);
+        }
+
+        [Fact]
+        public void BuildServerLaunchArgsResult_LegacyRequiredMode_RejectedNotSilentlyDowngraded()
+        {
+            using var host = BuildHost();
+
+            // `required` is the retired legacy value — the plugin migrates it to `token` BEFORE sending, so the sidecar
+            // never receives it. If one ever arrives, fail closed (never silently spawn an anonymous/mis-authed server).
+            var result = host.BuildServerLaunchArgsResult(Request("r-6", "required"));
+
+            Assert.False(result.Ok);
+            Assert.False(string.IsNullOrEmpty(result.Error));
+            Assert.Null(result.Args);
+        }
+    }
+}

--- a/bridge/tests/SidecarHostServerLaunchArgsTests.cs
+++ b/bridge/tests/SidecarHostServerLaunchArgsTests.cs
@@ -156,5 +156,21 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             Assert.False(string.IsNullOrEmpty(result.Error));
             Assert.Null(result.Args);
         }
+
+        [Fact]
+        public void BuildServerLaunchArgsResult_NumericAuthMode_RejectedNotSilentlyDowngraded()
+        {
+            using var host = BuildHost();
+
+            // Enum.TryParse also parses NUMERIC strings ("0" -> the first enum member, none). A numeric authMode must
+            // NOT be accepted — that would silently spawn an anonymous (auth=none) server. Only the NAMES none|oauth|token
+            // are valid; a numeric form fails closed, exactly like the legacy `required` rejection above.
+            var result = host.BuildServerLaunchArgsResult(Request("r-7", "0"));
+
+            Assert.False(result.Ok);
+            Assert.Equal("r-7", result.RequestId);
+            Assert.False(string.IsNullOrEmpty(result.Error));
+            Assert.Null(result.Args);
+        }
     }
 }

--- a/cli/src/lib/server-version.ts
+++ b/cli/src/lib/server-version.ts
@@ -9,4 +9,4 @@
 // (with all `gamedev-mcp-server-<rid>.zip` assets) MUST already exist on
 // GameDev-MCP-Server BEFORE a CLI release that pins it (docs/RELEASING.md).
 
-export const SERVER_VERSION = '9.0.0';
+export const SERVER_VERSION = '9.1.0';

--- a/cli/tests/configure-agent.test.ts
+++ b/cli/tests/configure-agent.test.ts
@@ -6,7 +6,7 @@ import type { DownloadServerResult } from '../src/lib/types.js';
 
 function okDownload(serverPath: string): () => Promise<DownloadServerResult> {
   return async () =>
-    ({ kind: 'success', success: true, serverPath, source: 'download', version: '9.0.0', warnings: [] }) as DownloadServerResult;
+    ({ kind: 'success', success: true, serverPath, source: 'download', version: '9.1.0', warnings: [] }) as DownloadServerResult;
 }
 
 describe('configureAgent (proxy to gamedev-mcp-server configure)', () => {


### PR DESCRIPTION
## Summary
- Migrate the LOCAL-server auth from 2-way `none`/`required` to the shared 3-way `none`/`oauth`/`token`; persisted (and runtime) legacy `Required` migrates to `Token`, so the retired `authorization=required` value that crashes the 9.x server is never emitted.
- CONSOLIDATION (owner "no code duplication" directive): the C++ `FUnrealMcpServerManager` no longer builds launch args — it delegates over a new `server-launch-args` IPC round-trip to the .NET sidecar, which calls the SHARED `com.IvanMurzak.McpPlugin.ServerLaunch.ServerLaunchArguments` builder (none/oauth/token, fail-closed). C++ `BuildLaunchArgs` deleted.
- UI: 3-way segment; token field + generate only in `token` mode; Cloud maps to `oauth`. `Configure` writes the matching client config per mode (`token` → `Authorization: Bearer <secret>`; `none`/`oauth` → URL-only native OAuth).
- Version bumps (freshness carve-out, both published): bridge `com.IvanMurzak.McpPlugin` 7.0.0 → 7.1.0; `ServerVersion` 9.0.0 → 9.1.0 (C++ + CLI mirror). Ships as part of 0.9.2 (bundles the already-merged g2 #228 + g3 #230).

## Test plan
- [x] Bridge (`dotnet build`+`test`): 265 pass, incl. 7 new `SidecarHostServerLaunchArgsTests` (none/token/oauth compose + fail-closed missing-credential).
- [x] CLI (`tsc`+`vitest`): 429 pass.
- [x] Plugin gate (UE 5.7): Suite 1 UBT build, Suite 1b RunUAT BuildPlugin (Game+Editor, hard gate — Runtime module changed), Suite 2 headless smoke (`[Unreal-MCP] plugin loaded`), Suite 3 Automation specs (failed=0, succeeded=339).
- Actual none/oauth/token server boot is unit-verified (bridge launch-arg tests) + build/headless-verified; windowed operator verification pending.

Closes #231