### PR TITLE
docs: README + cli/README auth vocabulary + pinned setup-mcp URL (auth-fixes R5/f2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Updating in place must always leave you running the **new** code. The risk is UE
 
 Connection settings persist to `<Project>/Saved/Config/UnrealMcp/ai-game-developer-config.json` (`Saved/` is gitignored by every UE template, so tokens never land in VCS by default).
 
+> **Pinned MCP client URL.** `unreal-mcp-cli setup-mcp <agent>` writes an MCP client config that points at the **project-pinned** cloud URL `<base>/mcp/p/<pin>`, so the agent routes to **this** project's editor even when your account drives several. Pass `--no-pin` to write the bare `<base>/mcp` URL instead. The pin is a routing path segment only — the OAuth resource stays `<base>/mcp`, and OAuth-capable clients (Claude Code, Cursor, …) still run their own device-code login against it.
+
 > That's it. Ask your AI *"Spawn three cubes in a row and a point light above them"* and watch it happen. ✨
 
 ![AI Game Developer — Unreal MCP](https://github.com/IvanMurzak/Unreal-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
@@ -596,7 +598,7 @@ The plugin reads configuration with the precedence **process env → `<Project>/
 | `UNREAL_MCP_HOST` | Server URL (Custom mode), e.g. `http://localhost:<port>` |
 | `UNREAL_MCP_CLOUD_URL` | Cloud backend URL (defaults to ai-game.dev) |
 | `UNREAL_MCP_TOKEN` | Auth token (sidecar IPC token / server token). **Secret — never commit.** |
-| `UNREAL_MCP_AUTH_OPTION` | `none` or `required` (local server auth) |
+| `UNREAL_MCP_AUTH_OPTION` | `none` or `oauth` (local server auth) |
 | `UNREAL_MCP_KEEP_CONNECTED` | Persist/restore the connected state |
 | `UNREAL_MCP_TOOLS` | Enabled-tools override (whitelist; empty = no filter) |
 | `UNREAL_MCP_START_SERVER` | Parsed and persisted as the `startServer` config flag (Custom mode); auto-spawning the local `gamedev-mcp-server` is **planned, not yet wired** — no code consumes this flag today, so start the server yourself (e.g. `unreal-mcp-cli`). |

--- a/cli/README.md
+++ b/cli/README.md
@@ -93,7 +93,7 @@ unreal-mcp-cli status
 | `remove-plugin [path]` | Remove the installed plugin |
 | `install-extension <id> [path]` | Install a third-party Unreal-MCP **extension** plugin into `<project>/Plugins/<name>`, enable it + its gating engine plugins (e.g. `Niagara`) in the `.uproject`, and (re)compile (on next editor open, or now with `--build`). `--source <dir>` installs from a local copy (offline/CI); `--version <x.y.z>` overrides the catalog pin. Idempotent. See [Extensions](#extensions) |
 | `configure` | Write `UNREAL_MCP_*` into `<project>/.env` and gitignore `.env` (§8) |
-| `setup-mcp <agent>` | Write an MCP client config snippet (claude-code, cursor, vscode-copilot). With `--transport stdio` it also downloads the pinned shared [`gamedev-mcp-server`](https://github.com/IvanMurzak/GameDev-MCP-Server) release into `<project>/Intermediate/UnrealMCP/server/<rid>/` (skipped when `UNREAL_MCP_SERVER_PATH` points at a local build) |
+| `setup-mcp <agent>` | Write an MCP client config snippet (claude-code, cursor, vscode-copilot). Over the default `http` transport it points the agent at the **project-pinned** cloud URL `<base>/mcp/p/<pin>` (so the agent routes to *this* project's editor); pass `--no-pin` for the bare `<base>/mcp` URL. OAuth-capable clients get a credential-free, URL-only config and run their own device-code login. With `--transport stdio` it instead downloads the pinned shared [`gamedev-mcp-server`](https://github.com/IvanMurzak/GameDev-MCP-Server) release into `<project>/Intermediate/UnrealMCP/server/<rid>/` (skipped when `UNREAL_MCP_SERVER_PATH` points at a local build) |
 | `login` | OAuth device-code auth against ai-game.dev |
 | `status` | Report project + plugin + connection + live reachability |
 | `wait-for-ready` | Block until the project's MCP server responds to a ping |
@@ -221,7 +221,8 @@ agent can drive the Unreal Editor. Core support today: **Claude Code**, **Cursor
 </div>
 
 ```bash
-unreal-mcp-cli setup-mcp claude-code ./MyGame       # write the agent's MCP client config
+unreal-mcp-cli setup-mcp claude-code ./MyGame       # pinned <base>/mcp/p/<pin> URL (routes to this project)
+unreal-mcp-cli setup-mcp claude-code ./MyGame --no-pin   # bare, unpinned <base>/mcp URL instead
 unreal-mcp-cli setup-mcp cursor ./MyGame --transport stdio
 ```
 


### PR DESCRIPTION
## Summary
- `README.md`: `UNREAL_MCP_AUTH_OPTION` value list `none/required` → `none/oauth` (drops the legacy `required` value; the plugin's ViewModel default is `oauth`), and a new pinned MCP client URL note — `setup-mcp` writes the project-pinned `<base>/mcp/p/<pin>` cloud URL by default, `--no-pin` for the bare `<base>/mcp`.
- `cli/README.md`: document the pinned `setup-mcp` default + `--no-pin` in the command table and the Supported AI Agents examples.
- Docs-only; matches the shipped g1 CLI behavior (#242). No legacy flow documented; `login` already reads OAuth device-code.

## Test plan
- [x] Docs-only change (`README.md` + `cli/README.md`) — no build/package/test input touched, so no code suites apply (profile `test.md` docs-only carve-out).

Closes #243