### PR TITLE
chore(deps): bump ReflectorNet to 5.3.3

### DIFF
--- a/UnrealMCP/ThirdPartyNotices.txt
+++ b/UnrealMCP/ThirdPartyNotices.txt
@@ -87,7 +87,7 @@ The MCP plugin host the sidecar runs (SignalR client + tool registry).
 --------------------------------------------------------------------------
 7. com.IvanMurzak.ReflectorNet
 --------------------------------------------------------------------------
-Version   : 5.3.1
+Version   : 5.3.3
 Publisher : Ivan Murzak
 License   : Apache License, Version 2.0
 Source    : https://github.com/IvanMurzak/ReflectorNet

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -51,7 +51,7 @@
 
   <!--
     Reused NuGet pins — normally owned by the upstream release pipelines and kept in lockstep
-    with Godot-MCP (Godot-MCP.csproj). Current: McpPlugin 7.5.0 + ReflectorNet 5.3.2.
+    with Godot-MCP (Godot-MCP.csproj). Current: McpPlugin 7.5.0 + ReflectorNet 5.3.3.
     The MCP/reflection stack is NOT forked. Historical context: the 6.8.0 bump consumed the new
     shared engine-agnostic com.IvanMurzak.McpPlugin.AgentConfig module (the AI-agent configurators
     + the AgentConfiguratorDescription UI-DTO) so the sidecar hosts the AI-agent configuration
@@ -82,6 +82,10 @@
     ⚠ DEVIATION (mcp-authorize i6, maintainer-authorized dependency-freshness bump, per the
     PIPELINE.md "Freshness-bump carve-out"): 7.1.0 -> 7.1.1 is the patch that carries the i1 BUG-A
     token-mode validator fix. Published on nuget.org; ReflectorNet stays 5.3.2 (7.1.1 keeps that floor).
+    ReflectorNet 5.3.2 -> 5.3.3: McpPlugin 7.5.1 raises its transitive ReflectorNet floor to >= 5.3.3,
+    so this explicit pin has to advance BEFORE the McpPlugin bump can restore (NU1605 package-downgrade
+    otherwise). Landed on its own so the release cascade can retry the McpPlugin bump; the McpPlugin pin
+    above is still 7.5.0 and remains the release pipeline's to move.
   -->
   <!--
     Local-LIB dev toggle (auth-fixes f1b — parity with the GameDev-MCP-Server + Unity/Godot
@@ -115,7 +119,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.2" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.3" />
     <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Why

`com.IvanMurzak.McpPlugin` **7.5.1** raised its transitive floor to `com.IvanMurzak.ReflectorNet >= 5.3.3` (7.5.0 required 5.3.2). The bridge pins ReflectorNet **directly** at 5.3.2, so the release pipeline's attempt to bump McpPlugin to 7.5.1 fails `dotnet restore`:

```
NU1605  Warning As Error: Detected package downgrade:
        com.IvanMurzak.ReflectorNet from 5.3.3 to 5.3.2
```

That halted the release cascade. This PR advances the explicit ReflectorNet pin so the McpPlugin bump can land.

**`com.IvanMurzak.McpPlugin` is deliberately NOT bumped here** — it stays at 7.5.0 and remains the release pipeline's to move.

## What changed

- **`bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj`**
  - the `PackageReference` pin 5.3.2 → 5.3.3 (the NuGet-mode `ItemGroup`; the `UseLocalMcpPlugin` source-mode group is unaffected)
  - the `Current: McpPlugin 7.5.0 + ReflectorNet …` lockstep note
  - a new history entry recording the floor rise
  - the existing `6.11.0` / `7.0.0` / `7.1.0` / `7.1.1` history lines are left **as written** — they are an accurate record of what those bumps did at the time, not statements about the current pin
- **`UnrealMCP/ThirdPartyNotices.txt`** — the shipped ReflectorNet attribution entry

## Verification

Run locally with McpPlugin still at its current 7.5.0, i.e. the ReflectorNet bump alone does not break anything on its own:

- `dotnet restore bridge/Unreal-MCP-Bridge.sln` — clean, no NU1605
- `dotnet build -c Debug --no-restore` — **0 warnings, 0 errors**
- `project.assets.json` resolves `com.IvanMurzak.ReflectorNet/5.3.3`
- `dotnet test` — **340 passed, 0 failed**
- `cd cli && npm test` — **44 files, 517 passed, 2 skipped**

## Note for the maintainer

`CLAUDE.md` (§ frozen NuGet pins) and `docs/ARCHITECTURE.md` also name ReflectorNet versions, but both are **pre-existing** stale/historical text, not pin declarations, so they are left alone here:

- `CLAUDE.md:242` states `5.3.1` / McpPlugin `6.10.0` — already two versions behind before this PR, and the paragraph itself says *"the authoritative pin is always whatever `bridge/src/…csproj` declares — read it live, do not trust this line."* Correcting it properly also means moving the McpPlugin number, which this PR must not touch.
- `docs/ARCHITECTURE.md:54` is a *"Drift corrected against the implementation"* note describing the state at design time (`6.7.0` / `5.3.1`); rewriting it would falsify a historical record.

Worth a separate doc-refresh pass once the McpPlugin bump lands.