### PR TITLE
chore: bump McpPlugin to 8.1.0

### DIFF
--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -51,7 +51,7 @@
 
   <!--
     Reused NuGet pins — normally owned by the upstream release pipelines and kept in lockstep
-    with Godot-MCP (Godot-MCP.csproj). Current: McpPlugin 8.0.0 + ReflectorNet 5.4.0.
+    with Godot-MCP (Godot-MCP.csproj). Current: McpPlugin 8.1.0 + ReflectorNet 5.4.0.
     The MCP/reflection stack is NOT forked. Historical context: the 6.8.0 bump consumed the new
     shared engine-agnostic com.IvanMurzak.McpPlugin.AgentConfig module (the AI-agent configurators
     + the AgentConfiguratorDescription UI-DTO) so the sidecar hosts the AI-agent configuration
@@ -123,7 +123,7 @@
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.4.0" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="8.0.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">


### PR DESCRIPTION
Automated downstream bump of `com.IvanMurzak.McpPlugin` `8.0.0` -> `8.1.0` (MCP-Plugin-dotnet release 1e2eda1f0640).