### PR TITLE
chore: bump gamedev-mcp-server to 9.2.0

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/Server/UnrealMcpServerManager.cpp
@@ -31,7 +31,7 @@
 
 // Single source of the consumed shared-server version. Kept in lockstep with cli/src/lib/server-version.ts
 // (SERVER_VERSION) and Unity's McpServerManager.ServerVersion — the three plugins consume the SAME server.
-const TCHAR* FUnrealMcpServerManager::ServerVersion = TEXT("9.1.1");
+const TCHAR* FUnrealMcpServerManager::ServerVersion = TEXT("9.2.0");
 const TCHAR* FUnrealMcpServerManager::ServerPathEnvVar = TEXT("UNREAL_MCP_SERVER_PATH");
 
 namespace

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpServerManagerSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpServerManagerSpec.cpp
@@ -150,7 +150,7 @@ void FUnrealMcpServerManagerSpec::Define()
 	{
 		It("is pinned to the lockstep value (kept in sync with cli/src/lib/server-version.ts)", [this]()
 		{
-			TestEqual(TEXT("pinned server version"), FString(FUnrealMcpServerManager::ServerVersion), FString(TEXT("9.1.1")));
+			TestEqual(TEXT("pinned server version"), FString(FUnrealMcpServerManager::ServerVersion), FString(TEXT("9.2.0")));
 		});
 	});
 

--- a/cli/src/lib/server-version.ts
+++ b/cli/src/lib/server-version.ts
@@ -9,4 +9,4 @@
 // (with all `gamedev-mcp-server-<rid>.zip` assets) MUST already exist on
 // GameDev-MCP-Server BEFORE a CLI release that pins it (docs/RELEASING.md).
 
-export const SERVER_VERSION = '9.1.1';
+export const SERVER_VERSION = '9.2.0';


### PR DESCRIPTION
Automated downstream bump of the pinned GameDev-MCP-Server version `9.1.1` -> `9.2.0` (adopts the just-released `v9.2.0` server: NuGet + Docker tag + all 7 RID zips are already live).