### PR TITLE
fix: make the default Custom host port-less so per-project ports survive

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConfigSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpConfigSpec.cpp
@@ -140,6 +140,56 @@ void FUnrealMcpConfigSpec::Define()
 			TestEqual(TEXT("default cloud base"), Config.ResolveCloudBaseUrl(), FString(FUnrealMcpConfig::DefaultCloudBaseUrl));
 		});
 
+		It("resolves a PORT-LESS host on the default path, so the derived per-project port survives", [this]()
+		{
+			// Issue #252 — the C++ half of a cross-language lockstep, and the guard that would have caught
+			// the regression at its source. The Custom-mode host is not merely a display string: the sidecar
+			// forwards it as precedence LEVEL 2 of the local-server bind port (SidecarHost.LocalBindHost →
+			// ProjectConnectionResolver.TryGetExplicitLoopbackPort). Because ResolveCustomHost() substitutes
+			// DefaultCustomHost for a blank entry, a port baked into that default is indistinguishable from a
+			// port the user actually TYPED — so it would win level 2 for EVERY project and collapse them all
+			// onto one port. Asserting the RESOLVED default-path host (not just the constant) is what makes
+			// this end-to-end: it is the exact string the sidecar receives over the §8 `config` message.
+			// The bridge xUnit suite asserts the other half (a port-less loopback host ⇒ per-project derived
+			// ports that DIFFER); this pins the source of truth those vectors mirror.
+			auto DeclaresExplicitPort = [](const FString& Url) -> bool
+			{
+				FString Authority = Url;
+				FString Scheme;
+				FString Remainder;
+				if (Url.Split(TEXT("://"), &Scheme, &Remainder))
+					Authority = Remainder;
+				// Drop any path/query so a colon beyond the authority can never read as a port.
+				int32 TerminatorIndex = INDEX_NONE;
+				for (int32 Index = 0; Index < Authority.Len(); ++Index)
+				{
+					const TCHAR Ch = Authority[Index];
+					if (Ch == TEXT('/') || Ch == TEXT('?') || Ch == TEXT('#'))
+					{
+						TerminatorIndex = Index;
+						break;
+					}
+				}
+				if (TerminatorIndex != INDEX_NONE)
+					Authority.LeftInline(TerminatorIndex);
+				int32 ColonIndex = INDEX_NONE;
+				return Authority.FindChar(TEXT(':'), ColonIndex);
+			};
+
+			TestFalse(TEXT("DefaultCustomHost declares no explicit port"),
+				DeclaresExplicitPort(FString(FUnrealMcpConfig::DefaultCustomHost)));
+
+			FUnrealMcpConfig Config; // fresh, no disk, no overrides — the default path
+			TestFalse(TEXT("a fresh config resolves to a port-less host"),
+				DeclaresExplicitPort(Config.ResolveCustomHost()));
+
+			// A genuinely user-typed port is still carried through verbatim — the owner ruling of 2026-07-19
+			// ("the Configure button must use exactly the port the user enters") is preserved, not undone.
+			Config.CustomHost = TEXT("http://localhost:27618");
+			TestTrue(TEXT("a user-typed port survives resolution"), DeclaresExplicitPort(Config.ResolveCustomHost()));
+			TestEqual(TEXT("…verbatim"), Config.ResolveCustomHost(), FString(TEXT("http://localhost:27618")));
+		});
+
 		It("file value beats the default", [this]()
 		{
 			TSharedPtr<FJsonObject> Disk = MakeShared<FJsonObject>();

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Config/UnrealMcpConfig.cpp
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Config/UnrealMcpConfig.cpp
@@ -25,7 +25,19 @@ const TCHAR* FUnrealMcpConfig::EnvBridgePath     = TEXT("UNREAL_MCP_BRIDGE_PATH"
 
 // --- Defaults. ---
 const TCHAR* FUnrealMcpConfig::DefaultCloudBaseUrl = TEXT("https://ai-game.dev");
-const TCHAR* FUnrealMcpConfig::DefaultCustomHost   = TEXT("http://localhost:8080");
+// Deliberately PORT-LESS (issue #252). The Custom-mode host is not just a display string: the sidecar
+// forwards it as precedence level 2 of the local-server bind port (SidecarHost.LocalBindHost →
+// ProjectConnectionResolver.TryGetExplicitLoopbackPort — "an explicit port the USER typed into Host"
+// beats the deterministic per-project derivation, per the owner ruling of 2026-07-19). Because
+// ResolveCustomHost() substitutes this default for a blank entry, ANY port written here is
+// indistinguishable from a port the user actually typed — so the old "http://localhost:8080" made every
+// project on default settings claim 8080 and collide with every other open editor. Carrying no port at
+// all is what keeps "the user expressed no opinion" representable, letting level 3 (the ProjectIdentity
+// v2 derivation, 20000–29999) supply a per-project port again. A typed port still wins: it arrives in
+// CustomHost and is parsed off the RAW string, never synthesised from the scheme (a port-less host is
+// NOT read as 80). Keep it port-less — see UnrealMcpConfigSpec's "no explicit port" guard, which is the
+// C++ half of that cross-language lockstep.
+const TCHAR* FUnrealMcpConfig::DefaultCustomHost   = TEXT("http://localhost");
 const TCHAR* FUnrealMcpConfig::DefaultLogLevel     = TEXT("Info");
 const TCHAR* FUnrealMcpConfig::DefaultTransport    = TEXT("http");
 

--- a/UnrealMCP/Source/UnrealMcpRuntime/Private/Config/UnrealMcpConfig.h
+++ b/UnrealMCP/Source/UnrealMcpRuntime/Private/Config/UnrealMcpConfig.h
@@ -85,7 +85,9 @@ public:
 
 	// --- Defaults. ---
 	static UNREALMCPRUNTIME_API const TCHAR* DefaultCloudBaseUrl; // https://ai-game.dev
-	static UNREALMCPRUNTIME_API const TCHAR* DefaultCustomHost;   // http://localhost:8080
+	// http://localhost — deliberately PORT-LESS so the local-server bind port falls through to the
+	// deterministic per-project derivation (issue #252); see the definition's comment.
+	static UNREALMCPRUNTIME_API const TCHAR* DefaultCustomHost;
 	static UNREALMCPRUNTIME_API const TCHAR* DefaultLogLevel;     // Info
 	static UNREALMCPRUNTIME_API const TCHAR* DefaultTransport;    // http
 

--- a/bridge/tests/ProjectConnectionResolverTests.cs
+++ b/bridge/tests/ProjectConnectionResolverTests.cs
@@ -304,6 +304,113 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         }
 
         /// <summary>
+        /// The C++ plugin's built-in Custom-mode host, <c>FUnrealMcpConfig::DefaultCustomHost</c>
+        /// (<c>UnrealMcpRuntime/Private/Config/UnrealMcpConfig.cpp</c>). This is the EXACT string the sidecar
+        /// receives as the §8 <c>config</c> message's <c>host</c> on the default path — <c>ResolveCustomHost()</c>
+        /// substitutes the default for a blank entry and adds no suffix — so it reaches level 2 verbatim through
+        /// <c>SidecarHost.LocalBindHost</c>.
+        ///
+        /// <para><b>Cross-language lockstep (issue #252).</b> C# cannot read the C++ constant, so this literal
+        /// mirrors it. The C++ half of the lockstep is <c>UnrealMcpConfigSpec</c>'s "resolves a PORT-LESS host on
+        /// the default path" guard: it asserts the real constant declares no explicit port, which is the single
+        /// property the three facts below depend on. If someone re-adds a port to the C++ default, that spec reds
+        /// even though these C# facts (pinned to this literal) would not — which is exactly why both halves
+        /// exist.</para>
+        /// </summary>
+        private const string PluginDefaultCustomHost = "http://localhost";
+
+        /// <summary>
+        /// <b>The regression guard for issue #252.</b> On DEFAULT settings two different projects must resolve to
+        /// DIFFERENT local-server ports — the per-project isolation that lets two Unreal editors run side by side.
+        ///
+        /// <para>This is the test that would have caught the defect. The old default host was the hardcoded
+        /// <c>http://localhost:8080</c>, and once the owner-ruled precedence made a typed loopback port beat the
+        /// derivation, that baked-in 8080 read as "the user typed 8080" for EVERY project — collapsing them all
+        /// onto one port. Nothing asserted that the DEFAULT path still reached level 3; the per-level facts above
+        /// all pass their host in explicitly, so none of them exercises the plugin's own default.</para>
+        /// </summary>
+        [Fact]
+        public void Resolve_PluginDefaultHost_YieldsDifferentPortsPerProject()
+        {
+            // Two golden-vector roots with distinct derivations (23940 / 29310) — see ProjectIdentity_MatchesGoldenVectors.
+            const string rootA = "/home/user/my-game";
+            const string rootB = "C:\\Users\\user\\my-game";
+
+            var a = ProjectConnectionResolver.Resolve(rootA, instanceId: "inst-a", localHost: PluginDefaultCustomHost);
+            var b = ProjectConnectionResolver.Resolve(rootB, instanceId: "inst-b", localHost: PluginDefaultCustomHost);
+
+            // The isolation property itself.
+            Assert.NotEqual(a.Port, b.Port);
+
+            // …and it holds because level 3 decided, not by coincidence: each project got ITS OWN derivation.
+            Assert.Equal(LocalServerPortSource.Derived, a.PortSource);
+            Assert.Equal(LocalServerPortSource.Derived, b.PortSource);
+            Assert.Equal(23940, a.Port);
+            Assert.Equal(29310, b.Port);
+            Assert.False(a.PortIsOverridden);
+            Assert.False(b.PortIsOverridden);
+
+            // Neither collapsed onto the OLD hardcoded default's port (the exact regression), nor onto the scheme
+            // default 80 that a Uri.Port-based reading of a port-less host would have produced.
+            Assert.NotEqual(8080, a.Port);
+            Assert.NotEqual(8080, b.Port);
+            Assert.NotEqual(80, a.Port);
+            Assert.NotEqual(80, b.Port);
+        }
+
+        /// <summary>
+        /// The port-less default must not be mistaken for "typed ports are ignored again": a port the user
+        /// actually enters still wins level 2 over the derivation. Guards the owner ruling of 2026-07-19 ("the
+        /// Configure button must use exactly the port the user enters") against being undone by the #252 fix —
+        /// the DEFAULT expresses no opinion, a USER entry still does.
+        /// </summary>
+        [Fact]
+        public void Resolve_TypedPort_StillOutranksThePluginDefaultHost()
+        {
+            const string root = "/home/user/my-game";   // golden vector → derived 23940
+
+            var onDefault = ProjectConnectionResolver.Resolve(root, instanceId: "inst-def", localHost: PluginDefaultCustomHost);
+            var onTyped = ProjectConnectionResolver.Resolve(root, instanceId: "inst-typed", localHost: "http://localhost:27618");
+
+            Assert.Equal(LocalServerPortSource.Derived, onDefault.PortSource);
+            Assert.Equal(23940, onDefault.Port);
+
+            Assert.Equal(LocalServerPortSource.TypedHost, onTyped.PortSource);
+            Assert.Equal(27618, onTyped.Port);
+
+            // Same project, different host: the user's entry is what moved the port.
+            Assert.NotEqual(onDefault.Port, onTyped.Port);
+        }
+
+        /// <summary>
+        /// Level 1 still outranks BOTH: a marker <c>portOverride</c> wins even on the port-less default host, so
+        /// the #252 fix did not disturb the deliberate per-project pin. The complement of
+        /// <see cref="Resolve_MarkerPortOverride_WinsOverTypedLoopbackHostPort"/>, which pins level 1 over a TYPED
+        /// host; this pins it over the DEFAULT one, where level 2 is absent and the derivation is the rival.
+        /// </summary>
+        [Fact]
+        public void Resolve_MarkerPortOverride_StillWinsOnThePluginDefaultHost()
+        {
+            RunInTempDir(dir =>
+            {
+                // Step off this temp dir's own derived port so "override != derived" stays deterministic (both
+                // live in the 20000–29999 band — same reasoning as the sibling marker facts).
+                var derivedPort = ProjectIdentity.DerivePort(dir);
+                var overridePort = derivedPort == 26543 ? 26544 : 26543;
+                new ProjectMarker { PortOverride = overridePort }.Write(dir);
+
+                var resolved = ProjectConnectionResolver.Resolve(
+                    dir, instanceId: "inst-marker-default", localHost: PluginDefaultCustomHost);
+
+                Assert.Equal(overridePort, resolved.Port);
+                Assert.Equal(LocalServerPortSource.MarkerOverride, resolved.PortSource);
+                Assert.True(resolved.PortIsOverridden);
+                // The marker, not the derivation, decided — so level 1 really outranks the default path.
+                Assert.NotEqual(derivedPort, resolved.Port);
+            });
+        }
+
+        /// <summary>
         /// The level-2 host parser, mirroring <c>AgentConfiguratorSettings.TryGetExplicitPort</c> + the writer's
         /// loopback gate: which host strings yield a typed port at all. Anything that yields <c>null</c> falls
         /// through to the derived port rather than binding something unusable.


### PR DESCRIPTION
## Summary

`FUnrealMcpConfig::DefaultCustomHost` was hardcoded to `http://localhost:8080` and seeded `CustomHost`
on every fresh config, so `ResolveCustomHost()` could not distinguish **"the user typed nothing"** from
**"the user deliberately typed 8080"**. Under the McpPlugin 7.3.0 precedence (marker `portOverride` >
explicit port typed into `Host` > deterministic v2 derived) that baked-in 8080 reads as an explicit
typed port and wins level 2 for *every* project — collapsing every open Unreal editor onto one port
instead of its own derived port in the 20000–29999 band.

**Fix: drop the port from the default** (`http://localhost`), so precedence level 3 applies naturally on
the default path while a genuinely user-typed port still wins level 2.

## Which shape, and why

The task offered two shapes. I chose **(a) port-less default** over **(b) make "unset" representable**,
because (b) as stated is actively unsafe and (a) makes one string honest instead of adding a parallel
channel.

The decisive consumer is one neither shape's description named: `SidecarHost.ApplyConnectionConfig`
assigns the pushed `host` **verbatim** to `_config.Host`, the SignalR **dial target**.

- **(b) is unsafe as stated.** If `ResolveCustomHost()` returned empty/sentinel, `ApplyConnectionConfig`
  treats a blank Custom-mode host as a signal to fall back to `cloudUrl` — silently retargeting a *local*
  connection at the **cloud**. Making (b) safe would have required a second IPC field (a `typedHost`
  alongside `host`), i.e. a new IPC surface plus a version-skew story, to express something (a) expresses
  by deleting five characters.
- **(a) costs nothing observable.** It moves the default-path dial from 8080 to 80 — but that dial is
  *already* non-functional on the default path: the local server binds the **derived** port, never 8080,
  so nothing was listening on the dialled port under either value. (Post-7.3.0 the 8080 default would
  have made dial == bind == 8080 "work" — but that is precisely the collision being removed.)
- (a) also keeps the UI's Server URL field showing a meaningful default (`http://localhost`) rather than
  (b)'s empty box, and it is the exact shape an already-green test
  (`LocalServerPortConsistencyTests.WrittenConfigPort_EqualsServerBindPort_WhenHostCarriesNoExplicitPort`,
  which uses `http://localhost/mcp`) validates end-to-end on both the writer and binder sides.

## Consumers checked

Every `DefaultCustomHost` / `ResolveCustomHost` / `ParsePortFromHost` reference in the repo:

| Consumer | Effect of the port-less default |
|---|---|
| `FUnrealMcpConfig()` ctor (`:91`) — seeds `CustomHost` | Seeds `http://localhost`; unchanged mechanism |
| `ResolveCustomHost()` (`:445`) — blank ⇒ default | Contract unchanged; now returns a port-less default |
| `BuildEffectiveConnectionConfig()` (`:466`) — §8 `config` `host` | Pushes `http://localhost` |
| `SidecarHost.ApplyConnectionConfig` → `_config.Host` (dial) | 8080 → 80; both already non-functional on the default path (see above) |
| `SidecarHost.LocalBindHost` → `ProjectConnectionResolver.TryGetExplicitLoopbackPort` | **The fix**: port-less ⇒ level 2 skipped ⇒ derived per-project port |
| `FAiAgentConnectionInfo::FromPluginConfig` (`UnrealMcpAgentConfigModels.cpp:18`) — `host + "/mcp"` | Written URL's port is re-derived by the shared writer, not taken from this string |
| `FUnrealMcpEditorCoordinator` (`:162`) | Log line only |
| `FUnrealMcpServerManager::ParsePortFromHost` (`:110`) | **No production caller** — the local-server port comes from `DerivedLocalServerPort` (PR #216). Would return 80 for a schemed port-less host, but nothing calls it outside its own spec, which passes literals |
| `FUnrealMcpEditorViewModel::ValidateServerUrl` (`:497`) | Validates scheme + non-empty host only — `http://localhost` passes |
| `UUnrealMcpRuntimeSubsystem::IsLoopbackHost` (`:413`) | Strips scheme then host; `localhost` is still loopback. Its "empty host ⇒ DefaultCustomHost is localhost" comment stays accurate |
| `UnrealMcpConfigSpec.cpp:139` | See "Intentionally untouched" |

## Per-project isolation preserved; typed ports still win

- Two different project roots on default settings resolve to **different** ports (23940 / 29310), both
  via level 3 — and neither collapses onto 8080 nor onto the scheme default 80.
- A port the user actually types still wins level 2 (`http://localhost:27618` → 27618).
- A marker `portOverride` still outranks both.

## Tests

- **`ProjectConnectionResolverTests.Resolve_PluginDefaultHost_YieldsDifferentPortsPerProject`** — *the
  test that would have caught this*. The existing per-level facts all pass their host in explicitly, so
  none of them exercised the plugin's own default; this one does, and asserts the isolation property
  directly.
- `Resolve_TypedPort_StillOutranksThePluginDefaultHost` — guards the owner ruling of 2026-07-19 against
  being undone by this fix.
- `Resolve_MarkerPortOverride_StillWinsOnThePluginDefaultHost` — level 1 over the default path (the
  complement of the existing level-1-over-a-*typed*-host fact).
- **`UnrealMcpConfigSpec` "resolves a PORT-LESS host on the default path"** — the C++ half of the
  cross-language lockstep. C# cannot read the C++ constant, so the bridge tests mirror it as a literal;
  this spec asserts the *real* constant (and a fresh config's *resolved* host) declares no explicit port,
  so re-adding a port to the C++ default reds here even though the C# literals would not.

## Intentionally untouched

- **`LocalServerPortConsistencyTests.WrittenConfigPort_EqualsServerBindPort_OnDefaultLocalPath`**
  (already `[Fact(Skip=...)]`) and
  **`AgentConfigServiceTests.Status_ConnectionSettingDrift_StaysConfigured_Under7xDeterministicUrl`**
  (green today, carries an in-file "CASCADE BLOCKER" comment) — both are known 7.3.0 cascade blockers,
  handled during the release cascade. **Left with a zero diff**: no assertion, skip state, or comment
  touched, so neither can conflict with the cascade PR that un-skips them.
  - Note for that cascade PR: `LocalServerPortConsistencyTests`' `RawCustomHost` comment (`:53-58`) says
    "the default host is the HARDCODED `FUnrealMcpConfig::DefaultCustomHost` `http://localhost:8080`".
    That prose is stale after this PR — the constant is `RawCustomHost`'s own literal now, not the plugin
    default. The *vector* remains valid (a host with a typed port); only the comment needs a refresh, and
    it is deliberately left to the PR that already owns this file.
- **`UnrealMcpConfigSpec.cpp:139`** (`ResolveCustomHost() == DefaultCustomHost`) — re-evaluated per the
  brief and **left alone**: it encodes the *fallback contract* ("a blank entry resolves to the built-in
  default"), which is still correct and still passes. It does not encode the old 8080 assumption, so
  editing it would have weakened a correct assertion for no gain.
- **`ParsePortFromHost` and its spec** — no production caller; its `DefaultPort = 8080` parameter default
  is now unrelated to the config default, and changing it would be churn on dead-ish code.

## Known limitation (deliberate, not fixed here)

A project whose config was **already persisted** carries the literal `"host": "http://localhost:8080"` on
disk (the old constructor seeded it, and `ToJson()` round-trips it), so it will still resolve 8080.
Auto-migrating a persisted 8080 to "unset" would silently override a user who genuinely typed 8080 —
reversing the owner ruling that a typed port must be honoured exactly. Since a persisted value is by
definition indistinguishable from a deliberate entry, this PR fixes the **default** path only and leaves
persisted values alone. Flagging for an explicit owner call rather than deciding it silently.

## Test plan

- [x] Suite 1 (UBT editor build) — exit 0, `build-ok`
- [x] Suite 1b (RunUAT BuildPlugin) — exit 0, `buildplugin-ok` (hard gate: `UnrealMcpRuntime/**` touched)
- [x] Suite 2 (headless boot smoke) — `smoke-ok`
- [x] Suite 3 (Automation specs) — `specs-passed`, **0 failed / 345 succeeded**; the new spec was
      confirmed registered and `Success` in `index.json` rather than inferred from the aggregate
- [x] Suite 4 (bridge build + xUnit) — 0 errors, **305 passed / 0 failed / 1 skipped** (the known
      cascade-blocker skip, untouched)

## Refine pass — verified findings (no code change)

A `/code-review --fix` + `/simplify` pass over this diff produced **no code changes**. The review traced
the full bind path end-to-end (`BuildEffectiveConnectionConfig` → §8 `config.host` → `SidecarHost`
`ApplyConnectionConfig`/`LocalBindHost` → `TryGetExplicitLoopbackPort`) and confirmed port 80 is never
synthesised on that path; a mutation test (flipping the mirrored C# literal back to
`http://localhost:8080`) reds 2 of the 3 new bridge facts, so they are live regression guards, not
vacuous. Three verified observations that do **not** change the diff:

- **The default path is now under a live, pin-independent parity guard.**
  `LocalServerPortConsistencyTests.WrittenConfigPort_EqualsServerBindPort_WhenHostCarriesNoExplicitPort`
  uses `http://localhost/mcp` — which *after this PR* is exactly the real default-path shape
  (`ResolveCustomHost()` + `/mcp`, per `FAiAgentConnectionInfo::FromPluginConfig`). That fact is **not**
  skipped and is pin-independent, so writer-vs-binder parity on the default path is guarded *today*,
  where before this PR that vector was only hypothetical. (Still a zero diff to the file.)

- **The cascade note above understates the stale prose.** Beyond the `RawCustomHost` comment (`:53-58`),
  two more sites in `LocalServerPortConsistencyTests.cs` are mis-described after this PR: the
  `[Fact(Skip = …)]` reason (`:81-85`) calls the typed loopback port "8080 **from the hardcoded
  DefaultCustomHost**", and the test name `…_OnDefaultLocalPath` plus its inline comment (`:88-89`) say
  "the default host carries an explicit 8080". Post-PR that test exercises a *typed*-8080 host, not the
  default local path. **Mechanically nothing breaks** — `RawCustomHost` is its own literal now, so the
  skip's "no assertion change required at 7.3.0" claim still holds; only the prose (and arguably the
  test name) needs a refresh, deliberately left to the cascade PR that owns the file.

- **Coverage nuance on the cross-language lockstep.** `UnrealMcpConfigSpec`'s "no explicit port" guard is
  the only half that reads the *real* C++ constant, and it runs in the `plugin BuildPlugin + Automation`
  job, whose `if:` skips **fork PRs**. On a same-repo PR (`UNREAL_RUNNER_READY=true`) it runs, so this PR
  is guarded — but on a fork PR the C++ constant is unguarded, since the always-running bridge leg mirrors
  the value as a literal. Flagged, not fixed: closing it means having a hosted leg read the constant out
  of `UnrealMcpConfig.cpp` (or a grep gate), a new mechanism beyond this issue's scope.

`/simplify` additionally proposed deleting `Resolve_TypedPort_StillOutranksThePluginDefaultHost` and
`Resolve_MarkerPortOverride_StillWinsOnThePluginDefaultHost` as restating existing per-level facts.
**Declined:** the task brief requires a test per precedence level, and the mutation test above shows the
typed-port fact reds under the regression it names. Left as written.

Closes #252
