### PR TITLE
feat(cli): provision the plugin-source signing publisher key (e2/e3)

### DIFF
--- a/cli/src/lib/plugin-signature.ts
+++ b/cli/src/lib/plugin-signature.ts
@@ -44,18 +44,18 @@ import { createHash, createPublicKey, verify as cryptoVerify } from 'node:crypto
  * `untrusted comment:` line). The matching SECRET key is minted offline / held in
  * CI secrets and NEVER ships in this package.
  *
- * ⚠ NOT YET PROVISIONED (e2 / D12 follow-up). While this holds the sentinel below,
- * every download-path install FAILS CLOSED with `public-key-not-provisioned` — an
- * unverified zip is never installed. Provisioning (see docs/RELEASING.md
- * "Plugin-source signing key"): mint a PASSWORDLESS minisign keypair
- * (`minisign -G -W -p unreal-mcp-plugin.pub -s unreal-mcp-plugin.key`), store the
- * secret-key file as the repo secret `MINISIGN_SECRET_KEY` (release.yml signs the
- * source zip with it), and REPLACE the sentinel below with the base64 line of
- * `unreal-mcp-plugin.pub`. Until then, offline/dev installs use `--plugin-source <dir>`
- * (a trusted local source skips signature verification, like `--server-source`).
+ * ✅ PROVISIONED 2026-07-21 (zero-config-engine-connect e2/e3). The key below is the
+ * base64 line of `unreal-mcp-plugin.pub` (minisign key id `194DD8FC6092DA33`); its
+ * passwordless secret key is held offline and as the repo secret `MINISIGN_SECRET_KEY`,
+ * which release.yml's "Sign the plugin-source zip" step uses (fail-closed — a release
+ * errors without it). To ROTATE: mint a new passwordless keypair (`minisign -G -W`),
+ * update `MINISIGN_SECRET_KEY`, replace the line below, and cut a new release. Old CLIs
+ * keep trusting the old key (no revocation channel — rotate only on compromise + ship
+ * the new CLI promptly). Offline/dev installs still skip verification via
+ * `--plugin-source <dir>` (a trusted local source, like `--server-source`).
  */
 export const MINISIGN_PUBLIC_KEY_UNSET = 'UNPROVISIONED';
-export const MINISIGN_PUBLIC_KEY = MINISIGN_PUBLIC_KEY_UNSET;
+export const MINISIGN_PUBLIC_KEY = 'RWQz2pJg/NhNGQhoFbZZiUuNKRdB2esdgZ0Wns1Rd+jbzFefv5zIeerB';
 
 /** Sibling-asset suffix of the detached minisign signature for the source zip. */
 export const PLUGIN_SOURCE_SIGNATURE_ASSET_SUFFIX = '.minisig';

--- a/cli/tests/plugin-signature.test.ts
+++ b/cli/tests/plugin-signature.test.ts
@@ -136,9 +136,18 @@ describe('verifyMinisign — fail-closed gate (accept-real / reject-tampered)', 
     const sig = kp.sign(data);
     expect(verifyMinisign(MINISIGN_PUBLIC_KEY_UNSET, sig, data)).toBe('public-key-not-provisioned');
     expect(verifyMinisign('', sig, data)).toBe('public-key-not-provisioned');
-    // The shipped default is still the sentinel (key provisioning is a follow-up).
-    expect(MINISIGN_PUBLIC_KEY).toBe(MINISIGN_PUBLIC_KEY_UNSET);
-    expect(verifyMinisign(MINISIGN_PUBLIC_KEY, sig, data)).toBe('public-key-not-provisioned');
+  });
+
+  it('ships a provisioned publisher key (not the sentinel) that parses', () => {
+    // The shipped default is the real minisign publisher key (provisioned 2026-07-21).
+    expect(MINISIGN_PUBLIC_KEY).not.toBe(MINISIGN_PUBLIC_KEY_UNSET);
+    expect(parseMinisignPublicKey(MINISIGN_PUBLIC_KEY)).not.toBeNull();
+    // A signature made with a DIFFERENT key is rejected against the pinned key, proving
+    // the baked key is a specific real key (not a wildcard) and still fails closed.
+    const foreign = makeMinisignKeypair();
+    const verdict = verifyMinisign(MINISIGN_PUBLIC_KEY, foreign.sign(data), data);
+    expect(verdict).not.toBe('verified');
+    expect(verdict).not.toBe('public-key-not-provisioned');
   });
 
   it('fails closed when the pinned key itself is malformed (public-key-unparsable)', () => {

--- a/cli/tests/plugin-source.test.ts
+++ b/cli/tests/plugin-source.test.ts
@@ -134,14 +134,14 @@ describe('resolvePluginSource — download + signature gate', () => {
     ).rejects.toThrow(/could not download its signature/i);
   });
 
-  it('FAILS CLOSED when the pinned signing key is un-provisioned (default sentinel key)', async () => {
-    const kp = makeMinisignKeypair();
+  it('FAILS CLOSED against a foreign-signed release (the baked publisher key is provisioned)', async () => {
+    const kp = makeMinisignKeypair(); // a DIFFERENT key than the baked-in production publisher key
     await expect(
-      // No publicKeyOverride → the baked-in sentinel key → never install unverified.
+      // No publicKeyOverride → the baked-in PRODUCTION key → a zip signed by any other key is rejected.
       resolvePluginSource({
         fetchImpl: zipAndSigResponse({ 'UnrealMCP/UnrealMCP.uplugin': strToU8('{}') }, kp),
       }),
-    ).rejects.toThrow(/signing key is not provisioned/i);
+    ).rejects.toThrow(/different key than this CLI trusts|fail-closed/i);
   });
 
   it('rejects a downloaded packaged plugin descriptor that pins EngineVersion (after verify)', async () => {


### PR DESCRIPTION
Bakes the **production minisign publisher public key** (id `194DD8FC6092DA33`) into `MINISIGN_PUBLIC_KEY`, replacing the `UNPROVISIONED` sentinel from #260. `install-plugin` now verifies downloaded plugin-source zips against the real key (fail-closed).

The matching **passwordless secret key** is installed as the `MINISIGN_SECRET_KEY` repo secret, which `release.yml`'s *Sign the plugin-source zip* step uses to sign the source zip on release (that step is fail-closed — a release errors without the secret).

Updates the two tests that asserted the sentinel default (`plugin-signature.test.ts`, `plugin-source.test.ts`) to assert the provisioned key + foreign-signature rejection instead. All 511 CLI tests pass locally.

Unblocks the **e3** Unreal-MCP release (zero-config-engine-connect rollout). Key custody documented in the workspace `.secrets/unreal-mcp/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)