### PR TITLE
chore: bump McpPlugin to 7.5.0

### DIFF
--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -51,7 +51,7 @@
 
   <!--
     Reused NuGet pins — normally owned by the upstream release pipelines and kept in lockstep
-    with Godot-MCP (Godot-MCP.csproj). Current: McpPlugin 7.3.0 + ReflectorNet 5.3.2.
+    with Godot-MCP (Godot-MCP.csproj). Current: McpPlugin 7.5.0 + ReflectorNet 5.3.2.
     The MCP/reflection stack is NOT forked. Historical context: the 6.8.0 bump consumed the new
     shared engine-agnostic com.IvanMurzak.McpPlugin.AgentConfig module (the AI-agent configurators
     + the AgentConfiguratorDescription UI-DTO) so the sidecar hosts the AI-agent configuration
@@ -116,7 +116,7 @@
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.2" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.3.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">


### PR DESCRIPTION
Automated downstream bump of `com.IvanMurzak.McpPlugin` `7.4.0` -> `7.5.0` (MCP-Plugin-dotnet release d13388cb9b24).