### PR TITLE
chore(deps): bump McpPlugin to 7.5.1

### DIFF
--- a/UnrealMCP/ThirdPartyNotices.txt
+++ b/UnrealMCP/ThirdPartyNotices.txt
@@ -76,7 +76,7 @@ Reactive-extensions library used transitively by com.IvanMurzak.McpPlugin.
 --------------------------------------------------------------------------
 6. com.IvanMurzak.McpPlugin (and com.IvanMurzak.McpPlugin.Common)
 --------------------------------------------------------------------------
-Version   : 6.10.0
+Version   : 7.5.1
 Publisher : Ivan Murzak
 License   : Apache License, Version 2.0
 Source    : https://github.com/IvanMurzak/com.IvanMurzak.McpPlugin

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -51,7 +51,7 @@
 
   <!--
     Reused NuGet pins — normally owned by the upstream release pipelines and kept in lockstep
-    with Godot-MCP (Godot-MCP.csproj). Current: McpPlugin 7.5.0 + ReflectorNet 5.3.3.
+    with Godot-MCP (Godot-MCP.csproj). Current: McpPlugin 7.5.1 + ReflectorNet 5.3.3.
     The MCP/reflection stack is NOT forked. Historical context: the 6.8.0 bump consumed the new
     shared engine-agnostic com.IvanMurzak.McpPlugin.AgentConfig module (the AI-agent configurators
     + the AgentConfiguratorDescription UI-DTO) so the sidecar hosts the AI-agent configuration
@@ -86,6 +86,9 @@
     so this explicit pin has to advance BEFORE the McpPlugin bump can restore (NU1605 package-downgrade
     otherwise). Landed on its own so the release cascade can retry the McpPlugin bump; the McpPlugin pin
     above is still 7.5.0 and remains the release pipeline's to move.
+    McpPlugin 7.5.0 -> 7.5.1: the downstream bump the entry above was preparing for, now landed. Patch
+    release from MCP-Plugin-dotnet; its raised transitive ReflectorNet floor (>= 5.3.3) is already
+    satisfied by the explicit ReflectorNet pin, so restore is clean (no NU1605).
   -->
   <!--
     Local-LIB dev toggle (auth-fixes f1b — parity with the GameDev-MCP-Server + Unity/Godot
@@ -120,7 +123,7 @@
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.3" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.5.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.5.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">


### PR DESCRIPTION
Downstream bump of `com.IvanMurzak.McpPlugin` `7.5.0` -> `7.5.1` (published on NuGet). This is the bump the ReflectorNet `5.3.3` landing (#269) was explicitly preparing for.

### Changed
| File | Classification |
| --- | --- |
| `bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj` | **live pin** (`<PackageReference>`) + the `Current:` lockstep note + a **newly appended** history entry |
| `UnrealMCP/ThirdPartyNotices.txt` | shipped-dependency attribution for the bundled sidecar |

### History block: appended, not rewritten
The csproj keeps a running record of past bumps (`6.11.0` / `7.0.0` / `7.1.0` / `7.1.1` / the `5.3.3` floor rise). Those lines are left exactly as written — they are an accurate record of what those bumps did. The `7.5.0 -> 7.5.1` move is a **new appended entry**, which also resolves the prior entry's "the McpPlugin pin above is still 7.5.0" note.

### ⚠ Pre-existing staleness corrected
`ThirdPartyNotices.txt` listed McpPlugin at **`6.10.0`** — the `6.11.0` -> `7.5.0` bumps never updated it (only ReflectorNet was refreshed, in #269). It now states `7.5.1`, matching what actually ships.

Deliberately **not** touched, per their own self-descriptions: `CLAUDE.md:242` (self-disclaims — "read it live, do not trust this line") and `docs/ARCHITECTURE.md:54` (a "Drift corrected against the implementation" historical record). Bridge source/test comments referencing `6.7.0`/`6.10.0`/`7.3.0` are behavioural history, left alone.

### ReflectorNet
Untouched at `5.3.3`. 7.5.1's transitive floor (`>= 5.3.3`) is already satisfied, so restore is clean — **no NU1605**.

### Verification
- `dotnet restore` clean, **no NU1605**; `dotnet build` **0 warnings, 0 errors**
- `project.assets.json` resolves `com.IvanMurzak.McpPlugin/7.5.1` + `com.IvanMurzak.ReflectorNet/5.3.3` in both bridge projects
- bridge xUnit **340/340**
- CLI **517 passed / 2 skipped** across 44 files