### PR TITLE
test: audit local-token lifecycle (BUG-B analog, i4)

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfigModelsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfigModelsSpec.cpp
@@ -306,7 +306,6 @@ void FUnrealMcpAgentConfigModelsSpec::Define()
 			// client bearer -> Claude Code 401). Lock the equality so the two token sinks can never diverge.
 			FUnrealMcpConfig Config;
 			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
-			Config.CustomHost = TEXT("http://localhost:8080");
 			Config.AuthOption = EUnrealMcpAuthOption::Token;
 			Config.CustomToken = TEXT("shared-local-secret");
 			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, FString(), 31234);

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfigModelsSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpAgentConfigModelsSpec.cpp
@@ -298,6 +298,22 @@ void FUnrealMcpAgentConfigModelsSpec::Define()
 			TestEqual("token forwarded", Info.Token, FString(TEXT("pat-secret-value")));
 		});
 
+		It("forwards the SAME resolved token the local-server launch uses (mcp-authorize i4, BUG-B lockstep)", [this]()
+		{
+			// The written client-config bearer (Info.Token) and the local-server launch arg both read
+			// FUnrealMcpConfig::ResolveEffectiveToken(), so they carry the SAME secret at a given instant — the
+			// property whose absence produced Unity BUG-B (a regenerated local token orphaned the already-written
+			// client bearer -> Claude Code 401). Lock the equality so the two token sinks can never diverge.
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.CustomHost = TEXT("http://localhost:8080");
+			Config.AuthOption = EUnrealMcpAuthOption::Token;
+			Config.CustomToken = TEXT("shared-local-secret");
+			const FAiAgentConnectionInfo Info = FAiAgentConnectionInfo::FromPluginConfig(Config, FString(), 31234);
+			TestEqual("client bearer == resolved effective token", Info.Token, Config.ResolveEffectiveToken());
+			TestEqual("resolved token is the stored secret", Config.ResolveEffectiveToken(), FString(TEXT("shared-local-secret")));
+		});
+
 		It("does not opt in for Custom + Token but an EMPTY secret", [this]()
 		{
 			FUnrealMcpConfig Config;

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConfigSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConfigSpec.cpp
@@ -268,6 +268,89 @@ void FUnrealMcpConfigSpec::Define()
 		});
 	});
 
+	// mcp-authorize i4 (BUG-B analog audit): the Custom-mode local server token must be STABLE — it must
+	// never silently regenerate the way Unity's LocalToken did (Unity-MCP #897), which orphaned the
+	// already-written client .mcp.json bearer and produced a Claude Code 401. On Unreal the token is the
+	// single persisted CustomToken field with NO generation on construct/load, so these invariants hold by
+	// construction; lock them so a future refactor cannot silently reintroduce the divergence.
+	Describe("local token lifecycle — BUG-B immunity (mcp-authorize i4)", [this]()
+	{
+		It("never mints a token on construction or on an empty-token load (no generate-if-empty)", [this]()
+		{
+			// A fresh config carries NO token — the store must not seed one. (Unity's SetDefault mis-seeded a
+			// generated secret, forcing a generate-if-empty re-mint that then drifted.) Custom+Token with an
+			// unset secret therefore resolves EMPTY, deterministically, every time — never an auto-minted value.
+			FUnrealMcpConfig Fresh;
+			TestTrue(TEXT("fresh custom token empty"), Fresh.CustomToken.IsEmpty());
+			TestTrue(TEXT("fresh cloud token empty"), Fresh.CloudToken.IsEmpty());
+
+			// An empty persisted token round-trips empty (never auto-minted on load).
+			TSharedPtr<FJsonObject> Empty = MakeShared<FJsonObject>();
+			Empty->SetStringField(TEXT("connectionMode"), TEXT("Custom"));
+			Empty->SetStringField(TEXT("authOption"), TEXT("Token"));
+			Empty->SetStringField(TEXT("token"), FString());
+			const FUnrealMcpConfig Loaded = FromDiskJson(Empty);
+			TestTrue(TEXT("empty token stays empty after load"), Loaded.CustomToken.IsEmpty());
+			TestTrue(TEXT("effective token empty (nothing minted)"), Loaded.ResolveEffectiveToken().IsEmpty());
+		});
+
+		It("round-trips a persisted custom token deterministically through Save()/LoadFromFile()", [this]()
+		{
+			const FString Path = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("UnrealMcpConfigSpec"), TEXT("token-roundtrip.json"));
+			IFileManager::Get().Delete(*Path, false, true, true);
+
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.AuthOption = EUnrealMcpAuthOption::Token;
+			Config.CustomToken = TEXT("persisted-local-secret-abc123");
+			TestTrue(TEXT("save ok"), Config.Save(Path));
+
+			FUnrealMcpConfig Reloaded;
+			Reloaded.LoadFromFile(Path);
+			TestEqual(TEXT("custom token survives save/load unchanged"),
+				Reloaded.CustomToken, FString(TEXT("persisted-local-secret-abc123")));
+			TestEqual(TEXT("effective token unchanged after reload"),
+				Reloaded.ResolveEffectiveToken(), FString(TEXT("persisted-local-secret-abc123")));
+
+			IFileManager::Get().Delete(*Path, false, true, true);
+		});
+
+		It("keeps the custom token unchanged across a connection-mode re-apply", [this]()
+		{
+			// Flipping Cloud<->Custom must NOT move the stored secret. (Unity's bug routed a generated token to
+			// the wrong slot on a mode-set.) CustomToken and CloudToken are independent persisted fields here.
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.AuthOption = EUnrealMcpAuthOption::Token;
+			Config.CustomToken = TEXT("stable-secret");
+
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Cloud;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+
+			TestEqual(TEXT("custom token unchanged after mode re-apply"), Config.CustomToken, FString(TEXT("stable-secret")));
+			TestTrue(TEXT("cloud token still empty"), Config.CloudToken.IsEmpty());
+			TestEqual(TEXT("effective token still the stored secret"), Config.ResolveEffectiveToken(), FString(TEXT("stable-secret")));
+		});
+
+		It("feeds the server-launch arg and the client-config bearer from the SAME resolved token", [this]()
+		{
+			// The local-server launch (coordinator -> ServerLaunchArgs) reads ResolveEffectiveToken(); the client
+			// config write (FAiAgentConnectionInfo::FromPluginConfig) reads the same. They therefore cannot diverge
+			// — the exact property whose absence caused Unity BUG-B. (The FromPluginConfig side is asserted in
+			// UnrealMcp.AgentConfigModels; here we lock the config-side resolution the launch + §1.3 config share.)
+			FUnrealMcpConfig Config;
+			Config.ConnectionMode = EUnrealMcpConnectionMode::Custom;
+			Config.AuthOption = EUnrealMcpAuthOption::Token;
+			Config.CustomToken = TEXT("one-source-of-truth");
+
+			const TSharedPtr<FJsonObject> Eff = Config.BuildEffectiveConnectionConfig();
+			TestEqual(TEXT("effective-config token == resolved token"),
+				Eff->GetStringField(TEXT("token")), Config.ResolveEffectiveToken());
+			TestEqual(TEXT("resolved token is the stored secret"),
+				Config.ResolveEffectiveToken(), FString(TEXT("one-source-of-truth")));
+		});
+	});
+
 	Describe("Save() baseline-restore (env/.env never persisted)", [this]()
 	{
 		It("round-trips the disk baseline while the in-memory config keeps the override", [this]()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -856,6 +856,26 @@ the connection-config task).
 - **Token protection:** masked in UI (reveal-on-hold), never logged at any level (log scrubber on
   the `log` IPC channel + NLog layout rule sidecar-side), file written with no extra ACL work but
   documented as secret; `UNREAL_MCP_TOKEN` recommended for CI instead of the file.
+- **Local-token lifecycle — BUG-B audit (mcp-authorize i4): absent by construction.** The Unity
+  sibling ([[i2]], Unity-MCP #897) hit BUG-B: the Custom-mode local server token *silently
+  regenerated* after Configure, so the already-written client `.mcp.json` bearer went stale → Claude
+  Code **401**. The Unreal C++ store is immune by design, so no fix is needed:
+  - **Single resolved source.** The Custom-mode secret is the one persisted `token` field
+    (`FUnrealMcpConfig::CustomToken`), read via `ResolveEffectiveToken()`. Both consumers read that
+    SAME value — the local-server launch arg (`FUnrealMcpEditorCoordinator` → the sidecar's shared
+    `ServerLaunchArguments` builder, `auth=token token=<secret>`) and the written client bearer
+    (`FAiAgentConnectionInfo::FromPluginConfig` → `AgentConfigService`) — so they can never diverge at
+    a given instant.
+  - **No silent regeneration.** Unlike Unity's `SetDefault` (which mis-seeded a generated secret into
+    the wrong slot and forced a drifting generate-if-empty re-mint), the C++ store performs NO token
+    generation on construct/load: `CustomToken` defaults empty, has no generate-if-empty fallback, and
+    lives in its own JSON field (never mode-routed at (de)serialize), so it round-trips deterministically
+    and survives a connection-mode re-apply unchanged.
+  - **Intentional change re-syncs.** The token changes ONLY on an explicit user action (typing it, or the
+    "New" button `GenerateCustomToken`); both re-persist + push the new config to the sidecar AND refresh
+    the agent configurators, whose tri-state status surfaces `ReconfigureNeeded` (the shared
+    `McpPlugin.AgentConfig` token-aware validator, mcp-authorize [[i1]]) so the user re-Configures.
+  - Locked by the `UnrealMcp.Config` + `UnrealMcp.AgentConfigModels` Automation specs.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -857,7 +857,7 @@ the connection-config task).
   the `log` IPC channel + NLog layout rule sidecar-side), file written with no extra ACL work but
   documented as secret; `UNREAL_MCP_TOKEN` recommended for CI instead of the file.
 - **Local-token lifecycle — BUG-B audit (mcp-authorize i4): absent by construction.** The Unity
-  sibling ([[i2]], Unity-MCP #897) hit BUG-B: the Custom-mode local server token *silently
+  sibling (mcp-authorize i2, Unity-MCP #897) hit BUG-B: the Custom-mode local server token *silently
   regenerated* after Configure, so the already-written client `.mcp.json` bearer went stale → Claude
   Code **401**. The Unreal C++ store is immune by design, so no fix is needed:
   - **Single resolved source.** The Custom-mode secret is the one persisted `token` field
@@ -874,7 +874,7 @@ the connection-config task).
   - **Intentional change re-syncs.** The token changes ONLY on an explicit user action (typing it, or the
     "New" button `GenerateCustomToken`); both re-persist + push the new config to the sidecar AND refresh
     the agent configurators, whose tri-state status surfaces `ReconfigureNeeded` (the shared
-    `McpPlugin.AgentConfig` token-aware validator, mcp-authorize [[i1]]) so the user re-Configures.
+    `McpPlugin.AgentConfig` token-aware validator, mcp-authorize i1) so the user re-Configures.
   - Locked by the `UnrealMcp.Config` + `UnrealMcp.AgentConfigModels` Automation specs.
 
 ---


### PR DESCRIPTION
## Summary

**mcp-authorize i4 — audit the Unreal local-token lifecycle for BUG-B and fix if present.** BUG-B (the Custom-mode `token`-mode local server secret going stale after Configure → the already-written client `.mcp.json` bearer no longer matches the running server → Claude Code **401**) was reproduced and fixed on **Unity** (sibling i2 / Unity-MCP #897). This PR audits the Unreal client-side lifecycle (C++ `UnrealMcpConfig` + the C++→.NET sidecar launch-arg path + the Configure write path).

**Audit result: NOT PRESENT — Unreal is immune by construction.** No runtime change is required; this PR records the conclusion and locks the immunity with regression tests.

### Evidence

- **Single resolved source.** The Custom-mode secret is the one persisted `token` field (`FUnrealMcpConfig::CustomToken`), read via `ResolveEffectiveToken()`. **Both** token sinks read that same resolved value:
  - the local-server launch arg — `UnrealMcpEditorCoordinator.cpp` (`ResolveEffectiveToken()`) → the sidecar's shared `ServerLaunchArguments` builder → `auth=token token=<secret>`;
  - the written client `.mcp.json` bearer — `FAiAgentConnectionInfo::FromPluginConfig` (`Info.Token = Config.ResolveEffectiveToken()`) → `AgentConfigService.HandleConfigure`.

  They therefore cannot diverge at a given instant.
- **No silent regeneration.** Unlike Unity's `SetDefault()` (which assigned `Token = GenerateToken()` *after* `ConnectionMode = Cloud`, mis-routing the local secret into `CloudToken` and forcing a drifting generate-if-empty re-mint), the C++ store performs **no token generation on construct/load**: `CustomToken` defaults empty, has no generate-if-empty fallback, and lives in its own JSON field (never mode-routed at (de)serialize). So it round-trips deterministically and survives a connection-mode re-apply unchanged.
- **Intentional change re-syncs.** The token changes only on an explicit user action — typing it (`SetCustomToken`) or the "New" button (`GenerateCustomToken`). Both re-persist + push the new config to the sidecar **and** refresh the agent configurators, whose tri-state `ReconfigureNeeded` status (the shared `McpPlugin.AgentConfig` token-aware validator, mcp-authorize i1) prompts the user to re-Configure — the same mechanism the Unity fix relies on.

### Changes (regression lock + doc, no runtime/editor source touched)

- `UnrealMcp.Config` spec — new "local token lifecycle — BUG-B immunity" invariants: no-mint-on-construct/empty-load, deterministic `Save()`/`LoadFromFile()` round-trip, stable-across-mode-reapply, and the launch-arg/`§1.3`-config shared-token resolution.
- `UnrealMcp.AgentConfigModels` spec — the written client bearer equals the resolved effective token the local-server launch uses (cross-sink lockstep).
- `docs/ARCHITECTURE.md` §8 — records the audit conclusion + evidence.

Scope note: **client-side only** — no server release, no plugin/`.uplugin` version bump, no McpPlugin re-pin (that is the separate i6 release task).

## Test plan

- [x] Target-specific local tests passed (profile `test.md`): UE plugin gate Suites **1** (UBT editor build, exit 0) + **2** (headless smoke, `[Unreal-MCP] plugin loaded`) + **3** (Automation, **failed=0 / succeeded=344**). Editor-test-module-only change, so Suite 1b (BuildPlugin) does not apply.

Closes #234