### PR TITLE
fix(bridge): always wire the machine credential store in the prod sidecar (B14)

### DIFF
--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -217,8 +217,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             _authenticator = authenticator
                 ?? new DeviceCodeAuthenticator(_ownedHttpClient!, loggerProvider?.CreateLogger(nameof(DeviceCodeAuthenticator)));
 
-            // mcp-authorize: wire the machine-credential lifecycle ONLY when the caller opted in with a store. Left
-            // null, the sidecar keeps the pre-existing static-bearer behavior exactly (Custom/env paths untouched).
+            // mcp-authorize: wire the machine-credential lifecycle when a store is supplied. B14: PRODUCTION MUST
+            // build the sidecar through CreateForProduction, which ALWAYS supplies the store, so a Cloud sign-in can
+            // never silently degrade to a static bearer without refresh (design 01 §7d, V11). A null store here is
+            // ONLY the static-bearer TEST seam (Custom/env-mode config/transition tests that carry no cloud
+            // credential); it mirrors the real pre-sign-in state (a wired-but-empty store also lands on the static
+            // path). No prod path reaches this constructor with a null store.
             if (credentialStore != null)
             {
                 _credentialStore = credentialStore;
@@ -228,6 +232,37 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                     _credentialStore, _tokenRefresher, loggerProvider?.CreateLogger(nameof(PluginCredentialProvider)));
             }
         }
+
+        /// <summary>
+        /// B14 — the PRODUCTION construction path. Unlike the raw constructor (whose optional
+        /// <paramref name="credentialStore"/> is a TEST seam for the static/Custom-bearer path), this factory
+        /// GUARANTEES the shared machine credential store — and with it the on-401 refresh + token-refresher —
+        /// is wired, so a Cloud sign-in can never silently degrade to a static bearer without refresh (the B14
+        /// silent-degradation path). <see cref="Program"/> builds the sidecar through here; the store can no
+        /// longer be dropped by editing the entry point. The store defaults to the real <c>~/.ai-game-dev</c>
+        /// machine store; the bridge xUnit suite injects an isolated temp store (and optionally a scripted
+        /// refresher) to prove the prod wiring includes the store and exercises the refresh path without touching
+        /// real machine state.
+        /// </summary>
+        internal static SidecarHost CreateForProduction(
+            IpcClient ipc,
+            string sidecarVersion,
+            ILoggerProvider? loggerProvider = null,
+            string? fallbackHost = null,
+            string? fallbackToken = null,
+            DeviceCodeAuthenticator? authenticator = null,
+            McpAgentConfig.MachineCredentialStore? credentialStore = null,
+            ITokenRefresher? tokenRefresher = null)
+            => new SidecarHost(
+                ipc,
+                sidecarVersion,
+                loggerProvider,
+                fallbackHost,
+                fallbackToken,
+                authenticator,
+                // B14 guarantee: null collapses to the real machine store, so the store is ALWAYS wired in prod.
+                credentialStore: credentialStore ?? new McpAgentConfig.MachineCredentialStore(),
+                tokenRefresher: tokenRefresher);
 
         public IMcpPlugin? Plugin => _plugin;
         public ConnectionConfig Config => _config;

--- a/bridge/src/Program.cs
+++ b/bridge/src/Program.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using com.IvanMurzak.McpPlugin.AgentConfig;
 using com.IvanMurzak.Unreal.MCP.Bridge.Host;
 using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
 using com.IvanMurzak.Unreal.MCP.Bridge.Sidecar;
@@ -80,18 +79,21 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge
                 sidecarVersion: SidecarVersion,
                 logger: loggerProvider.CreateLogger(nameof(IpcClient)));
 
-            using var host = new SidecarHost(
+            // B14 (design 01 §7d, V11): build via CreateForProduction, which ALWAYS wires the shared machine
+            // credential store (~/.ai-game-dev/credentials.json, 0600 / DPAPI — read by the engine plugins, the
+            // CLIs, and the local server so sign-in is once-per-machine). That store presence enables the
+            // device-code sign-in, boot auto-adopt (zero-button), and proactive/on-401 refresh. Routing prod
+            // through the factory (instead of the raw constructor's optional-store test seam) makes it impossible
+            // to drop the store from the entry point, so a Cloud sign-in can never silently degrade to a static
+            // bearer without refresh. The factory defaults to the real ~/.ai-game-dev store; the xUnit suite
+            // injects a temp dir instead.
+            using var host = SidecarHost.CreateForProduction(
                 ipc,
                 SidecarVersion,
                 loggerProvider,
                 fallbackHost: Environment.GetEnvironmentVariable("UNREAL_MCP_HOST")
                               ?? Environment.GetEnvironmentVariable("UNREAL_MCP_CLOUD_URL"),
-                fallbackToken: Environment.GetEnvironmentVariable("UNREAL_MCP_TOKEN"),
-                // mcp-authorize (D12): the shared machine credential store (~/.ai-game-dev/credentials.json, 0600 /
-                // DPAPI) — read by the engine plugins, the CLIs, and the local server so sign-in is once-per-machine.
-                // Its presence enables the device-code sign-in, boot auto-adopt (zero-button), and proactive/on-401
-                // refresh. Left default (~/.ai-game-dev); the xUnit suite injects a temp dir instead.
-                credentialStore: new MachineCredentialStore());
+                fallbackToken: Environment.GetEnvironmentVariable("UNREAL_MCP_TOKEN"));
             host.Build();
 
             // No-orphan watchdogs (§6) ------------------------------------------------------------------

--- a/bridge/tests/SidecarHostProdWiringTests.cs
+++ b/bridge/tests/SidecarHostProdWiringTests.cs
@@ -1,0 +1,140 @@
+/*
+┌───────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)              │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unreal-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                   │
+│  Licensed under the Apache License, Version 2.0.                  │
+│  See the LICENSE file in the project root for more information.   │
+└───────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.Unreal.MCP.Bridge.Auth;
+using com.IvanMurzak.Unreal.MCP.Bridge.Host;
+using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
+using Xunit;
+
+namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
+{
+    /// <summary>
+    /// B14 regression (design 01 §7d / auth-fixes V11) — the PRODUCTION sidecar wiring
+    /// (<see cref="SidecarHost.CreateForProduction"/>, the exact path <see cref="Program"/> boots through)
+    /// ALWAYS wires the shared machine credential store + token refresher, so a Cloud sign-in can never silently
+    /// degrade to a static bearer without refresh. Before B14 the store was optional on the raw constructor and
+    /// only wired if the entry point remembered to pass it (`if (credentialStore != null)`); the factory now makes
+    /// that structural. A per-test temp store isolates these from the real <c>~/.ai-game-dev</c> — no network, no
+    /// shared machine state.
+    /// </summary>
+    public class SidecarHostProdWiringTests
+    {
+        private static string NewStoreDir()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "umcp-prodwire-" + Guid.NewGuid().ToString("N")[..12]);
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        private static IpcClient NewIpc() => new("127.0.0.1", 39998, token: "ipc-token", sidecarVersion: "0.1.0");
+
+        private static JsonObject CloudConfig(string cloudUrl = "https://ai-game.dev") =>
+            new() { ["mode"] = "Cloud", ["cloudUrl"] = cloudUrl };
+
+        // A scripted HTTP handler for the /oauth/token refresh endpoint: returns one fixed body + status.
+        private sealed class RefreshHandler : HttpMessageHandler
+        {
+            private readonly string _json;
+            private readonly HttpStatusCode _status;
+            public int Calls { get; private set; }
+
+            public RefreshHandler(string json, HttpStatusCode status)
+            {
+                _json = json;
+                _status = status;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Calls++;
+                return Task.FromResult(new HttpResponseMessage(_status)
+                {
+                    Content = new StringContent(_json, Encoding.UTF8, "application/json"),
+                });
+            }
+        }
+
+        [Fact]
+        public void CreateForProduction_AlwaysWiresCredentialStore_EvenWithNoExplicitStore()
+        {
+            // The B14 core assertion: the prod factory NEVER yields an unwired sidecar. Even with NO explicit store
+            // — the exact shape a future Program.cs edit that dropped the store arg would hit — the machine-credential
+            // provider is wired, so Cloud mode presents the refreshable credential rather than a static-only bearer.
+            // Asserts only the wiring (creds-independent), so it holds on CI (no credential file) and locally alike.
+            using var host = SidecarHost.CreateForProduction(NewIpc(), "0.1.0");
+            Assert.NotNull(host.CredentialProvider);
+        }
+
+        [Fact]
+        public void CreateForProduction_WithSeededStore_DrivesCloudBearerFromStore_NotStatic()
+        {
+            // Prod wiring auto-adopts a seeded machine credential (zero-button boot, D12) and drives the Cloud bearer
+            // from it — proving the store the factory wires actually feeds the connection layer's credential provider.
+            var dir = NewStoreDir();
+            new MachineCredentialStore(dir).Write(new MachineCredentials
+            {
+                Version = 1,
+                AccessToken = "seeded-jwt",
+                RefreshToken = "seeded-refresh",
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+                ServerTarget = "https://ai-game.dev",
+            });
+
+            using var host = SidecarHost.CreateForProduction(NewIpc(), "0.1.0", credentialStore: new MachineCredentialStore(dir));
+            Assert.NotNull(host.CredentialProvider);
+            Assert.True(host.CredentialProvider!.IsSignedIn);
+
+            host.ApplyConnectionConfig(CloudConfig());
+            Assert.Equal("seeded-jwt", host.CurrentBearer);
+        }
+
+        [Fact]
+        public async Task CreateForProduction_RefreshPath_RotatesExpiredStoredCredential()
+        {
+            // Exercise the refresh path through the PROD wiring: a stale (past-exp) stored credential is refreshed
+            // via the wired token refresher before the connection layer is handed a bearer. A static-only sidecar
+            // (the B14 defect) would instead present the stale token forever with no refresh.
+            var dir = NewStoreDir();
+            new MachineCredentialStore(dir).Write(new MachineCredentials
+            {
+                Version = 1,
+                AccessToken = "stale-jwt",
+                RefreshToken = "old-refresh",
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-5), // already expired → forces a refresh
+                ServerTarget = "https://ai-game.dev",
+            });
+
+            var handler = new RefreshHandler(
+                "{\"access_token\":\"rotated-jwt\",\"refresh_token\":\"new-refresh\",\"token_type\":\"Bearer\",\"expires_in\":3600}",
+                HttpStatusCode.OK);
+            var refresher = new OAuthTokenRefresher(new HttpClient(handler));
+
+            using var host = SidecarHost.CreateForProduction(
+                NewIpc(), "0.1.0",
+                credentialStore: new MachineCredentialStore(dir),
+                tokenRefresher: refresher);
+            host.ApplyConnectionConfig(CloudConfig());
+
+            var bearer = await Task.Run(() => host.CurrentBearer);
+
+            Assert.True(handler.Calls >= 1, "the wired refresher must be invoked to rotate the expired credential");
+            Assert.Equal("rotated-jwt", bearer);
+        }
+    }
+}

--- a/bridge/tests/SidecarHostProdWiringTests.cs
+++ b/bridge/tests/SidecarHostProdWiringTests.cs
@@ -9,6 +9,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -33,13 +34,26 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
     /// that structural. A per-test temp store isolates these from the real <c>~/.ai-game-dev</c> — no network, no
     /// shared machine state.
     /// </summary>
-    public class SidecarHostProdWiringTests
+    public class SidecarHostProdWiringTests : IDisposable
     {
-        private static string NewStoreDir()
+        // Temp store dirs created by this test instance, deleted in Dispose (best-effort) so repeated runs do not
+        // leak %TEMP% dirs — matches the sibling SidecarHostProjectConfigTests' RunInTempDir cleanup convention.
+        private readonly List<string> _tempDirs = new();
+
+        private string NewStoreDir()
         {
             var dir = Path.Combine(Path.GetTempPath(), "umcp-prodwire-" + Guid.NewGuid().ToString("N")[..12]);
             Directory.CreateDirectory(dir);
+            _tempDirs.Add(dir);
             return dir;
+        }
+
+        public void Dispose()
+        {
+            foreach (var dir in _tempDirs)
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { /* best-effort cleanup */ }
+            }
         }
 
         private static IpcClient NewIpc() => new("127.0.0.1", 39998, token: "ipc-token", sidecarVersion: "0.1.0");
@@ -47,23 +61,18 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         private static JsonObject CloudConfig(string cloudUrl = "https://ai-game.dev") =>
             new() { ["mode"] = "Cloud", ["cloudUrl"] = cloudUrl };
 
-        // A scripted HTTP handler for the /oauth/token refresh endpoint: returns one fixed body + status.
+        // A scripted HTTP handler for the /oauth/token refresh endpoint: returns one fixed 200 body.
         private sealed class RefreshHandler : HttpMessageHandler
         {
             private readonly string _json;
-            private readonly HttpStatusCode _status;
             public int Calls { get; private set; }
 
-            public RefreshHandler(string json, HttpStatusCode status)
-            {
-                _json = json;
-                _status = status;
-            }
+            public RefreshHandler(string json) => _json = json;
 
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 Calls++;
-                return Task.FromResult(new HttpResponseMessage(_status)
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent(_json, Encoding.UTF8, "application/json"),
                 });
@@ -121,8 +130,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             });
 
             var handler = new RefreshHandler(
-                "{\"access_token\":\"rotated-jwt\",\"refresh_token\":\"new-refresh\",\"token_type\":\"Bearer\",\"expires_in\":3600}",
-                HttpStatusCode.OK);
+                "{\"access_token\":\"rotated-jwt\",\"refresh_token\":\"new-refresh\",\"token_type\":\"Bearer\",\"expires_in\":3600}");
             var refresher = new OAuthTokenRefresher(new HttpClient(handler));
 
             using var host = SidecarHost.CreateForProduction(

--- a/docs/DEVICE-AUTH-SMOKE.md
+++ b/docs/DEVICE-AUTH-SMOKE.md
@@ -1,0 +1,65 @@
+# Device-flow smoke (editor Cloud Authorize) — sidecar parity + B14
+
+This is the manual smoke that proves the Unreal editor Cloud sign-in reaches parity with Unity/Godot
+**through the .NET sidecar** and that the machine credential store is definitely wired (auth-fixes **B14**,
+verification **V11**). It exists because Unreal's device flow is unique: unlike the C# engines that host the
+McpPlugin auth stack in-process, the Unreal **plugin** only relays `auth-start` over IPC and the
+**sidecar** (`unreal-mcp-bridge`) runs the OAuth device-code flow.
+
+## IPC surface (verified unchanged by the unified flow)
+
+The plugin↔sidecar auth surface is **stable** — the auth-fixes redesign changed the server audience handling
+(B11/c2) and the LIB dual-hash metadata (f1b), **none of which touch these IPC messages**:
+
+| Direction | Message | Payload |
+|---|---|---|
+| plugin → sidecar | `auth-start` / `auth-cancel` / `auth-revoke` | a bare message `type` — **no `client_id`, no audience, no params** (`UnrealMcpEditorViewModel::Authorize` → `OnSendAuth("auth-start")`; `IpcProtocol.MessageTypes`) |
+| sidecar → plugin | `device-auth` (feed) | `{ state: pending\|authorized\|failed, verificationUrl, userCode, token, message }` (`DeviceCodeAuthenticator` emits; `UnrealMcpEditorViewModel::ApplyDeviceAuth` consumes) |
+
+The plugin **client_id stays `unreal-mcp-plugin`** and lives entirely **bridge-side**
+(`DeviceCodeAuthenticator.DefaultClientId`), used only in the sidecar's `POST /oauth/device_authorization`
++ `POST /oauth/token` calls (form `client_id` + `scope=mcp:plugin`). It never crosses the IPC boundary, so
+the unified flow needs **no IPC change** — this smoke confirms that end-to-end.
+
+## Preconditions
+
+- Local server stack from fresh `main` (skill `local-test`): backend + `mcp-server`, `MCP_AUTH=oauth`.
+- `engines/unreal/test-project` open in UE 5.7 with the `Plugins/UnrealMCP` junction pointed at the plugin.
+- Clean state between runs: remove `~/.ai-game-dev/credentials.json`, reset the testbed `.mcp.json`,
+  revoke any live sessions.
+
+## Smoke steps (V11)
+
+1. **Open the AI Game Developer window** → select **Cloud** mode → click **Authorize**.
+   - The ViewModel sends `auth-start` over IPC; if the sidecar is not yet handshaken it enters the transient
+     **Connecting** state and flushes the queued `auth-start` on handshake (issue #99). Expect the state to
+     advance to **Pending**.
+2. **Device-code feed.** The sidecar streams a `device-auth` message carrying `verificationUrl` + `userCode`;
+   the window shows them. Open the URL in a browser, sign in, and approve.
+3. **Authorized.** The sidecar's poll succeeds; it emits `device-auth { state: authorized, token }` and — because
+   prod always wires the store (B14, below) — **persists** the credential to the machine store and adopts it live.
+   The window's cloud-auth indicator lights **Authorized**.
+4. **Machine store wired (B14 check).** Confirm `~/.ai-game-dev/credentials.json` now exists and carries
+   `accessToken` + `refreshToken` + `expiresAt` + `serverTarget` (the cloud base, `/mcp` stripped). This is the
+   proof the sidecar did **not** silently degrade to a static bearer.
+5. **Agent sees engine tools.** Point a real agent (Claude Code `.mcp.json` in the testbed) at the pinned URL and
+   confirm `tools/list` returns the full engine toolset — not the 3 native tools.
+6. **Silent refresh (ties to V10).** Shorten the access-token TTL locally (or wait for `exp`); the sidecar
+   refreshes via the wired refresher on the next dial / on 401 with no user action — the connection stays live.
+
+## B14 — the machine store is ALWAYS wired
+
+The sidecar is built through `SidecarHost.CreateForProduction(...)` (the only path `Program.Main` uses), which
+**unconditionally** wires the shared `MachineCredentialStore` + `OAuthTokenRefresher`. The raw `SidecarHost`
+constructor still accepts a null store, but that overload is a **test-only** seam for the static/Custom-bearer
+path — no production path reaches it. So a Cloud sign-in can never fall back to a static bearer without refresh
+(the pre-B14 `if (credentialStore != null)` silent-degradation risk is removed).
+
+Automated coverage lives in `bridge/tests/SidecarHostProdWiringTests.cs`:
+
+- `CreateForProduction_AlwaysWiresCredentialStore_EvenWithNoExplicitStore` — the factory never yields an unwired
+  sidecar (the exact shape a dropped-store regression would hit).
+- `CreateForProduction_WithSeededStore_DrivesCloudBearerFromStore_NotStatic` — a seeded credential drives the
+  Cloud bearer (zero-button boot).
+- `CreateForProduction_RefreshPath_RotatesExpiredStoredCredential` — an expired stored credential is refreshed
+  via the wired refresher before the connection layer receives a bearer.


### PR DESCRIPTION
## Summary
- **B14 (security):** the machine credential store was wired only if `Program.cs` remembered to pass it (`if (credentialStore != null)`), so a Cloud sign-in could silently degrade to a static bearer with **no refresh**. Prod now builds through a new `SidecarHost.CreateForProduction(...)` factory that **unconditionally** wires the shared `MachineCredentialStore` + token refresher — the store can no longer be dropped from the entry point. The raw constructor keeps its optional-store seam for the static/Custom-bearer tests (no prod path reaches it with a null store).
- **Regression tests** (`bridge/tests/SidecarHostProdWiringTests.cs`): the prod factory always wires the store (even with no explicit store); a seeded store drives the Cloud bearer; an expired stored credential is refreshed via the wired refresher.
- **IPC device-flow surface check:** the plugin↔sidecar surface (`auth-start`/`device-auth`, `client_id` stays `unreal-mcp-plugin`, bridge-side only) needs **no change** for the unified flow — `auth-start` carries no client_id/audience and the `device-auth` feed shape is unchanged. Documented the device-flow smoke for V11/k2 in `docs/DEVICE-AUTH-SMOKE.md`.

This is the **unblocked half (f1a)** of design task `f1-unreal-plugin-b14-dualhash`. The dual-hash metadata half (f1b) is tracked separately — it needs c1's LIB primitives not yet in the consumed NuGet pin (McpPlugin **7.1.1**, **not** bumped here).

## Test plan
- [x] Target-specific local tests passed (bridge Suite 4 — `dotnet build` + `dotnet test`: **269/269** pass, 0 warnings/errors).

Closes #239