### PR TITLE
release: 0.15.0 — BLAKE2b fallback so Unreal plugin install works under Electron

### DIFF
--- a/UnrealMCP/UnrealMCP.uplugin
+++ b/UnrealMCP/UnrealMCP.uplugin
@@ -1,7 +1,7 @@
 {
   "FileVersion": 3,
   "Version": 1,
-  "VersionName": "0.14.0",
+  "VersionName": "0.15.0",
   "FriendlyName": "Unreal MCP (AI Game Developer)",
   "Description": "Model Context Protocol (MCP) integration for the Unreal Editor. Exposes editor operations as AI Tools so MCP-aware AI assistants (Claude, Cursor, Copilot, ...) can inspect and drive your Unreal project. Requires Unreal Engine 5.5+ (no EngineVersion pin: UE treats that field as an exact-build match, not a floor, and would refuse to load on newer engines).",
   "Category": "AI",

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>com.IvanMurzak.Unreal.MCP.Bridge</RootNamespace>
     <AssemblyName>unreal-mcp-bridge</AssemblyName>
-    <Version>0.14.0</Version>
+    <Version>0.15.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2026 Ivan Murzak</Copyright>

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unreal-mcp-cli",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@baizor/gamedev-cli-core": "^0.4.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Cross-platform CLI tool for Unreal-MCP (Skills & MCP). Resolves and launches the Unreal editor with MCP connection env vars, runs MCP/system tools over HTTP, probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and manages the UnrealMCP plugin. Works with Claude Code, Cursor, Copilot, and any MCP client.",
   "type": "module",
   "main": "dist/lib.js",


### PR DESCRIPTION
Version bump only (via `commands/bump-version.ps1`): `.uplugin` VersionName, bridge csproj `<Version>`, `cli/package.json` + `package-lock.json`. 0.14.0 → 0.15.0.

Merging this to `main` trips `release.yml`'s `check-version` gate and cuts the real release: GitHub Release + `v0.15.0` tag, signed plugin assets, and **`unreal-mcp-cli@0.15.0` to npm**.

## Why this release exists

It ships #283. The desktop app runs under Electron, whose BoringSSL build has **no BLAKE2**:

| runtime | openssl | digests | blake | `createHash('blake2b512')` |
|---|---|---|---|---|
| Node 22.18.0 | 3.0.16 | 52 | `blake2b512`, `blake2s256` | works |
| **Electron 43.0.0** | **`0.0.0`** | **9** | **`[]`** | **throws `Digest method not supported`** |

Our releases carry prehashed (`ED`) minisign signatures, so `verifyMinisign` hashed with `blake2b512` on every install. Unreal plugin install was therefore **100% broken in the packaged app** — and fine from the CLI, which runs under Node. Unity and Godot were unaffected because their CLIs hash `sha256` only.

## Why this is the blocking release

`unreal-mcp-cli` is not independently releasable — it publishes as the terminal npm job of this pipeline. Until `0.15.0` is on npm, `AI-Game-Dev-App` cannot depend on the fix, so an app release would ship Unreal install still broken.

## Evidence

Verified on the **real** 131 MB `v0.14.0` asset and its real `.minisig`: pre-fix Node `verified` / Electron throws; post-fix **both** `verified`; one corrupted byte → `signature-mismatch` on both. The vendored hash was independently checked against canonical RFC 7693 vectors under Electron, and byte-for-byte against native OpenSSL across 1/127/**128**/129/256/1000-byte inputs and non-zero-`byteOffset` pooled buffers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2qQmU8TqJ1qn3yu1MFtUM