### PR TITLE
ci: per-run disk cleanup for self-hosted UE runner jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,6 +445,44 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+      - name: Cleanup this job's build outputs (self-hosted disk hygiene)
+        # Self-hosted disk hygiene. This runner is SHARED with other repos' jobs and
+        # its RUNNER_TEMP + the persistent runner-local host project are NOT auto-pruned
+        # after a job, so per-run BuildPlugin packages and host logs accumulate across
+        # runs (a contributor to disk-full spikes during heavy concurrent CI). Remove
+        # ONLY THIS job's own regenerable outputs. Deliberately NOT touched:
+        #   • host DerivedDataCache / Intermediate / Binaries — a persistent
+        #     shared-for-speed cache; deleting it forces a full shader/host recompile
+        #     every run (§ guardrail: never prune a cache other runs rely on for speed).
+        #   • the host Plugins\UnrealMCP junction — owned by the self-heal step above.
+        #   • Docker — these UE jobs use no containers, and the daemon is shared with
+        #     the context-engine / ai-pipeline runners' ACTIVE jobs.
+        # Best-effort: a cleanup failure must NEVER red an otherwise-green run.
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          function Remove-Tree([string]$p) {
+            if ([string]::IsNullOrWhiteSpace($p) -or -not (Test-Path -LiteralPath $p)) { return }
+            Write-Host "Removing $p"
+            cmd /c rmdir /s /q "$p" 2>$null
+            if (Test-Path -LiteralPath $p) { Remove-Item -LiteralPath $p -Recurse -Force -ErrorAction SilentlyContinue }
+          }
+          # 1. This job's per-run BuildPlugin / report outputs under RUNNER_TEMP.
+          foreach ($name in @('UnrealMCP-Package','UnrealMCP-Dist-Package','UnrealMCP-Source-Package','AutomationReport')) {
+            Remove-Tree (Join-Path $env:RUNNER_TEMP $name)
+          }
+          # 2. This job's UBT logs under RUNNER_TEMP.
+          Get-ChildItem -Path $env:RUNNER_TEMP -Filter 'UBT-*.log' -File -ErrorAction SilentlyContinue |
+            Remove-Item -Force -ErrorAction SilentlyContinue
+          # 3. Host project transient logs/crashes ONLY (unbounded growers; NOT the
+          #    DDC / Intermediate / Binaries speed caches).
+          if (-not [string]::IsNullOrWhiteSpace($env:HOST_UPROJECT) -and (Test-Path -LiteralPath $env:HOST_UPROJECT)) {
+            $hostRoot = Split-Path -Parent $env:HOST_UPROJECT
+            foreach ($sub in @('Saved\Logs','Saved\Crashes')) { Remove-Tree (Join-Path $hostRoot $sub) }
+          }
+          Write-Host "Per-run cleanup done (DDC / Intermediate / Binaries and Docker intentionally preserved)."
+
   # ── ARTIFACT BUILD — SIGNED BRIDGE BUNDLE (runs on a real release OR a
   #    dry-run rehearsal). The self-contained bridge is built + code-signed per
   #    RID here, then (T4) STAGED INTO the plugin tree before BuildPlugin so the
@@ -894,6 +932,29 @@ jobs:
           path: ./dist/unreal-mcp-plugin-${{ needs.check-version.outputs.version }}.zip
           if-no-files-found: error
           retention-days: 7
+
+      - name: Cleanup this job's build outputs (self-hosted disk hygiene)
+        # Self-hosted disk hygiene. The release packaging outputs are the LARGEST
+        # per-run artifacts on this shared runner (compiled BuildPlugin package +
+        # staged source package). RUNNER_TEMP is not auto-pruned after a job, so
+        # remove ONLY THIS job's own regenerable outputs here (the uploaded artifacts
+        # are already safely stored). This job builds no host project and touches no
+        # Docker, so neither the host DDC/Intermediate/Binaries speed cache nor the
+        # shared Docker daemon is relevant. Best-effort: never red a green run.
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          function Remove-Tree([string]$p) {
+            if ([string]::IsNullOrWhiteSpace($p) -or -not (Test-Path -LiteralPath $p)) { return }
+            Write-Host "Removing $p"
+            cmd /c rmdir /s /q "$p" 2>$null
+            if (Test-Path -LiteralPath $p) { Remove-Item -LiteralPath $p -Recurse -Force -ErrorAction SilentlyContinue }
+          }
+          foreach ($name in @('UnrealMCP-Package','UnrealMCP-Source-Package')) {
+            Remove-Tree (Join-Path $env:RUNNER_TEMP $name)
+          }
+          Write-Host "Per-run release-packaging cleanup done."
 
   # ── PUBLISH (gated on a REAL release: tag absent + version bumped, NOT a
   #    dry-run). Every job here is hard-skipped during the ci-workflows dry-run. ─

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -275,6 +275,44 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+      - name: Cleanup this job's build outputs (self-hosted disk hygiene)
+        # Self-hosted disk hygiene. This runner is SHARED with other repos' jobs and
+        # its RUNNER_TEMP + the persistent runner-local host project are NOT auto-pruned
+        # after a job, so per-run BuildPlugin packages and host logs accumulate across
+        # runs (a contributor to disk-full spikes during heavy concurrent CI). Remove
+        # ONLY THIS job's own regenerable outputs. Deliberately NOT touched:
+        #   • host DerivedDataCache / Intermediate / Binaries — a persistent
+        #     shared-for-speed cache; deleting it forces a full shader/host recompile
+        #     every run (§ guardrail: never prune a cache other runs rely on for speed).
+        #   • the host Plugins\UnrealMCP junction — owned by the self-heal step above.
+        #   • Docker — these UE jobs use no containers, and the daemon is shared with
+        #     the context-engine / ai-pipeline runners' ACTIVE jobs.
+        # Best-effort: a cleanup failure must NEVER red an otherwise-green run.
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          function Remove-Tree([string]$p) {
+            if ([string]::IsNullOrWhiteSpace($p) -or -not (Test-Path -LiteralPath $p)) { return }
+            Write-Host "Removing $p"
+            cmd /c rmdir /s /q "$p" 2>$null
+            if (Test-Path -LiteralPath $p) { Remove-Item -LiteralPath $p -Recurse -Force -ErrorAction SilentlyContinue }
+          }
+          # 1. This job's per-run BuildPlugin / report outputs under RUNNER_TEMP.
+          foreach ($name in @('UnrealMCP-Package','UnrealMCP-Dist-Package','UnrealMCP-Source-Package','AutomationReport')) {
+            Remove-Tree (Join-Path $env:RUNNER_TEMP $name)
+          }
+          # 2. This job's UBT logs under RUNNER_TEMP.
+          Get-ChildItem -Path $env:RUNNER_TEMP -Filter 'UBT-*.log' -File -ErrorAction SilentlyContinue |
+            Remove-Item -Force -ErrorAction SilentlyContinue
+          # 3. Host project transient logs/crashes ONLY (unbounded growers; NOT the
+          #    DDC / Intermediate / Binaries speed caches).
+          if (-not [string]::IsNullOrWhiteSpace($env:HOST_UPROJECT) -and (Test-Path -LiteralPath $env:HOST_UPROJECT)) {
+            $hostRoot = Split-Path -Parent $env:HOST_UPROJECT
+            foreach ($sub in @('Saved\Logs','Saved\Crashes')) { Remove-Tree (Join-Path $hostRoot $sub) }
+          }
+          Write-Host "Per-run cleanup done (DDC / Intermediate / Binaries and Docker intentionally preserved)."
+
   # (d) connection + tool smoke — the live RELAY path the Automation specs do NOT
   # cover: a real MCP client -> gamedev-mcp-server -> sidecar -> plugin -> editor
   # round-trip, exercised by the self-contained scripts/connection_smoke.py
@@ -405,3 +443,29 @@ jobs:
           # editor the script spawns.
           & $py scripts/connection_smoke.py --mode custom --project "$env:HOST_UPROJECT" --ue "$editorCmd" --server-port 18080 --timeout 240
           if ($LASTEXITCODE -ne 0) { throw "connection + tool smoke FAILED (exit $LASTEXITCODE)" }
+
+      - name: Cleanup this job's build outputs (self-hosted disk hygiene)
+        # See the plugin job's cleanup note. Removes ONLY this job's own regenerable
+        # RUNNER_TEMP package + host transient logs; preserves the host
+        # DDC / Intermediate / Binaries speed cache, the junction (self-heal above),
+        # and Docker (unused here; daemon shared with other runners).
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          function Remove-Tree([string]$p) {
+            if ([string]::IsNullOrWhiteSpace($p) -or -not (Test-Path -LiteralPath $p)) { return }
+            Write-Host "Removing $p"
+            cmd /c rmdir /s /q "$p" 2>$null
+            if (Test-Path -LiteralPath $p) { Remove-Item -LiteralPath $p -Recurse -Force -ErrorAction SilentlyContinue }
+          }
+          foreach ($name in @('UnrealMCP-Package','UnrealMCP-Dist-Package','UnrealMCP-Source-Package','AutomationReport')) {
+            Remove-Tree (Join-Path $env:RUNNER_TEMP $name)
+          }
+          Get-ChildItem -Path $env:RUNNER_TEMP -Filter 'UBT-*.log' -File -ErrorAction SilentlyContinue |
+            Remove-Item -Force -ErrorAction SilentlyContinue
+          if (-not [string]::IsNullOrWhiteSpace($env:HOST_UPROJECT) -and (Test-Path -LiteralPath $env:HOST_UPROJECT)) {
+            $hostRoot = Split-Path -Parent $env:HOST_UPROJECT
+            foreach ($sub in @('Saved\Logs','Saved\Crashes')) { Remove-Tree (Join-Path $hostRoot $sub) }
+          }
+          Write-Host "Per-run cleanup done (DDC / Intermediate / Binaries and Docker intentionally preserved)."


### PR DESCRIPTION
## Why

The self-hosted Windows UE runner (`[self-hosted, windows, unreal-5-7]`) is **shared** across multiple repos on the owner's machine (IVANPC also hosts Context-Engine ×3, ai-pipeline, and Unreal-AI-* extension runners). Its `RUNNER_TEMP` and the **persistent runner-local host project** are not auto-pruned after a job, so per-run BuildPlugin packages (hundreds of MB each) and the host project's `Saved` logs accumulate across runs. This standing garbage contributes to disk-full spikes during heavy concurrent CI (observed during the mcp-authorize i6 release wave).

## What

Adds a final `if: always()` **cleanup step** to every self-hosted job in both workflows:

- `test_pull_request.yml` → `plugin`, `connection-smoke`
- `release.yml` → `plugin`, `build-plugin-zip`

Each step removes **only that job's own regenerable outputs**:

- `RUNNER_TEMP\UnrealMCP-Package`, `UnrealMCP-Dist-Package`, `UnrealMCP-Source-Package`, `AutomationReport`
- `RUNNER_TEMP\UBT-*.log`
- host project `Saved\Logs` + `Saved\Crashes` (unbounded growers; guarded on `HOST_UPROJECT`)

## Deliberately preserved (never pruned)

- **host `DerivedDataCache` / `Intermediate` / `Binaries`** — a persistent shared-for-speed cache; deleting it would force a full shader/host recompile on every run.
- **the host `Plugins\UnrealMCP` junction** — owned by the existing self-heal step; cleanup never touches it.
- **Docker** — these UE jobs use no containers, and the daemon is shared with the Context-Engine / ai-pipeline runners' active jobs, so pruning it here could hit another runner's live build.

## Safety

Best-effort and non-fatal (`$ErrorActionPreference = 'Continue'`, `-ErrorAction SilentlyContinue`), so a cleanup failure can never turn an otherwise-green run red. Scope is strictly per-run/per-job disposable output — no shared base image, no other job's data, no persistent speed cache.

Both files validated as well-formed YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)