### PR TITLE
fix(bridge): honour a user-typed loopback port in the local-server bind port

### DIFF
--- a/bridge/src/Host/ProjectConnectionResolver.cs
+++ b/bridge/src/Host/ProjectConnectionResolver.cs
@@ -9,17 +9,38 @@
 */
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.McpPlugin.Common;
 
 namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 {
     /// <summary>
+    /// Which of the three precedence levels supplied the resolved local-server bind
+    /// <see cref="ProjectConnection.Port"/> (auth-fixes T1 / defect A, owner ruling 2026-07-19). Ordered
+    /// least- to most-specific so <see cref="ProjectConnection.PortIsOverridden"/> can be expressed as
+    /// "anything but <see cref="Derived"/>".
+    /// </summary>
+    internal enum LocalServerPortSource
+    {
+        /// <summary>Level 3 — the deterministic <see cref="ProjectIdentity"/> hash-derived per-project port.</summary>
+        Derived,
+
+        /// <summary>Level 2 — an explicit port the user typed into the Custom-mode loopback host.</summary>
+        TypedHost,
+
+        /// <summary>Level 1 — the committable project marker's <c>portOverride</c>.</summary>
+        MarkerOverride,
+    }
+
+    /// <summary>
     /// The resolved connection identity of the editor's project (mcp-authorize PR 3, design docs 04/06):
-    /// the routing <see cref="Pin"/> + deterministic local <see cref="Port"/> (McpPlugin
-    /// <see cref="ProjectIdentity"/>), the enrolled <see cref="ServerTarget"/> and the full
+    /// the routing <see cref="Pin"/> + local-server bind <see cref="Port"/> (McpPlugin
+    /// <see cref="ProjectIdentity"/> plus the typed-host level — see
+    /// <see cref="ProjectConnectionResolver.Resolve"/>), the enrolled <see cref="ServerTarget"/> and the full
     /// <see cref="ProjectPathHash"/> read/derived from the committable project marker + project root, plus the
     /// ready-to-attach <see cref="Metadata"/> handshake payload. Every field is derived deterministically —
     /// no live socket, no shared state.
@@ -27,11 +48,20 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
     internal sealed record ProjectConnection(
         string Pin,
         int Port,
-        bool PortIsOverridden,
+        LocalServerPortSource PortSource,
         string? ServerTarget,
         string ProjectPathHash,
         string ProjectName,
-        ConnectionInstanceMetadata Metadata);
+        ConnectionInstanceMetadata Metadata)
+    {
+        /// <summary>
+        /// Whether <see cref="Port"/> is a USER-chosen port — the marker's <c>portOverride</c> (level 1) or a
+        /// port typed into the loopback host (level 2) — rather than the deterministic derivation (level 3).
+        /// Informational only: it rides the <c>project-config-result</c> so the C++ plugin can log
+        /// "[user override]".
+        /// </summary>
+        public bool PortIsOverridden => PortSource != LocalServerPortSource.Derived;
+    }
 
     /// <summary>
     /// Resolves the sidecar's <b>connection identity</b> for the editor's project (mcp-authorize PR 3,
@@ -42,7 +72,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
     ///         (<see cref="ProjectMarker"/>) for the user's optional port override + the enrolled server target;</item>
     ///   <item>derives the routing pin + deterministic local port via the single-source
     ///         <see cref="ProjectIdentity"/> — byte-for-byte the committed golden vectors (trim trailing
-    ///         separators, <c>ToLowerInvariant</c> only, separators NOT converted);</item>
+    ///         separators, <c>ToLowerInvariant</c> only, separators NOT converted) — then layers the
+    ///         user-typed loopback port over it (see <see cref="Resolve"/>'s precedence list);</item>
     ///   <item>builds the <see cref="ConnectionInstanceMetadata"/> the sidecar attaches to its SignalR hub
     ///         connection (via <see cref="ConnectionConfig.InstanceMetadata"/>) so the server's account+instance
     ///         pairing plane (b3) registers THIS editor session under the resolved account.</item>
@@ -58,11 +89,37 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
         /// <summary>
         /// Resolve the full connection identity for <paramref name="projectRoot"/>. Reads the on-disk project
-        /// marker (may be absent) for the port override + server target, derives the pin/port, and builds the
-        /// instance-metadata handshake payload. <paramref name="instanceId"/> is the per-editor-session GUID
-        /// (stable across reconnects); <paramref name="machineName"/> defaults to the host machine name.
+        /// marker (may be absent) for the port override + server target, resolves the local-server bind port,
+        /// derives the pin, and builds the instance-metadata handshake payload. <paramref name="instanceId"/> is
+        /// the per-editor-session GUID (stable across reconnects); <paramref name="machineName"/> defaults to the
+        /// host machine name.
+        ///
+        /// <para><b>Bind-port precedence</b> (auth-fixes T1 / defect A, owner ruling 2026-07-19) — the SAME three
+        /// levels the shared McpPlugin writer applies in <c>AgentConfiguratorSettings.PinnedPort</c>, so the port
+        /// the local <c>gamedev-mcp-server</c> BINDS is the port the Configure button WRITES:
+        /// <list type="number">
+        ///   <item>the project marker's <c>portOverride</c> — a deliberate per-project pin, wins outright;</item>
+        ///   <item>an explicit port in <paramref name="localHost"/> — the port the USER typed into the Custom-mode
+        ///         host — applied only for an absolute LOOPBACK host, mirroring the writer's
+        ///         <c>ConnectionMode.Local &amp;&amp; uri.IsLoopback</c> gate;</item>
+        ///   <item>the deterministic <see cref="ProjectIdentity"/> hash-derived per-project port.</item>
+        /// </list>
+        /// Level 2 is the auth-fixes T1 change. Before it this resolver stopped at levels 1+3 — deliberately, to
+        /// mirror the OLD writer, which overwrote a loopback URL's port with the derived one. MCP-Plugin-dotnet
+        /// #174/#176 reversed that on the writer side, so keeping the binder at two levels would make the sidecar
+        /// listen on the derived port while the written config named the typed one — the reported "Configure
+        /// writes a port the server does not listen on" bug, newly introduced into Unreal.</para>
+        ///
+        /// <para><paramref name="localHost"/> is the plugin's effective <b>Custom-mode</b> host
+        /// (<c>FUnrealMcpConfig::ResolveCustomHost()</c>, delivered over the §8 <c>config</c> IPC message). Pass
+        /// <c>null</c> in Cloud mode or when no config has been applied — level 2 is then skipped and the
+        /// pre-change levels 1+3 behaviour holds exactly.</para>
         /// </summary>
-        public static ProjectConnection Resolve(string projectRoot, string instanceId, string? machineName = null)
+        public static ProjectConnection Resolve(
+            string projectRoot,
+            string instanceId,
+            string? machineName = null,
+            string? localHost = null)
         {
             if (projectRoot == null)
                 throw new ArgumentNullException(nameof(projectRoot));
@@ -71,6 +128,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
             var marker = SafeReadMarker(projectRoot);
             var identity = ProjectIdentity.Derive(projectRoot, marker);
+            var typedPort = TryGetExplicitLoopbackPort(localHost);
+            var (port, portSource) = identity.PortIsOverridden
+                ? (identity.Port, LocalServerPortSource.MarkerOverride)   // 1. marker portOverride
+                : typedPort.HasValue
+                    ? (typedPort.Value, LocalServerPortSource.TypedHost)  // 2. port typed into the loopback host
+                    : (identity.Port, LocalServerPortSource.Derived);     // 3. deterministic derivation
             var projectName = ResolveProjectName(projectRoot);
 
             // ConnectionInstanceMetadata.Create derives projectPathHash from the SAME normalized root the pin
@@ -84,13 +147,74 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
             return new ProjectConnection(
                 Pin: identity.Pin,
-                Port: identity.Port,
-                PortIsOverridden: identity.PortIsOverridden,
+                Port: port,
+                PortSource: portSource,
                 ServerTarget: marker?.ServerTarget,
                 ProjectPathHash: metadata.ProjectPathHash,
                 ProjectName: projectName,
                 Metadata: metadata);
         }
+
+        /// <summary>
+        /// The port the user explicitly typed into <paramref name="host"/>, or <c>null</c> when there is none —
+        /// precedence level 2 of <see cref="Resolve"/>. Returns <c>null</c> unless <paramref name="host"/> parses
+        /// as an ABSOLUTE LOOPBACK URI, mirroring the writer's <c>ConnectionMode.Local &amp;&amp; uri.IsLoopback</c>
+        /// gate in <c>AgentConfiguratorSettings.BuildPinnedHttpUrl</c>: a hosted / non-loopback target keeps its
+        /// authority verbatim there and has no local server to bind here, so neither side rewrites its port.
+        /// </summary>
+        internal static int? TryGetExplicitLoopbackPort(string? host)
+        {
+            if (string.IsNullOrWhiteSpace(host))
+                return null;
+            if (!Uri.TryCreate(host, UriKind.Absolute, out var uri) || !uri.IsLoopback)
+                return null;
+            return TryGetExplicitPort(host!);
+        }
+
+        /// <summary>
+        /// Read an EXPLICITLY-typed port out of a host string, or <c>null</c> when there is none. Deliberately
+        /// parses the RAW string rather than reading <c>Uri.Port</c>: <c>Uri.Port</c> synthesises the scheme
+        /// default (80/443) for a port-less host, which would make "the user typed no port" indistinguishable from
+        /// "the user typed 80" and silently bind 80 instead of the derived per-project port.
+        ///
+        /// <para>Mirrors <c>AgentConfiguratorSettings.TryGetExplicitPort</c> (McpPlugin #174) step for step —
+        /// including the <c>&gt; 0 &amp;&amp; &lt;= Consts.Hub.MaxPort</c> guard, so an unusable port falls back to
+        /// the derived one on BOTH sides rather than diverging. It is duplicated here rather than called because
+        /// the LIB member is <c>internal</c> and ships in 7.3.0, while this binder must hold on the 7.2.0 pin.</para>
+        /// </summary>
+        internal static int? TryGetExplicitPort(string? host)
+        {
+            if (string.IsNullOrWhiteSpace(host))
+                return null;
+
+            // Isolate the authority: after "scheme://" (if present), up to the first '/', '?' or '#'.
+            var schemeEnd = host!.IndexOf("://", StringComparison.Ordinal);
+            var start = schemeEnd >= 0 ? schemeEnd + 3 : 0;
+            var end = host.IndexOfAny(AuthorityTerminators, start);
+            var authority = end >= 0 ? host.Substring(start, end - start) : host.Substring(start);
+
+            // Drop any userinfo ("user:pass@host:port") — its colon is not a port separator.
+            var at = authority.LastIndexOf('@');
+            if (at >= 0)
+                authority = authority.Substring(at + 1);
+
+            // For an IPv6 literal the port follows the closing bracket ("[::1]:8080"); the colons inside the
+            // brackets are part of the address. LastIndexOf returns -1 for a normal host, so the search then
+            // starts at 0 and finds a plain "host:port" colon.
+            var colon = authority.IndexOf(':', authority.LastIndexOf(']') + 1);
+            if (colon < 0 || colon == authority.Length - 1)
+                return null;
+
+            // NumberStyles.None is the whole validator: it rejects sign, whitespace, separators and any
+            // non-ASCII-digit character, so a hand-rolled digit scan on top would be redundant.
+            if (!int.TryParse(authority.Substring(colon + 1), NumberStyles.None, CultureInfo.InvariantCulture, out var port))
+                return null;
+
+            return port > 0 && port <= Consts.Hub.MaxPort ? port : (int?)null;
+        }
+
+        /// <summary>The characters that terminate a URL's authority component (path / query / fragment).</summary>
+        private static readonly char[] AuthorityTerminators = { '/', '?', '#' };
 
         /// <summary>
         /// The human-facing project name: the basename (no extension) of the first top-level <c>*.uproject</c>

--- a/bridge/src/Host/ProjectConnectionResolver.cs
+++ b/bridge/src/Host/ProjectConnectionResolver.cs
@@ -87,6 +87,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         /// <summary>The engine identifier this sidecar reports in its instance metadata (design 04/06).</summary>
         internal const string Engine = "unreal";
 
+        /// <summary>The characters that terminate a URL's authority component (path / query / fragment).</summary>
+        private static readonly char[] AuthorityTerminators = { '/', '?', '#' };
+
         /// <summary>
         /// Resolve the full connection identity for <paramref name="projectRoot"/>. Reads the on-disk project
         /// marker (may be absent) for the port override + server target, resolves the local-server bind port,
@@ -159,16 +162,23 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         /// The port the user explicitly typed into <paramref name="host"/>, or <c>null</c> when there is none —
         /// precedence level 2 of <see cref="Resolve"/>. Returns <c>null</c> unless <paramref name="host"/> parses
         /// as an ABSOLUTE LOOPBACK URI, mirroring the writer's <c>ConnectionMode.Local &amp;&amp; uri.IsLoopback</c>
-        /// gate in <c>AgentConfiguratorSettings.BuildPinnedHttpUrl</c>: a hosted / non-loopback target keeps its
-        /// authority verbatim there and has no local server to bind here, so neither side rewrites its port.
+        /// gate in <c>AgentConfiguratorSettings.BuildPinnedHttpUrl</c>.
+        ///
+        /// <para>That gate mirrors where the writer REWRITES a port, which is not the same as what it EMITS. For a
+        /// Cloud / hosted target neither side acts — the writer keeps the authority verbatim and there is no local
+        /// server to bind. But for a Local-mode NON-loopback host (<c>http://0.0.0.0:8080</c>, a LAN IP) the writer
+        /// still emits that authority verbatim, port included, while this binder falls back to the derived port —
+        /// so the two names DIVERGE there. That asymmetry is pre-existing and deliberate (a non-loopback authority
+        /// is not something the local <c>gamedev-mcp-server</c> binds); it is spelled out here so the "mirrors the
+        /// writer" claim is not read as an exact equivalence.</para>
         /// </summary>
         internal static int? TryGetExplicitLoopbackPort(string? host)
         {
-            if (string.IsNullOrWhiteSpace(host))
-                return null;
+            // No null/blank guard needed: Uri.TryCreate already fails for null, "" and all-whitespace (pinned by
+            // this method's theory rows). TryGetExplicitPort keeps its own guard — that one mirrors the LIB.
             if (!Uri.TryCreate(host, UriKind.Absolute, out var uri) || !uri.IsLoopback)
                 return null;
-            return TryGetExplicitPort(host!);
+            return TryGetExplicitPort(host);
         }
 
         /// <summary>
@@ -181,6 +191,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         /// including the <c>&gt; 0 &amp;&amp; &lt;= Consts.Hub.MaxPort</c> guard, so an unusable port falls back to
         /// the derived one on BOTH sides rather than diverging. It is duplicated here rather than called because
         /// the LIB member is <c>internal</c> and ships in 7.3.0, while this binder must hold on the 7.2.0 pin.</para>
+        ///
+        /// <para>Test seam: <c>internal</c> rather than <c>private</c> because the loopback entry point cannot
+        /// reach all of this method's guards — see <c>TryGetExplicitPort_MirrorsTheLibParserIncludingItsGuards</c>
+        /// for why the suite drives it directly.</para>
         /// </summary>
         internal static int? TryGetExplicitPort(string? host)
         {
@@ -212,9 +226,6 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
 
             return port > 0 && port <= Consts.Hub.MaxPort ? port : (int?)null;
         }
-
-        /// <summary>The characters that terminate a URL's authority component (path / query / fragment).</summary>
-        private static readonly char[] AuthorityTerminators = { '/', '?', '#' };
 
         /// <summary>
         /// The human-facing project name: the basename (no extension) of the first top-level <c>*.uproject</c>

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -130,7 +130,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         private readonly HttpClient? _ownedHttpClient;
         // Whether the last applied connection config selected Cloud mode. Gates the §7 cloud-auth indicator:
         // a Custom-mode bearer is a LOCAL token, not a cloud authorization, so it must not light "Authorized".
-        private bool _isCloudMode;
+        // Volatile for the same reason as _customHost below: LocalBindHost gates on it from the project-config
+        // Task.Run worker while ApplyConnectionConfig writes it on the IPC reader thread.
+        private volatile bool _isCloudMode;
 
         // The plugin's effective CUSTOM-mode host (FUnrealMcpConfig::ResolveCustomHost()) as last pushed over the
         // §8 `config` message — the source of precedence level 2 for the local-server bind port (see
@@ -313,9 +315,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         /// (<see cref="ProjectConnectionResolver.Resolve"/>): the plugin's effective Custom-mode host, or
         /// <c>null</c> in Cloud mode. The Cloud gate mirrors the writer, which only rewrites a loopback port for
         /// <c>ConnectionMode.Local</c> — in Cloud mode the written URL keeps its authority verbatim and no local
-        /// server runs, so the derived port stands. Internal so the bridge xUnit suite can assert the gate.
+        /// server runs, so the derived port stands. The xUnit suite asserts this gate end-to-end through
+        /// <see cref="BuildProjectConfigResult"/>, so it needs no wider accessibility than <c>private</c>.
         /// </summary>
-        internal string? LocalBindHost => _isCloudMode ? null : Volatile.Read(ref _customHost);
+        private string? LocalBindHost => _isCloudMode ? null : Volatile.Read(ref _customHost);
 
         /// <summary>Test seam: the per-editor-session instance id (stable across reconnects) reported in the metadata.</summary>
         internal string InstanceId => _instanceId;
@@ -525,7 +528,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             Volatile.Write(ref _projectRootPath, projectPath);
             try
             {
-                var resolved = ProjectConnectionResolver.Resolve(projectPath!, _instanceId, machineName: null, localHost: LocalBindHost);
+                var resolved = ProjectConnectionResolver.Resolve(projectPath!, _instanceId, localHost: LocalBindHost);
                 _config.InstanceMetadata = resolved.Metadata;
                 _config.ProjectRootPath = projectPath;
                 // Log the reported project root (the deterministic hash INPUT) alongside the resulting
@@ -637,6 +640,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             // Remember the raw Custom-mode host for the local-server bind-port precedence (level 2). Captured
             // BEFORE the mode-aware selection below so the Cloud /mcp suffix never reaches the port parser. An
             // absent key leaves the previous value (partial pushes); an explicit blank clears it back to derived.
+            //
+            // ⚠ KNOWN GAP — a host edited MID-SESSION updates this field but does not reach the C++ side until the
+            // next handshake, so the plugin's cached bind port can go stale while the writer emits the new port.
+            // Pre-T1 the resolved port depended only on immutable inputs, which is why caching it per handshake was
+            // correct. NOT fixed here: the two candidate fixes sit on opposite sides of the IPC boundary, so the
+            // choice is a design call — analysis and options are in PR #251 for owner sequencing.
             if (host != null)
                 Volatile.Write(ref _customHost, string.IsNullOrWhiteSpace(host) ? null : host);
             var selected = isCloud ? cloudUrl : host;
@@ -868,7 +877,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                     Error = "No project path available to resolve the connection identity (handshake not applied and request carried none).",
                 };
 
-            var resolved = ProjectConnectionResolver.Resolve(projectRoot!, _instanceId, machineName: null, localHost: LocalBindHost);
+            var resolved = ProjectConnectionResolver.Resolve(projectRoot!, _instanceId, localHost: LocalBindHost);
             return new ProjectConfigResultMessage
             {
                 RequestId = request.RequestId,

--- a/bridge/src/Host/SidecarHost.cs
+++ b/bridge/src/Host/SidecarHost.cs
@@ -132,6 +132,15 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         // a Custom-mode bearer is a LOCAL token, not a cloud authorization, so it must not light "Authorized".
         private bool _isCloudMode;
 
+        // The plugin's effective CUSTOM-mode host (FUnrealMcpConfig::ResolveCustomHost()) as last pushed over the
+        // §8 `config` message — the source of precedence level 2 for the local-server bind port (see
+        // ProjectConnectionResolver.Resolve). Deliberately NOT _config.Host: that carries the Cloud /mcp suffix,
+        // the --host argv fallback, and the McpPlugin default (Consts.Hub.DefaultHost = http://localhost:8080), so
+        // reading it would apply a "typed" port the plugin never sent. Null until the plugin actually pushes one,
+        // which keeps a config-less sidecar (and every test that drives the resolver directly) on levels 1+3.
+        // Volatile: written on the IPC reader thread, read from the project-config Task.Run worker.
+        private string? _customHost;
+
         // §7 connected-AI-agent roster (issue #109). The plugin's "AI agents" status row reflects
         // StatusMessage.AiAgents; before this it was hardcoded empty. The roster is the formatted label list
         // ("AI agent: {ClientName} ({ClientVersion})") for the currently-connected MCP clients, sourced from
@@ -298,6 +307,15 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         /// <see cref="ConnectionConfig.InstanceMetadata"/>.
         /// </summary>
         internal ConnectionInstanceMetadata? InstanceMetadata => _config.InstanceMetadata;
+
+        /// <summary>
+        /// The host whose explicitly-typed port may claim precedence level 2 of the local-server bind port
+        /// (<see cref="ProjectConnectionResolver.Resolve"/>): the plugin's effective Custom-mode host, or
+        /// <c>null</c> in Cloud mode. The Cloud gate mirrors the writer, which only rewrites a loopback port for
+        /// <c>ConnectionMode.Local</c> — in Cloud mode the written URL keeps its authority verbatim and no local
+        /// server runs, so the derived port stands. Internal so the bridge xUnit suite can assert the gate.
+        /// </summary>
+        internal string? LocalBindHost => _isCloudMode ? null : Volatile.Read(ref _customHost);
 
         /// <summary>Test seam: the per-editor-session instance id (stable across reconnects) reported in the metadata.</summary>
         internal string InstanceId => _instanceId;
@@ -507,7 +525,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             Volatile.Write(ref _projectRootPath, projectPath);
             try
             {
-                var resolved = ProjectConnectionResolver.Resolve(projectPath!, _instanceId);
+                var resolved = ProjectConnectionResolver.Resolve(projectPath!, _instanceId, machineName: null, localHost: LocalBindHost);
                 _config.InstanceMetadata = resolved.Metadata;
                 _config.ProjectRootPath = projectPath;
                 // Log the reported project root (the deterministic hash INPUT) alongside the resulting
@@ -515,8 +533,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                 // the exact string each runtime feeds into ProjectIdentity, and the hash it derives (the
                 // handshake routing key). Non-secret — the credential travels separately in the Authorization header.
                 _logger?.LogInformation(
-                    "Resolved project identity for '{ProjectName}' (pin {Pin}, port {Port}{Override}, instance {InstanceId}); hash input '{HashInput}' -> projectPathHash {ProjectPathHash}; attaching instance metadata to the hub handshake.",
-                    resolved.ProjectName, resolved.Pin, resolved.Port, resolved.PortIsOverridden ? " [user override]" : string.Empty, _instanceId, projectPath, resolved.ProjectPathHash);
+                    "Resolved project identity for '{ProjectName}' (pin {Pin}, port {Port} [{PortSource}], instance {InstanceId}); hash input '{HashInput}' -> projectPathHash {ProjectPathHash}; attaching instance metadata to the hub handshake.",
+                    resolved.ProjectName, resolved.Pin, resolved.Port, resolved.PortSource, _instanceId, projectPath, resolved.ProjectPathHash);
 #if USE_LOCAL_MCP_PLUGIN
                 // Dual-hash transition (auth-fixes T3 / defect B5, MCP-Plugin-dotnet #165): built against the
                 // source LIB, ConnectionInstanceMetadata carries the v1 legacy hash alongside the v2 primary so a
@@ -615,6 +633,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
             // must not silently flip us out of Cloud.
             if (mode != null)
                 _isCloudMode = isCloud;
+
+            // Remember the raw Custom-mode host for the local-server bind-port precedence (level 2). Captured
+            // BEFORE the mode-aware selection below so the Cloud /mcp suffix never reaches the port parser. An
+            // absent key leaves the previous value (partial pushes); an explicit blank clears it back to derived.
+            if (host != null)
+                Volatile.Write(ref _customHost, string.IsNullOrWhiteSpace(host) ? null : host);
             var selected = isCloud ? cloudUrl : host;
             if (string.IsNullOrWhiteSpace(selected))
                 selected = isCloud ? host : cloudUrl;
@@ -822,9 +846,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
         /// Resolve a <c>project-config</c> request into its terminal result. Prefers the project root the request
         /// carries (race-free — the C++ plugin knows <c>FPaths::ProjectDir()</c>); falls back to the handshake-reported
         /// root cached by <see cref="ApplyProjectIdentity"/>. Resolution goes through the SAME
-        /// <see cref="ProjectConnectionResolver.Resolve"/> PR 3 uses, so the returned pin/port carry byte-for-byte
-        /// <c>ProjectIdentity</c> golden-vector parity and the marker's <c>portOverride</c> precedence. Internal so the
-        /// bridge xUnit suite asserts the resolved DTO (parity + override) without the IPC send.
+        /// <see cref="ProjectConnectionResolver.Resolve"/> PR 3 uses, so the returned pin carries byte-for-byte
+        /// <c>ProjectIdentity</c> golden-vector parity and the port follows the full marker &gt; typed-host &gt;
+        /// derived precedence (auth-fixes T1 / defect A), fed the Custom-mode host via <see cref="LocalBindHost"/>.
+        /// Internal so the bridge xUnit suite asserts the resolved DTO (parity + each precedence level) without the
+        /// IPC send.
         /// </summary>
         internal ProjectConfigResultMessage BuildProjectConfigResult(JsonObject node)
         {
@@ -842,7 +868,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Host
                     Error = "No project path available to resolve the connection identity (handshake not applied and request carried none).",
                 };
 
-            var resolved = ProjectConnectionResolver.Resolve(projectRoot!, _instanceId);
+            var resolved = ProjectConnectionResolver.Resolve(projectRoot!, _instanceId, machineName: null, localHost: LocalBindHost);
             return new ProjectConfigResultMessage
             {
                 RequestId = request.RequestId,

--- a/bridge/src/Ipc/ProjectConfigMessages.cs
+++ b/bridge/src/Ipc/ProjectConfigMessages.cs
@@ -22,10 +22,12 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
     ///
     /// The plugin sends a <see cref="ProjectConfigRequestMessage"/> (carrying its project root); the sidecar
     /// resolves the identity via <c>ProjectConnectionResolver</c> (byte-for-byte <c>ProjectIdentity</c> golden-vector
-    /// parity + the project marker's <c>portOverride</c> precedence) and answers with a
-    /// <see cref="ProjectConfigResultMessage"/>. The marker port override always wins — it is baked into
-    /// <see cref="ProjectConfigResultMessage.Port"/> by the resolver, and surfaced via
-    /// <see cref="ProjectConfigResultMessage.PortIsOverridden"/> for logging.
+    /// parity for the pin) and answers with a <see cref="ProjectConfigResultMessage"/>.
+    /// <see cref="ProjectConfigResultMessage.Port"/> arrives fully resolved by the three-level precedence the shared
+    /// McpPlugin config writer also applies (auth-fixes T1 / defect A, owner ruling 2026-07-19): the project
+    /// marker's <c>portOverride</c>, else a port the user typed into the Custom-mode loopback host, else the
+    /// deterministic derivation. Whether the winner was a USER choice (either of the first two) rather than the
+    /// derivation is surfaced via <see cref="ProjectConfigResultMessage.PortIsOverridden"/> for logging.
     /// </summary>
 
     /// <summary>plugin → sidecar: request the resolved {pin, derived port, serverTarget} for the plugin's project.</summary>
@@ -55,9 +57,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         [JsonPropertyName("error")] public string? Error { get; set; }
         /// <summary>The routing pin — first 8 hex chars of the ProjectIdentity SHA-256 (D14/D15).</summary>
         [JsonPropertyName("pin")] public string? Pin { get; set; }
-        /// <summary>The deterministic per-project local-server port (marker <c>portOverride</c> if set, else the SHA-derived 20000–29999 port).</summary>
+        /// <summary>The resolved per-project local-server bind port: the marker <c>portOverride</c> if set, else a port explicitly typed into the Custom-mode loopback host, else the SHA-derived 20000–29999 port.</summary>
         [JsonPropertyName("port")] public int Port { get; set; }
-        /// <summary>Whether <see cref="Port"/> came from the marker's user <c>portOverride</c> (informational; the override is already applied to <see cref="Port"/>).</summary>
+        /// <summary>Whether <see cref="Port"/> is a USER choice — the marker's <c>portOverride</c> or a port typed into the loopback host — rather than the deterministic derivation (informational; the winner is already applied to <see cref="Port"/>).</summary>
         [JsonPropertyName("portIsOverridden")] public bool PortIsOverridden { get; set; }
         /// <summary>The enrolled server target (hosted vs local) from the project marker, or null when unenrolled.</summary>
         [JsonPropertyName("serverTarget")] public string? ServerTarget { get; set; }

--- a/bridge/src/Ipc/ProjectConfigMessages.cs
+++ b/bridge/src/Ipc/ProjectConfigMessages.cs
@@ -30,7 +30,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
     /// derivation is surfaced via <see cref="ProjectConfigResultMessage.PortIsOverridden"/> for logging.
     /// </summary>
 
-    /// <summary>plugin → sidecar: request the resolved {pin, derived port, serverTarget} for the plugin's project.</summary>
+    /// <summary>plugin → sidecar: request the resolved {pin, resolved port, serverTarget} for the plugin's project.</summary>
     public sealed class ProjectConfigRequestMessage
     {
         [JsonPropertyName("type")] public string Type { get; set; } = IpcProtocol.Type.ProjectConfig;

--- a/bridge/tests/AgentConfigServiceTests.cs
+++ b/bridge/tests/AgentConfigServiceTests.cs
@@ -180,6 +180,17 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             // for host/port drift. The engine-side reconciliation of the new config model — MapSettings token drop,
             // the 8080→derived-port migration — is a later mcp-authorize PR; this locks the adopted 7.0 behavior so
             // that later change is deliberate.)
+            //
+            // ⚠ CASCADE BLOCKER — this test's PREMISE is reversed by McpPlugin 7.3.0 (PRs #174/#176) and it WILL
+            // FAIL on the pin bump (verified locally against the LIB source: `dotnet test -p:UseLocalMcpPlugin=true`
+            // reds line 202, `IsConfigured` false). Reason: 7.3.0's `AgentConfiguratorSettings.PinnedPort` inserts
+            // "an explicit port typed into the Host" BETWEEN the marker override and the derived port, so the
+            // written URL is no longer host-independent — the :12345 → :54321 drift below genuinely changes the
+            // desired URL and the on-disk entry becomes stale. Under 7.3.0 the CORRECT expectation is
+            // ReconfigureNeeded (which is what this scenario returned pre-7.0). Update this test IN THE SAME PR
+            // that bumps the pin — do not weaken it here; on the current 7.2.0 pin the assertions below are right.
+            // (Second Unreal-side blocker for the auth-fixes T1 cascade, alongside the pending
+            // LocalServerPortConsistencyTests.WrittenConfigPort_EqualsServerBindPort_OnDefaultLocalPath.)
             // Configure once so the entry lands on disk (project-local .mcp.json under the isolated temp _projectRoot)...
             var configure = _service.HandleConfigure(new AgentConfigureRequestMessage
             {

--- a/bridge/tests/AgentConfigServiceTests.cs
+++ b/bridge/tests/AgentConfigServiceTests.cs
@@ -183,7 +183,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             //
             // ⚠ CASCADE BLOCKER — this test's PREMISE is reversed by McpPlugin 7.3.0 (PRs #174/#176) and it WILL
             // FAIL on the pin bump (verified locally against the LIB source: `dotnet test -p:UseLocalMcpPlugin=true`
-            // reds line 202, `IsConfigured` false). Reason: 7.3.0's `AgentConfiguratorSettings.PinnedPort` inserts
+            // reds the trailing `Assert.True(d.IsConfigured)` below). Reason: 7.3.0's `AgentConfiguratorSettings.PinnedPort` inserts
             // "an explicit port typed into the Host" BETWEEN the marker override and the derived port, so the
             // written URL is no longer host-independent — the :12345 → :54321 drift below genuinely changes the
             // desired URL and the on-disk entry becomes stale. Under 7.3.0 the CORRECT expectation is

--- a/bridge/tests/LocalServerPortConsistencyTests.cs
+++ b/bridge/tests/LocalServerPortConsistencyTests.cs
@@ -76,7 +76,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         /// host the writer gets — the sidecar reads it off the §8 <c>config</c> message (<c>SidecarHost.LocalBindHost</c>),
         /// so passing it here is what makes this a like-for-like parity check rather than two different questions.</summary>
         private static int ServerBindPort(string projectRoot, string host = RawCustomHost) =>
-            ProjectConnectionResolver.Resolve(projectRoot, instanceId: "editor-session", machineName: null, localHost: host).Port;
+            ProjectConnectionResolver.Resolve(projectRoot, instanceId: "editor-session", localHost: host).Port;
 
         [Fact(Skip = "Needs McpPlugin 7.3.0 (PRs #174/#176). The binder now honours the typed loopback port (8080 " +
                      "from the hardcoded DefaultCustomHost), but the pinned 7.2.0 writer still overwrites it with " +

--- a/bridge/tests/LocalServerPortConsistencyTests.cs
+++ b/bridge/tests/LocalServerPortConsistencyTests.cs
@@ -18,11 +18,10 @@ using ConnectionMode = com.IvanMurzak.McpPlugin.AgentConfig.ConnectionMode;
 namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
 {
     /// <summary>
-    /// mcp-authorize g3 (Phase-4 completion, design 04 D15 / 06): locks the local self-hosted invariant that
-    /// <b>the editor local server's BIND port == the port Configure WRITES into a client config == the
-    /// ProjectIdentity-derived per-project port</b>. Both come from the SAME McpPlugin
-    /// <see cref="ProjectIdentity"/> derivation, so the "Configure button writes a URL the local server
-    /// actually listens on" contract holds:
+    /// mcp-authorize g3 (Phase-4 completion, design 04 D15 / 06), re-anchored by auth-fixes T1 (defect A, owner
+    /// ruling 2026-07-19): locks the local self-hosted invariant that <b>the editor local server's BIND port ==
+    /// the port Configure WRITES into a client config</b> — the "Configure button writes a URL the local server
+    /// actually listens on" contract:
     /// <list type="bullet">
     ///   <item><b>Server bind side</b> — <see cref="ProjectConnectionResolver.Resolve"/> resolves the port the
     ///         sidecar delivers over the PR-4 <c>project-config</c> IPC; the C++
@@ -30,45 +29,64 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
     ///         <c>FUnrealMcpServerManager::Start</c> (off the old fixed-8080 <c>ParsePortFromHost</c> default,
     ///         migrated in PR #216).</item>
     ///   <item><b>Written config side</b> — the shared b6 writer
-    ///         <see cref="AgentConfiguratorSettings.PinnedHttpUrl"/> rewrites a loopback <see cref="ConnectionMode.Local"/>
-    ///         URL's port to <see cref="AgentConfiguratorSettings.ResolvedPort"/> (= <see cref="ProjectIdentity.Port"/>),
-    ///         ignoring the raw engine-supplied host port.</item>
+    ///         <see cref="AgentConfiguratorSettings.PinnedHttpUrl"/> sets a loopback
+    ///         <see cref="ConnectionMode.Local"/> URL's port.</item>
     /// </list>
-    /// Both honor the D15 project-marker <c>portOverride</c>, so an explicit user override still wins on both
-    /// sides. A future regression that repoints either side back onto a fixed port (or trusts the raw
-    /// engine-supplied host port) breaks this — deterministically, without a live socket or editor.
+    ///
+    /// <para><b>What changed.</b> The invariant used to be the stronger "…== the ProjectIdentity-DERIVED port",
+    /// because both sides stopped at {marker <c>portOverride</c>, derived} and both deliberately IGNORED a port
+    /// the user typed into the host. MCP-Plugin-dotnet #174/#176 reversed that on the writer side (owner ruling:
+    /// "the Configure button must use exactly the port the user enters"), inserting a typed-host level BETWEEN
+    /// the two. This suite therefore now locks <b>bind == written</b> under the shared three-level precedence —
+    /// marker <c>portOverride</c> &gt; explicit port typed into the loopback host &gt; deterministic derivation —
+    /// rather than pinning both onto the derivation. The per-level BINDER contract lives in
+    /// <c>ProjectConnectionResolverTests</c>; this file is the writer-vs-binder PARITY suite.</para>
+    ///
+    /// <para><b>Pin sensitivity.</b> Parity on a host whose typed port differs from the derived one can only hold
+    /// once the bridge consumes a writer that implements level 2 — McpPlugin <b>7.3.0</b>. On the current 7.2.0
+    /// pin the writer still overwrites the typed port, so that one vector is marked pending below; the vectors
+    /// that resolve identically under BOTH writers (marker override, and a host carrying no explicit port) stay
+    /// green and keep this suite live. All deterministic — no live socket or editor.</para>
     /// </summary>
     public class LocalServerPortConsistencyTests
     {
         // The URL shape the C++ editor UI actually sends as the b6 request's `host` on the default local path
-        // (FAiAgentConnectionInfo::FromPluginConfig → ResolveCustomHost() + "/mcp", default host localhost:8080).
-        // The b6 writer must DERIVE the loopback port from ProjectIdentity, NOT trust this raw 8080.
+        // (FAiAgentConnectionInfo::FromPluginConfig → ResolveCustomHost() + "/mcp"). NOTE the default host is the
+        // HARDCODED FUnrealMcpConfig::DefaultCustomHost "http://localhost:8080" — unlike Unity, whose default host
+        // already carries the derived port. So under the new precedence this 8080 IS a "typed" port to both sides.
         private const string RawCustomHost = "http://localhost:8080/mcp";
         private const int RawHostPort = 8080;
 
         /// <summary>Build the settings the sidecar's <c>AgentConfigService.MapSettings</c> hands a configurator for the
         /// default (credential-free, native-OAuth) local path, then return the port of the URL that gets written.</summary>
-        private static int WrittenConfigPort(string projectRoot)
+        private static int WrittenConfigPort(string projectRoot, string host = RawCustomHost)
         {
             var settings = AgentConfiguratorSettings.CreateForHost(
                 projectRootPath: projectRoot,
                 executableFullPath: string.Empty,
-                port: RawHostPort,          // the raw engine-supplied port — must NOT be what gets written
+                port: RawHostPort,          // the raw engine-supplied port — not itself a precedence level
                 timeoutMs: 30000,
-                host: RawCustomHost,
+                host: host,
                 token: null,
                 connectionMode: ConnectionMode.Local);
             return new Uri(settings.PinnedHttpUrl).Port;
         }
 
-        /// <summary>The port the C++ editor local server binds: the sidecar-resolved, IPC-delivered derived port.</summary>
-        private static int ServerBindPort(string projectRoot) =>
-            ProjectConnectionResolver.Resolve(projectRoot, instanceId: "editor-session").Port;
+        /// <summary>The port the C++ editor local server binds: the sidecar-resolved, IPC-delivered port. Fed the SAME
+        /// host the writer gets — the sidecar reads it off the §8 <c>config</c> message (<c>SidecarHost.LocalBindHost</c>),
+        /// so passing it here is what makes this a like-for-like parity check rather than two different questions.</summary>
+        private static int ServerBindPort(string projectRoot, string host = RawCustomHost) =>
+            ProjectConnectionResolver.Resolve(projectRoot, instanceId: "editor-session", machineName: null, localHost: host).Port;
 
-        [Fact]
+        [Fact(Skip = "Needs McpPlugin 7.3.0 (PRs #174/#176). The binder now honours the typed loopback port (8080 " +
+                     "from the hardcoded DefaultCustomHost), but the pinned 7.2.0 writer still overwrites it with " +
+                     "the derived port, so the two legitimately disagree until the bridge csproj pin advances. " +
+                     "Un-skip in the same PR that bumps com.IvanMurzak.McpPlugin to 7.3.0 — no assertion change " +
+                     "required, it is the pin that makes it pass.")]
         public void WrittenConfigPort_EqualsServerBindPort_OnDefaultLocalPath()
         {
-            // Canonical golden vector (/home/user/my-game → 23940) — no project marker, so the hash-derived port.
+            // Canonical golden vector (/home/user/my-game → 23940) — no project marker, and the default host
+            // carries an explicit 8080, so precedence level 2 (typed host) decides on BOTH sides.
             const string projectRoot = "/home/user/my-game";
             var derived = ProjectIdentity.Derive(projectRoot).Port;
             Assert.Equal(23940, derived);
@@ -76,16 +94,47 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             var bind = ServerBindPort(projectRoot);
             var written = WrittenConfigPort(projectRoot);
 
-            // The DoD: server bind == written config == the ProjectIdentity-derived port.
-            Assert.Equal(derived, bind);
-            Assert.Equal(derived, written);
+            // The DoD: server bind == written config.
             Assert.Equal(bind, written);
 
-            // And the written port is the DERIVED port, never the raw fixed host port — proving the migration off
-            // the old fixed-8080 default really happened on the writer side too.
-            Assert.NotEqual(RawHostPort, written);
+            // Both name the port typed into the host, not the derivation — the owner-ruled precedence. The
+            // NotEqual proves level 2 actually decided (8080 and 23940 differ), so an accidental fallback to the
+            // derivation on either side would fail here rather than pass by coincidence.
+            Assert.Equal(RawHostPort, bind);
+            Assert.Equal(RawHostPort, written);
+            Assert.NotEqual(derived, written);
         }
 
+        /// <summary>
+        /// Parity on a host carrying NO explicit port: precedence level 2 does not apply, so both sides fall back
+        /// to the deterministic derivation. Pin-independent — the 7.2.0 and 7.3.0 writers agree here — so this is
+        /// the vector that keeps the derived-port half of the invariant under live guard while the default-path
+        /// fact above waits on the pin bump. It also pins the load-bearing "explicit port" reading: a port-less
+        /// host must NOT be read as the scheme default (<c>Uri.Port</c> would say 80 and bind 80).
+        /// </summary>
+        [Fact]
+        public void WrittenConfigPort_EqualsServerBindPort_WhenHostCarriesNoExplicitPort()
+        {
+            const string projectRoot = "/home/user/my-game";
+            const string portlessHost = "http://localhost/mcp";
+            var derived = ProjectIdentity.Derive(projectRoot).Port;
+            Assert.Equal(23940, derived);
+
+            var bind = ServerBindPort(projectRoot, portlessHost);
+            var written = WrittenConfigPort(projectRoot, portlessHost);
+
+            Assert.Equal(bind, written);
+            Assert.Equal(derived, bind);
+            Assert.NotEqual(80, bind);
+        }
+
+        /// <summary>
+        /// D15: an explicit user override in the committable project marker is precedence level 1 — it outranks
+        /// BOTH the typed host port and the derivation, on the bind and written sides alike. Pin-independent: the
+        /// 7.2.0 writer resolves it via <c>ResolvedPort</c> and the 7.3.0 writer via <c>PinnedPort</c>'s level 1,
+        /// to the same value. Deliberately left as it was written — the new precedence does not disturb it, and
+        /// weakening or re-pointing a still-correct assertion would lose the coverage.
+        /// </summary>
         [Fact]
         public void WrittenConfigPort_EqualsServerBindPort_WithD15PortOverride()
         {
@@ -110,6 +159,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
                 Assert.Equal(bind, written);
                 // The override is NOT the hash-derived port (proves the override path is exercised, not a coincidence).
                 Assert.NotEqual(overridePort, derivedPort);
+                // …nor the port typed into RawCustomHost, so this also proves level 1 outranks level 2: the marker
+                // wins even though the host carries an explicit 8080. (Structural — the override is drawn from the
+                // 20000–29999 band — but asserted so a future band/default change cannot silently void the claim.)
+                Assert.NotEqual(RawHostPort, overridePort);
             });
         }
 

--- a/bridge/tests/ProjectConnectionResolverTests.cs
+++ b/bridge/tests/ProjectConnectionResolverTests.cs
@@ -220,7 +220,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         {
             const string root = "/home/user/my-game";   // golden vector → derived 23940
             var resolved = ProjectConnectionResolver.Resolve(
-                root, instanceId: "inst-typed", machineName: null, localHost: "http://localhost:27618/mcp");
+                root, instanceId: "inst-typed", localHost: "http://localhost:27618/mcp");
 
             Assert.Equal(27618, resolved.Port);
             Assert.Equal(LocalServerPortSource.TypedHost, resolved.PortSource);
@@ -245,7 +245,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
                 new ProjectMarker { PortOverride = overridePort }.Write(dir);
 
                 var resolved = ProjectConnectionResolver.Resolve(
-                    dir, instanceId: "inst-both", machineName: null, localHost: "http://localhost:27618/mcp");
+                    dir, instanceId: "inst-both", localHost: "http://localhost:27618/mcp");
 
                 Assert.Equal(overridePort, resolved.Port);
                 Assert.Equal(LocalServerPortSource.MarkerOverride, resolved.PortSource);
@@ -266,7 +266,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         {
             const string root = "/home/user/my-game";
             var resolved = ProjectConnectionResolver.Resolve(
-                root, instanceId: "inst-portless", machineName: null, localHost: "http://localhost/mcp");
+                root, instanceId: "inst-portless", localHost: "http://localhost/mcp");
 
             Assert.Equal(23940, resolved.Port);
             Assert.Equal(LocalServerPortSource.Derived, resolved.PortSource);
@@ -284,7 +284,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         {
             const string root = "/home/user/my-game";
             var resolved = ProjectConnectionResolver.Resolve(
-                root, instanceId: "inst-remote", machineName: null, localHost: "https://mcp.example.com:9999/mcp");
+                root, instanceId: "inst-remote", localHost: "https://mcp.example.com:9999/mcp");
 
             Assert.Equal(23940, resolved.Port);
             Assert.Equal(LocalServerPortSource.Derived, resolved.PortSource);
@@ -316,8 +316,8 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         [InlineData("http://LOCALHOST:27618", 27618)]         // loopback detection is case-insensitive
         [InlineData("http://localhost/mcp", null)]            // no port typed — NOT the scheme default 80
         [InlineData("http://localhost:/mcp", null)]           // empty port
-        [InlineData("http://localhost:abc/mcp", null)]        // non-numeric
-        [InlineData("http://localhost:70000", null)]          // out of range (> Consts.Hub.MaxPort)
+        [InlineData("http://localhost:abc/mcp", null)]        // non-numeric — rejected by Uri.TryCreate, see below
+        [InlineData("http://localhost:70000", null)]          // out of range — rejected by Uri.TryCreate, see below
         [InlineData("http://localhost:0", null)]              // zero is not a bindable port
         [InlineData("https://mcp.example.com:9999", null)]    // not loopback
         [InlineData("localhost:27618", null)]                 // not an absolute URI
@@ -326,6 +326,36 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         public void TryGetExplicitLoopbackPort_ReadsOnlyAnExplicitLoopbackPort(string? host, int? expected)
         {
             Assert.Equal(expected, ProjectConnectionResolver.TryGetExplicitLoopbackPort(host));
+        }
+
+        /// <summary>
+        /// The raw-string parser DIRECTLY, because the loopback entry point above cannot reach all of it: it gates
+        /// on <c>Uri.TryCreate(..., Absolute)</c> first, and <c>Uri</c> rejects an out-of-range or non-numeric port
+        /// itself — so the <c>&gt; 0 &amp;&amp; &lt;= Consts.Hub.MaxPort</c> range guard and the
+        /// <c>NumberStyles.None</c> validator never execute through it, and the two rows above marked "rejected by
+        /// Uri.TryCreate" pass for that reason rather than by exercising the guards.
+        ///
+        /// <para>Those two guards are precisely the parts most likely to DRIFT from
+        /// <c>AgentConfiguratorSettings.TryGetExplicitPort</c>, which this method deliberately duplicates (the LIB
+        /// member is <c>internal</c> and ships in 7.3.0, while the binder must hold on the 7.2.0 pin). Leaving them
+        /// uncovered would defeat the point of mirroring the LIB step for step, so these rows mirror the LIB's own
+        /// parser rows — a divergence here means the binder and the writer would disagree on a port.</para>
+        /// </summary>
+        [Theory]
+        [InlineData("http://localhost:65535", 65535)]                  // upper bound is inclusive
+        [InlineData("http://localhost:65536", null)]                   // range guard — UNREACHABLE via the loopback gate
+        [InlineData("http://localhost:99999999999999999999", null)]    // int.TryParse overflow, not an exception
+        [InlineData("http://localhost:+80", null)]                     // NumberStyles.None rejects a sign
+        [InlineData("http://localhost:-80", null)]
+        [InlineData("http://localhost:8 0", null)]                     // ...and embedded whitespace
+        [InlineData("http://localhost:8080?x=1", 8080)]                // query terminates the authority
+        [InlineData("http://localhost:8080#frag", 8080)]               // ...as does a fragment
+        [InlineData("//localhost:8080", null)]                         // scheme-relative: authority is empty before the first '/'
+        [InlineData("localhost:8080", 8080)]                           // scheme-less IS parsed here; the loopback gate is what rejects it
+        [InlineData("http://[::1]", null)]                             // bracketed IPv6 address alone carries no port
+        public void TryGetExplicitPort_MirrorsTheLibParserIncludingItsGuards(string? host, int? expected)
+        {
+            Assert.Equal(expected, ProjectConnectionResolver.TryGetExplicitPort(host));
         }
 
         [Fact]

--- a/bridge/tests/ProjectConnectionResolverTests.cs
+++ b/bridge/tests/ProjectConnectionResolverTests.cs
@@ -203,6 +203,131 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             });
         }
 
+        // ── Local-server bind-port precedence (auth-fixes T1 / defect A, owner ruling 2026-07-19) ────────────
+        // The binder's OWN contract: marker portOverride (1) > explicit port typed into the loopback host (2) >
+        // deterministic derivation (3) — the same three levels the shared McpPlugin writer applies, so the port
+        // the local gamedev-mcp-server BINDS is the port the Configure button WRITES. These assert the resolver
+        // directly (given root + marker + host → port), so they hold on the CURRENT McpPlugin pin; the
+        // writer-vs-binder parity that needs 7.3.0 lives in LocalServerPortConsistencyTests.
+
+        /// <summary>
+        /// Level 2 beats level 3: with no marker, a port the user typed into the Custom-mode loopback host is what
+        /// the local server binds — NOT the hash-derived port. This is the behaviour reversal T1 delivers; before
+        /// it the resolver ignored the typed port to mirror the OLD writer.
+        /// </summary>
+        [Fact]
+        public void Resolve_TypedLoopbackHostPort_WinsOverDerivedPort()
+        {
+            const string root = "/home/user/my-game";   // golden vector → derived 23940
+            var resolved = ProjectConnectionResolver.Resolve(
+                root, instanceId: "inst-typed", machineName: null, localHost: "http://localhost:27618/mcp");
+
+            Assert.Equal(27618, resolved.Port);
+            Assert.Equal(LocalServerPortSource.TypedHost, resolved.PortSource);
+            Assert.True(resolved.PortIsOverridden);
+            // The typed port really displaced the derivation (not a coincidental match).
+            Assert.NotEqual(ProjectIdentity.DerivePort(root), resolved.Port);
+        }
+
+        /// <summary>
+        /// Level 1 beats level 2: a marker <c>portOverride</c> is a deliberate per-project pin, so it wins even
+        /// when the host ALSO carries an explicit port. Both are user choices; the marker is the more specific one.
+        /// </summary>
+        [Fact]
+        public void Resolve_MarkerPortOverride_WinsOverTypedLoopbackHostPort()
+        {
+            RunInTempDir(dir =>
+            {
+                // Step off the temp dir's own derived port so "override != derived" stays deterministic (same
+                // reasoning as LocalServerPortConsistencyTests — both live in the 20000–29999 band).
+                var derivedPort = ProjectIdentity.DerivePort(dir);
+                var overridePort = derivedPort == 26543 ? 26544 : 26543;
+                new ProjectMarker { PortOverride = overridePort }.Write(dir);
+
+                var resolved = ProjectConnectionResolver.Resolve(
+                    dir, instanceId: "inst-both", machineName: null, localHost: "http://localhost:27618/mcp");
+
+                Assert.Equal(overridePort, resolved.Port);
+                Assert.Equal(LocalServerPortSource.MarkerOverride, resolved.PortSource);
+                Assert.True(resolved.PortIsOverridden);
+                // Neither of the two losing levels was picked — so the ordering, not a value collision, decided.
+                Assert.NotEqual(27618, resolved.Port);
+                Assert.NotEqual(derivedPort, resolved.Port);
+            });
+        }
+
+        /// <summary>
+        /// Level 3 stands when the host carries NO explicit port. Load-bearing: <c>Uri.Port</c> would synthesise
+        /// the scheme default (80) here, which would make "no port typed" indistinguishable from "80 typed" and
+        /// bind 80 instead of the per-project derived port — which is why the resolver parses the RAW host string.
+        /// </summary>
+        [Fact]
+        public void Resolve_HostWithoutExplicitPort_FallsBackToDerivedPort()
+        {
+            const string root = "/home/user/my-game";
+            var resolved = ProjectConnectionResolver.Resolve(
+                root, instanceId: "inst-portless", machineName: null, localHost: "http://localhost/mcp");
+
+            Assert.Equal(23940, resolved.Port);
+            Assert.Equal(LocalServerPortSource.Derived, resolved.PortSource);
+            Assert.False(resolved.PortIsOverridden);
+            Assert.NotEqual(80, resolved.Port);
+        }
+
+        /// <summary>
+        /// A NON-loopback host contributes no level 2, mirroring the writer's
+        /// <c>ConnectionMode.Local &amp;&amp; uri.IsLoopback</c> gate: a hosted target keeps its authority verbatim
+        /// there and has no local server to bind here, so the derived port stands on both sides.
+        /// </summary>
+        [Fact]
+        public void Resolve_NonLoopbackHostPort_IsIgnored()
+        {
+            const string root = "/home/user/my-game";
+            var resolved = ProjectConnectionResolver.Resolve(
+                root, instanceId: "inst-remote", machineName: null, localHost: "https://mcp.example.com:9999/mcp");
+
+            Assert.Equal(23940, resolved.Port);
+            Assert.Equal(LocalServerPortSource.Derived, resolved.PortSource);
+        }
+
+        /// <summary>
+        /// An absent host (Cloud mode, or no config pushed yet) leaves the pre-T1 levels 1+3 behaviour exactly as
+        /// it was — the change is strictly additive for every caller that supplies no host.
+        /// </summary>
+        [Fact]
+        public void Resolve_NoHost_KeepsDerivedPort()
+        {
+            var resolved = ProjectConnectionResolver.Resolve("/home/user/my-game", instanceId: "inst-nohost");
+
+            Assert.Equal(23940, resolved.Port);
+            Assert.Equal(LocalServerPortSource.Derived, resolved.PortSource);
+        }
+
+        /// <summary>
+        /// The level-2 host parser, mirroring <c>AgentConfiguratorSettings.TryGetExplicitPort</c> + the writer's
+        /// loopback gate: which host strings yield a typed port at all. Anything that yields <c>null</c> falls
+        /// through to the derived port rather than binding something unusable.
+        /// </summary>
+        [Theory]
+        [InlineData("http://localhost:27618/mcp", 27618)]     // the canonical typed-port case
+        [InlineData("http://127.0.0.1:27618", 27618)]         // IPv4 loopback literal
+        [InlineData("http://[::1]:27618/mcp", 27618)]         // IPv6 literal — port follows the closing bracket
+        [InlineData("http://user:pass@localhost:27618", 27618)] // userinfo colon is not a port separator
+        [InlineData("http://LOCALHOST:27618", 27618)]         // loopback detection is case-insensitive
+        [InlineData("http://localhost/mcp", null)]            // no port typed — NOT the scheme default 80
+        [InlineData("http://localhost:/mcp", null)]           // empty port
+        [InlineData("http://localhost:abc/mcp", null)]        // non-numeric
+        [InlineData("http://localhost:70000", null)]          // out of range (> Consts.Hub.MaxPort)
+        [InlineData("http://localhost:0", null)]              // zero is not a bindable port
+        [InlineData("https://mcp.example.com:9999", null)]    // not loopback
+        [InlineData("localhost:27618", null)]                 // not an absolute URI
+        [InlineData("", null)]
+        [InlineData(null, null)]
+        public void TryGetExplicitLoopbackPort_ReadsOnlyAnExplicitLoopbackPort(string? host, int? expected)
+        {
+            Assert.Equal(expected, ProjectConnectionResolver.TryGetExplicitLoopbackPort(host));
+        }
+
         [Fact]
         public void PersistServerTarget_BlankInputs_AreNoOps()
         {

--- a/bridge/tests/SidecarHostProjectConfigTests.cs
+++ b/bridge/tests/SidecarHostProjectConfigTests.cs
@@ -110,6 +110,74 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             });
         }
 
+        /// <summary>
+        /// Precedence level 2 end-to-end through the host (auth-fixes T1 / defect A): the §8 <c>config</c> message
+        /// carries the plugin's effective Custom-mode host, and a port the user typed into it becomes the port the
+        /// local server binds. Proves the wiring — <c>ApplyConnectionConfig</c> → <c>LocalBindHost</c> →
+        /// <c>ProjectConnectionResolver.Resolve</c> — not just the resolver, which is covered per-level in
+        /// <c>ProjectConnectionResolverTests</c>.
+        /// </summary>
+        [Fact]
+        public void BuildProjectConfigResult_TypedCustomHostPort_WinsOverDerivedPort()
+        {
+            using var host = BuildHost();
+            host.ApplyConnectionConfig(new JsonObject
+            {
+                ["mode"] = "Custom",
+                ["host"] = "http://localhost:27618",
+                ["cloudUrl"] = "https://ai-game.dev",
+            });
+
+            var result = host.BuildProjectConfigResult(Request("r-5", "/home/user/my-game"));
+
+            Assert.True(result.Ok);
+            Assert.Equal("34ea75f2", result.Pin);   // the PIN is untouched by the port precedence
+            Assert.Equal(27618, result.Port);
+            Assert.True(result.PortIsOverridden);   // a user choice, not the derivation
+            Assert.NotEqual(23940, result.Port);    // the golden derived port really was displaced
+        }
+
+        /// <summary>
+        /// Cloud mode contributes no level 2, mirroring the writer's <c>ConnectionMode.Local</c> gate: the written
+        /// URL keeps its authority verbatim and no local server runs, so the derived port stands even though the
+        /// same message carried a Custom host with an explicit port.
+        /// </summary>
+        [Fact]
+        public void BuildProjectConfigResult_CloudMode_IgnoresTypedCustomHostPort()
+        {
+            using var host = BuildHost();
+            host.ApplyConnectionConfig(new JsonObject
+            {
+                ["mode"] = "Cloud",
+                ["host"] = "http://localhost:27618",
+                ["cloudUrl"] = "https://ai-game.dev",
+            });
+
+            var result = host.BuildProjectConfigResult(Request("r-6", "/home/user/my-game"));
+
+            Assert.True(result.Ok);
+            Assert.Equal(23940, result.Port);
+            Assert.False(result.PortIsOverridden);
+        }
+
+        /// <summary>
+        /// A blank host clears level 2 back to the derivation — a user who empties the Host field gets the
+        /// per-project derived port, not a stale typed one from an earlier push.
+        /// </summary>
+        [Fact]
+        public void BuildProjectConfigResult_BlankCustomHost_FallsBackToDerivedPort()
+        {
+            using var host = BuildHost();
+            host.ApplyConnectionConfig(new JsonObject { ["mode"] = "Custom", ["host"] = "http://localhost:27618" });
+            host.ApplyConnectionConfig(new JsonObject { ["mode"] = "Custom", ["host"] = "" });
+
+            var result = host.BuildProjectConfigResult(Request("r-7", "/home/user/my-game"));
+
+            Assert.True(result.Ok);
+            Assert.Equal(23940, result.Port);
+            Assert.False(result.PortIsOverridden);
+        }
+
         [Fact]
         public void BuildProjectConfigResult_FallsBackToHandshakeRoot_WhenRequestOmitsPath()
         {

--- a/bridge/tests/SidecarHostProjectConfigTests.cs
+++ b/bridge/tests/SidecarHostProjectConfigTests.cs
@@ -21,9 +21,10 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
 {
     /// <summary>
     /// Proves the mcp-authorize PR 4 project-config IPC channel (design 04/06): the new message round-trips over the
-    /// NDJSON wire, and the sidecar resolves a <c>project-config</c> request into the derived {pin, port, serverTarget}
-    /// with byte-for-byte <see cref="ProjectIdentity"/> golden-vector parity and the project marker's
-    /// <c>portOverride</c> precedence — all without a live socket (mirrors <c>SidecarHostInstanceMetadataTests</c>).
+    /// NDJSON wire, and the sidecar resolves a <c>project-config</c> request into the resolved {pin, port, serverTarget}
+    /// with byte-for-byte <see cref="ProjectIdentity"/> golden-vector parity for the pin and the full
+    /// marker <c>portOverride</c> &gt; typed-host &gt; derived bind-port precedence (auth-fixes T1) for the port —
+    /// all without a live socket (mirrors <c>SidecarHostInstanceMetadataTests</c>).
     /// </summary>
     public class SidecarHostProjectConfigTests
     {


### PR DESCRIPTION
## Summary

- The sidecar's local-server **bind** port now follows the same **three-level precedence** the shared McpPlugin config writer applies, so the port the local `gamedev-mcp-server` binds is the port the Configure button writes:
  1. project-marker `portOverride`
  2. **an explicit port typed into the Custom-mode loopback `Host`** ← new
  3. the deterministic `ProjectIdentity`-derived per-project port
- Implemented in `ProjectConnectionResolver.Resolve`, fed the plugin's effective Custom-mode host over the **existing** §8 `config` IPC message (`SidecarHost.LocalBindHost`). **No C++ change, no new IPC field, no McpPlugin pin bump.**
- Level 2 is gated to an **absolute loopback host in non-Cloud mode**, mirroring the writer's `ConnectionMode.Local && uri.IsLoopback` rule exactly.

## Why mirroring the old writer is no longer correct

The resolver previously stopped at levels 1+3 *on purpose* — to mirror the writer, which overwrote a loopback URL's port with the derived one. MCP-Plugin-dotnet [#174](https://github.com/IvanMurzak/MCP-Plugin-dotnet/pull/174) / [#176](https://github.com/IvanMurzak/MCP-Plugin-dotnet/pull/176) (shipping in **7.3.0**) reversed that, per the owner ruling that *"the Configure button must use exactly the port the user enters"*. Once Unreal picks up 7.3.0, a two-level binder would listen on the derived port while the written config named the typed one — the originally reported bug, newly introduced into Unreal.

**Unity already behaves this way** on its binder side (`uri.Port`); **Godot is being aligned in parallel**. Unreal was the remaining engine.

The typed port is read off the **raw host string**, not `Uri.Port`: `Uri.Port` synthesises the scheme default (80/443) for a port-less host, which would make "no port typed" indistinguishable from "80 typed" and bind 80 instead of the per-project derived port.

## ⚠ Needs McpPlugin 7.3.0 before it can go green

`LocalServerPortConsistencyTests.WrittenConfigPort_EqualsServerBindPort_OnDefaultLocalPath` compares the binder against the **LIB writer's runtime output**, so it cannot pass on the pinned 7.2.0 writer. It is marked `[Fact(Skip = …)]` naming 7.3.0 — **not weakened, not deleted**. Verified both directions locally:

- on the pinned **7.2.0**: bind `8080` vs written `23940` → fails (so the skip is honest, not a cover-up);
- against the **LIB source** (`dotnet test -p:UseLocalMcpPlugin=true`, LIB `main` = #174+#176): **passes**.

Un-skip in the same PR that bumps the pin — no assertion change is needed, the pin alone makes it pass.

## 🔴 Second cascade blocker found (not in the brief — please sequence it)

`AgentConfigServiceTests.Status_ConnectionSettingDrift_StaysConfigured_Under7xDeterministicUrl` **also fails under 7.3.0** (verified: `IsConfigured` false at line 202). Its premise — "the written URL is host-independent, so Host drift does not make the entry stale" — is exactly what `PinnedPort` reverses; under 7.3.0 the correct expectation becomes `ReconfigureNeeded`. It is **green on today's pin**, so no assertion was touched; a `⚠ CASCADE BLOCKER` comment was added in-file so the bump PR cannot miss it.

## 📌 Judgment call worth reviewing: Unreal's default host makes 8080 a "typed" port

Unlike Unity — whose default `Host` already carries the derived port — Unreal's `FUnrealMcpConfig::DefaultCustomHost` is the **hardcoded `http://localhost:8080`**. `ResolveCustomHost()` collapses "user typed nothing" and "user typed 8080" into the same string, so neither the writer nor the binder can tell them apart. Consequence: **post-7.3.0, the default path resolves to 8080 on both sides**, and the per-project derived port only applies when the user edits the Host or sets a marker `portOverride`.

I implemented the precedence faithfully rather than special-casing the default, because a carve-out would reintroduce the writer/binder disagreement this PR exists to remove — and aligned-at-8080 is strictly better than the alternative (writer says 8080, binder says derived → nothing connects). But it does mean two concurrently-open Unreal projects would contend for 8080 by default. **Suggested follow-up: make `DefaultCustomHost` derive per-project (Unity-shaped)** — that restores per-project ports *and* keeps both sides in agreement. Flagging rather than doing it: it is a C++ change outside this task's stated bridge scope.

## 🟠 Third item for sequencing (found in review): a MID-SESSION host edit does not refresh the plugin's cached bind port

Surfaced by the `/code-review` pass on this PR. **Flagged, not fixed** — the two candidate fixes sit on opposite sides of the IPC boundary, so the choice is yours.

**The gap.** Before this change the resolved bind port depended only on **immutable** inputs (project root + on-disk marker), so the C++ side caching it once per handshake was correct. It now *also* depends on `_customHost`, which changes mid-session:

1. The user edits **Host** to `http://localhost:9000` in the UI.
2. `OnPushConfig → SetEffectiveConfig → PushConfig` delivers a fresh §8 `config` to the live sidecar — **no re-handshake**. `_customHost` updates.
3. But `SendProjectConfigRequest` is issued from the **handshake sink alone** (`UnrealMcpEditorCoordinator.cpp`), so `FUnrealMcpEditorCoordinator::DerivedLocalServerPort` keeps its handshake-time value.
4. Configure (b6) reads the *live* config → the writer emits **9000**; the local server still binds the **old** port.

That is the same class of divergence this PR exists to remove, on the primary flow it serves (a user typing a port into Host). It is latent until the 7.3.0 pin bump, so it belongs to the same cascade as the two blockers above. The initial handshake path is unaffected — the ack carries `config` and `OnHandshakeAccepted` applies it before `ApplyProjectIdentity`.

**Two candidate fixes** (verified feasible; I did not pick one):

- **(a) bridge-side** — re-emit an unsolicited `project-config-result` from `ApplyConnectionConfig` when `_customHost` actually changes and the project root is known. Verified safe on the C++ side: `ApplyProjectConfigResult` does **not** correlate on `requestId`, and its survivor reattach is guarded by `bLocalServerReattachAttempted`, so a re-emit only refreshes the cached port/pin. Contained to this repo's bridge leg (fast Suite 4 gate).
- **(b) C++-side** — re-request `project-config` after each `PushConfig`. Keeps the request/response protocol symmetric (the sidecar never spontaneously emits a result) and puts the trigger where the config change originates — at the cost of a C++ change and the full UE plugin gate.

(b) is arguably the cleaner design; (a) is cheaper and in-scope for this task. Picking on scope-convenience alone would be letting scope drive design, which is why this is flagged rather than landed. A short `⚠ KNOWN GAP` note in `SidecarHost.ApplyConnectionConfig` points here.

## Test plan

- [x] Suite 4 (bridge `dotnet build` + xUnit) on the pinned 7.2.0 build: **291 passed, 0 failed**, 1 intentionally skipped (the pending fact above).
- [x] Full suite against the LIB **source** (7.3.0): 293 passed, 1 failed — the pre-existing `AgentConfigServiceTests` blocker documented above, not this diff.
- [x] New binder-contract coverage for **all three precedence levels**, including marker `portOverride` **and** a typed Host port together (marker wins), plus a 14-row theory over the host parser (IPv6 literal, userinfo, out-of-range, non-numeric, port-less, non-loopback, non-absolute).
- [x] New `SidecarHost` wiring tests: typed Custom host wins, Cloud mode ignores it, blank host falls back to derived.
- No `UnrealMCP/**`, `cli/**` or workflow changes → plugin/cli/actionlint suites not applicable.
- [x] **Refine pass** (`/code-review --fix` + `/simplify`): Suite 4 re-run green — build 0 warnings / 0 errors, **302 passed, 0 failed**, 1 intentionally skipped. Added a theory driving the duplicated LIB parser **directly**, closing a real coverage hole: the loopback gate's `Uri.TryCreate` rejects out-of-range / non-numeric ports first, so the range guard and the `NumberStyles.None` validator — the parts most likely to drift from the LIB copy — were never executed by any test. McpPlugin pin re-verified unchanged at **7.2.0**.

Closes #250
