### PR TITLE
chore(deps): bump McpPlugin 7.1.0 -> 7.1.1

### DIFF
--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -79,10 +79,13 @@
     launch-arg logic) + the Consts.MCP.Server.AuthOption { none, oauth, token } enum the g6 consolidation
     delegates to (the sidecar calls ServerLaunchArguments.BuildCommandLine so the C++ editor no longer
     duplicates arg-building). Published on nuget.org; ReflectorNet stays 5.3.2 (7.1.0 keeps that floor).
+    ⚠ DEVIATION (mcp-authorize i6, maintainer-authorized dependency-freshness bump, per the
+    PIPELINE.md "Freshness-bump carve-out"): 7.1.0 -> 7.1.1 is the patch that carries the i1 BUG-A
+    token-mode validator fix. Published on nuget.org; ReflectorNet stays 5.3.2 (7.1.1 keeps that floor).
   -->
   <ItemGroup>
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.2" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.1.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.1.1" />
   </ItemGroup>
 
   <!-- The xUnit suite exercises a couple of internal helpers (e.g. ProxyTool.CalculateTokenCount). -->


### PR DESCRIPTION
## What

Bumps the `com.IvanMurzak.McpPlugin` NuGet pin in the .NET sidecar (`bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj`) from **7.1.0 → 7.1.1**.

## Why

This is the **mcp-authorize i6** McpPlugin adoption. **7.1.1** is the patch that carries the **i1 BUG-A token-mode validator fix**. McpPlugin 7.1.1 is already published on NuGet.

## Scope

- Only the `com.IvanMurzak.McpPlugin` pin changes. `com.IvanMurzak.ReflectorNet` stays **5.3.2** (7.1.1 keeps that floor — no transitive bump required).
- Added a matching `DEVIATION` note to the pin comment block, consistent with the file's convention for each prior McpPlugin bump.

## Local verification

`dotnet restore` + `dotnet build bridge/Unreal-MCP-Bridge.sln --configuration Debug` both succeed against the new pin — **0 warnings, 0 errors**. The authoritative gate is CI on this PR (bridge build/xUnit + the UE build legs).