### PR TITLE
feat(bridge): dual-hash instance metadata + local-LIB build switch (auth-fixes f1b)

### DIFF
--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -510,9 +510,22 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 var resolved = ProjectConnectionResolver.Resolve(projectPath!, _instanceId);
                 _config.InstanceMetadata = resolved.Metadata;
                 _config.ProjectRootPath = projectPath;
+                // Log the reported project root (the deterministic hash INPUT) alongside the resulting
+                // projectPathHash. This is the OQ1/k2 evidence the auth-fixes design wants captured per engine:
+                // the exact string each runtime feeds into ProjectIdentity, and the hash it derives (the
+                // handshake routing key). Non-secret — the credential travels separately in the Authorization header.
                 _logger?.LogInformation(
-                    "Resolved project identity for '{ProjectName}' (pin {Pin}, port {Port}{Override}, instance {InstanceId}); attaching instance metadata to the hub handshake.",
-                    resolved.ProjectName, resolved.Pin, resolved.Port, resolved.PortIsOverridden ? " [user override]" : string.Empty, _instanceId);
+                    "Resolved project identity for '{ProjectName}' (pin {Pin}, port {Port}{Override}, instance {InstanceId}); hash input '{HashInput}' -> projectPathHash {ProjectPathHash}; attaching instance metadata to the hub handshake.",
+                    resolved.ProjectName, resolved.Pin, resolved.Port, resolved.PortIsOverridden ? " [user override]" : string.Empty, _instanceId, projectPath, resolved.ProjectPathHash);
+#if USE_LOCAL_MCP_PLUGIN
+                // Dual-hash transition (auth-fixes T3 / defect B5, MCP-Plugin-dotnet #165): built against the
+                // source LIB, ConnectionInstanceMetadata carries the v1 legacy hash alongside the v2 primary so a
+                // session pinned by an OLD (v1) config still matches this plugin. Surfaced only in the local-LIB
+                // build; the NuGet pin gains this field in the release wave (k3/R1).
+                _logger?.LogInformation(
+                    "Dual-hash active: projectPathHashLegacy (v1) {ProjectPathHashLegacy} sent alongside the v2 projectPathHash.",
+                    resolved.Metadata.ProjectPathHashLegacy);
+#endif
             }
             catch (Exception ex)
             {

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -83,9 +83,45 @@
     PIPELINE.md "Freshness-bump carve-out"): 7.1.0 -> 7.1.1 is the patch that carries the i1 BUG-A
     token-mode validator fix. Published on nuget.org; ReflectorNet stays 5.3.2 (7.1.1 keeps that floor).
   -->
-  <ItemGroup>
+  <!--
+    Local-LIB dev toggle (auth-fixes f1b — parity with the GameDev-MCP-Server + Unity/Godot
+    `UseLocalMcpPlugin` pattern). Build with `-p:UseLocalMcpPlugin=true` to reference the
+    MCP-Plugin-dotnet + ReflectorNet SOURCE (checked out as sibling submodules in the `software`
+    workspace under `shared/`) instead of the published NuGet packages. This lets the sidecar compile
+    against UNPUBLISHED McpPlugin primitives — e.g. the dual-hash transition landed in
+    MCP-Plugin-dotnet #165 (`ProjectIdentity.DeriveProjectPathHashV2` +
+    `ConnectionInstanceMetadata.ProjectPathHashLegacy`) — BEFORE they ship on NuGet.
+
+    It DEFAULTS OFF: a plain `dotnet build` / `dotnet test` — and ALL CI — stays on the NuGet pins
+    below, so the switch NEVER affects the shipped binary or the PR gate. The NuGet pins advance to a
+    version carrying those primitives in the release wave (k3/R1), after which the switch is a pure
+    dev convenience. Override the source location with `-p:McpPluginRepoPath=<path>` /
+    `-p:ReflectorNetRepoPath=<path>`; the committed defaults are workspace-RELATIVE (never a
+    machine-absolute path), and are used ONLY when the switch is on.
+  -->
+  <PropertyGroup>
+    <UseLocalMcpPlugin Condition="'$(UseLocalMcpPlugin)' == ''">false</UseLocalMcpPlugin>
+    <McpPluginRepoPath Condition="'$(McpPluginRepoPath)' == ''">$(MSBuildThisFileDirectory)../../../../../shared/MCP-Plugin-dotnet</McpPluginRepoPath>
+    <ReflectorNetRepoPath Condition="'$(ReflectorNetRepoPath)' == ''">$(MSBuildThisFileDirectory)../../../../../shared/ReflectorNet</ReflectorNetRepoPath>
+  </PropertyGroup>
+
+  <!--
+    The local-LIB build defines USE_LOCAL_MCP_PLUGIN so source can `#if`-gate calls to primitives that
+    exist ONLY in the source LIB (not yet on the NuGet pin) — the default build compiles the
+    NuGet-only path, keeping CI green.
+  -->
+  <PropertyGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">
+    <DefineConstants>$(DefineConstants);USE_LOCAL_MCP_PLUGIN</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.2" />
     <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">
+    <ProjectReference Include="$(McpPluginRepoPath)/McpPlugin/McpPlugin.csproj" />
+    <ProjectReference Include="$(ReflectorNetRepoPath)/ReflectorNet/ReflectorNet.csproj" />
   </ItemGroup>
 
   <!-- The xUnit suite exercises a couple of internal helpers (e.g. ProxyTool.CalculateTokenCount). -->

--- a/bridge/tests/ProjectConnectionResolverTests.cs
+++ b/bridge/tests/ProjectConnectionResolverTests.cs
@@ -85,6 +85,59 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             Assert.StartsWith("https://ai-game.dev/mcp/hub/mcp-server?", url);
         }
 
+#if USE_LOCAL_MCP_PLUGIN
+        /// <summary>
+        /// Dual-hash transition (auth-fixes T3 / defect B5, MCP-Plugin-dotnet #165). Built against the
+        /// SOURCE LIB (<c>-p:UseLocalMcpPlugin=true</c>) the sidecar's instance metadata carries BOTH the v2
+        /// <c>projectPathHash</c> (separator-normalized) AND the v1 legacy hash, so a session pinned by an
+        /// OLD (v1) config still matches this NEW plugin. A Windows-style BACKSLASH root is used
+        /// deliberately: v2 converts <c>'\' -&gt; '/'</c> before hashing while v1 does not, so the two
+        /// hashes DIFFER — proving the legacy hash is emitted independently, not the v2 hash echoed.
+        /// (Excluded from the default NuGet build, whose pinned McpPlugin lacks these primitives; the pin
+        /// gains them in the release wave k3/R1.)
+        /// </summary>
+        [Fact]
+        public void Resolve_Metadata_EmitsBothV2AndLegacyHashes_ForWindowsRoot()
+        {
+            const string root = @"C:\Users\user\my-game";
+            var resolved = ProjectConnectionResolver.Resolve(root, instanceId: "inst-dual", machineName: "DESKTOP-X");
+
+            var meta = resolved.Metadata;
+            // Primary hash is the v2 (separator-normalized) hash; legacy is the v1 hash of the same root.
+            Assert.Equal(ProjectIdentity.DeriveProjectPathHashV2(root), meta.ProjectPathHash);
+            Assert.Equal(ProjectIdentity.DeriveProjectPathHash(root), meta.ProjectPathHashLegacy);
+            // On a backslash path the two normalizations diverge, so the hashes MUST differ (the whole point
+            // of the transition — kills the Windows v1/v2 pin mismatch, defect B5).
+            Assert.NotEqual(meta.ProjectPathHash, meta.ProjectPathHashLegacy);
+            Assert.Equal(64, meta.ProjectPathHash.Length);
+            Assert.Equal(64, meta.ProjectPathHashLegacy.Length);
+
+            // Both hashes travel as non-secret hub query params so the server can pin-match on EITHER.
+            var values = resolved.Metadata.ToQuery().Values;
+            Assert.Contains(meta.ProjectPathHash, values);
+            Assert.Contains(meta.ProjectPathHashLegacy, values);
+        }
+
+        /// <summary>
+        /// A POSIX root (no backslashes) hashes IDENTICALLY under v1 and v2 — the only v2 step is
+        /// <c>'\' -&gt; '/'</c> — so the legacy hash EQUALS the primary; it is still emitted, so an old
+        /// v1-pinned config matches. Locks that the dual-hash payload is present even when the two coincide.
+        /// </summary>
+        [Fact]
+        public void Resolve_Metadata_EmitsLegacyHash_EvenWhenEqualToV2_ForPosixRoot()
+        {
+            const string root = "/home/user/my-game";
+            var resolved = ProjectConnectionResolver.Resolve(root, instanceId: "inst-posix");
+
+            var meta = resolved.Metadata;
+            Assert.Equal(ProjectIdentity.DeriveProjectPathHashV2(root), meta.ProjectPathHash);
+            Assert.Equal(ProjectIdentity.DeriveProjectPathHash(root), meta.ProjectPathHashLegacy);
+            // No backslashes -> v1 and v2 normalization coincide -> identical hashes, both present.
+            Assert.Equal(meta.ProjectPathHash, meta.ProjectPathHashLegacy);
+            Assert.False(string.IsNullOrEmpty(meta.ProjectPathHashLegacy));
+        }
+#endif
+
         [Fact]
         public void ResolveProjectName_PrefersUProjectBasename_ThenDirectoryName()
         {

--- a/bridge/tests/com.IvanMurzak.Unreal.MCP.Bridge.Tests.csproj
+++ b/bridge/tests/com.IvanMurzak.Unreal.MCP.Bridge.Tests.csproj
@@ -9,6 +9,21 @@
     <AssemblyName>Unreal-MCP-Bridge.Tests</AssemblyName>
   </PropertyGroup>
 
+  <!--
+    Mirror the bridge csproj's local-LIB toggle so `-p:UseLocalMcpPlugin=true` (a global build
+    property, applied to every project in the solution) also defines USE_LOCAL_MCP_PLUGIN here — the
+    guarded dual-hash tests (which reference primitives that exist ONLY in the source LIB, e.g.
+    ProjectIdentity.DeriveProjectPathHashV2 / ConnectionInstanceMetadata.ProjectPathHashLegacy from
+    MCP-Plugin-dotnet #165) compile ONLY in local-LIB mode and are excluded from the default (NuGet)
+    build that CI runs.
+  -->
+  <PropertyGroup>
+    <UseLocalMcpPlugin Condition="'$(UseLocalMcpPlugin)' == ''">false</UseLocalMcpPlugin>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">
+    <DefineConstants>$(DefineConstants);USE_LOCAL_MCP_PLUGIN</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />


### PR DESCRIPTION
## Summary
- **Local-LIB build switch (PART 1):** a `-p:UseLocalMcpPlugin=true` MSBuild toggle (parity with the GameDev-MCP-Server / Unity / Godot `UseLocalMcpPlugin` pattern) swaps the `com.IvanMurzak.McpPlugin` NuGet `PackageReference` for a `ProjectReference` to the local `MCP-Plugin-dotnet` + `ReflectorNet` source. **Defaults OFF** — a plain `dotnet build`/`dotnet test` and ALL CI stay on the NuGet pins (`McpPlugin` **7.1.1**, NOT bumped). The source path is workspace-relative + overridable (`-p:McpPluginRepoPath=`), never machine-absolute. This unblocks compiling against the unpublished dual-hash primitives (MCP-Plugin-dotnet #165) before they ship on NuGet.
- **Dual-hash metadata (PART 2):** built against the source LIB, `ConnectionInstanceMetadata.Create()` emits BOTH the v2 `projectPathHash` (separator-normalized) and the v1 `projectPathHashLegacy`, which the bridge already attaches to the hub handshake via `ProjectConnectionResolver.Resolve` — so a session pinned by an OLD (v1) config still matches this plugin (auth-fixes T3 / defect B5), matching the Unity (#905) and Godot (#296) dual-hash behavior. The reported project root (hash INPUT) + resulting hash are now logged (OQ1/k2 evidence).
- Guarded (`#if USE_LOCAL_MCP_PLUGIN`) tests prove both hashes are emitted — a backslash path where v1 differs from v2, plus a POSIX path where they coincide.

Off the critical path — **inert until the NuGet pin advances in release wave k3/R1** (the dual-hash payload is only present in a local-LIB build; the shipped binary is unchanged). The NuGet pin is deliberately NOT bumped here.

## Test plan
- [x] Bridge Suite 4 default (NuGet 7.1.1) — `dotnet build` + `dotnet test`: **269/269** pass, 0 warnings/errors (the CI gate; guarded dual-hash tests excluded).
- [x] Bridge Suite 4 local-LIB (`-p:UseLocalMcpPlugin=true`) — `dotnet build` + `dotnet test`: **271/271** pass (269 + 2 dual-hash), 0 errors (LIB-source CS0109 warnings are pre-existing, not from this change).

Closes #245