### PR TITLE
fix(cli): BLAKE2b-512 fallback so plugin-source signature verification works under Electron

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -29,6 +29,7 @@
     "pretest": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
+    "verify:real-asset": "node scripts/verify-real-asset.mjs",
     "prepublishOnly": "npm run build",
     "prepack": "npm run build"
   },

--- a/cli/scripts/verify-real-asset.mjs
+++ b/cli/scripts/verify-real-asset.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// Verify a REAL published plugin-source release asset against its REAL `.minisig`
+// and the pinned publisher key — through both digest backends — on WHATEVER
+// runtime you launch it with.
+//
+// This exists because the bug it guards is runtime-specific and therefore
+// invisible to a Node-only test suite: `node:crypto` has no `blake2b512` on
+// Electron/BoringSSL, and minisign's default `ED` algorithm is prehashed
+// (Ed25519 over BLAKE2b-512(file)). The npm CI legs run on Node, which HAS the
+// native digest — so the only way to observe the Electron behaviour is to run
+// this file under Electron. Deliberately dependency-free so it can.
+//
+//   # 1. fetch the assets (any released version)
+//   gh release download v0.14.0 --repo IvanMurzak/Unreal-MCP \
+//     --pattern 'unreal-mcp-plugin-source-*.zip*' --dir /tmp/rel
+//
+//   # 2. Node (native digest available)
+//   npm run build && node cli/scripts/verify-real-asset.mjs /tmp/rel 0.14.0
+//
+//   # 3. Electron (native digest ABSENT — the case the fallback exists for)
+//   ELECTRON_RUN_AS_NODE=1 /path/to/electron.exe \
+//     cli/scripts/verify-real-asset.mjs /tmp/rel 0.14.0
+//
+// Exits 0 only if the real asset VERIFIES and a one-byte corruption of it is
+// REJECTED — a verifier that cannot reject is the failure mode that matters.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const dir = process.argv[2];
+const version = process.argv[3] ?? '0.14.0';
+if (!dir) {
+  console.error('usage: verify-real-asset.mjs <dir-with-release-assets> [version]');
+  process.exit(2);
+}
+
+const distUrl = pathToFileURL(join(import.meta.dirname, '..', 'dist', 'lib', 'plugin-signature.js'));
+const { verifyMinisign, nativeBlake2b512, fallbackBlake2b512, blake2b512, MINISIGN_PUBLIC_KEY, describeDigestRuntime } =
+  await import(distUrl.href).catch((err) => {
+    console.error('Could not load dist/lib/plugin-signature.js — run `npm run build` first.\n' + err.message);
+    process.exit(2);
+  });
+
+const zipName = `unreal-mcp-plugin-source-${version}.zip`;
+const zip = readFileSync(join(dir, zipName));
+const signatureText = readFileSync(join(dir, `${zipName}.minisig`), 'utf8');
+
+const time = (fn) => {
+  const t = Date.now();
+  const value = fn();
+  return { value, ms: Date.now() - t };
+};
+
+console.log(`runtime      : ${describeDigestRuntime()}`);
+console.log(`asset        : ${zipName} (${zip.length} bytes)`);
+
+const native = time(() => nativeBlake2b512(zip));
+const fallback = time(() => fallbackBlake2b512(zip));
+console.log(`native   b2b : ${native.value ? native.value.toString('hex') : 'UNAVAILABLE on this runtime'} [${native.ms} ms]`);
+console.log(`fallback b2b : ${fallback.value ? fallback.value.toString('hex') : 'FAILED'} [${fallback.ms} ms]`);
+if (native.value && fallback.value) {
+  console.log(`agree        : ${native.value.equals(fallback.value)}`);
+}
+console.log(`policy pick  : ${blake2b512(zip)?.toString('hex') ?? 'NULL'}`);
+
+const results = {
+  'real asset, production policy': verifyMinisign(MINISIGN_PUBLIC_KEY, signatureText, zip),
+  'real asset, fallback forced': verifyMinisign(MINISIGN_PUBLIC_KEY, signatureText, zip, {
+    blake2b512: fallbackBlake2b512,
+  }),
+};
+
+const corrupted = Buffer.from(zip);
+corrupted[Math.floor(corrupted.length / 2)] ^= 0x01;
+results['corrupted asset, production policy'] = verifyMinisign(MINISIGN_PUBLIC_KEY, signatureText, corrupted);
+results['corrupted asset, fallback forced'] = verifyMinisign(MINISIGN_PUBLIC_KEY, signatureText, corrupted, {
+  blake2b512: fallbackBlake2b512,
+});
+
+console.log('');
+for (const [label, verdict] of Object.entries(results)) {
+  console.log(`${label.padEnd(36)} => ${verdict}`);
+}
+
+const ok =
+  results['real asset, production policy'] === 'verified' &&
+  results['real asset, fallback forced'] === 'verified' &&
+  results['corrupted asset, production policy'] === 'signature-mismatch' &&
+  results['corrupted asset, fallback forced'] === 'signature-mismatch';
+
+console.log(`\nRESULT=${ok ? 'OK' : 'FAILED'}`);
+process.exit(ok ? 0 : 1);

--- a/cli/src/lib/blake2b.ts
+++ b/cli/src/lib/blake2b.ts
@@ -1,0 +1,292 @@
+// `blake2b` — a self-contained, dependency-free BLAKE2b-512 (RFC 7693) used as a
+// FALLBACK when the host runtime's `node:crypto` cannot produce a `blake2b512`
+// digest.
+//
+// WHY THIS EXISTS (measured, 2026-08-20, this workspace):
+//
+//   runtime               process.versions.openssl   getHashes().length   blake2b512
+//   Node   22.18.0        3.0.16  (OpenSSL)          52                   ✅ works
+//   Electron 43.0.0       0.0.0   (BoringSSL)         9                   ❌ throws
+//                                                                            'Digest method
+//                                                                             not supported'
+//
+// Electron links **BoringSSL**, whose digest table is a small fixed set
+// (`md4 md5 ripemd160 sha1 sha224 sha256 sha384 sha512 sha512-256`) with no
+// BLAKE2 family at all. The AI Game Dev desktop app value-imports this package and
+// runs it IN-PROCESS under Electron, so `createHash('blake2b512')` throws there.
+//
+// That matters here and only here: minisign's default `ED` algorithm is
+// PREHASHED — the Ed25519 signature covers BLAKE2b-512(file), not the file bytes —
+// and every Unreal-MCP release asset is signed that way (verified against the real
+// `unreal-mcp-plugin-source-0.14.0.zip.minisig`, whose signature blob begins `ED`).
+// So plugin-source signature verification, the fail-closed gate that runs BEFORE a
+// downloaded zip is ever extracted, could not run at all in the packaged app.
+//
+// The fix deliberately preserves verifiability of EVERY ALREADY-PUBLISHED release:
+// re-signing old assets with the legacy non-prehashed `Ed` tag was rejected because
+// it would strand shipped signatures. A correct BLAKE2b-512 here keeps them valid.
+//
+// CORRECTNESS. A hash that is *almost* right is worse than none — it would silently
+// reject good releases. This implementation is pinned by `tests/blake2b.test.ts`
+// against the official RFC 7693 / BLAKE2 reference test vectors (empty input, the
+// canonical `abc` vector, and multi-block inputs past the 128-byte block size), and
+// differentially against Node's native OpenSSL `blake2b512` over a spread of
+// lengths that straddle every buffering boundary.
+//
+// NO NEW DEPENDENCY. Vendored rather than taken from npm: this is the supply-chain
+// verification path itself, so widening the dependency graph to fix it would be
+// self-defeating. ~120 lines, no I/O, no imports.
+//
+// IMPLEMENTATION NOTES. BLAKE2b is defined over 64-bit words, which JS lacks
+// natively; `BigInt` is ~100x too slow for a 131 MB release asset. So every 64-bit
+// word is held as TWO 32-bit lanes in a `Uint32Array`, little-endian: index `2*i` is
+// the LOW half of word `i`, index `2*i + 1` is the HIGH half. This is the standard
+// portable formulation of RFC 7693 §3.1-§3.2.
+
+/**
+ * BLAKE2b IV (RFC 7693 §2.6) — the SHA-512 IV — as 32-bit lanes, low half first.
+ * Word 0 `0x6a09e667f3bcc908` becomes `0xf3bcc908, 0x6a09e667`.
+ */
+const IV32 = new Uint32Array([
+  0xf3bcc908, 0x6a09e667, 0x84caa73b, 0xbb67ae85, 0xfe94f82b, 0x3c6ef372, 0x5f1d36f1, 0xa54ff53a, 0xade682d1,
+  0x510e527f, 0x2b3e6c1f, 0x9b05688c, 0xfb41bd6b, 0x1f83d9ab, 0x137e2179, 0x5be0cd19,
+]);
+
+/**
+ * The BLAKE2b message-word permutation SIGMA (RFC 7693 §2.7), 12 rounds x 16
+ * indices. BLAKE2b uses 12 rounds, so rounds 10 and 11 reuse rows 0 and 1.
+ * Pre-doubled, because `m` also stores each 64-bit word as two lanes, so message
+ * word `n` lives at `m[2n]` / `m[2n + 1]`.
+ */
+// prettier-ignore
+const SIGMA_X2 = new Uint8Array([
+  0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30,
+  28, 20, 8, 16, 18, 30, 26, 12, 2, 24, 0, 4, 22, 14, 10, 6,
+  22, 16, 24, 0, 10, 4, 30, 26, 20, 28, 6, 12, 14, 2, 18, 8,
+  14, 18, 6, 2, 26, 24, 22, 28, 4, 12, 10, 20, 8, 0, 30, 16,
+  18, 0, 10, 14, 4, 8, 20, 30, 28, 2, 22, 24, 12, 16, 6, 26,
+  4, 24, 12, 20, 0, 22, 16, 6, 8, 26, 14, 10, 30, 28, 2, 18,
+  24, 10, 2, 30, 28, 26, 8, 20, 0, 14, 12, 6, 18, 4, 16, 22,
+  26, 22, 14, 28, 24, 2, 6, 18, 10, 0, 30, 8, 16, 12, 4, 20,
+  12, 30, 28, 18, 22, 6, 0, 16, 24, 4, 26, 14, 2, 8, 20, 10,
+  20, 4, 16, 8, 14, 12, 2, 10, 30, 22, 18, 28, 6, 24, 26, 0,
+  0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30,
+  28, 20, 8, 16, 18, 30, 26, 12, 2, 24, 0, 4, 22, 14, 10, 6,
+]);
+
+/** Bytes per BLAKE2b compression block (RFC 7693 §2.1: bb = 128). */
+export const BLAKE2B_BLOCK_BYTES = 128;
+/** Output length of BLAKE2b-512, in bytes. */
+export const BLAKE2B_512_BYTES = 64;
+
+/**
+ * Streaming BLAKE2b-512 state.
+ *
+ * `t` is the RFC's byte counter. It is a JS number rather than a 64-bit pair, so
+ * it is exact up to `Number.MAX_SAFE_INTEGER` (2^53-1 bytes = 8 PiB) — six orders
+ * of magnitude beyond any release asset. Only its low 64 bits are ever consumed,
+ * split back into two lanes at compression time.
+ */
+interface Blake2bState {
+  /** Chaining value h[0..7], as 16 lanes. */
+  readonly h: Uint32Array;
+  /** The 128-byte block buffer. */
+  readonly b: Uint8Array;
+  /** Bytes currently held in `b`. */
+  c: number;
+  /** Total bytes fed in (RFC's `t`). */
+  t: number;
+}
+
+/** Scratch working vectors, reused across calls (this module is synchronous and single-threaded). */
+const v = new Uint32Array(32);
+const m = new Uint32Array(32);
+
+/** `v[a..a+1] += v[b..b+1]` over the 64-bit lane pair, with carry. */
+function add64AA(a: number, b: number): void {
+  const lo = v[a]! + v[b]!;
+  let hi = v[a + 1]! + v[b + 1]!;
+  if (lo >= 0x100000000) hi++;
+  v[a] = lo;
+  v[a + 1] = hi;
+}
+
+/** `v[a..a+1] += (lo, hi)` over the 64-bit lane pair, with carry. `b0` may be negative (int32). */
+function add64AC(a: number, b0: number, b1: number): void {
+  let lo = v[a]! + b0;
+  if (b0 < 0) lo += 0x100000000;
+  let hi = v[a + 1]! + b1;
+  if (lo >= 0x100000000) hi++;
+  v[a] = lo;
+  v[a + 1] = hi;
+}
+
+/**
+ * The BLAKE2b mixing function G (RFC 7693 §3.1), operating on lane pairs.
+ * Rotation constants are the BLAKE2b set: R1=32, R2=24, R3=16, R4=63 — each
+ * applied as a right-rotation across the two 32-bit lanes.
+ */
+function mixG(a: number, b: number, c: number, d: number, ix: number, iy: number): void {
+  const x0 = m[ix]!;
+  const x1 = m[ix + 1]!;
+  const y0 = m[iy]!;
+  const y1 = m[iy + 1]!;
+
+  // v[a] = v[a] + v[b] + x
+  add64AA(a, b);
+  add64AC(a, x0, x1);
+
+  // v[d] = (v[d] ^ v[a]) >>> 32  — a rotation by exactly 32 bits is a lane swap.
+  let xor0 = v[d]! ^ v[a]!;
+  let xor1 = v[d + 1]! ^ v[a + 1]!;
+  v[d] = xor1;
+  v[d + 1] = xor0;
+
+  // v[c] = v[c] + v[d]
+  add64AA(c, d);
+
+  // v[b] = (v[b] ^ v[c]) >>> 24
+  xor0 = v[b]! ^ v[c]!;
+  xor1 = v[b + 1]! ^ v[c + 1]!;
+  v[b] = (xor0 >>> 24) ^ (xor1 << 8);
+  v[b + 1] = (xor1 >>> 24) ^ (xor0 << 8);
+
+  // v[a] = v[a] + v[b] + y
+  add64AA(a, b);
+  add64AC(a, y0, y1);
+
+  // v[d] = (v[d] ^ v[a]) >>> 16
+  xor0 = v[d]! ^ v[a]!;
+  xor1 = v[d + 1]! ^ v[a + 1]!;
+  v[d] = (xor0 >>> 16) ^ (xor1 << 16);
+  v[d + 1] = (xor1 >>> 16) ^ (xor0 << 16);
+
+  // v[c] = v[c] + v[d]
+  add64AA(c, d);
+
+  // v[b] = (v[b] ^ v[c]) >>> 63  — i.e. rotate LEFT by 1 across the lane pair.
+  xor0 = v[b]! ^ v[c]!;
+  xor1 = v[b + 1]! ^ v[c + 1]!;
+  v[b] = (xor1 >>> 31) ^ (xor0 << 1);
+  v[b + 1] = (xor0 >>> 31) ^ (xor1 << 1);
+}
+
+/** The BLAKE2b compression function F (RFC 7693 §3.2). `last` sets the final-block flag f0. */
+function compress(state: Blake2bState, last: boolean): void {
+  const { h, b } = state;
+
+  for (let i = 0; i < 16; i++) {
+    v[i] = h[i]!;
+    v[i + 16] = IV32[i]!;
+  }
+
+  // v[12] ^= t (low 64 bits). Lane 24/25 is word 12. The high 64 bits of the
+  // counter (v[13], lanes 26/27) stay zero — `t` never exceeds 2^53.
+  v[24] = v[24]! ^ state.t;
+  v[25] = v[25]! ^ state.t / 0x100000000;
+
+  // Final block: v[14] = ~v[14].
+  if (last) {
+    v[28] = ~v[28]!;
+    v[29] = ~v[29]!;
+  }
+
+  // Load the block as 16 little-endian 64-bit words → 32 lanes.
+  for (let i = 0; i < 32; i++) {
+    const j = i * 4;
+    m[i] = b[j]! ^ (b[j + 1]! << 8) ^ (b[j + 2]! << 16) ^ (b[j + 3]! << 24);
+  }
+
+  for (let r = 0; r < 12; r++) {
+    const s = r * 16;
+    // Column rounds.
+    mixG(0, 8, 16, 24, SIGMA_X2[s]!, SIGMA_X2[s + 1]!);
+    mixG(2, 10, 18, 26, SIGMA_X2[s + 2]!, SIGMA_X2[s + 3]!);
+    mixG(4, 12, 20, 28, SIGMA_X2[s + 4]!, SIGMA_X2[s + 5]!);
+    mixG(6, 14, 22, 30, SIGMA_X2[s + 6]!, SIGMA_X2[s + 7]!);
+    // Diagonal rounds.
+    mixG(0, 10, 20, 30, SIGMA_X2[s + 8]!, SIGMA_X2[s + 9]!);
+    mixG(2, 12, 22, 24, SIGMA_X2[s + 10]!, SIGMA_X2[s + 11]!);
+    mixG(4, 14, 16, 26, SIGMA_X2[s + 12]!, SIGMA_X2[s + 13]!);
+    mixG(6, 8, 18, 28, SIGMA_X2[s + 14]!, SIGMA_X2[s + 15]!);
+  }
+
+  for (let i = 0; i < 16; i++) {
+    h[i] = h[i]! ^ v[i]! ^ v[i + 16]!;
+  }
+}
+
+/** Fresh unkeyed BLAKE2b-512 state (RFC 7693 §2.5 parameter block: depth/fanout 1, no key). */
+function init(): Blake2bState {
+  const h = new Uint32Array(IV32);
+  // h[0] ^= 0x0101kknn  (kk = key length = 0, nn = digest length = 64).
+  h[0] = h[0]! ^ 0x01010000 ^ (0 << 8) ^ BLAKE2B_512_BYTES;
+  return { h, b: new Uint8Array(BLAKE2B_BLOCK_BYTES), c: 0, t: 0 };
+}
+
+/**
+ * Absorb `input`. The final block must NOT be compressed here (it needs the `last`
+ * flag), so a full buffer is only flushed once we know more bytes are coming —
+ * that lazy flush is what makes an exactly-block-multiple input hash correctly.
+ * Copies in bulk rather than byte-at-a-time: the release asset is ~131 MB.
+ */
+function update(state: Blake2bState, input: Uint8Array): void {
+  let i = 0;
+  while (i < input.length) {
+    if (state.c === BLAKE2B_BLOCK_BYTES) {
+      state.t += state.c;
+      compress(state, false);
+      state.c = 0;
+    }
+    const n = Math.min(BLAKE2B_BLOCK_BYTES - state.c, input.length - i);
+    state.b.set(input.subarray(i, i + n), state.c);
+    state.c += n;
+    i += n;
+  }
+}
+
+/** Zero-pad the trailing block, compress it with the final-block flag, and emit 64 LE bytes. */
+function final(state: Blake2bState): Uint8Array {
+  state.t += state.c;
+  state.b.fill(0, state.c);
+  compress(state, true);
+
+  const out = new Uint8Array(BLAKE2B_512_BYTES);
+  for (let i = 0; i < BLAKE2B_512_BYTES; i++) {
+    out[i] = (state.h[i >> 2]! >> (8 * (i & 3))) & 0xff;
+  }
+  return out;
+}
+
+/**
+ * Pure-JS BLAKE2b-512 of `data` (unkeyed, 64-byte digest), per RFC 7693.
+ *
+ * Deterministic and allocation-light; no dependencies, no I/O. Byte-identical to
+ * `createHash('blake2b512')` on runtimes that have it — proven by the differential
+ * test in `tests/blake2b.test.ts`.
+ */
+export function blake2b512Js(data: Uint8Array): Uint8Array {
+  const state = init();
+  update(state, data);
+  return final(state);
+}
+
+/**
+ * Streaming form, for callers that hold the payload in chunks. Same digest as
+ * feeding the concatenation to {@link blake2b512Js}.
+ */
+export function createBlake2b512Js(): { update(chunk: Uint8Array): void; digest(): Uint8Array } {
+  const state = init();
+  let done = false;
+  return {
+    update(chunk: Uint8Array): void {
+      if (done) throw new Error('blake2b512: update() called after digest()');
+      update(state, chunk);
+    },
+    digest(): Uint8Array {
+      if (done) throw new Error('blake2b512: digest() called twice');
+      done = true;
+      return final(state);
+    },
+  };
+}

--- a/cli/src/lib/plugin-signature.ts
+++ b/cli/src/lib/plugin-signature.ts
@@ -31,12 +31,35 @@
 //               protecting the trusted comment from tampering.
 //
 // Everything here is PURE (no I/O, no network): parsing is byte-slicing and the
-// verify is deterministic `node:crypto` (Ed25519 + BLAKE2b-512). The HTTP fetch
-// that surrounds this verdict lives in `plugin-source.ts`, so every decision
-// below is unit-testable with no real download — the suite proves ACCEPT-real /
+// verify is deterministic (Ed25519 + BLAKE2b-512). The HTTP fetch that surrounds
+// this verdict lives in `plugin-source.ts`, so every decision below is
+// unit-testable with no real download — the suite proves ACCEPT-real /
 // REJECT-tampered against a genuine (pynacl-generated) minisign vector.
+//
+// BLAKE2b-512 IS NOT UNIVERSALLY AVAILABLE. `node:crypto` delegates digests to the
+// runtime's TLS library, and only OpenSSL builds carry the BLAKE2 family. Measured
+// on this workspace 2026-08-20:
+//
+//   Node 22.18.0      openssl 3.0.16   52 digests   blake2b512 ✅
+//   Electron 43.0.0   openssl 0.0.0     9 digests   blake2b512 ❌ throws
+//                     (BoringSSL)                   'Digest method not supported'
+//
+// The AI Game Dev desktop app value-imports this package and runs it IN-PROCESS
+// under Electron, so an unguarded `createHash('blake2b512')` threw straight out of
+// `verifyMinisign` — past every fail-closed verdict below — and surfaced to the
+// user as the bare string `Digest method not supported`. Since minisign's default
+// `ED` algorithm is PREHASHED (Ed25519 over BLAKE2b-512(file)) and every shipped
+// Unreal-MCP release is signed that way, Unreal plugin install was broken outright
+// in the packaged app. Unity/Godot are unaffected: their CLIs only hash `sha256`.
+//
+// The fix is `./blake2b.ts`, a vendored RFC 7693 BLAKE2b-512 used ONLY when the
+// runtime lacks the native digest. Native stays first and unchanged. Re-signing
+// with the legacy `Ed` tag was rejected because it would strand every
+// already-published signature; a correct fallback keeps them all verifiable.
 
 import { createHash, createPublicKey, verify as cryptoVerify } from 'node:crypto';
+
+import { blake2b512Js } from './blake2b.js';
 
 /**
  * The pinned publisher public key the downloaded plugin-source zip is verified
@@ -71,6 +94,8 @@ const ED25519_PUBLIC_KEY_LEN = 32;
 const ED25519_SIGNATURE_LEN = 64;
 const PUBLIC_KEY_BLOB_LEN = 2 + KEY_ID_LEN + ED25519_PUBLIC_KEY_LEN; // 42
 const SIGNATURE_BLOB_LEN = 2 + KEY_ID_LEN + ED25519_SIGNATURE_LEN; // 74
+/** A BLAKE2b-512 digest is exactly 64 bytes; anything else is not a usable digest. */
+const BLAKE2B_512_DIGEST_LEN = 64;
 
 /**
  * The fixed 12-byte ASN.1 SPKI prefix for a raw Ed25519 public key. Prepending it
@@ -80,6 +105,98 @@ const SIGNATURE_BLOB_LEN = 2 + KEY_ID_LEN + ED25519_SIGNATURE_LEN; // 74
  * of an Ed25519 key begins with exactly these bytes.)
  */
 const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
+
+/**
+ * A BLAKE2b-512 implementation. Returns `null` when it cannot produce a digest —
+ * never throws, so a missing digest becomes a fail-closed VERDICT rather than an
+ * exception escaping `verifyMinisign`.
+ */
+export type Blake2b512Fn = (data: Uint8Array) => Buffer | null;
+
+/**
+ * BLAKE2b-512 via `node:crypto`. Returns `null` — rather than throwing — on any
+ * runtime whose TLS library lacks the digest (Electron/BoringSSL throws
+ * `Digest method not supported` here; see the header note).
+ */
+export function nativeBlake2b512(data: Uint8Array): Buffer | null {
+  try {
+    return createHash('blake2b512').update(data).digest();
+  } catch {
+    return null;
+  }
+}
+
+/** BLAKE2b-512 via the vendored pure-JS RFC 7693 implementation. Never throws. */
+export function fallbackBlake2b512(data: Uint8Array): Buffer | null {
+  try {
+    return Buffer.from(blake2b512Js(data));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The native-first / fallback-second digest policy, with both implementations
+ * injected so the policy itself is testable on a single runtime. A digest counts
+ * only if it is present AND exactly 64 bytes; anything else falls through, and
+ * `null` out the bottom means NOTHING could be hashed (fail-closed).
+ *
+ * `native` is tried first and its result is used unchanged whenever it is usable,
+ * so on an OpenSSL runtime the fallback is never even called.
+ */
+export function selectBlake2b512(data: Uint8Array, native: Blake2b512Fn, fallback: Blake2b512Fn): Buffer | null {
+  let digest: Buffer | null = null;
+  try {
+    digest = native(data);
+  } catch {
+    digest = null;
+  }
+  if (digest && digest.length === BLAKE2B_512_DIGEST_LEN) return digest;
+
+  try {
+    digest = fallback(data);
+  } catch {
+    return null;
+  }
+  return digest && digest.length === BLAKE2B_512_DIGEST_LEN ? digest : null;
+}
+
+/**
+ * The production digest policy: **native first, vendored fallback second**.
+ *
+ * On a runtime that has `blake2b512` this is exactly the previous behaviour — the
+ * native OpenSSL digest, byte for byte. The fallback runs only where the native
+ * digest is unavailable, and produces the identical bytes (proven by the
+ * differential tests in `tests/blake2b.test.ts`, and measured end-to-end against
+ * the real v0.14.0 release asset under Electron 43).
+ *
+ * Returns `null` only if BOTH fail, which callers MUST treat as "did not verify".
+ */
+export function blake2b512(data: Uint8Array): Buffer | null {
+  return selectBlake2b512(data, nativeBlake2b512, fallbackBlake2b512);
+}
+
+/** The subset of `process.versions` that identifies which crypto backend is in play. */
+export interface DigestRuntimeVersions {
+  readonly node?: string | undefined;
+  readonly electron?: string | undefined;
+  readonly openssl?: string | undefined;
+}
+
+/**
+ * A one-line description of the runtime whose crypto backend is being blamed, for
+ * the `digest-unavailable` message. Without this the failure reaches the user as
+ * an unattributable four-word string; with it, a bug report carries the one fact
+ * that explains it (`electron 43.0.0, openssl 0.0.0` = BoringSSL, no BLAKE2).
+ * `versions` is injectable so the wording is testable without a second runtime.
+ */
+export function describeDigestRuntime(versions: DigestRuntimeVersions = process.versions): string {
+  const parts: string[] = [];
+  if (versions.electron) parts.push(`electron ${versions.electron}`);
+  if (versions.node) parts.push(`node ${versions.node}`);
+  if (versions.openssl) parts.push(`openssl ${versions.openssl}`);
+  return parts.length > 0 ? parts.join(', ') : 'unknown runtime';
+}
 
 /** Parsed minisign public key. */
 export interface MinisignPublicKey {
@@ -116,6 +233,13 @@ export type SignatureVerdict =
   | 'key-id-mismatch'
   /** The signature's algorithm tag is neither `ED` (prehashed) nor `Ed` (legacy). */
   | 'unsupported-algorithm'
+  /**
+   * A prehashed (`ED`) signature needs BLAKE2b-512 of the file, and NEITHER the
+   * runtime's native digest NOR the vendored fallback could produce one. Nothing
+   * is verified in that state, so it is fail-closed like any other non-`verified`
+   * verdict — the download is rejected, never installed unverified.
+   */
+  | 'digest-unavailable'
   /** The Ed25519 signature over the file did not verify (tampered zip / wrong key). */
   | 'signature-mismatch'
   /** The Ed25519 global signature over the trusted comment did not verify. */
@@ -234,18 +358,36 @@ function ed25519Verify(message: Buffer, keyObject: ReturnType<typeof createPubli
   }
 }
 
+/** Options for {@link verifyMinisign}. Production callers pass none. */
+export interface VerifyMinisignOptions {
+  /**
+   * INTERNAL TEST SEAM — the BLAKE2b-512 implementation used for prehashed (`ED`)
+   * signatures. Defaults to {@link blake2b512} (native first, vendored fallback
+   * second), which is what every production caller gets; `plugin-source.ts` does
+   * NOT forward this, and no CLI flag reaches it.
+   *
+   * It selects WHICH implementation computes the digest — it can never skip,
+   * weaken, or short-circuit verification. A wrong digest fails Ed25519 and lands
+   * on `signature-mismatch`; a `null` digest lands on `digest-unavailable`. Both
+   * are fail-closed.
+   */
+  readonly blake2b512?: Blake2b512Fn;
+}
+
 /**
  * The single fail-closed decision `plugin-source.ts` calls BEFORE `unzipSync`:
  * verify `fileBytes` against `signatureText` (the `.minisig`) using the pinned
  * `publicKeyText`. Returns `'verified'` ONLY when the pinned key parsed, the
- * signature parsed, their key ids matched, and BOTH the file signature and the
- * trusted-comment global signature verified with Ed25519; every other outcome is
- * a distinct fail-closed verdict. Pure, deterministic, never throws.
+ * signature parsed, their key ids matched, a digest was obtainable for a
+ * prehashed signature, and BOTH the file signature and the trusted-comment global
+ * signature verified with Ed25519; every other outcome is a distinct fail-closed
+ * verdict. Deterministic, and never throws.
  */
 export function verifyMinisign(
   publicKeyText: string | null | undefined,
   signatureText: string | null | undefined,
   fileBytes: Uint8Array,
+  options: VerifyMinisignOptions = {},
 ): SignatureVerdict {
   const pkText = (publicKeyText ?? '').trim();
   if (pkText.length === 0 || pkText === MINISIGN_PUBLIC_KEY_UNSET) return 'public-key-not-provisioned';
@@ -263,8 +405,24 @@ export function verifyMinisign(
   if (!keyObject) return 'public-key-unparsable';
 
   // Prehashed (`ED`) signs BLAKE2b-512 of the file; legacy (`Ed`) signs the file bytes.
-  const message =
-    sig.algorithm === ALGO_PREHASHED ? createHash('blake2b512').update(fileBytes).digest() : Buffer.from(fileBytes);
+  // The digest fn is native-first with a vendored pure-JS fallback, because
+  // Electron/BoringSSL has no `blake2b512` (header note). A `null` digest means
+  // NOTHING was verified, so it must fail closed rather than fall through to a
+  // comparison against arbitrary bytes.
+  let message: Buffer;
+  if (sig.algorithm === ALGO_PREHASHED) {
+    let digest: Buffer | null;
+    try {
+      digest = (options.blake2b512 ?? blake2b512)(fileBytes);
+    } catch {
+      // Keeps the "never throws" contract even for an injected implementation.
+      digest = null;
+    }
+    if (!digest || digest.length !== BLAKE2B_512_DIGEST_LEN) return 'digest-unavailable';
+    message = digest;
+  } else {
+    message = Buffer.from(fileBytes);
+  }
   if (!ed25519Verify(message, keyObject, sig.signature)) return 'signature-mismatch';
 
   // Global signature protects the trusted comment: Ed25519 over ( signature || trusted_comment ).
@@ -274,8 +432,18 @@ export function verifyMinisign(
   return 'verified';
 }
 
-/** A short, actionable human-readable reason for a non-`'verified'` verdict. Pure. */
-export function signatureFailureReason(verdict: SignatureVerdict, assetName: string): string {
+/**
+ * A short, actionable human-readable reason for a non-`'verified'` verdict.
+ *
+ * Pure for every verdict except `digest-unavailable`, whose wording embeds a
+ * description of the current runtime's crypto backend (that is the single fact
+ * that explains the failure). Pass `runtimeDescription` to pin it in a test.
+ */
+export function signatureFailureReason(
+  verdict: SignatureVerdict,
+  assetName: string,
+  runtimeDescription: string = describeDigestRuntime(),
+): string {
   switch (verdict) {
     case 'public-key-not-provisioned':
       return (
@@ -291,6 +459,13 @@ export function signatureFailureReason(verdict: SignatureVerdict, assetName: str
       return `the '${assetName}' signature was made with a different key than this CLI trusts`;
     case 'unsupported-algorithm':
       return `the '${assetName}' signature uses an unsupported algorithm`;
+    case 'digest-unavailable':
+      return (
+        `the '${assetName}' signature is prehashed (BLAKE2b-512) and this runtime could not compute that ` +
+        `digest — neither its built-in crypto (${runtimeDescription}) nor the bundled fallback ` +
+        `produced one, so the download was NOT verified. Please report this with the runtime details above; ` +
+        `meanwhile, pass --plugin-source <dir> to install from a trusted local checkout`
+      );
     case 'signature-mismatch':
       return `the downloaded plugin source did not match its '${assetName}' signature (tampered or wrong key)`;
     case 'global-signature-mismatch':

--- a/cli/tests/blake2b.test.ts
+++ b/cli/tests/blake2b.test.ts
@@ -219,3 +219,35 @@ describe('vendored BLAKE2b-512 — streaming form', () => {
     }
   });
 });
+
+describe('vendored BLAKE2b-512 — typed-array views with a non-zero byteOffset', () => {
+  // NOT a hypothetical: `readFileSync` returns a Node Buffer, which is a view onto
+  // a POOLED ArrayBuffer at a non-zero byteOffset — so this is the shape the real
+  // release asset arrives in. An implementation that reached for `input.buffer`
+  // instead of honouring `byteOffset`/`length` would hash the whole pool and stay
+  // green on every other test in this file, because they all pass offset-0 arrays.
+  const CASES: ReadonlyArray<readonly [number, number, number]> = [
+    [1000, 7, 300],
+    [500, 128, 256],
+    [4096, 1, 4095],
+    [300, 299, 1],
+    [2000, 64, 1024],
+  ];
+
+  for (const [total, offset, length] of CASES) {
+    it(`hashes a ${length}-byte view at byteOffset ${offset} as its own bytes`, () => {
+      const backing = Buffer.from(pattern(total));
+      const view = new Uint8Array(backing.buffer, backing.byteOffset + offset, length);
+      expect(view.byteOffset).not.toBe(0);
+      const native = createHash('blake2b512').update(view).digest('hex');
+      expect(hex(blake2b512Js(view))).toBe(native);
+      // And it must equal hashing those same bytes copied to a fresh, offset-0 array.
+      expect(hex(blake2b512Js(Uint8Array.from(view)))).toBe(native);
+    });
+  }
+
+  it('hashes a pooled Node Buffer identically to node:crypto', () => {
+    const buf = Buffer.from('hello world — pooled buffers carry a non-zero byteOffset', 'utf8');
+    expect(hex(blake2b512Js(buf))).toBe(createHash('blake2b512').update(buf).digest('hex'));
+  });
+});

--- a/cli/tests/blake2b.test.ts
+++ b/cli/tests/blake2b.test.ts
@@ -1,0 +1,221 @@
+// Correctness proof for the vendored pure-JS BLAKE2b-512 (`src/lib/blake2b.ts`),
+// which is the FALLBACK digest that makes minisign `ED` (prehashed) signature
+// verification work on runtimes whose crypto backend has no BLAKE2 — notably
+// Electron/BoringSSL, where the desktop app runs this package in-process.
+//
+// WHY THIS FILE IS SHAPED LIKE THIS. A hash that is *almost* right is worse than
+// no hash: it would silently refuse every good release. And this suite runs under
+// NODE, which HAS `blake2b512` — so a test that merely called the verification
+// path would take the NATIVE branch and prove nothing about the fallback. Every
+// assertion below therefore calls the pure-JS implementation DIRECTLY, and the
+// expected values are pinned to constants produced by OTHER implementations:
+//
+//   * the official published BLAKE2b-512 vectors (empty, "abc", the pangram, and
+//     the classic one-million-'a' vector);
+//   * the BLAKE2 known-answer-test unkeyed sequence inputs (in[i] = i & 0xff) at
+//     lengths that straddle the 128-byte block boundary;
+//   * all of the above regenerated 2026-08-20 from CPython 3.12.10
+//     `hashlib.blake2b` — the BLAKE2 REFERENCE implementation, independent of both
+//     OpenSSL and this code — so these are cross-implementation vectors, not a
+//     recording of our own output.
+//
+// The differential block additionally compares against Node's native OpenSSL
+// digest, a fourth independent implementation, across every buffering boundary.
+
+import { describe, it, expect } from 'vitest';
+import { createHash, getHashes } from 'node:crypto';
+import { blake2b512Js, createBlake2b512Js, BLAKE2B_BLOCK_BYTES, BLAKE2B_512_BYTES } from '../src/lib/blake2b.js';
+
+const hex = (bytes: Uint8Array): string => Buffer.from(bytes).toString('hex');
+
+/** in[i] = i & 0xff — the BLAKE2 KAT unkeyed sequence input. */
+function sequence(n: number): Uint8Array {
+  const out = new Uint8Array(n);
+  for (let i = 0; i < n; i++) out[i] = i & 0xff;
+  return out;
+}
+
+/** A deterministic non-repeating pattern, so a block-ordering bug cannot cancel out. */
+function pattern(n: number): Uint8Array {
+  const out = new Uint8Array(n);
+  for (let i = 0; i < n; i++) out[i] = (i * 167 + 13) & 0xff;
+  return out;
+}
+
+describe('vendored BLAKE2b-512 — official published vectors', () => {
+  it('hashes the empty input to the RFC 7693 / reference value', () => {
+    expect(hex(blake2b512Js(new Uint8Array(0)))).toBe(
+      '786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419' +
+        'd25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce',
+    );
+  });
+
+  it('hashes "abc" to the RFC 7693 Appendix A value', () => {
+    expect(hex(blake2b512Js(Buffer.from('abc', 'utf8')))).toBe(
+      'ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d1' +
+        '7d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923',
+    );
+  });
+
+  it('hashes the standard pangram to the published value', () => {
+    expect(hex(blake2b512Js(Buffer.from('The quick brown fox jumps over the lazy dog', 'utf8')))).toBe(
+      'a8add4bdddfd93e4877d2746e62817b116364a1fa7bc148d95090bc7333b3673' +
+        'f82401cf7aa2e4cb1ecd90296e3f14cb5413f8ed77be73045b13914cdcd6a918',
+    );
+  });
+
+  // 1,000,000 bytes = 7813 full blocks — the strongest single check that the
+  // counter, the lazy final-block flush and the block loop all hold at scale.
+  it('hashes one million "a" bytes to the published value (7813 blocks)', () => {
+    const million = new Uint8Array(1_000_000).fill(0x61);
+    expect(hex(blake2b512Js(million))).toBe(
+      '98fb3efb7206fd19ebf69b6f312cf7b64e3b94dbe1a17107913975a793f177e1' +
+        'd077609d7fba363cbba00d05f7aa4e4fa8715d6428104c0a75643b0ff3fd3eaf',
+    );
+  });
+});
+
+describe('vendored BLAKE2b-512 — KAT sequence inputs across the block boundary', () => {
+  // in[i] = i & 0xff at 127 / 128 / 129 / 255 / 256 bytes. 128 is EXACTLY one
+  // block: the case a naive implementation gets wrong, because the final block
+  // must be compressed with the last-block flag rather than flushed early.
+  const CASES: ReadonlyArray<readonly [number, string]> = [
+    [
+      127,
+      'b6292669ccd38d5f01caae96ba272c76a879a45743afa0725d83b9ebb26665b7' +
+        '31f1848c52f11972b6644f554c064fa90780dbbbf3a89d4fc31f67df3e5857ef',
+    ],
+    [
+      128,
+      '2319e3789c47e2daa5fe807f61bec2a1a6537fa03f19ff32e87eecbfd64b7e0e' +
+        '8ccff439ac333b040f19b0c4ddd11a61e24ac1fe0f10a039806c5dcc0da3d115',
+    ],
+    [
+      129,
+      'f59711d44a031d5f97a9413c065d1e614c417ede998590325f49bad2fd444d3e' +
+        '4418be19aec4e11449ac1a57207898bc57d76a1bcf3566292c20c683a5c4648f',
+    ],
+    [
+      255,
+      '5b21c5fd8868367612474fa2e70e9cfa2201ffeee8fafab5797ad58fefa17c9b' +
+        '5b107da4a3db6320baaf2c8617d5a51df914ae88da3867c2d41f0cc14fa67928',
+    ],
+    [
+      256,
+      '1ecc896f34d3f9cac484c73f75f6a5fb58ee6784be41b35f46067b9c65c63a67' +
+        '94d3d744112c653f73dd7deb6666204c5a9bfa5b46081fc10fdbe7884fa5cbf8',
+    ],
+  ];
+
+  for (const [n, expected] of CASES) {
+    it(`matches the reference digest for the ${n}-byte sequence input`, () => {
+      expect(hex(blake2b512Js(sequence(n)))).toBe(expected);
+    });
+  }
+
+  it('exposes the RFC block size and digest length it was built against', () => {
+    expect(BLAKE2B_BLOCK_BYTES).toBe(128);
+    expect(BLAKE2B_512_BYTES).toBe(64);
+  });
+});
+
+describe('vendored BLAKE2b-512 — multi-block pattern vectors (CPython reference)', () => {
+  const CASES: ReadonlyArray<readonly [number, string]> = [
+    [
+      129,
+      '05a880ec1f4512c1136fe0cda87c6e2c2af4958b28979c932a3596190f4cb1a1' +
+        '2be2c11f5d1d8f17e69c702e22fb7fb2dbeb071060c9566108809152ea14b5c3',
+    ],
+    [
+      1000,
+      'a76e210917c8640f5e6eb177432dc0f134f547c90dddfff29e9a322dba3b1b38' +
+        '53ce81842e744013745fe9c9685f56ca9c2a26c16a633f01c644fc9d7073ec2f',
+    ],
+    [
+      4096,
+      'c7f16e79c5b29833f793e56fcc255b6f9eb90e2e8f1e3870582d0df9c561f9c9' +
+        '40764830f87bcefcb650f964aae954e091be71409a9928cd384d51c9d68534b2',
+    ],
+    [
+      100_000,
+      '00fd0d71de9a0a35dda83d6e64f4ffc8c59c83ca54f0b8ee1d6f3adaf59dad82' +
+        'b122837e35972c3c481f7b0276a524150477737cb5e44dcdafc5f1fe6209a7ad',
+    ],
+  ];
+
+  for (const [n, expected] of CASES) {
+    it(`matches the reference digest for the ${n}-byte pattern (${Math.ceil(n / 128)} blocks)`, () => {
+      expect(hex(blake2b512Js(pattern(n)))).toBe(expected);
+    });
+  }
+});
+
+describe('vendored BLAKE2b-512 — differential against native OpenSSL', () => {
+  // This suite runs on Node, which HAS blake2b512 (OpenSSL). Asserting the
+  // vendored implementation is byte-identical to it is the strongest cheap
+  // control we have — and it is exactly the equality the fix depends on, since
+  // release signatures are produced against the real minisign/OpenSSL digest.
+  it('has the native digest available in this runtime (guards the test below from being vacuous)', () => {
+    // If this ever fails, the "differential" assertions would be comparing the
+    // fallback to itself and would prove nothing — so assert the premise.
+    expect(getHashes()).toContain('blake2b512');
+    expect(() => createHash('blake2b512')).not.toThrow();
+  });
+
+  const LENGTHS = [0, 1, 2, 63, 64, 65, 127, 128, 129, 191, 192, 255, 256, 257, 383, 384, 1023, 1024, 1025, 65_536];
+
+  for (const n of LENGTHS) {
+    it(`agrees with node:crypto blake2b512 at ${n} bytes`, () => {
+      const data = pattern(n);
+      const native = createHash('blake2b512').update(data).digest('hex');
+      expect(hex(blake2b512Js(data))).toBe(native);
+    });
+  }
+
+  it('agrees with node:crypto over 200 random lengths up to 4 KiB', () => {
+    for (let i = 0; i < 200; i++) {
+      const n = Math.floor(Math.random() * 4096);
+      const data = new Uint8Array(n);
+      for (let j = 0; j < n; j++) data[j] = (j * 251 + i * 31) & 0xff;
+      const native = createHash('blake2b512').update(data).digest('hex');
+      expect(hex(blake2b512Js(data)), `length ${n}`).toBe(native);
+    }
+  });
+});
+
+describe('vendored BLAKE2b-512 — streaming form', () => {
+  it('produces the same digest as the one-shot form for ragged chunk sizes', () => {
+    const data = pattern(5000);
+    for (const chunk of [1, 7, 127, 128, 129, 333, 4096]) {
+      const s = createBlake2b512Js();
+      for (let i = 0; i < data.length; i += chunk) s.update(data.subarray(i, Math.min(i + chunk, data.length)));
+      expect(hex(s.digest()), `chunk ${chunk}`).toBe(hex(blake2b512Js(data)));
+    }
+  });
+
+  it('refuses to be reused after digest() (a reused state would silently mis-hash)', () => {
+    const s = createBlake2b512Js();
+    s.update(Buffer.from('abc'));
+    s.digest();
+    expect(() => s.digest()).toThrow(/digest\(\) called twice/);
+    expect(() => s.update(Buffer.from('x'))).toThrow(/after digest\(\)/);
+  });
+
+  it('is deterministic — the shared scratch vectors do not leak between calls', () => {
+    // The module reuses module-level Uint32Array scratch space across calls.
+    // Interleaving two different inputs proves no state survives a call.
+    const a = pattern(700);
+    const b = sequence(900);
+    const firstA = hex(blake2b512Js(a));
+    const firstB = hex(blake2b512Js(b));
+    expect(hex(blake2b512Js(a))).toBe(firstA);
+    expect(hex(blake2b512Js(b))).toBe(firstB);
+    expect(hex(blake2b512Js(a))).toBe(firstA);
+  });
+
+  it('always returns exactly 64 bytes', () => {
+    for (const n of [0, 1, 128, 1000]) {
+      expect(blake2b512Js(pattern(n)).length).toBe(64);
+    }
+  });
+});

--- a/cli/tests/fixtures/unreal-mcp-plugin-source-0.14.0.zip.minisig
+++ b/cli/tests/fixtures/unreal-mcp-plugin-source-0.14.0.zip.minisig
@@ -1,0 +1,4 @@
+untrusted comment: signature from minisign secret key
+RUQz2pJg/NhNGTAPLOxyIhFK3sHVPXd78ORPZ9a+mAnd0yUe+S/uFgBsFiK6YMlf69Y9hI1UCEeK+jUpSAVK4C85jDHeRLle0wI=
+trusted comment: unreal-mcp plugin source 0.14.0 signed by AI Game Dev release CI
+GQFKkeaL5sL9GBfth4KVQ9MlV67ajgHGQHWpMM7n4/BRf/+Iryi8UoRPw7kRDSzEowshKm7e0oj4BOHsWP8ACg==

--- a/cli/tests/plugin-signature-digest.test.ts
+++ b/cli/tests/plugin-signature-digest.test.ts
@@ -1,0 +1,365 @@
+// The BLAKE2b-512 FALLBACK inside signature verification.
+//
+// THE VACUITY TRAP THIS FILE EXISTS TO AVOID. Node HAS `blake2b512`. So a test
+// that just calls `verifyMinisign(...)` on this runtime takes the NATIVE branch
+// and would pass with the fallback deleted — proving nothing about the code path
+// that actually runs in the packaged Electron app. Every assertion below either
+// forces the fallback explicitly (via the documented `blake2b512` seam, or by
+// calling `fallbackBlake2b512` directly), or injects a native implementation that
+// fails the way Electron/BoringSSL really fails.
+//
+// The suite is organised as four claims:
+//   1. the native-first/fallback-second POLICY switches over correctly, including
+//      when native throws `Digest method not supported` exactly as Electron does;
+//   2. the fallback and the native digest are INTERCHANGEABLE inside a real
+//      signature verification — sign with one, verify with the other;
+//   3. an unobtainable digest FAILS CLOSED and can never read as verified, with a
+//      positive control in the same fixture family proving the fixture verifies
+//      when the digest IS obtainable;
+//   4. the REAL published v0.14.0 release signature is prehashed and matches the
+//      pinned key — i.e. the premise of this whole fix holds on a real artifact.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHash, getHashes } from 'node:crypto';
+import {
+  MINISIGN_PUBLIC_KEY,
+  parseMinisignPublicKey,
+  parseMinisignSignature,
+  verifyMinisign,
+  signatureFailureReason,
+  describeDigestRuntime,
+  nativeBlake2b512,
+  fallbackBlake2b512,
+  blake2b512,
+  selectBlake2b512,
+  type SignatureVerdict,
+} from '../src/lib/plugin-signature.js';
+import { makeMinisignKeypair } from './minisign-fixture.js';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+
+/** The exact error Electron 43 / BoringSSL throws (measured 2026-08-20). */
+const ELECTRON_DIGEST_ERROR = 'Digest method not supported';
+const electronNativeDigest = (): Buffer => {
+  throw new Error(ELECTRON_DIGEST_ERROR);
+};
+
+/** Deterministic, non-repeating payload of `n` bytes. */
+function payload(n: number): Uint8Array {
+  const out = new Uint8Array(n);
+  for (let i = 0; i < n; i++) out[i] = (i * 167 + 13) & 0xff;
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Premise. If Node ever loses `blake2b512`, several controls below silently stop
+// discriminating (they would be comparing the fallback with itself). Assert it.
+// ---------------------------------------------------------------------------
+describe('runtime premise', () => {
+  it('this test runtime HAS the native blake2b512 digest', () => {
+    expect(getHashes()).toContain('blake2b512');
+    expect(nativeBlake2b512(payload(10))).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Claim 1 — the native-first / fallback-second policy.
+// ---------------------------------------------------------------------------
+describe('digest policy: native first, vendored fallback second', () => {
+  const data = payload(5000);
+  const trueDigest = createHash('blake2b512').update(data).digest();
+
+  it('uses the fallback when native throws Electron/BoringSSL\'s exact error', () => {
+    const got = selectBlake2b512(data, electronNativeDigest, fallbackBlake2b512);
+    expect(got).not.toBeNull();
+    expect(got!.equals(trueDigest)).toBe(true);
+  });
+
+  it('uses the fallback when native reports unavailability by returning null', () => {
+    const got = selectBlake2b512(data, () => null, fallbackBlake2b512);
+    expect(got!.equals(trueDigest)).toBe(true);
+  });
+
+  it('uses the fallback when native returns a wrong-width digest', () => {
+    const got = selectBlake2b512(data, () => Buffer.alloc(32, 0xaa), fallbackBlake2b512);
+    expect(got!.equals(trueDigest)).toBe(true);
+  });
+
+  it('prefers native and does NOT consult the fallback when native works', () => {
+    const sentinel = Buffer.alloc(64, 0x5a);
+    const got = selectBlake2b512(data, () => sentinel, () => {
+      throw new Error('fallback must not be reached when native succeeds');
+    });
+    expect(got!.equals(sentinel)).toBe(true);
+  });
+
+  it('returns null — never a partial or fabricated digest — when BOTH fail', () => {
+    expect(selectBlake2b512(data, () => null, () => null)).toBeNull();
+    expect(selectBlake2b512(data, electronNativeDigest, () => {
+      throw new Error('no digest here either');
+    })).toBeNull();
+    expect(selectBlake2b512(data, () => null, () => Buffer.alloc(8))).toBeNull();
+  });
+
+  it('the production policy agrees with the fallback byte for byte', () => {
+    for (const n of [0, 1, 127, 128, 129, 4096]) {
+      const d = payload(n);
+      expect(blake2b512(d)!.toString('hex'), `length ${n}`).toBe(fallbackBlake2b512(d)!.toString('hex'));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Claim 2 — native and fallback are interchangeable inside a REAL verification.
+// The fixture SIGNS with node's native BLAKE2b-512 (see minisign-fixture.ts);
+// verifying those signatures through the fallback is therefore a genuine
+// cross-implementation agreement test, not a self-comparison.
+// ---------------------------------------------------------------------------
+describe('signatures signed with the NATIVE digest verify through the FALLBACK', () => {
+  const key = makeMinisignKeypair();
+  const forceFallback = { blake2b512: fallbackBlake2b512 };
+
+  // Empty, sub-block, exactly one block, just over one block, and multi-block.
+  const SIZES = [0, 1, 100, 128, 129, 4096, 200_000];
+
+  for (const n of SIZES) {
+    it(`verifies a prehashed signature over ${n} bytes with native forced unavailable`, () => {
+      const data = payload(n);
+      const sig = key.sign(data);
+      expect(verifyMinisign(key.publicKeyLine, sig, data, forceFallback)).toBe('verified');
+    });
+
+    it(`REJECTS a one-byte corruption of the ${n}-byte payload through the fallback`, () => {
+      const data = payload(n);
+      const sig = key.sign(data);
+      // A verifier that cannot reject is worse than no verifier. For the empty
+      // payload, corruption means appending a byte (there is none to flip).
+      const tampered = n === 0 ? Uint8Array.from([0x01]) : Uint8Array.from(data);
+      if (n > 0) tampered[Math.floor(n / 2)] ^= 0x01;
+      expect(verifyMinisign(key.publicKeyLine, sig, tampered, forceFallback)).toBe('signature-mismatch');
+    });
+  }
+
+  it('produces the same verdict under the fallback as under native, across the same corpus', () => {
+    for (const n of SIZES) {
+      const data = payload(n);
+      const sig = key.sign(data);
+      const nativeVerdict = verifyMinisign(key.publicKeyLine, sig, data, { blake2b512: nativeBlake2b512 });
+      const fallbackVerdict = verifyMinisign(key.publicKeyLine, sig, data, forceFallback);
+      expect(fallbackVerdict, `length ${n}`).toBe(nativeVerdict);
+      expect(fallbackVerdict).toBe('verified');
+    }
+  });
+
+  it('never consults the digest at all for a LEGACY (Ed) signature', () => {
+    // Legacy signs raw bytes. If the fallback were wired in unconditionally, this
+    // would blow up — the seam proves the digest is scoped to prehashed only.
+    const data = payload(300);
+    const legacySig = key.sign(data, { legacy: true });
+    const verdict = verifyMinisign(key.publicKeyLine, legacySig, data, {
+      blake2b512: () => {
+        throw new Error('digest must not be computed for a legacy Ed signature');
+      },
+    });
+    expect(verdict).toBe('verified');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Claim 3 — fail closed. Every assertion here has a positive control built from
+// the SAME keypair, payload and signature, differing only in the digest backend,
+// so "did not verify" cannot be an artefact of a broken fixture.
+// ---------------------------------------------------------------------------
+describe('fail-closed when no digest can be produced', () => {
+  const key = makeMinisignKeypair();
+  const data = payload(2048);
+  const sig = key.sign(data);
+
+  it('POSITIVE CONTROL: this exact fixture verifies when a digest IS available', () => {
+    expect(verifyMinisign(key.publicKeyLine, sig, data, { blake2b512: fallbackBlake2b512 })).toBe('verified');
+    expect(verifyMinisign(key.publicKeyLine, sig, data)).toBe('verified');
+  });
+
+  it('returns digest-unavailable — not verified — when the digest backend yields null', () => {
+    expect(verifyMinisign(key.publicKeyLine, sig, data, { blake2b512: () => null })).toBe('digest-unavailable');
+  });
+
+  it('returns digest-unavailable — not verified — when the digest backend THROWS', () => {
+    expect(
+      verifyMinisign(key.publicKeyLine, sig, data, {
+        blake2b512: () => {
+          throw new Error(ELECTRON_DIGEST_ERROR);
+        },
+      }),
+    ).toBe('digest-unavailable');
+  });
+
+  it('returns digest-unavailable for a wrong-width digest rather than hashing on regardless', () => {
+    expect(verifyMinisign(key.publicKeyLine, sig, data, { blake2b512: () => Buffer.alloc(32) })).toBe(
+      'digest-unavailable',
+    );
+  });
+
+  it('a WRONG but well-formed digest fails closed as signature-mismatch, never verified', () => {
+    const verdict = verifyMinisign(key.publicKeyLine, sig, data, { blake2b512: () => Buffer.alloc(64, 0xff) });
+    expect(verdict).toBe('signature-mismatch');
+    expect(verdict).not.toBe('verified');
+  });
+
+  it('verifyMinisign never throws, whatever the injected backend does', () => {
+    for (const backend of [
+      () => {
+        throw new Error('boom');
+      },
+      () => {
+        throw 'not even an Error';
+      },
+      () => null,
+      () => Buffer.alloc(0),
+    ]) {
+      expect(() => verifyMinisign(key.publicKeyLine, sig, data, { blake2b512: backend as never })).not.toThrow();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Claim 4 — the REAL published release signature. This is the premise the whole
+// fix rests on: our releases really are prehashed (`ED`), so the BLAKE2b path
+// really does run on every Unreal plugin install.
+// ---------------------------------------------------------------------------
+describe('the real v0.14.0 release signature', () => {
+  const realSignatureText = readFileSync(join(FIXTURES, 'unreal-mcp-plugin-source-0.14.0.zip.minisig'), 'utf8');
+
+  /**
+   * BLAKE2b-512 of the real published `unreal-mcp-plugin-source-0.14.0.zip`
+   * (131,089,755 bytes; sha256 7db3a5c4…786a), measured 2026-08-20 with BOTH
+   * node:crypto's native OpenSSL digest and the vendored fallback — they agreed
+   * byte for byte. The zip itself is far too large to commit; this digest is the
+   * part the signature actually covers.
+   */
+  const REAL_ZIP_BLAKE2B512 = Buffer.from(
+    '843e643e37733305730d7b6fbeff832152d98b16445de0b0d42534c400fb0744' +
+      'eae650fcf7d95672641da4f761db1c4a40838da242f5a1ecc1ae39df9c66c8d8',
+    'hex',
+  );
+
+  it('is tagged ED — PREHASHED — so verification really does need BLAKE2b-512', () => {
+    const sig = parseMinisignSignature(realSignatureText);
+    expect(sig).not.toBeNull();
+    expect(sig!.algorithm).toBe('ED');
+  });
+
+  it('was made with the key this CLI pins', () => {
+    const pub = parseMinisignPublicKey(MINISIGN_PUBLIC_KEY);
+    const sig = parseMinisignSignature(realSignatureText);
+    expect(pub).not.toBeNull();
+    expect(pub!.keyId.equals(sig!.keyId)).toBe(true);
+    // These are the 8 key-id bytes in WIRE order. `minisign -R` prints the same
+    // id as a little-endian u64, i.e. 194DD8FC6092DA33 — the form quoted in the
+    // MINISIGN_PUBLIC_KEY docblock and docs/RELEASING.md. Same key, two spellings.
+    expect(pub!.keyId.toString('hex')).toBe('33da9260fcd84d19');
+    expect(Buffer.from(pub!.keyId).reverse().toString('hex').toUpperCase()).toBe('194DD8FC6092DA33');
+  });
+
+  // The real signature + the real pinned key + the real file's BLAKE2b-512 digest
+  // ⇒ verified. Combined with the vector/differential proof that our fallback
+  // COMPUTES that digest from those bytes, this closes the chain end to end.
+  // (The full-file run is `npm run verify:real-asset`; measured verified under
+  // both Node 22 and Electron 43 on 2026-08-20.)
+  it('verifies against the pinned key when handed the real payload digest', () => {
+    expect(verifyMinisign(MINISIGN_PUBLIC_KEY, realSignatureText, new Uint8Array(0), {
+      blake2b512: () => REAL_ZIP_BLAKE2B512,
+    })).toBe('verified');
+  });
+
+  it('does NOT verify when that digest is altered by a single bit', () => {
+    const flipped = Buffer.from(REAL_ZIP_BLAKE2B512);
+    flipped[0] ^= 0x01;
+    expect(verifyMinisign(MINISIGN_PUBLIC_KEY, realSignatureText, new Uint8Array(0), { blake2b512: () => flipped })).toBe(
+      'signature-mismatch',
+    );
+  });
+
+  // OPT-IN full end-to-end over the real 131 MB asset. Not committed (too large);
+  // point UNREAL_MCP_REAL_ASSET_DIR at a directory holding the downloaded zip and
+  // its .minisig to run it. Reports loudly rather than silently skipping.
+  const realDir = process.env.UNREAL_MCP_REAL_ASSET_DIR;
+  const realZipPath = realDir ? join(realDir, 'unreal-mcp-plugin-source-0.14.0.zip') : '';
+  const haveRealZip = realZipPath !== '' && existsSync(realZipPath);
+
+  it.runIf(haveRealZip)(
+    'full end-to-end: the real 131 MB asset verifies through the FALLBACK and rejects a corrupted byte',
+    () => {
+      const zip = readFileSync(realZipPath);
+      expect(fallbackBlake2b512(zip)!.equals(REAL_ZIP_BLAKE2B512)).toBe(true);
+      expect(verifyMinisign(MINISIGN_PUBLIC_KEY, realSignatureText, zip, { blake2b512: fallbackBlake2b512 })).toBe(
+        'verified',
+      );
+      const corrupted = Buffer.from(zip);
+      corrupted[Math.floor(corrupted.length / 2)] ^= 0x01;
+      expect(verifyMinisign(MINISIGN_PUBLIC_KEY, realSignatureText, corrupted, { blake2b512: fallbackBlake2b512 })).toBe(
+        'signature-mismatch',
+      );
+    },
+    120_000,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Error text. The original failure reached the user as four bare words with no
+// indication of what failed or what to do; that is what these pin.
+// ---------------------------------------------------------------------------
+describe('failure messages carry context and a way forward', () => {
+  it('names the asset, the runtime and the escape hatch for digest-unavailable', () => {
+    const reason = signatureFailureReason(
+      'digest-unavailable',
+      'unreal-mcp-plugin-source-0.14.0.zip.minisig',
+      'electron 43.0.0, node 24.17.0, openssl 0.0.0',
+    );
+    expect(reason).toContain('unreal-mcp-plugin-source-0.14.0.zip.minisig');
+    expect(reason).toContain('BLAKE2b-512');
+    expect(reason).toContain('electron 43.0.0, node 24.17.0, openssl 0.0.0');
+    expect(reason).toContain('--plugin-source');
+    expect(reason).toContain('NOT verified');
+    // The bare four-word string the user used to see is not an acceptable message.
+    expect(reason).not.toBe('Digest method not supported');
+    expect(reason.length).toBeGreaterThan(80);
+  });
+
+  it('describes the runtime crypto backend from process.versions', () => {
+    expect(describeDigestRuntime({ electron: '43.0.0', node: '24.17.0', openssl: '0.0.0' })).toBe(
+      'electron 43.0.0, node 24.17.0, openssl 0.0.0',
+    );
+    expect(describeDigestRuntime({ node: '22.18.0', openssl: '3.0.16' })).toBe('node 22.18.0, openssl 3.0.16');
+    expect(describeDigestRuntime({})).toBe('unknown runtime');
+    // The default reads the live runtime, and must not be empty.
+    expect(describeDigestRuntime().length).toBeGreaterThan(0);
+  });
+
+  it('gives every failing verdict a distinct message that does not claim success', () => {
+    const failing: SignatureVerdict[] = [
+      'public-key-not-provisioned',
+      'public-key-unparsable',
+      'signature-unparsable',
+      'key-id-mismatch',
+      'unsupported-algorithm',
+      'digest-unavailable',
+      'signature-mismatch',
+      'global-signature-mismatch',
+    ];
+    const seen = new Set<string>();
+    for (const verdict of failing) {
+      const reason = signatureFailureReason(verdict, 'asset.minisig', 'test runtime');
+      // The `default:` arm of that switch returns "the signature was verified".
+      // A new verdict that forgot its case would land there and tell the user the
+      // opposite of the truth — so assert no failing verdict can produce it.
+      expect(reason, verdict).not.toContain('was verified');
+      expect(reason.length, verdict).toBeGreaterThan(20);
+      expect(seen.has(reason), `duplicate message for ${verdict}`).toBe(false);
+      seen.add(reason);
+    }
+  });
+});

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -110,13 +110,42 @@ precedent).
   runs, but an unsigned source zip cannot be verified, so it must not ship.)
 - **CLI side** — `cli/src/lib/plugin-signature.ts` (`verifyMinisign`) fetches the
   `.minisig` and verifies it against the baked-in `MINISIGN_PUBLIC_KEY` BEFORE the
-  zip is extracted. Any failure — missing / tampered / wrong-key / un-provisioned —
-  is a HARD fail; the zip is never installed. A local `--plugin-source <dir>` is a
-  trusted source and skips verification (the offline / dev / CI path).
+  zip is extracted. Any failure — missing / tampered / wrong-key / un-provisioned /
+  no-digest-available — is a HARD fail; the zip is never installed. A local
+  `--plugin-source <dir>` is a trusted source and skips verification (the offline /
+  dev / CI path).
+- **BLAKE2b-512 availability (why `cli/src/lib/blake2b.ts` exists).** `minisign -S`
+  defaults to the **prehashed `ED`** algorithm, so the Ed25519 signature covers
+  BLAKE2b-512(zip), not the zip bytes — every asset we have published is `ED`.
+  `node:crypto` gets its digests from the runtime's TLS library, and **only OpenSSL
+  builds carry BLAKE2**. Measured 2026-08-20: Node 22.18.0 (OpenSSL 3.0.16) offers
+  52 digests including `blake2b512`; **Electron 43.0.0 (BoringSSL, `openssl` reports
+  `0.0.0`) offers 9 and throws `Digest method not supported`**. The AI Game Dev
+  desktop app value-imports this package and runs it in-process under Electron, so
+  an unguarded `createHash('blake2b512')` broke Unreal plugin install outright
+  there. `verifyMinisign` now hashes **native-first with a vendored pure-JS RFC 7693
+  fallback**; if neither works it returns the fail-closed verdict
+  `digest-unavailable`. Re-signing old assets with the legacy `Ed` tag was
+  deliberately NOT done — it would strand every already-published signature.
+  **Do not "simplify" this back to a bare `createHash` call.** To re-check a real
+  release asset on any runtime:
 
-**⚠ Provisioning — REQUIRED before the next release (currently a follow-up).** The
-signing key is not yet minted, so `MINISIGN_PUBLIC_KEY` holds the sentinel
-`UNPROVISIONED` and the CLI download path fails closed. To provision:
+  ```bash
+  gh release download v0.14.0 --repo IvanMurzak/Unreal-MCP \
+    --pattern 'unreal-mcp-plugin-source-*.zip*' --dir /tmp/rel
+  cd cli && npm run build
+  npm run verify:real-asset -- /tmp/rel 0.14.0                  # Node
+  ELECTRON_RUN_AS_NODE=1 <electron> scripts/verify-real-asset.mjs /tmp/rel 0.14.0
+  ```
+
+**✅ Provisioned 2026-07-21** — `MINISIGN_PUBLIC_KEY` in
+`cli/src/lib/plugin-signature.ts` holds the real publisher key (minisign key id
+`194DD8FC6092DA33`; the same 8 bytes read off the wire in order are
+`33da9260fcd84d19` — minisign displays the id as a little-endian u64), and
+released assets carry a valid `.minisig`; the
+`UNPROVISIONED` sentinel remains only as the fail-closed default. (This paragraph
+previously said the key was "not yet minted" — stale since the key was provisioned.)
+To ROTATE the key:
 
 1. Mint a **passwordless** keypair (no key password, so CI signs non-interactively):
    `minisign -G -W -p unreal-mcp-plugin.pub -s unreal-mcp-plugin.key`. Keep


### PR DESCRIPTION
## The defect

Unreal plugin install is **100% broken in the packaged desktop app**, failing with the bare string `Digest method not supported`.

`cli/src/lib/plugin-signature.ts:267` hashed with `createHash('blake2b512')`. `node:crypto` delegates digests to the runtime's TLS library, and **only OpenSSL builds carry the BLAKE2 family**. Measured on this machine, 2026-08-20:

| runtime | `process.versions.openssl` | `getHashes()` | blake hashes | `createHash('blake2b512')` |
|---|---|---|---|---|
| Node 22.18.0 | `3.0.16` (OpenSSL) | 52 | `blake2b512`, `blake2s256` | works |
| **Electron 43.0.0** | **`0.0.0`** (BoringSSL) | **9** | **`[]`** | **throws `Digest method not supported`** |

minisign's default `ED` algorithm is **PREHASHED** — the Ed25519 signature covers `BLAKE2b-512(file)`, not the file bytes — and every published release is signed that way (the real `unreal-mcp-plugin-source-0.14.0.zip.minisig` signature blob begins `ED`). So that line ran on **every** Unreal plugin install. The desktop app value-imports this package (`packages/core/src/project/create-project.ts` does `import * as unrealCli from "unreal-mcp-cli"`) and runs it **in-process** under Electron, so the throw escaped `verifyMinisign` past every fail-closed verdict.

Unity and Godot are unaffected — their CLIs only hash `sha256`. `blake2b512` appears exactly once in `cli/src/`.

### Before / after, on the real 131 MB v0.14.0 release asset

| | Node 22.18.0 | Electron 43.0.0 |
|---|---|---|
| **pre-fix** (the parent commit's file, compiled and run as-is) | `verified` | `Error: Digest method not supported` |
| **post-fix** | `verified` | `verified` |
| post-fix, one byte corrupted | `signature-mismatch` | `signature-mismatch` |

## The fix

- **`cli/src/lib/blake2b.ts`** — a vendored, dependency-free RFC 7693 BLAKE2b-512.
- **`verifyMinisign` hashes native-first, fallback second.** The native path is unchanged and still preferred; on an OpenSSL runtime the fallback is never called.
- **Fail closed.** New `digest-unavailable` verdict when neither backend yields a 64-byte digest. Verification can never pass without a digest, and `verifyMinisign` no longer throws for any input.
- **Every already-published signature stays verifiable.** That is why this is a fallback and not a re-sign with the legacy `Ed` tag.

### Why vendored, not an npm package

This *is* the supply-chain verification path, so widening the dependency graph to fix it would be self-defeating. The implementation is ~120 lines, no imports, no I/O, and carries its own test vectors. 64-bit words are held as 32-bit lane pairs — `BigInt` is orders of magnitude too slow for a 131 MB asset. Measured throughput ~34 MB/s: **native 94 ms vs fallback 3.9 s** on the real asset, i.e. a one-time ~4 s cost on Electron installs only.

## Tests — and the vacuity trap they avoid

**Node HAS `blake2b512`.** A test that merely calls the verification path on this runtime takes the NATIVE branch and passes with the fallback deleted. Every assertion here therefore either forces the fallback explicitly or injects a native implementation that fails the way Electron really fails.

`tests/blake2b.test.ts` (40 tests) pins the implementation to constants produced by **other implementations**: the official published vectors (empty, `abc`, the pangram, one-million-`a`) and the BLAKE2 KAT sequence inputs at 127/128/129/255/256 bytes — all regenerated from **CPython 3.12.10 `hashlib.blake2b`**, the BLAKE2 reference implementation, independent of both OpenSSL and this code — plus a differential against native OpenSSL across 20 boundary lengths and 200 random ones. The SIGMA table was checked against RFC 7693 section 2.7 programmatically, not by eye.

`tests/plugin-signature-digest.test.ts` (37 tests) proves the policy switches over on Electron's exact error; that signatures signed with the **native** digest verify through the **fallback** at 0 / 1 / 100 / 128 / 129 / 4096 / 200,000 bytes; that a corrupted payload is **rejected** in every one of those cases; that a missing digest fails closed; and that the real v0.14.0 signature is `ED` and matches the pinned key.

### Plant rounds (each its own run, reverted after)

Correctness of the hash — `tests/blake2b.test.ts`, 40/40 green unplanted:

| plant | result |
|---|---|
| one SIGMA index corrupted | **28 failed** |
| rotation 24 to 25 | **34 failed** |
| final-block flag disabled | **34 failed** |
| **eager block flush** (the subtle one) | **8 failed — exactly the exact-block-multiple lengths (128/256/384/1024/4096/65536), nothing else** |
| param block digest length 64 to 32 | **34 failed** |

That fourth row is the point of the boundary table: a suite without exact-block-multiple inputs would have scored fully green on that bug.

Security behaviour — `tests/plugin-signature-digest.test.ts`, 37/37 green unplanted:

| plant | result |
|---|---|
| fallback neutralised (as if deleted) | **20 failed** |
| fail **open**: use the raw file bytes when the digest is null | **3 failed — exactly the fail-closed assertions** |
| `digest-unavailable` returns `verified` instead | **3 failed** |
| fallback "almost right" (one output byte flipped) | **14 failed** |
| drop the `digest-unavailable` message case, so it falls to the `default:` arm that returns *"the signature was verified"* | **2 failed** |

Every "X did not happen" assertion has a positive control on the **same** keypair, payload and signature differing only in the digest backend, so a failure cannot be an artefact of a broken fixture.

**Baseline:** pristine `main` = **532 passed / 1 skipped**, zero failing. This branch = **609 passed / 1 skipped**, zero failing (+76; the +1 skipped is the opt-in real-asset test). The 1 pre-existing skip is not mine.

## Electron probe — measured, not wired into CI

`cli/scripts/verify-real-asset.mjs` (`npm run verify:real-asset`) re-runs the real-asset check on any runtime. Verbatim, on this branch:

```
$ ELECTRON_RUN_AS_NODE=1 electron.exe scripts/verify-real-asset.mjs <dir> 0.14.0
runtime      : electron 43.0.0, node 24.17.0, openssl 0.0.0
asset        : unreal-mcp-plugin-source-0.14.0.zip (131089755 bytes)
native   b2b : UNAVAILABLE on this runtime [0 ms]
fallback b2b : 843e643e37733305730d7b6fbeff832152d98b16445de0b0d42534c400fb0744eae650fcf7d95672641da4f761db1c4a40838da242f5a1ecc1ae39df9c66c8d8 [4108 ms]
policy pick  : 843e643e37733305730d7b6fbeff832152d98b16445de0b0d42534c400fb0744eae650fcf7d95672641da4f761db1c4a40838da242f5a1ecc1ae39df9c66c8d8

real asset, production policy        => verified
real asset, fallback forced          => verified
corrupted asset, production policy   => signature-mismatch
corrupted asset, fallback forced     => signature-mismatch

RESULT=OK
```

The same script under Node 22.18.0 prints `agree : true` between the two backends, with the identical digest.

**This is NOT wired into CI, deliberately.** `test_cli.yml` runs on Node 20/22, and adding Electron as a devDependency of `unreal-mcp-cli` would widen the supply chain of the package whose supply-chain check this is. The right home for an Electron-runtime CI leg is `AI-Game-Dev-App`, which already has Electron — suggested as a follow-up, not done here.

## Error text

Scoped to the CLI's own message only; app-side surfacing is PR #423 and is not duplicated here. The `digest-unavailable` failure now names the asset, the runtime crypto backend, and the escape hatch, instead of four unattributable words.

## Also

`docs/RELEASING.md` claimed the minisign signing key was *"not yet minted"* and that `MINISIGN_PUBLIC_KEY` held the `UNPROVISIONED` sentinel. Stale — it was provisioned 2026-07-21 and the source holds the real key. Corrected, with a note that minisign displays the key id little-endian (`194DD8FC6092DA33`) while the wire bytes read `33da9260fcd84d19` — both spellings are now recorded so they do not look like a contradiction.

## Release — no action taken

`unreal-mcp-cli` is **not independently releasable**; it publishes as the terminal npm job of the Unreal-MCP plugin's release pipeline. **Merging this ships nothing to the desktop app.** No release was run, triggered, or requested. To reach users this needs, in order: (1) an Unreal-MCP version bump via the release pipeline, publishing a new `unreal-mcp-cli`; (2) an `AI-Game-Dev-App` dependency bump off `unreal-mcp-cli@^0.14.0`; (3) an app release. Owner's call.
