### PR TITLE
chore: bump ReflectorNet to 5.4.0

### DIFF
--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -51,7 +51,7 @@
 
   <!--
     Reused NuGet pins — normally owned by the upstream release pipelines and kept in lockstep
-    with Godot-MCP (Godot-MCP.csproj). Current: McpPlugin 7.5.1 + ReflectorNet 5.3.3.
+    with Godot-MCP (Godot-MCP.csproj). Current: McpPlugin 7.5.1 + ReflectorNet 5.4.0.
     The MCP/reflection stack is NOT forked. Historical context: the 6.8.0 bump consumed the new
     shared engine-agnostic com.IvanMurzak.McpPlugin.AgentConfig module (the AI-agent configurators
     + the AgentConfiguratorDescription UI-DTO) so the sidecar hosts the AI-agent configuration
@@ -122,7 +122,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.3" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.4.0" />
     <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.5.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Automated downstream bump of `com.IvanMurzak.ReflectorNet` `5.3.3` -> `5.4.0` (ReflectorNet release 1dff550140a4).