### PR TITLE
fix(cli): token-mode gate + 3-level bind-port resolution (defects C+D)

### DIFF
--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -15,7 +15,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { readEnvFile } from './env-file.js';
-import { generatePortFromDirectory } from './port.js';
+import { generatePortFromDirectory, isAbsoluteLoopbackHost, resolveLocalBindPort } from './port.js';
+import { readProjectMarker } from './project-marker.js';
 
 export interface ResolvedConnection {
   /** Base URL with no trailing slash. */
@@ -85,11 +86,19 @@ export function resolveConnection(opts: ResolveConnectionOptions): ResolvedConne
   if (pluginConfig) {
     const fromConfig = resolveConnectionFromPluginConfig(pluginConfig);
     if (fromConfig.url) {
-      return { url: stripTrailingSlash(fromConfig.url), token: token ?? fromConfig.token, source: 'plugin-config' };
+      return {
+        url: resolveCustomHostUrl(fromConfig.url, projectDir),
+        token: token ?? fromConfig.token,
+        source: 'plugin-config',
+      };
     }
   }
 
-  const port = generatePortFromDirectory(projectDir);
+  // No host anywhere → deterministic localhost fallback, still honoring a marker
+  // portOverride (level 1) over the v1 derivation (level 3); there is no host so the
+  // typed-host level 2 is N/A. Mirrors the binder's default-host resolution.
+  const marker = readProjectMarker(projectDir);
+  const { port } = resolveLocalBindPort({ projectDir, markerPortOverride: marker?.portOverride });
   return { url: `http://localhost:${port}`, token, source: 'deterministic-port' };
 }
 
@@ -102,6 +111,31 @@ function nonEmpty(value: string | undefined): string | undefined {
 
 export function stripTrailingSlash(url: string): string {
   return url.trim().replace(/\/+$/, '');
+}
+
+/**
+ * Resolve the effective connection URL for a Custom-mode plugin-config `host` (defect D
+ * / D21). A LOOPBACK host is pointed at the port the sidecar actually binds via the
+ * three-level precedence (marker `portOverride` → typed loopback port → v1 derivation),
+ * so a port-less `http://localhost` (or a legacy default `:8080`) no longer connects to
+ * the wrong port. A NON-loopback host (a LAN IP / remote target) is used verbatim — the
+ * local `gamedev-mcp-server` binds no such authority, mirroring the bridge binder's
+ * deliberate levels-1+3-only divergence for non-loopback hosts. Pure given the marker on
+ * disk.
+ */
+function resolveCustomHostUrl(host: string, projectDir: string): string {
+  const stripped = stripTrailingSlash(host);
+  if (!isAbsoluteLoopbackHost(stripped)) return stripped;
+
+  const marker = readProjectMarker(projectDir);
+  const { port } = resolveLocalBindPort({ projectDir, host: stripped, markerPortOverride: marker?.portOverride });
+
+  // Rebuild <scheme>://<host>:<port>, preserving any path/query the host carried. Building
+  // the authority by hand (rather than URL.port =) keeps the resolved port explicit even
+  // when it equals a scheme default that WHATWG would otherwise elide.
+  const url = new URL(stripped);
+  const authoritativePath = url.pathname === '/' ? '' : url.pathname;
+  return stripTrailingSlash(`${url.protocol}//${url.hostname}:${port}${authoritativePath}${url.search}`);
 }
 
 // --- Plugin on-disk JSON config (issue #71) -------------------------------
@@ -129,9 +163,9 @@ export interface PluginConnectionConfig {
   cloudToken?: string;
   /** Custom-mode host (full base URL). */
   host?: string;
-  /** Bearer token for Custom mode (only on the wire when authOption is Required). */
+  /** Bearer token for Custom mode (only on the wire when authOption resolves to Token). */
   token?: string;
-  /** "Required" | "None" — Custom-mode auth gate for `token`. */
+  /** "None" | "Token" | "Oauth" (legacy "Required" → Token) — Custom-mode auth gate for `token`. */
   authOption?: string;
 }
 
@@ -178,8 +212,10 @@ export function isCloudMode(config: PluginConnectionConfig): boolean {
  * Resolve a `{ url, token }` from a plugin config, mirroring the plugin's
  * routing (FUnrealMcpConfig):
  *   - Cloud  -> url = appendMcp(cloudUrl), token = cloudToken
- *   - Custom -> url = host,                token = (authOption Required ? token : undefined)
- * `url` may be undefined when the relevant field is blank.
+ *   - Custom -> url = host,                token = (authOption resolves to Token ? token : undefined)
+ * `url` may be undefined when the relevant field is blank. The Custom `url` here is the RAW
+ * host; loopback port resolution (defect D) happens in `resolveConnection`, which has the
+ * project dir + marker to apply the three-level bind-port precedence.
  */
 export function resolveConnectionFromPluginConfig(config: PluginConnectionConfig): {
   url: string | undefined;
@@ -192,13 +228,30 @@ export function resolveConnectionFromPluginConfig(config: PluginConnectionConfig
       token: nonEmpty(config.cloudToken),
     };
   }
-  // Custom mode: the token only goes on the wire when auth is Required (mirrors
-  // FUnrealMcpConfig::ResolveEffectiveToken).
-  const authRequired = (config.authOption ?? '').trim().toLowerCase() === 'required';
+  // Custom mode: the token only goes on the wire in `Token` auth mode — `None`
+  // (anonymous/loopback) and `Oauth` (native OAuth, no static bearer) send NOTHING,
+  // regardless of any stored token (mirrors FUnrealMcpConfig::ResolveEffectiveToken).
   return {
     url: nonEmpty(config.host),
-    token: authRequired ? nonEmpty(config.token) : undefined,
+    token: parseCustomAuthMode(config.authOption) === 'token' ? nonEmpty(config.token) : undefined,
   };
+}
+
+/** The Custom-mode auth modes the plugin persists (PascalCase on disk, matched case-insensitively). */
+export type CustomAuthMode = 'none' | 'token' | 'oauth';
+
+/**
+ * Map a persisted `authOption` string to the Custom-mode auth mode, mirroring the plugin's
+ * `FUnrealMcpConfig::TryParseAuthOption` (`UnrealMcpConfig.cpp:625-651`): `None`/`Token`/`Oauth`
+ * plus the g5 migration `Required` → `Token` (the retired shared-secret gate). Anything absent
+ * or unrecognized resolves to `none` — so no bearer is ever sent for a config the plugin did not
+ * mark as Token. Replaces the retired `authOption === 'required'` gate (defect C). Pure.
+ */
+export function parseCustomAuthMode(raw: string | undefined): CustomAuthMode {
+  const v = (raw ?? '').trim().toLowerCase();
+  if (v === 'token' || v === 'required') return 'token'; // 'required' is the legacy alias for Token (g5 migration)
+  if (v === 'oauth') return 'oauth';
+  return 'none';
 }
 
 /**

--- a/cli/src/utils/port.ts
+++ b/cli/src/utils/port.ts
@@ -94,3 +94,129 @@ export function deriveProjectPin(dir: string): string {
   const hash = createHash('sha256').update(normalizeProjectRoot(dir), 'utf-8').digest();
   return hash.subarray(0, PROJECT_PIN_LENGTH / 2).toString('hex');
 }
+
+// --- Local-server bind-port precedence (defect D / D21) -------------------
+//
+// The sidecar resolves the port its local `gamedev-mcp-server` BINDS with a
+// three-level precedence (bridge `ProjectConnectionResolver.Resolve`, owner
+// ruling 2026-07-19). The CLI must resolve the SAME port so a `run-tool` /
+// `status` reaches the server the plugin actually bound — instead of taking a
+// Custom-mode host verbatim (port-less `http://localhost` → :80, legacy
+// `:8080`), which named a port the sidecar does not listen on. Highest wins:
+//   1. the committable project marker's `portOverride` (a deliberate pin);
+//   2. an explicit port the user typed into the Custom-mode LOOPBACK host;
+//   3. the deterministic `ProjectIdentity` v1 derivation (generatePortFromDirectory).
+// Mirror of `bridge/src/Host/ProjectConnectionResolver.cs:100-139`.
+
+/** The inclusive maximum TCP port — mirrors McpPlugin `Consts.Hub.MaxPort`. */
+export const MAX_TCP_PORT = 65535;
+
+/** Characters that terminate a URL's authority component (path / query / fragment). */
+const AUTHORITY_TERMINATORS = new Set(['/', '?', '#']);
+
+/** Which precedence level supplied the resolved local bind port (diagnostic). */
+export type LocalServerPortSource = 'marker-override' | 'typed-host' | 'derived';
+
+export interface LocalBindPortResolution {
+  /** The resolved local-server bind port. */
+  port: number;
+  /** Which precedence level decided it. */
+  source: LocalServerPortSource;
+}
+
+/**
+ * True when `host` parses as an ABSOLUTE LOOPBACK URL (`localhost`, `127.0.0.0/8`,
+ * or `::1`). Mirrors the bridge binder's `Uri.TryCreate(Absolute) && uri.IsLoopback`
+ * gate: a bare `localhost:27618` (no `//` authority) or a non-loopback host is not a
+ * match, so level 2 is skipped and the derived port is used. Pure; never throws.
+ */
+export function isAbsoluteLoopbackHost(host: string | undefined): boolean {
+  if (host == null) return false;
+  let url: URL;
+  try {
+    url = new URL(host);
+  } catch {
+    return false; // not an absolute URL (or an invalid port that WHATWG rejects — e.g. :abc / :70000)
+  }
+  const hostname = url.hostname.toLowerCase();
+  if (hostname.length === 0) return false; // e.g. `localhost:27618` parses as scheme `localhost:` with no authority
+  if (hostname === 'localhost') return true;
+  if (hostname === '::1' || hostname === '[::1]') return true; // IPv6 loopback (Node keeps brackets on hostname)
+  return /^127(?:\.\d{1,3}){3}$/.test(hostname); // IPv4 loopback 127.0.0.0/8
+}
+
+/**
+ * Read an EXPLICITLY-typed port out of a host string, or `undefined` when there is
+ * none. Parses the RAW string rather than a synthesised scheme default, so "the user
+ * typed no port" (`http://localhost` → undefined, NOT 80) stays distinct from "the
+ * user typed 80". Step-for-step mirror of the bridge binder's `TryGetExplicitPort`
+ * (`ProjectConnectionResolver.cs:199-228`) including its `> 0 && <= MaxPort` guard and
+ * strict-digit validation, so the CLI and the sidecar never disagree on a port. Pure.
+ */
+export function tryGetExplicitPort(host: string | undefined): number | undefined {
+  if (host == null || host.trim().length === 0) return undefined;
+
+  // Isolate the authority: after "scheme://" (if present), up to the first '/', '?' or '#'.
+  const schemeEnd = host.indexOf('://');
+  const start = schemeEnd >= 0 ? schemeEnd + 3 : 0;
+  let end = -1;
+  for (let i = start; i < host.length; i++) {
+    if (AUTHORITY_TERMINATORS.has(host[i]!)) {
+      end = i;
+      break;
+    }
+  }
+  let authority = end >= 0 ? host.substring(start, end) : host.substring(start);
+
+  // Drop any userinfo ("user:pass@host:port") — its colon is not a port separator.
+  const at = authority.lastIndexOf('@');
+  if (at >= 0) authority = authority.substring(at + 1);
+
+  // For an IPv6 literal the port follows the closing bracket ("[::1]:8080"); the colons
+  // inside the brackets belong to the address. lastIndexOf(']') is -1 for a normal host,
+  // so the search then starts at 0 and finds a plain "host:port" colon.
+  const colon = authority.indexOf(':', authority.lastIndexOf(']') + 1);
+  if (colon < 0 || colon === authority.length - 1) return undefined;
+
+  const portStr = authority.substring(colon + 1);
+  // ASCII digits only — mirrors `NumberStyles.None` (no sign, whitespace, or separators).
+  if (!/^[0-9]+$/.test(portStr)) return undefined;
+  const port = Number(portStr);
+  if (!Number.isSafeInteger(port)) return undefined; // int.TryParse overflow → null on the C# side
+  return port > 0 && port <= MAX_TCP_PORT ? port : undefined;
+}
+
+/**
+ * The port the user explicitly typed into a Custom-mode LOOPBACK `host`, or `undefined`
+ * when there is none — precedence level 2. Mirror of the bridge binder's
+ * `TryGetExplicitLoopbackPort` (`ProjectConnectionResolver.cs:175-182`): a non-loopback
+ * host (a LAN IP / remote) yields `undefined` so it falls through to the derived port,
+ * matching the writer's `ConnectionMode.Local && uri.IsLoopback` gate. Pure.
+ */
+export function tryGetExplicitLoopbackPort(host: string | undefined): number | undefined {
+  if (!isAbsoluteLoopbackHost(host)) return undefined;
+  return tryGetExplicitPort(host);
+}
+
+/**
+ * Resolve the local-server bind port for a project via the three-level precedence
+ * (marker `portOverride` → typed loopback-host port → v1 derivation). Mirror of the
+ * bridge binder's `ProjectConnectionResolver.Resolve` port block
+ * (`ProjectConnectionResolver.cs:135-139`). `host` is the Custom-mode host (level 2
+ * source); pass `undefined` when there is no host (Cloud / default fallback). Pure.
+ */
+export function resolveLocalBindPort(opts: {
+  projectDir: string;
+  host?: string;
+  markerPortOverride?: number;
+}): LocalBindPortResolution {
+  const override = opts.markerPortOverride;
+  if (typeof override === 'number' && Number.isInteger(override) && override > 0 && override <= MAX_TCP_PORT) {
+    return { port: override, source: 'marker-override' }; // 1. marker portOverride wins outright
+  }
+  const typed = tryGetExplicitLoopbackPort(opts.host);
+  if (typed !== undefined) {
+    return { port: typed, source: 'typed-host' }; // 2. port typed into the loopback host
+  }
+  return { port: generatePortFromDirectory(opts.projectDir), source: 'derived' }; // 3. deterministic derivation
+}

--- a/cli/tests/config.test.ts
+++ b/cli/tests/config.test.ts
@@ -5,11 +5,13 @@ import {
   resolveConnection,
   readPluginConfig,
   resolveConnectionFromPluginConfig,
+  parseCustomAuthMode,
   appendMcp,
   isCloudMode,
   PLUGIN_CONFIG_RELATIVE_PATH,
 } from '../src/utils/config.js';
 import { generatePortFromDirectory } from '../src/utils/port.js';
+import { writeProjectMarker } from '../src/utils/project-marker.js';
 import { makeTempDir, rmTempDir } from './helpers.js';
 
 const tempDirs: string[] = [];
@@ -84,6 +86,25 @@ describe('resolveConnectionFromPluginConfig', () => {
     const r = resolveConnectionFromPluginConfig({ connectionMode: 'Custom', host: 'http://localhost:9001', authOption: 'None', token: 'tk' });
     expect(r.url).toBe('http://localhost:9001');
     expect(r.token).toBeUndefined();
+  });
+
+  // Defect C — the current plugin writes authOption "Token"; the retired `'required'` gate
+  // dropped the token. The gate now keys on Token (with Required as the legacy migration alias).
+  it('Custom + authOption Token → token sent (defect C: the retired required-gate is gone)', () => {
+    const r = resolveConnectionFromPluginConfig({ connectionMode: 'Custom', host: 'http://localhost:9001', authOption: 'Token', token: 'tk' });
+    expect(r.token).toBe('tk');
+  });
+  it('Custom + authOption Oauth → token undefined (native OAuth sends no static bearer)', () => {
+    const r = resolveConnectionFromPluginConfig({ connectionMode: 'Custom', host: 'http://localhost:9001', authOption: 'Oauth', token: 'tk' });
+    expect(r.token).toBeUndefined();
+  });
+  it('Custom + legacy authOption Required → token sent (g5 migration → Token)', () => {
+    const r = resolveConnectionFromPluginConfig({ connectionMode: 'Custom', host: 'http://localhost:9001', authOption: 'Required', token: 'tk' });
+    expect(r.token).toBe('tk');
+  });
+  it('Custom + missing/unrecognized authOption → token undefined (defaults to None)', () => {
+    expect(resolveConnectionFromPluginConfig({ connectionMode: 'Custom', host: 'http://localhost:9001', token: 'tk' }).token).toBeUndefined();
+    expect(resolveConnectionFromPluginConfig({ connectionMode: 'Custom', host: 'http://localhost:9001', authOption: 'bogus', token: 'tk' }).token).toBeUndefined();
   });
 
   it('isCloudMode is case-insensitive', () => {
@@ -175,6 +196,73 @@ describe('resolveConnection — plugin-config layer (issue #71)', () => {
     const dir = makeProject({ config: { connectionMode: 'Custom' } });
     const r = resolveConnection({ projectDir: dir, processEnv: {} });
     expect(r.url).toBe(`http://localhost:${generatePortFromDirectory(dir)}`);
+    expect(r.source).toBe('deterministic-port');
+  });
+
+  // Defect C wired through resolveConnection: the current-plugin `Token` config sends the token.
+  it('Custom config + authOption Token → token sent via the plugin-config layer (defect C)', () => {
+    const dir = makeProject({ config: { connectionMode: 'Custom', host: 'http://localhost:9100', authOption: 'Token', token: 'tk' } });
+    const r = resolveConnection({ projectDir: dir, processEnv: {} });
+    expect(r.token).toBe('tk');
+    expect(r.source).toBe('plugin-config');
+  });
+});
+
+describe('parseCustomAuthMode (defect C — token-mode gate)', () => {
+  it('maps None/Token/Oauth case-insensitively', () => {
+    expect(parseCustomAuthMode('None')).toBe('none');
+    expect(parseCustomAuthMode('token')).toBe('token');
+    expect(parseCustomAuthMode('OAUTH')).toBe('oauth');
+  });
+  it('migrates the retired Required → token', () => {
+    expect(parseCustomAuthMode('Required')).toBe('token');
+    expect(parseCustomAuthMode('required')).toBe('token');
+  });
+  it('defaults absent / unrecognized to none (no bearer)', () => {
+    expect(parseCustomAuthMode(undefined)).toBe('none');
+    expect(parseCustomAuthMode('')).toBe('none');
+    expect(parseCustomAuthMode('bogus')).toBe('none');
+  });
+});
+
+describe('resolveConnection — Custom-mode loopback port resolution (defect D / D21)', () => {
+  it('port-less loopback host (http://localhost) → derived port, NOT verbatim :80', () => {
+    const dir = makeProject({ config: { connectionMode: 'Custom', host: 'http://localhost', authOption: 'None' } });
+    const r = resolveConnection({ projectDir: dir, processEnv: {} });
+    expect(r.url).toBe(`http://localhost:${generatePortFromDirectory(dir)}`);
+    expect(r.source).toBe('plugin-config');
+  });
+
+  it('a typed loopback port with no marker is kept (level 2 beats the derivation)', () => {
+    const dir = makeProject({ config: { connectionMode: 'Custom', host: 'http://localhost:8080', authOption: 'None' } });
+    const r = resolveConnection({ projectDir: dir, processEnv: {} });
+    expect(r.url).toBe('http://localhost:8080');
+    expect(r.source).toBe('plugin-config');
+  });
+
+  it('a marker portOverride wins over a legacy :8080 host (verbatim :8080 no longer used)', () => {
+    const dir = makeProject({ config: { connectionMode: 'Custom', host: 'http://localhost:8080', authOption: 'None' } });
+    writeProjectMarker(dir, { portOverride: 21234 });
+    const r = resolveConnection({ projectDir: dir, processEnv: {} });
+    expect(r.url).toBe('http://localhost:21234');
+  });
+
+  it('a marker portOverride also rewrites a port-less loopback host', () => {
+    const dir = makeProject({ config: { connectionMode: 'Custom', host: 'http://localhost', authOption: 'None' } });
+    writeProjectMarker(dir, { portOverride: 25000 });
+    expect(resolveConnection({ projectDir: dir, processEnv: {} }).url).toBe('http://localhost:25000');
+  });
+
+  it('a NON-loopback Custom host is used verbatim (the local server binds no LAN authority)', () => {
+    const dir = makeProject({ config: { connectionMode: 'Custom', host: 'http://192.168.1.5:8080', authOption: 'None' } });
+    expect(resolveConnection({ projectDir: dir, processEnv: {} }).url).toBe('http://192.168.1.5:8080');
+  });
+
+  it('the deterministic fallback honors a marker portOverride when there is no host', () => {
+    const dir = makeProject();
+    writeProjectMarker(dir, { portOverride: 26543 });
+    const r = resolveConnection({ projectDir: dir, processEnv: {} });
+    expect(r.url).toBe('http://localhost:26543');
     expect(r.source).toBe('deterministic-port');
   });
 });

--- a/cli/tests/port.test.ts
+++ b/cli/tests/port.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { generatePortFromDirectory, normalizeProjectRoot, deriveProjectPin } from '../src/utils/port.js';
+import {
+  generatePortFromDirectory,
+  normalizeProjectRoot,
+  deriveProjectPin,
+  tryGetExplicitPort,
+  tryGetExplicitLoopbackPort,
+  isAbsoluteLoopbackHost,
+  resolveLocalBindPort,
+} from '../src/utils/port.js';
 
 describe('generatePortFromDirectory', () => {
   it('is deterministic and in the 20000-29999 range', () => {
@@ -86,5 +94,118 @@ describe('deriveProjectPin — ProjectIdentity golden-vector parity', () => {
   it('is 8 lowercase hex chars and independent of any port override', () => {
     const pin = deriveProjectPin('/home/user/my-game');
     expect(pin).toMatch(/^[0-9a-f]{8}$/);
+  });
+});
+
+// --- Defect D / D21: local-server bind-port precedence -------------------
+//
+// Parity with the bridge binder `ProjectConnectionResolver` (design 04, owner
+// ruling 2026-07-19). Rows below mirror `ProjectConnectionResolverTests.cs`
+// theory tables so the CLI and the sidecar can never disagree on a port.
+
+describe('tryGetExplicitLoopbackPort — reads only an explicit LOOPBACK port', () => {
+  // Mirrors ProjectConnectionResolverTests.TryGetExplicitLoopbackPort_ReadsOnlyAnExplicitLoopbackPort.
+  const ROWS: ReadonlyArray<[string | undefined, number | undefined]> = [
+    ['http://localhost:27618/mcp', 27618],       // canonical typed-port case
+    ['http://127.0.0.1:27618', 27618],           // IPv4 loopback literal
+    ['http://[::1]:27618/mcp', 27618],           // IPv6 literal — port follows the closing bracket
+    ['http://user:pass@localhost:27618', 27618], // userinfo colon is not a port separator
+    ['http://LOCALHOST:27618', 27618],           // loopback detection is case-insensitive
+    ['http://localhost/mcp', undefined],         // no port typed — NOT the scheme default 80
+    ['http://localhost:/mcp', undefined],        // empty port
+    ['http://localhost:abc/mcp', undefined],     // non-numeric — rejected before parsing
+    ['http://localhost:70000', undefined],       // out of range
+    ['http://localhost:0', undefined],           // zero is not a bindable port
+    ['https://mcp.example.com:9999', undefined], // not loopback
+    ['localhost:27618', undefined],              // not an absolute URI
+    ['', undefined],
+    [undefined, undefined],
+  ];
+  for (const [host, expected] of ROWS) {
+    it(`${JSON.stringify(host)} → ${expected}`, () => {
+      expect(tryGetExplicitLoopbackPort(host)).toBe(expected);
+    });
+  }
+});
+
+describe('tryGetExplicitPort — raw-string parser mirrors the LIB incl. its guards', () => {
+  // Mirrors ProjectConnectionResolverTests.TryGetExplicitPort_MirrorsTheLibParserIncludingItsGuards.
+  const ROWS: ReadonlyArray<[string | undefined, number | undefined]> = [
+    ['http://localhost:65535', 65535],                 // upper bound is inclusive
+    ['http://localhost:65536', undefined],             // range guard
+    ['http://localhost:99999999999999999999', undefined], // overflow, not an exception
+    ['http://localhost:+80', undefined],               // no sign
+    ['http://localhost:-80', undefined],
+    ['http://localhost:8 0', undefined],               // no embedded whitespace
+    ['http://localhost:8080?x=1', 8080],               // query terminates the authority
+    ['http://localhost:8080#frag', 8080],              // ...as does a fragment
+    ['//localhost:8080', undefined],                   // authority empty before the first '/'
+    ['localhost:8080', 8080],                          // scheme-less IS parsed here; the loopback gate rejects it
+    ['http://[::1]', undefined],                       // bracketed IPv6 alone carries no port
+  ];
+  for (const [host, expected] of ROWS) {
+    it(`${JSON.stringify(host)} → ${expected}`, () => {
+      expect(tryGetExplicitPort(host)).toBe(expected);
+    });
+  }
+});
+
+describe('isAbsoluteLoopbackHost', () => {
+  it('matches localhost / 127.0.0.0/8 / ::1 (case-insensitive)', () => {
+    expect(isAbsoluteLoopbackHost('http://localhost:8080')).toBe(true);
+    expect(isAbsoluteLoopbackHost('http://LocalHost')).toBe(true);
+    expect(isAbsoluteLoopbackHost('http://127.0.0.1')).toBe(true);
+    expect(isAbsoluteLoopbackHost('http://127.9.9.9:1')).toBe(true);
+    expect(isAbsoluteLoopbackHost('http://[::1]:1')).toBe(true);
+  });
+  it('rejects non-loopback, non-absolute, and unparseable hosts', () => {
+    expect(isAbsoluteLoopbackHost('https://mcp.example.com')).toBe(false);
+    expect(isAbsoluteLoopbackHost('http://192.168.1.5:8080')).toBe(false);
+    expect(isAbsoluteLoopbackHost('localhost:8080')).toBe(false); // parses as scheme, no authority
+    expect(isAbsoluteLoopbackHost('http://localhost:abc')).toBe(false); // WHATWG rejects the port
+    expect(isAbsoluteLoopbackHost('')).toBe(false);
+    expect(isAbsoluteLoopbackHost(undefined)).toBe(false);
+  });
+});
+
+describe('resolveLocalBindPort — three-level precedence (marker → typed → derived)', () => {
+  const projectDir = 'C:\\Projects\\MyGame';
+  const derived = generatePortFromDirectory(projectDir);
+
+  it('1. marker portOverride wins over a typed loopback host AND the derivation', () => {
+    const r = resolveLocalBindPort({ projectDir, host: 'http://localhost:8080', markerPortOverride: 21234 });
+    expect(r).toEqual({ port: 21234, source: 'marker-override' });
+  });
+
+  it('2. typed loopback-host port wins over the derivation when there is no marker', () => {
+    const r = resolveLocalBindPort({ projectDir, host: 'http://localhost:8080' });
+    expect(r).toEqual({ port: 8080, source: 'typed-host' });
+  });
+
+  it('3a. derives when the loopback host carries no explicit port (port-less http://localhost)', () => {
+    const r = resolveLocalBindPort({ projectDir, host: 'http://localhost' });
+    expect(r).toEqual({ port: derived, source: 'derived' });
+  });
+
+  it('3b. derives when the host is non-loopback (a LAN IP the local server never binds)', () => {
+    const r = resolveLocalBindPort({ projectDir, host: 'http://192.168.1.5:8080' });
+    expect(r).toEqual({ port: derived, source: 'derived' });
+  });
+
+  it('3c. derives when there is no host at all (default fallback)', () => {
+    const r = resolveLocalBindPort({ projectDir });
+    expect(r).toEqual({ port: derived, source: 'derived' });
+  });
+
+  it('ignores an out-of-range / non-integer marker portOverride and falls through', () => {
+    expect(resolveLocalBindPort({ projectDir, markerPortOverride: 0 }).source).toBe('derived');
+    expect(resolveLocalBindPort({ projectDir, markerPortOverride: 70000 }).source).toBe('derived');
+    expect(resolveLocalBindPort({ projectDir, markerPortOverride: 8080.5 }).source).toBe('derived');
+  });
+
+  it('parity: the derivation level uses the Windows backslash-root derivation byte-for-byte', () => {
+    // C:\\Users\\user\\my-game → 29310 (port.ts golden vector), proving level 3 == the binder.
+    expect(resolveLocalBindPort({ projectDir: 'C:\\Users\\user\\my-game', host: 'http://localhost' }))
+      .toEqual({ port: 29310, source: 'derived' });
   });
 });


### PR DESCRIPTION
## Summary
- **Defect C — token gate.** The Custom-mode bearer was gated on the retired `authOption === 'required'`, so the current plugin's `Token` config silently dropped the token. Replaced with `parseCustomAuthMode` (`None`/`Token`/`Oauth`, legacy `Required` → Token) mirroring the plugin's `TryParseAuthOption`; the token goes on the wire iff the mode resolves to `Token` (mirror of `FUnrealMcpConfig::ResolveEffectiveToken`).
- **Defect D — bind-port resolution.** A Custom-mode host was taken verbatim (port-less `http://localhost` → :80, legacy `:8080`). Now a loopback host's port is resolved via the sidecar binder's 3-level precedence — marker `portOverride` → explicit port typed into a loopback host → v1 `generatePortFromDirectory` derivation (mirror of `bridge/src/Host/ProjectConnectionResolver.cs`). Non-loopback hosts stay verbatim (the local server binds no such authority).

Scope confined to `cli/src/utils/config.ts` + `cli/src/utils/port.ts` (+ tests).

## Test plan
- [x] Target-specific local tests passed (see profile test.md) — cli Suite 6 (`tsc` + `vitest`): 487 passed, 2 skipped, 0 failures (MCP env vars unset per Suite 6).
- [x] Port-resolution + token-gate parity tests mirror the bridge `ProjectConnectionResolverTests.cs` theory rows (incl. Windows backslash roots).

Closes #257