### PR TITLE
feat(cli): unreal-mcp-cli → cli-core (OAuth login, pinned setup-mcp, v2 enroll — B5 fix)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.9.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@baizor/gamedev-cli-core": "0.1.0",
         "chalk": "^5.6.2",
         "commander": "^13.1.0",
         "fflate": "^0.8.3",
@@ -24,6 +25,15 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@baizor/gamedev-cli-core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@baizor/gamedev-cli-core/-/gamedev-cli-core-0.1.0.tgz",
+      "integrity": "sha512-LFpO0WAXuMs+BtQpLn6mqK8JoiL7udYptrvFhv40aLk/AOz7yhCs2pPXwMdd29XH1siv3rPPc7fv+gNVqCNN1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.14.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -68,6 +68,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@baizor/gamedev-cli-core": "0.1.0",
     "chalk": "^5.6.2",
     "commander": "^13.1.0",
     "fflate": "^0.8.3",

--- a/cli/src/commands/setup-mcp.ts
+++ b/cli/src/commands/setup-mcp.ts
@@ -11,6 +11,7 @@ export const setupMcpCommand = new Command('setup-mcp')
   .option('--transport <t>', 'Transport: http | stdio (default http)')
   .option('--url <url>', 'Explicit MCP server URL override')
   .option('--token <token>', 'Bearer token override')
+  .option('--no-pin', 'Write an unpinned <base>/mcp URL instead of the default pinned <base>/mcp/p/<pin>')
   .option('--dry-run', 'Print the snippet instead of writing it')
   .option('--list', 'List all supported agent ids and their config paths')
   .action(async (agent: string | undefined, opts) => {
@@ -36,6 +37,8 @@ export const setupMcpCommand = new Command('setup-mcp')
       transport: opts.transport as McpTransport | undefined,
       url: opts.url,
       token: opts.token,
+      // Commander maps `--no-pin` to `pin === false`; the default (pinned) is `pin !== false`.
+      noPin: opts.pin === false,
       dryRun: opts.dryRun,
     });
     ui.printWarnings(result.warnings);

--- a/cli/src/lib/enroll.ts
+++ b/cli/src/lib/enroll.ts
@@ -22,7 +22,13 @@
 
 import { MachineCredentialStore, type MachineCredentials, CREDENTIALS_VERSION } from '../utils/machine-credentials.js';
 import { upsertServerTarget } from '../utils/project-marker.js';
-import { deriveProjectPin } from '../utils/port.js';
+// B5 FIX (auth-fixes design 02 T3): the routing pin is derived with cli-core's
+// v2 ProjectIdentity (`derivePinV2`), which normalizes `\`→`/` before hashing.
+// `path.resolve` (below) yields a Windows backslash root; the legacy v1
+// `deriveProjectPin` hashed those backslashes verbatim, so the enroll pin never
+// prefix-matched the plugin's forward-slash `projectPathHash` and pinned routing
+// silently failed on Windows. v2 collapses `C:\a\b` and `C:/a/b` to one hash.
+import { derivePinV2 } from '@baizor/gamedev-cli-core';
 import { upsertProjectPin } from '../utils/pin-upsert.js';
 import { asError } from '../utils/error.js';
 import { fetchWithTimeout } from '../utils/http.js';
@@ -165,8 +171,9 @@ export async function enrollPlugin(opts: EnrollOptions): Promise<EnrollResult> {
     // 2. Record the enrolled server target in the committable project marker.
     const markerPath = upsertServerTarget(projectDir, serverTarget) ?? '';
 
-    // 3. Upsert the D14 routing pin into any existing project-local agent config.
-    const pin = deriveProjectPin(projectDir);
+    // 3. Upsert the D14 routing pin (cli-core v2 identity — B5 fix) into any
+    //    existing project-local agent config.
+    const pin = derivePinV2(projectDir);
     const { updatedFiles } = upsertProjectPin(projectDir, pin, { serverTarget });
     if (updatedFiles.length > 0) {
       emitProgress(opts.onProgress, {

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -8,7 +8,11 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { isUnrealProjectDir } from '../utils/project.js';
+// T5/B1: recognise the project root via cli-core's shared marker probe using the
+// Unreal engine adapter (any `*.uproject` in the root) — one policy across the
+// three CLIs. Warn-not-refuse: install-plugin's `requireMarker` is effectively
+// false (a not-yet-initialised tree is a valid, rarer flow).
+import { probeProjectMarkers, unrealAdapter } from '@baizor/gamedev-cli-core';
 import { asError } from '../utils/error.js';
 import { isSymlink } from '../utils/fs.js';
 import { emitProgress } from './progress.js';
@@ -89,8 +93,9 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     // Guard against a wrong-cwd run silently scaffolding Plugins/UnrealMCP in
     // an arbitrary directory (consistent with `close`/`status`, which key on
     // a `.uproject`). Warn rather than refuse — installing into a not-yet-
-    // initialised project tree is a valid, if rarer, flow.
-    if (!isUnrealProjectDir(projectDir)) {
+    // initialised project tree is a valid, if rarer, flow. The marker set comes
+    // from the shared cli-core Unreal adapter (any `*.uproject`).
+    if (!probeProjectMarkers(projectDir, unrealAdapter.markers).found) {
       warnings.push(`No .uproject found in ${projectDir} — is this an Unreal project directory?`);
     }
     const resolvedSource = await resolvePluginSource({

--- a/cli/src/lib/login.ts
+++ b/cli/src/lib/login.ts
@@ -27,6 +27,7 @@ import {
   unrealAdapter,
   DEFAULT_PLUGIN_SCOPE,
   type DeviceAuthTransport,
+  type MachineCredentials as CoreMachineCredentials,
 } from '@baizor/gamedev-cli-core';
 import * as path from 'path';
 import { asError } from '../utils/error.js';
@@ -107,7 +108,8 @@ export async function login(opts: LoginOptions = {}): Promise<LoginResult> {
     const result = await deviceLogin({
       serverBaseUrl: baseUrl,
       clientId: unrealAdapter.clientId,
-      scope: DEFAULT_PLUGIN_SCOPE,
+      // Scope is carried by the transport above; `deviceLogin` reads its own
+      // `scope` only to build a DEFAULT transport, which we always override.
       // Record the AS root on the credential (never a pinned hub URL) — b2 MED-2.
       serverTarget: baseUrl,
       transport,
@@ -160,13 +162,7 @@ interface PersistOutcome {
  */
 async function persistCredential(
   opts: LoginOptions,
-  credentials: {
-    accessToken?: string;
-    refreshToken?: string;
-    expiresAt?: string;
-    serverTarget?: string;
-    subject?: unknown;
-  },
+  credentials: CoreMachineCredentials,
 ): Promise<PersistOutcome> {
   if (opts.projectDir) {
     const dir = path.resolve(opts.projectDir);
@@ -187,7 +183,7 @@ async function persistCredential(
     refreshToken: credentials.refreshToken ?? undefined,
     expiresAt: credentials.expiresAt ?? undefined,
     serverTarget: credentials.serverTarget ?? undefined,
-    subject: typeof credentials.subject === 'string' ? credentials.subject : undefined,
+    subject: credentials.subject,
   };
   await store.write(localCreds);
   return { persistedTo: 'machine-store', credentialPath: store.credentialsPath };

--- a/cli/src/lib/login.ts
+++ b/cli/src/lib/login.ts
@@ -1,27 +1,39 @@
-// `login` — OAuth 2.0 device authorization flow against ai-game.dev.
-// Requests a device code, surfaces the verification URL + user code via
-// `onProgress`, then polls the token endpoint until the user authorizes
-// (or the flow times out). On success, persists the credential into the
-// SHARED machine credential store (`~/.ai-game-dev/credentials.json`, mcp-authorize
-// design 06/09 D12) so sign-in happens once per machine — never into a
-// committable project file on the default path. The `--path` override still
-// keeps a project-local `.env` (gitignored) for per-project accounts.
-// fetch + sleep + clock are injectable for tests. Library-safe: never throws
-// past the boundary.
+// `login` — OAuth 2.1 device authorization flow (RFC 8628) against ai-game.dev,
+// now on the shared `@baizor/gamedev-cli-core` `deviceLogin` engine (auth-fixes
+// design 02 T1). It POSTs `client_id` (`unreal-mcp-cli`) + scope (`mcp:plugin`)
+// to `{base}/oauth/device_authorization`, surfaces the verification URL + user
+// code via `onProgress`, then redeems the grant at `{base}/oauth/token` — an
+// ES256 hub JWT plus a rotating refresh token. This REPLACES the legacy JSON
+// device-authorization endpoints and **never mints a PAT** (personal access
+// tokens stay a manual, human-only tool).
+//
+// On success the FULL credential set (accessToken, refreshToken, expiresAt,
+// serverTarget, subject) is persisted into the SHARED machine credential store
+// (`~/.ai-game-dev/credentials.json`, mcp-authorize design 06/09 D12) so sign-in
+// happens once per machine — never into a committable project file on the default
+// path. The `--path` override still keeps a project-local `.env` (gitignored) for
+// per-project accounts. transport + delay + clock are injectable for tests.
+// Library-safe: never throws past the boundary.
 
 import { writeEnvFile, ensureEnvGitignored } from '../utils/env-file.js';
-import { MachineCredentialStore, type MachineCredentials, CREDENTIALS_VERSION } from '../utils/machine-credentials.js';
+import {
+  MachineCredentialStore,
+  type MachineCredentials,
+  CREDENTIALS_VERSION,
+} from '../utils/machine-credentials.js';
+import {
+  deviceLogin,
+  HttpDeviceAuthTransport,
+  unrealAdapter,
+  DEFAULT_PLUGIN_SCOPE,
+  type DeviceAuthTransport,
+} from '@baizor/gamedev-cli-core';
 import * as path from 'path';
 import { asError } from '../utils/error.js';
-import { fetchWithTimeout } from '../utils/http.js';
 import { emitProgress } from './progress.js';
 import type { ProgressCallback } from './types.js';
 
 const DEFAULT_BASE_URL = 'https://ai-game.dev';
-const DEFAULT_DEVICE_PATH = '/api/auth/device/authorize';
-const DEFAULT_TOKEN_PATH = '/api/auth/device/token';
-/** Per-request deadline so a hung endpoint can't stall the flow forever. */
-const PER_REQUEST_TIMEOUT_MS = 30_000;
 
 export interface LoginOptions {
   baseUrl?: string;
@@ -33,11 +45,17 @@ export interface LoginOptions {
   projectDir?: string;
   /** Test seam: override the machine credential store base dir (default `~/.ai-game-dev`). */
   storeBaseDir?: string;
-  /** Overall poll deadline. Default 300000 ms (5 min). */
+  /**
+   * Overall poll deadline (ms). Accepted for CLI/back-compat; the effective
+   * deadline is the device-code `expires_in` the authorization server returns
+   * (RFC 8628), which `deviceLogin` enforces.
+   */
   timeoutMs?: number;
   fetchImpl?: typeof fetch;
   sleepImpl?: (ms: number) => Promise<void>;
   nowImpl?: () => number;
+  /** Test seam: inject a device-authorization transport (bypasses the HTTP transport). */
+  transport?: DeviceAuthTransport;
   onProgress?: ProgressCallback;
 }
 
@@ -61,125 +79,69 @@ export interface LoginSuccess {
 export interface LoginFailure {
   kind: 'failure';
   success: false;
-  /** Coarse reason — `access_denied`, `expired_token`, `timeout`, ... */
+  /** Coarse reason — `denied`, `expired`, `cancelled`, `error`, ... (cli-core `deviceLogin` reasons). */
   reason: string;
   error: Error;
 }
 
 export type LoginResult = LoginSuccess | LoginFailure;
 
-interface DeviceCodeResponse {
-  device_code: string;
-  user_code: string;
-  verification_uri: string;
-  verification_uri_complete?: string;
-  interval?: number;
-  expires_in?: number;
-}
-
-const realSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
-
 export async function login(opts: LoginOptions = {}): Promise<LoginResult> {
   const baseUrl = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
-  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
-  const sleep = opts.sleepImpl ?? realSleep;
-  const now = opts.nowImpl ?? Date.now;
-  const timeoutMs = typeof opts.timeoutMs === 'number' && opts.timeoutMs > 0 ? opts.timeoutMs : 300_000;
 
   try {
     emitProgress(opts.onProgress, { phase: 'start', message: 'Requesting device authorization' });
 
-    const codeResp = await fetchWithTimeout(
-      fetchImpl,
-      `${baseUrl}${DEFAULT_DEVICE_PATH}`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: '{}',
-      },
-      { timeoutMs: PER_REQUEST_TIMEOUT_MS },
-    );
-    if (!codeResp.ok) {
-      return fail('device-code-failed', `Device code request failed: HTTP ${codeResp.status}`);
-    }
-    const code = (await codeResp.json()) as DeviceCodeResponse;
-    if (!code.device_code || !code.user_code || !code.verification_uri) {
-      return fail('device-code-malformed', 'Device code response missing required fields.');
-    }
+    // Build the RFC 8628 device-auth transport. `client_id` is the Unreal product
+    // id from the shared engine adapter; scope selects the mcp:plugin JWT +
+    // refresh-token response. A test may inject its own transport directly.
+    const transport =
+      opts.transport ??
+      new HttpDeviceAuthTransport({
+        serverBaseUrl: baseUrl,
+        clientId: unrealAdapter.clientId,
+        scope: DEFAULT_PLUGIN_SCOPE,
+        fetchImpl: opts.fetchImpl,
+      });
 
-    emitProgress(opts.onProgress, {
-      phase: 'info',
-      message:
-        `To authorize, open ${code.verification_uri_complete ?? code.verification_uri} ` +
-        `and enter code ${code.user_code}`,
+    const result = await deviceLogin({
+      serverBaseUrl: baseUrl,
+      clientId: unrealAdapter.clientId,
+      scope: DEFAULT_PLUGIN_SCOPE,
+      // Record the AS root on the credential (never a pinned hub URL) — b2 MED-2.
+      serverTarget: baseUrl,
+      transport,
+      delay: opts.sleepImpl,
+      now: opts.nowImpl,
+      onUserCode: (userCode, verificationUri) => {
+        emitProgress(opts.onProgress, {
+          phase: 'info',
+          message: `To authorize, open ${verificationUri} and enter code ${userCode}`,
+        });
+      },
+      onPolling: () => {
+        emitProgress(opts.onProgress, { phase: 'info', message: 'Waiting for authorization…' });
+      },
     });
 
-    let intervalMs = Math.max(1, code.interval ?? 5) * 1000;
-    const start = now();
-    const deadline = start + timeoutMs;
-
-    while (now() < deadline) {
-      await sleep(intervalMs);
-      const tokenResp = await fetchWithTimeout(
-        fetchImpl,
-        `${baseUrl}${DEFAULT_TOKEN_PATH}`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ device_code: code.device_code }),
-        },
-        { timeoutMs: PER_REQUEST_TIMEOUT_MS },
-      );
-
-      if (tokenResp.ok) {
-        const body = (await tokenResp.json()) as TokenResponse;
-        if (!body.access_token) {
-          return fail('token-malformed', 'Token response missing access_token.');
-        }
-        const persisted = await persistCredential(opts, body, baseUrl, now);
-        emitProgress(opts.onProgress, { phase: 'done', message: 'Login complete.' });
-        return {
-          kind: 'success',
-          success: true,
-          token: body.access_token,
-          persisted: true,
-          persistedTo: persisted.persistedTo,
-          credentialPath: persisted.credentialPath,
-          envPath: persisted.envPath,
-        };
-      }
-
-      // Pending / slow-down / terminal errors per the device-flow spec.
-      const errBody = (await tokenResp.json().catch(() => ({}))) as { error?: string };
-      const error = errBody.error ?? `http-${tokenResp.status}`;
-      if (error === 'authorization_pending') continue;
-      if (error === 'slow_down') {
-        // RFC 8628 §3.5: on `slow_down` the poll interval MUST be increased by
-        // 5 seconds for this and ALL subsequent requests — a persistent
-        // back-off, not a one-shot extra sleep. The next loop iteration sleeps
-        // the new interval at the top before polling again.
-        intervalMs += 5000;
-        continue;
-      }
-      // access_denied, expired_token, or anything else terminal.
-      return fail(error, `Authorization failed: ${error}`);
+    if (!result.ok) {
+      return { kind: 'failure', success: false, reason: result.reason, error: new Error(result.message) };
     }
 
-    return fail('timeout', `Login timed out after ${timeoutMs}ms.`);
+    const persisted = await persistCredential(opts, result.credentials);
+    emitProgress(opts.onProgress, { phase: 'done', message: 'Login complete.' });
+    return {
+      kind: 'success',
+      success: true,
+      token: result.credentials.accessToken ?? '',
+      persisted: true,
+      persistedTo: persisted.persistedTo,
+      credentialPath: persisted.credentialPath,
+      envPath: persisted.envPath,
+    };
   } catch (err) {
-    const error = asError(err);
-    // A per-request `fetchWithTimeout` deadline surfaces as an AbortError;
-    // classify that as a timeout rather than a generic network error.
-    const reason = error.name === 'AbortError' ? 'timeout' : 'network-error';
-    return { kind: 'failure', success: false, reason, error };
+    return { kind: 'failure', success: false, reason: 'error', error: asError(err) };
   }
-}
-
-interface TokenResponse {
-  access_token?: string;
-  refresh_token?: string;
-  /** Seconds until `access_token` expires (RFC 8628 / OAuth). */
-  expires_in?: number;
 }
 
 interface PersistOutcome {
@@ -192,13 +154,19 @@ interface PersistOutcome {
  * Persist the freshly-authorized credential. The default path writes the shared
  * machine store (`~/.ai-game-dev/credentials.json`, DPAPI/0600) so the token
  * NEVER lands in a committable project file; the `--path` override keeps the
- * legacy project-local `.env` (gitignored) for per-project accounts.
+ * project-local `.env` (gitignored) for per-project accounts. The store is
+ * byte-compatible with the C# / cli-core store, so the returned cli-core
+ * credential set is written through verbatim.
  */
 async function persistCredential(
   opts: LoginOptions,
-  body: TokenResponse,
-  serverTarget: string,
-  now: () => number,
+  credentials: {
+    accessToken?: string;
+    refreshToken?: string;
+    expiresAt?: string;
+    serverTarget?: string;
+    subject?: unknown;
+  },
 ): Promise<PersistOutcome> {
   if (opts.projectDir) {
     const dir = path.resolve(opts.projectDir);
@@ -208,25 +176,19 @@ async function persistCredential(
     // committable token file behind even if the process dies between the two
     // writes).
     ensureEnvGitignored(dir);
-    writeEnvFile(envPath, { UNREAL_MCP_TOKEN: body.access_token, UNREAL_MCP_CONNECTION_MODE: 'Cloud' });
+    writeEnvFile(envPath, { UNREAL_MCP_TOKEN: credentials.accessToken ?? '', UNREAL_MCP_CONNECTION_MODE: 'Cloud' });
     return { persistedTo: 'project-env', credentialPath: envPath, envPath };
   }
 
   const store = new MachineCredentialStore(opts.storeBaseDir);
-  const credentials: MachineCredentials = {
+  const localCreds: MachineCredentials = {
     version: CREDENTIALS_VERSION,
-    accessToken: body.access_token,
-    refreshToken: body.refresh_token ?? undefined,
-    expiresAt:
-      typeof body.expires_in === 'number' && body.expires_in > 0
-        ? new Date(now() + body.expires_in * 1000).toISOString()
-        : undefined,
-    serverTarget,
+    accessToken: credentials.accessToken,
+    refreshToken: credentials.refreshToken ?? undefined,
+    expiresAt: credentials.expiresAt ?? undefined,
+    serverTarget: credentials.serverTarget ?? undefined,
+    subject: typeof credentials.subject === 'string' ? credentials.subject : undefined,
   };
-  await store.write(credentials);
+  await store.write(localCreds);
   return { persistedTo: 'machine-store', credentialPath: store.credentialsPath };
-}
-
-function fail(reason: string, message: string): LoginFailure {
-  return { kind: 'failure', success: false, reason, error: new Error(message) };
 }

--- a/cli/src/lib/setup-mcp.ts
+++ b/cli/src/lib/setup-mcp.ts
@@ -11,6 +11,11 @@
 
 import * as path from 'path';
 import { platform } from 'os';
+// cli-core owns the T4 pinned-routing policy: `pinUrl` appends the `/p/<pin>`
+// routing segment and `derivePinV2` is the shared v2 ProjectIdentity pin
+// (`\`→`/`-normalized), so the CLI writes the SAME pinned URL the C# Editor
+// Configure and the sibling CLIs write for a given project.
+import { pinUrl, derivePinV2 } from '@baizor/gamedev-cli-core';
 import { resolveConnection, appendMcp } from '../utils/config.js';
 import { asError } from '../utils/error.js';
 import { generatePortFromDirectory } from '../utils/port.js';
@@ -122,7 +127,15 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
       // `/mcp` segment is appended ONCE here (idempotently, tolerating a URL
       // that already ends in `/mcp`) so the agent closures use `url` verbatim;
       // this avoids the historical `/mcp` double-append.
-      const httpUrl = appendMcp(conn.url);
+      //
+      // T4 (defect B4/B8): the URL is PINNED by default —
+      // `<base>/mcp/p/<pin-v2>` — so the config routes strictly to THIS
+      // project's engine instance even when the account has several, exactly as
+      // the Editor Configure does. `--no-pin` is the escape hatch (unpinned).
+      // M8: the pin is a routing path segment, not part of the OAuth resource;
+      // the canonical resource stays `<base>/mcp`.
+      const canonicalUrl = appendMcp(conn.url);
+      const httpUrl = opts.noPin ? canonicalUrl : pinUrl(canonicalUrl, derivePinV2(projectDir));
       const token = conn.token ?? '';
       // D11 / Flow A: OAuth-capable clients get a CREDENTIAL-FREE, URL-only config
       // so they run their own native OAuth; a static Bearer header is emitted only

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -388,6 +388,11 @@ export interface SetupMcpOptions {
   transport?: McpTransport;
   url?: string;
   token?: string;
+  /**
+   * `--no-pin`: write an UNPINNED `<base>/mcp` URL instead of the default pinned
+   * `<base>/mcp/p/<pin-v2>` (T4 escape hatch). Default `false` (pinned).
+   */
+  noPin?: boolean;
   /** Return the snippet instead of writing it. Default `false` (write). */
   dryRun?: boolean;
   /**

--- a/cli/tests/cli-core-parity.test.ts
+++ b/cli/tests/cli-core-parity.test.ts
@@ -1,0 +1,105 @@
+// Parity between unreal-mcp-cli and the shared `@baizor/gamedev-cli-core`
+// (auth-fixes design T7 / g1 DoD). These assertions prove the CLI's migrated
+// surfaces derive identical values to the golden-vector-gated core — the same
+// contract the C# LIB + Editor Configure follow — so a config the CLI writes and
+// a config the Editor writes route to the same engine instance.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import { setupMcp } from '../src/lib/setup-mcp.js';
+import { MCP_SERVER_NAME } from '../src/utils/agents.js';
+import { deriveProjectPin, generatePortFromDirectory } from '../src/utils/port.js';
+import { resolveServerBinaryPath } from '../src/lib/download-server.js';
+import {
+  resolveSetupMcpPlan,
+  getAgentById as coreGetAgentById,
+  unrealAdapter,
+  derivePinV2,
+  derivePortV2,
+  derivePin,
+  derivePort,
+  pinUrl,
+} from '@baizor/gamedev-cli-core';
+import { makeTempDir, rmTempDir } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+describe('engine adapter parity (unrealAdapter)', () => {
+  it('server-entry name matches the CLI registry and is `unreal-mcp`', () => {
+    expect(MCP_SERVER_NAME).toBe(unrealAdapter.serverName);
+    expect(unrealAdapter.serverName).toBe('unreal-mcp');
+  });
+
+  it('OAuth client id is `unreal-mcp-cli`', () => {
+    expect(unrealAdapter.clientId).toBe('unreal-mcp-cli');
+  });
+
+  it('stdio transport is ON for Unreal', () => {
+    expect(unrealAdapter.stdioSupported).toBe(true);
+  });
+});
+
+describe('project-identity parity (local v1 == cli-core v1 — golden-vector gated)', () => {
+  const roots = ['/home/dev/proj', 'C:/Users/dev/My Project', '/a/b/c/', 'C:\\Users\\dev\\proj'];
+  it('local deriveProjectPin == core derivePin', () => {
+    for (const r of roots) expect(deriveProjectPin(r)).toBe(derivePin(r));
+  });
+  it('local generatePortFromDirectory == core derivePort', () => {
+    for (const r of roots) expect(generatePortFromDirectory(r)).toBe(derivePort(r));
+  });
+});
+
+describe('server install-layout parity (§6 == cli-core unrealAdapter)', () => {
+  it('resolves the same binary path per RID', () => {
+    const project = tmp();
+    for (const [platform, arch] of [
+      ['win32', 'x64'],
+      ['linux', 'x64'],
+      ['darwin', 'arm64'],
+    ] as [NodeJS.Platform, string][]) {
+      expect(resolveServerBinaryPath(project, platform, arch)).toBe(
+        unrealAdapter.serverBinaryPath(project, platform, arch),
+      );
+    }
+  });
+});
+
+describe('pinned setup-mcp parity vs the shared Configure policy (T4 DoD)', () => {
+  it('the http URL the CLI writes equals cli-core resolveSetupMcpPlan().resolvedUrl', async () => {
+    const dir = tmp();
+    const base = 'https://ai-game.dev';
+    const r = await setupMcp({ agentId: 'claude-code', projectDir: dir, transport: 'http', url: base });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    const writtenUrl = JSON.parse(fs.readFileSync(r.configPath, 'utf-8')).mcpServers['unreal-mcp'].url;
+
+    const pin = derivePinV2(dir);
+
+    // (a) The URL uses cli-core's exact routing helper + v2 pin.
+    expect(writtenUrl).toBe(pinUrl('https://ai-game.dev/mcp', pin));
+
+    // (b) The URL matches cli-core's shared setup-mcp policy — the SAME plan the
+    //     Editor Configure / sibling CLIs run (golden-vector-gated vs the C# LIB).
+    const plan = resolveSetupMcpPlan({
+      adapter: unrealAdapter,
+      agent: coreGetAgentById('claude-code')!,
+      transport: 'http',
+      projectRoot: dir,
+      pin,
+      port: derivePortV2(dir),
+      timeoutMs: 10000,
+      authorization: 'none',
+      noPin: false,
+      url: 'https://ai-game.dev/mcp',
+    });
+    expect(writtenUrl).toBe(plan.resolvedUrl);
+  });
+});

--- a/cli/tests/enroll-b5.test.ts
+++ b/cli/tests/enroll-b5.test.ts
@@ -1,0 +1,83 @@
+// B5 regression (auth-fixes design 02 T3 / defect B5): a Windows project root
+// reported with backslashes (`C:\a\b` — what `path.resolve` yields inside
+// enroll) must derive a routing pin that PREFIX-MATCHES the plugin's
+// forward-slash `projectPathHash` (`C:/a/b`). The legacy v1 identity hashed
+// separators verbatim, so the enroll pin never matched the plugin's hash and
+// pinned routing silently failed on Windows. cli-core's v2 identity converts
+// `\`→`/` before hashing, killing B5.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as path from 'path';
+import { enrollPlugin } from '../src/lib/enroll.js';
+import { deriveProjectPin } from '../src/utils/port.js';
+import {
+  derivePinV2,
+  deriveProjectPathHashV2,
+  derivePin,
+  deriveProjectPathHash,
+} from '@baizor/gamedev-cli-core';
+import { makeTempDir, rmTempDir, fakeResponse } from './helpers.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmTempDir(dirs.pop()!);
+});
+function tmp(): string {
+  const d = makeTempDir();
+  dirs.push(d);
+  return d;
+}
+
+describe('B5 — Windows backslash enroll pin matches the plugin hash (cli-core v2 identity)', () => {
+  const backslashRoot = 'C:\\Users\\dev\\MyProject';
+  const forwardRoot = 'C:/Users/dev/MyProject';
+
+  it('v2: a backslash root pin is a prefix of the plugin forward-slash projectPathHash', () => {
+    const pinFromBackslash = derivePinV2(backslashRoot);
+    const pluginHash = deriveProjectPathHashV2(forwardRoot); // what the plugin reports
+
+    // The pin is the first 8 hex chars of the v2 hash; because v2 normalizes
+    // `\`→`/`, both spellings hash identically, so the backslash-derived pin
+    // prefix-matches the plugin's forward-slash hash. THIS is the B5 fix.
+    expect(pluginHash.startsWith(pinFromBackslash)).toBe(true);
+
+    // The two spellings derive the exact same v2 pin.
+    expect(pinFromBackslash).toBe(derivePinV2(forwardRoot));
+  });
+
+  it('documents the pre-fix bug: the legacy v1 pin did NOT match on backslashes', () => {
+    // Local v1 pin over the backslash root vs the plugin's v1 forward-slash hash.
+    const v1PinFromBackslash = deriveProjectPin(backslashRoot); // no `\`→`/` normalization
+    const v1PluginHash = deriveProjectPathHash(forwardRoot);
+    // The whole point of B5: these did NOT prefix-match (the silent Windows failure).
+    expect(v1PluginHash.startsWith(v1PinFromBackslash)).toBe(false);
+
+    // Sanity: the local v1 pin equals cli-core's v1 pin for the same spelling
+    // (parity), so the divergence above is purely the separator normalization.
+    expect(v1PinFromBackslash).toBe(derivePin(backslashRoot));
+  });
+
+  it('enroll writes a v2 pin that prefix-matches the plugin projectPathHash for the enrolled root', async () => {
+    const store = tmp();
+    const project = tmp();
+    const r = await enrollPlugin({
+      enrollCode: 'ABCD-1234',
+      projectDir: project,
+      storeBaseDir: store,
+      fetchImpl: (async () =>
+        fakeResponse({
+          ok: true,
+          status: 200,
+          body: JSON.stringify({ access_token: 't', server_url: 'https://ai-game.dev' }),
+        })) as unknown as typeof fetch,
+    });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+
+    // Whatever separators `path.resolve` produced on this OS, the plugin's v2
+    // hash of the same resolved root prefix-matches the enroll pin.
+    const resolved = path.resolve(project);
+    expect(deriveProjectPathHashV2(resolved).startsWith(r.pin)).toBe(true);
+    expect(r.pin).toBe(derivePinV2(resolved));
+  });
+});

--- a/cli/tests/enroll.test.ts
+++ b/cli/tests/enroll.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { enrollPlugin } from '../src/lib/enroll.js';
 import { MachineCredentialStore } from '../src/utils/machine-credentials.js';
 import { readProjectMarker } from '../src/utils/project-marker.js';
-import { deriveProjectPin } from '../src/utils/port.js';
+import { derivePinV2 } from '@baizor/gamedev-cli-core';
 import { makeTempDir, rmTempDir, fakeResponse } from './helpers.js';
 
 const dirs: string[] = [];
@@ -83,8 +83,8 @@ describe('enrollPlugin', () => {
     // Marker recorded the server target.
     expect(readProjectMarker(project)).toEqual({ serverTarget: 'https://ai-game.dev' });
 
-    // Pin upserted into the existing project-local config.
-    const pin = deriveProjectPin(project);
+    // Pin upserted into the existing project-local config (cli-core v2 identity — B5 fix).
+    const pin = derivePinV2(project);
     expect(r.pin).toBe(pin);
     expect(r.pinnedConfigFiles).toContain(path.join(project, '.mcp.json'));
     const parsed = JSON.parse(fs.readFileSync(path.join(project, '.mcp.json'), 'utf-8'));

--- a/cli/tests/login.test.ts
+++ b/cli/tests/login.test.ts
@@ -4,7 +4,12 @@ import * as path from 'path';
 import { login } from '../src/lib/login.js';
 import { readEnvFile } from '../src/utils/env-file.js';
 import { MachineCredentialStore } from '../src/utils/machine-credentials.js';
-import { makeTempDir, rmTempDir, fakeResponse } from './helpers.js';
+import type {
+  DeviceAuthTransport,
+  DeviceAuthorizeResponse,
+  DeviceTokenResponse,
+} from '@baizor/gamedev-cli-core';
+import { makeTempDir, rmTempDir } from './helpers.js';
 
 const dirs: string[] = [];
 afterEach(() => {
@@ -22,49 +27,70 @@ interface SuccessBody {
   expires_in?: number;
 }
 
-function deviceFlowFetch(pendingCount: number, success: SuccessBody = { access_token: 'final-token' }): typeof fetch {
-  let tokenCalls = 0;
-  return (async (url: string) => {
-    if (String(url).endsWith('/authorize')) {
-      return fakeResponse({
-        ok: true,
-        status: 200,
-        body: JSON.stringify({
-          device_code: 'dev123',
-          user_code: 'WXYZ-1234',
-          verification_uri: 'https://ai-game.dev/activate',
-          interval: 1,
-        }),
-      });
-    }
-    // token endpoint
-    tokenCalls += 1;
-    if (tokenCalls <= pendingCount) {
-      return fakeResponse({ ok: false, status: 400, body: JSON.stringify({ error: 'authorization_pending' }) });
-    }
-    return fakeResponse({ ok: true, status: 200, body: JSON.stringify(success) });
-  }) as unknown as typeof fetch;
+/**
+ * A fake cli-core device-auth transport: `pendingCount` `authorization_pending`
+ * polls, then the success token. Bypasses the HTTP transport entirely, so the
+ * test exercises the CLI's adapter (delegation + persistence), not core's RFC
+ * 8628 state machine (which cli-core unit-tests itself).
+ */
+function deviceFlowTransport(
+  pendingCount: number,
+  success: SuccessBody = { access_token: 'final-token' },
+): DeviceAuthTransport {
+  let polls = 0;
+  return {
+    async requestDeviceCode(): Promise<DeviceAuthorizeResponse> {
+      return {
+        device_code: 'dev123',
+        user_code: 'WXYZ-1234',
+        verification_uri: 'https://ai-game.dev/activate',
+        expires_in: 900,
+        interval: 0,
+      };
+    },
+    async pollToken(): Promise<DeviceTokenResponse> {
+      polls += 1;
+      if (polls <= pendingCount) return { error: 'authorization_pending' };
+      return {
+        access_token: success.access_token,
+        refresh_token: success.refresh_token,
+        expires_in: success.expires_in,
+        token_type: 'Bearer',
+      };
+    },
+  };
 }
 
-describe('login (device flow)', () => {
+/** A transport that returns a terminal OAuth error on the first poll. */
+function terminalTransport(error: string): DeviceAuthTransport {
+  return {
+    async requestDeviceCode(): Promise<DeviceAuthorizeResponse> {
+      return { device_code: 'd', user_code: 'u', verification_uri: 'https://ai-game.dev/activate', expires_in: 900 };
+    },
+    async pollToken(): Promise<DeviceTokenResponse> {
+      return { error };
+    },
+  };
+}
+
+describe('login (OAuth 2.1 device flow → cli-core)', () => {
   it('polls past authorization_pending and returns the token', async () => {
     const r = await login({
       storeBaseDir: tmp(),
-      fetchImpl: deviceFlowFetch(2),
+      transport: deviceFlowTransport(2),
       sleepImpl: async () => {},
       nowImpl: () => 0,
-      timeoutMs: 100000,
     });
     expect(r.kind).toBe('success');
     if (r.kind === 'success') expect(r.token).toBe('final-token');
   });
 
-  it('persists to the shared machine store by default (not a project .env)', async () => {
+  it('persists the FULL credential set to the shared machine store by default (not a project .env)', async () => {
     const store = tmp();
     const project = tmp();
     const r = await login({
       storeBaseDir: store,
-      fetchImpl: deviceFlowFetch(0, { access_token: 'jwt-1', refresh_token: 'refresh-1', expires_in: 3600 }),
+      transport: deviceFlowTransport(0, { access_token: 'jwt-1', refresh_token: 'refresh-1', expires_in: 3600 }),
       sleepImpl: async () => {},
       nowImpl: () => 1_000_000, // fixed clock for a deterministic expiresAt
     });
@@ -91,7 +117,7 @@ describe('login (device flow)', () => {
     const dir = tmp();
     const r = await login({
       projectDir: dir,
-      fetchImpl: deviceFlowFetch(0),
+      transport: deviceFlowTransport(0),
       sleepImpl: async () => {},
       nowImpl: () => 0,
     });
@@ -106,49 +132,15 @@ describe('login (device flow)', () => {
     expect(fs.readFileSync(path.join(dir, '.gitignore'), 'utf-8')).toContain('.env');
   });
 
-  it('increases the poll interval persistently after slow_down (RFC 8628)', async () => {
-    let tokenCalls = 0;
-    const fetchImpl = (async (url: string) => {
-      if (String(url).endsWith('/authorize')) {
-        return fakeResponse({ ok: true, status: 200, body: JSON.stringify({ device_code: 'd', user_code: 'u', verification_uri: 'v', interval: 1 }) });
-      }
-      tokenCalls += 1;
-      if (tokenCalls === 1) {
-        return fakeResponse({ ok: false, status: 400, body: JSON.stringify({ error: 'slow_down' }) });
-      }
-      return fakeResponse({ ok: true, status: 200, body: JSON.stringify({ access_token: 'final-token' }) });
-    }) as unknown as typeof fetch;
-    const sleeps: number[] = [];
-    const r = await login({ storeBaseDir: tmp(), fetchImpl, sleepImpl: async (ms) => { sleeps.push(ms); }, nowImpl: () => 0, timeoutMs: 100000 });
-    expect(r.kind).toBe('success');
-    // One sleep per poll (at the top of the loop): 1000ms before the first
-    // (slow_down) poll, then a PERSISTENTLY increased 6000ms before the retry —
-    // not a one-shot extra sleep at the old 1000ms cadence.
-    expect(sleeps).toEqual([1000, 6000]);
+  it('fails cleanly on access_denied', async () => {
+    const r = await login({ transport: terminalTransport('access_denied'), sleepImpl: async () => {}, nowImpl: () => 0 });
+    expect(r.kind).toBe('failure');
+    if (r.kind === 'failure') expect(r.reason).toBe('denied');
   });
 
-  it('fails on access_denied', async () => {
-    const fetchImpl = (async (url: string) => {
-      if (String(url).endsWith('/authorize')) {
-        return fakeResponse({ ok: true, status: 200, body: JSON.stringify({ device_code: 'd', user_code: 'u', verification_uri: 'v', interval: 1 }) });
-      }
-      return fakeResponse({ ok: false, status: 400, body: JSON.stringify({ error: 'access_denied' }) });
-    }) as unknown as typeof fetch;
-    const r = await login({ fetchImpl, sleepImpl: async () => {}, nowImpl: () => 0 });
+  it('fails cleanly on expired_token', async () => {
+    const r = await login({ transport: terminalTransport('expired_token'), sleepImpl: async () => {}, nowImpl: () => 0 });
     expect(r.kind).toBe('failure');
-    if (r.kind === 'failure') expect(r.reason).toBe('access_denied');
-  });
-
-  it('times out when the user never authorizes', async () => {
-    let clock = 0;
-    const fetchImpl = (async (url: string) => {
-      if (String(url).endsWith('/authorize')) {
-        return fakeResponse({ ok: true, status: 200, body: JSON.stringify({ device_code: 'd', user_code: 'u', verification_uri: 'v', interval: 1 }) });
-      }
-      return fakeResponse({ ok: false, status: 400, body: JSON.stringify({ error: 'authorization_pending' }) });
-    }) as unknown as typeof fetch;
-    const r = await login({ fetchImpl, sleepImpl: async (ms) => { clock += ms; }, nowImpl: () => clock, timeoutMs: 3000 });
-    expect(r.kind).toBe('failure');
-    if (r.kind === 'failure') expect(r.reason).toBe('timeout');
+    if (r.kind === 'failure') expect(r.reason).toBe('expired');
   });
 });

--- a/cli/tests/setup-mcp.test.ts
+++ b/cli/tests/setup-mcp.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { setupMcp, listAgentIds, shouldWriteAuthHeader } from '../src/lib/setup-mcp.js';
 import { agentRegistry, getAgentById, getAgentIds, MCP_SERVER_NAME } from '../src/utils/agents.js';
+import { derivePinV2 } from '@baizor/gamedev-cli-core';
 import { makeTempDir, rmTempDir } from './helpers.js';
 
 const dirs: string[] = [];
@@ -141,7 +142,8 @@ describe('setupMcp — http transport', () => {
     if (r.kind !== 'success') return;
     const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
     expect(written.mcpServers.other).toBeDefined();
-    expect(written.mcpServers['unreal-mcp'].url).toBe('http://localhost:5220/mcp');
+    // Pinned by default (T4): `<base>/mcp/p/<pin-v2>`.
+    expect(written.mcpServers['unreal-mcp'].url).toBe(`http://localhost:5220/mcp/p/${derivePinV2(dir)}`);
     expect(written.mcpServers['unreal-mcp'].type).toBe('http');
   });
 
@@ -151,7 +153,7 @@ describe('setupMcp — http transport', () => {
     expect(r.kind).toBe('success');
     if (r.kind !== 'success') return;
     const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
-    expect(written.mcpServers['unreal-mcp'].url).toBe('http://h/mcp');
+    expect(written.mcpServers['unreal-mcp'].url).toBe(`http://h/mcp/p/${derivePinV2(dir)}`);
     expect(written.mcpServers['unreal-mcp'].headers).toEqual({ Authorization: 'Bearer tok' });
   });
 
@@ -161,7 +163,17 @@ describe('setupMcp — http transport', () => {
     expect(r.kind).toBe('success');
     if (r.kind !== 'success') return;
     const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
-    expect(written.mcpServers['unreal-mcp'].url).toBe('http://h/mcp');
+    // Still no `/mcp/mcp` — the pin segment is appended once after the single `/mcp`.
+    expect(written.mcpServers['unreal-mcp'].url).toBe(`http://h/mcp/p/${derivePinV2(dir)}`);
+  });
+
+  it('--no-pin writes an UNPINNED <base>/mcp URL (T4 escape hatch)', async () => {
+    const dir = tmp();
+    const r = await setupMcp({ agentId: 'claude-code', projectDir: dir, transport: 'http', url: 'http://localhost:5220', noPin: true });
+    expect(r.kind).toBe('success');
+    if (r.kind !== 'success') return;
+    const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
+    expect(written.mcpServers['unreal-mcp'].url).toBe('http://localhost:5220/mcp');
   });
 
   it('writes vscode-copilot config under the top-level `servers` key (not `mcpServers`)', async () => {
@@ -170,7 +182,7 @@ describe('setupMcp — http transport', () => {
     expect(r.kind).toBe('success');
     if (r.kind !== 'success') return;
     const written = JSON.parse(fs.readFileSync(r.configPath, 'utf-8'));
-    expect(written.servers['unreal-mcp'].url).toBe('http://localhost:5220/mcp');
+    expect(written.servers['unreal-mcp'].url).toBe(`http://localhost:5220/mcp/p/${derivePinV2(dir)}`);
     expect(written.mcpServers).toBeUndefined();
   });
 
@@ -182,7 +194,7 @@ describe('setupMcp — http transport', () => {
     expect(r.configPath).toMatch(/[\\/]\.codex[\\/]config\.toml$/);
     const content = fs.readFileSync(r.configPath, 'utf-8');
     expect(content).toContain('[mcp_servers.unreal-mcp]');
-    expect(content).toContain('url = "http://localhost:5220/mcp"');
+    expect(content).toContain(`url = "http://localhost:5220/mcp/p/${derivePinV2(dir)}"`);
     expect(content).toContain('tool_timeout_sec = 300');
   });
 
@@ -212,7 +224,7 @@ describe('setupMcp — D11 credential-free OAuth config (http)', () => {
       const body = getAgentById(agentId)!.bodyPath;
       const entry = written[body]['unreal-mcp'];
       expect(entry.type).toBe('http');
-      expect(entry.url).toBe('https://ai-game.dev/mcp');
+      expect(entry.url).toBe(`https://ai-game.dev/mcp/p/${derivePinV2(dir)}`);
       expect(entry.headers).toBeUndefined();
     });
   }
@@ -223,7 +235,7 @@ describe('setupMcp — D11 credential-free OAuth config (http)', () => {
     expect(r.kind).toBe('success');
     if (r.kind !== 'success') return;
     const content = fs.readFileSync(r.configPath, 'utf-8');
-    expect(content).toContain('url = "https://ai-game.dev/mcp"');
+    expect(content).toContain(`url = "https://ai-game.dev/mcp/p/${derivePinV2(dir)}"`);
     expect(content.toLowerCase()).not.toContain('authorization');
   });
 
@@ -240,7 +252,7 @@ describe('setupMcp — D11 credential-free OAuth config (http)', () => {
     expect(r.kind).toBe('success');
     if (r.kind !== 'success') return;
     const entry = JSON.parse(fs.readFileSync(r.configPath, 'utf-8')).mcpServers['unreal-mcp'];
-    expect(entry.url).toBe('https://ai-game.dev/mcp');
+    expect(entry.url).toBe(`https://ai-game.dev/mcp/p/${derivePinV2(dir)}`);
     expect(entry.headers).toBeUndefined();
   });
 
@@ -258,7 +270,7 @@ describe('setupMcp — D11 credential-free OAuth config (http)', () => {
     expect(r.kind).toBe('success');
     if (r.kind !== 'success') return;
     const entry = JSON.parse(fs.readFileSync(r.configPath, 'utf-8')).mcpServers['unreal-mcp'];
-    expect(entry.url).toBe('https://ai-game.dev/mcp');
+    expect(entry.url).toBe(`https://ai-game.dev/mcp/p/${derivePinV2(dir)}`);
     expect(entry.headers).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Migrate `unreal-mcp-cli` onto `@baizor/gamedev-cli-core@0.1.0` so login / `setup-mcp` / `enroll` / `install-plugin` follow one shared auth + identity model (auth-fixes T1/T3/T4/T5/T7; adapter `unrealAdapter`, serverName `unreal-mcp`, stdio ON).
- **login:** legacy JSON device flow → cli-core `deviceLogin` (RFC 8628 OAuth 2.1, `client_id=unreal-mcp-cli`, `scope=mcp:plugin`); stores the full credential set (access + rotating refresh + expiry + serverTarget + subject); **no PAT minting**, no legacy `/api/auth/device/*` calls.
- **enroll (B5 fix):** pin now derived with cli-core `derivePinV2` (`\`→`/` normalization) so a Windows backslash `path.resolve` root prefix-matches the plugin's forward-slash `projectPathHash`.
- **setup-mcp (B4/B8):** http config pins the URL by default (`<base>/mcp/p/<pin-v2>`) via cli-core `pinUrl`; `--no-pin` escape hatch; credential-free unless `--token` (M7) preserved.
- **install-plugin:** project-root probe aligned on the shared `unrealAdapter` markers.

## Test plan
- [x] B5 regression: backslash root pin prefix-matches the plugin's forward-slash v2 hash (`tests/enroll-b5.test.ts`).
- [x] No legacy `/api/auth/device/*` calls (grep = 0); PAT minting gone.
- [x] Pinned setup-mcp parity vs the cli-core Configure policy + adapter/identity/server-layout parity (`tests/cli-core-parity.test.ts`).
- [x] `tsc` clean + vitest green (439 passed, 2 skipped) with the MCP env cleared (CI-equivalent).

security_critical — owner reviews before the k3 release wave.

Closes #241