### PR TITLE
SignInRequired on the status contract + UE-side D4 assisted re-auth consumer

### DIFF
--- a/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/DevControl/UnrealMcpDevControlServer.cpp
@@ -103,6 +103,7 @@ namespace
 			case EUnrealMcpDeviceAuthState::Pending:    return TEXT("Pending");
 			case EUnrealMcpDeviceAuthState::Authorized: return TEXT("Authorized");
 			case EUnrealMcpDeviceAuthState::Failed:     return TEXT("Failed");
+			case EUnrealMcpDeviceAuthState::SignInRequired: return TEXT("SignInRequired"); // d1 persistent dead-credential state
 			case EUnrealMcpDeviceAuthState::Idle: default: return TEXT("Idle");
 		}
 	}
@@ -379,11 +380,22 @@ int32 FUnrealMcpDevControlServer::RouteRequest(
 		{
 			StatusJson->SetArrayField(TEXT("aiAgents"), *InAgents);
 		}
+		// oauth-client-error-hygiene d1: forward an optional `cloudAuthState` verbatim ("Authorized" /
+		// "SignInRequired") so a smoke test / the live window can drive the Cloud sign-in indicator — including
+		// the D4 assisted re-auth once-gate — exactly the way the sidecar's §1.3 status feed would.
+		FString InCloudAuthState;
+		if (Body->TryGetStringField(TEXT("cloudAuthState"), InCloudAuthState) && !InCloudAuthState.IsEmpty())
+		{
+			StatusJson->SetStringField(TEXT("cloudAuthState"), InCloudAuthState);
+		}
 		ViewModelPtr->ApplyStatus(StatusJson);
 
 		OutResult->SetBoolField(TEXT("ok"), true);
 		OutResult->SetStringField(TEXT("connectionState"), DevControlConnectionStateLabel(ViewModelPtr->GetConnectionState()));
 		OutResult->SetNumberField(TEXT("aiAgentCount"), ViewModelPtr->GetAiAgents().Num());
+		// d1: echo the device-auth indicator too, so an injected cloudAuthState's effect (Pending on the
+		// assisted initiation, SignInRequired once the carousel guard holds) is assertable in one round-trip.
+		OutResult->SetStringField(TEXT("deviceAuthState"), DevControlDeviceAuthLabel(ViewModelPtr->GetDeviceAuthState()));
 		return 200;
 	}
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/SUnrealMcpMainWindow.cpp
@@ -657,6 +657,23 @@ TSharedRef<SWidget> SUnrealMcpMainWindow::BuildCloudAuthRow()
 					? EVisibility::Visible : EVisibility::Collapsed;
 			})
 			.Text_Lambda([this]() { return IsViewModelValid() ? FText::FromString(ViewModel->GetDeviceAuthError()) : FText::GetEmpty(); })
+		]
+		// Sign-in required (oauth-client-error-hygiene d1): the machine credential died terminally — the
+		// sidecar's `status` feed reported cloudAuthState=SignInRequired. A PERSISTENT line (D4 ladder step 3:
+		// after the one unattended assisted re-auth per session, no sign-in carousel) whose manual recovery is
+		// the Authorize button in the row above.
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 6, 0, 0)
+		[
+			SNew(STextBlock)
+			.AutoWrapText(true)
+			.ColorAndOpacity(FSlateColor(FUnrealMcpStyle::StatusOffline()))
+			.Visibility_Lambda([this]()
+			{
+				return (IsViewModelValid() && ViewModel->GetDeviceAuthState() == EUnrealMcpDeviceAuthState::SignInRequired)
+					? EVisibility::Visible : EVisibility::Collapsed;
+			})
+			.Text(LOCTEXT("SignInRequired",
+				"Sign in required — your saved sign-in is no longer valid. Click Authorize to open the sign-in page in your browser."))
 		];
 
 	// Whole Cloud body is visible only in Cloud mode.

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.cpp
@@ -313,12 +313,19 @@ void FUnrealMcpEditorViewModel::ApplyStatus(const TSharedPtr<FJsonObject>& Statu
 
 	ConnectionState = ParseConnectionState(StateRaw, bKeep);
 
-	// A `status` reflecting an authorized cloud session promotes the device-auth indicator.
+	// A `status` reflecting an authorized cloud session promotes the device-auth indicator; a
+	// "SignInRequired" (the machine credential died terminally — oauth-client-error-hygiene d1) demotes it
+	// to the persistent sign-in-required state and runs the D4 assisted re-auth ladder. Any OTHER value —
+	// the legacy documented "Unauthorized" (never emitted by a shipped sidecar) or a future addition — is
+	// deliberately ignored, never an error: the §1.3 contract requires consumers to tolerate unrecognized
+	// cloudAuthState values so the set can grow without a lockstep plugin release.
 	FString CloudAuthState;
 	if (Status->TryGetStringField(TEXT("cloudAuthState"), CloudAuthState))
 	{
 		if (CloudAuthState.Equals(TEXT("Authorized"), ESearchCase::IgnoreCase))
 			DeviceAuthState = EUnrealMcpDeviceAuthState::Authorized;
+		else if (CloudAuthState.Equals(TEXT("SignInRequired"), ESearchCase::IgnoreCase))
+			HandleSignInRequired();
 	}
 
 	AiAgents.Reset();
@@ -339,6 +346,49 @@ void FUnrealMcpEditorViewModel::ApplyStatus(const TSharedPtr<FJsonObject>& Statu
 					AiAgents.Add(Label);
 			}
 		}
+	}
+}
+
+void FUnrealMcpEditorViewModel::HandleSignInRequired()
+{
+	// A device flow already in flight owns the indicator: Pending means the user is (or is about to be)
+	// verifying in the browser, Connecting means an auth-start is queued awaiting the sidecar handshake
+	// (issue #99). A SignInRequired status racing either must not collapse the pending instructions or
+	// double-initiate the flow — the flow's own device-auth feed will settle the state.
+	if (DeviceAuthState == EUnrealMcpDeviceAuthState::Pending || DeviceAuthState == EUnrealMcpDeviceAuthState::Connecting)
+		return;
+
+	// Render the persistent sign-in-required state (the d1 "silent red" fix: the user SEES why the
+	// connection cannot come up instead of an eternally amber dot). The window shows the companion line +
+	// the manual Authorize button while in this state.
+	DeviceAuthState = EUnrealMcpDeviceAuthState::SignInRequired;
+
+	// D4 recovery-ladder step 2 — involve the user, unattended, at most ONCE per editor session per reason
+	// class (step 3, the carousel guard — Unity c1 parity): initiate the SIDECAR-owned device flow so its
+	// `device-auth` feed delivers the verification URL and ApplyDeviceAuth's one-shot OnOpenBrowser opens
+	// the default browser on it. A second same-reason verdict (the assisted flow failed, its device code
+	// expired unattended, or the fresh credential died again) must NOT re-open anything — persistent status
+	// + manual Authorize only. Cloud-gated: a Custom-mode editor has no cloud sign-in to assist.
+	if (Config.ConnectionMode != EUnrealMcpConnectionMode::Cloud)
+		return;
+	const FString ReasonClass = TEXT("SignInRequired");
+	if (AssistedAuthAttemptedReasons.Contains(ReasonClass))
+		return;
+	AssistedAuthAttemptedReasons.Add(ReasonClass);
+
+	// Fast-path send only: this status just arrived FROM the sidecar, so it is connected/handshaken. If the
+	// send still fails (racing an IPC drop), stay in SignInRequired — an UNATTENDED initiation must never
+	// spawn/restart the bridge or arm the issue-#99 queue/timeout machinery; the manual Authorize button
+	// routes through that robust path when the user acts. Reset the URL/code so the flow's fresh
+	// verification URL triggers ApplyDeviceAuth's first-URL browser open.
+	DeviceVerificationUrl.Reset();
+	DeviceUserCode.Reset();
+	DeviceAuthError.Reset();
+	if (OnSendAuth && OnSendAuth(TEXT("auth-start")))
+	{
+		DeviceAuthState = EUnrealMcpDeviceAuthState::Pending;
+		UE_LOG(LogUnrealMcp, Log,
+			TEXT("[Unreal-MCP] cloud sign-in required — starting the assisted re-authorization (the browser will open on the verification page)."));
 	}
 }
 

--- a/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
+++ b/UnrealMCP/Source/UnrealMcpEditor/Private/UI/UnrealMcpEditorViewModel.h
@@ -52,7 +52,15 @@ enum class EUnrealMcpDeviceAuthState : uint8
 	/** The device-code flow succeeded and a cloud token was stored. */
 	Authorized,
 	/** The flow failed, was denied, or expired. */
-	Failed
+	Failed,
+	/**
+	 * The machine credential died terminally (the sidecar's §1.3 `status` feed reported
+	 * `cloudAuthState: "SignInRequired"` — a refresh was rejected with a dead-family verdict): the user must
+	 * sign in again. A PERSISTENT state (oauth-client-error-hygiene d1 / recovery-ladder D4 step 3): once the
+	 * one unattended assisted re-auth per session has been spent, this renders status-only and the manual
+	 * Authorize button is the recovery action — no unattended sign-in carousel.
+	 */
+	SignInRequired
 };
 
 /**
@@ -389,6 +397,27 @@ private:
 	FString DeviceUserCode;
 	FString DeviceAuthError;
 	TArray<FString> AiAgents;
+
+	// --- D4 assisted re-auth (oauth-client-error-hygiene d1): once-gate + carousel guard. ---
+	/**
+	 * Reason classes for which the ONE unattended assisted re-auth of this editor session already fired
+	 * (recovery-ladder D4 step 3, the carousel guard — same semantics as Unity c1). A second same-reason
+	 * verdict (the assisted flow failed, expired unattended, or the fresh credential died again) renders the
+	 * persistent SignInRequired status ONLY; recovery is then the manual Authorize button. Session-scoped by
+	 * construction: the view-model lives from module startup to shutdown, so a full editor restart re-arms
+	 * the gate (deliberate — D4 wants the user involved until authorization succeeds). The only reason class
+	 * the status channel carries today is "SignInRequired" itself; keyed by string so a future
+	 * reason-bearing status (e.g. invalid_target's "server configuration error") inherits the guard.
+	 */
+	TSet<FString> AssistedAuthAttemptedReasons;
+	/**
+	 * Handle a `status` message whose cloudAuthState is "SignInRequired" (d1): render the persistent
+	 * sign-in-required state and — in Cloud mode, at most once per session per reason class — initiate the
+	 * sidecar-owned device flow unattended so the browser opens on the verification URL (the sidecar's
+	 * `device-auth` feed then drives ApplyDeviceAuth's one-shot OnOpenBrowser). Never restarts the bridge
+	 * (fast-path send only) and never stomps a device flow already in flight.
+	 */
+	void HandleSignInRequired();
 
 	// --- Issue #99: queue-while-connecting / flush-on-handshake / bounded-timeout for Authorize. ---
 	/** True when an auth-start is queued, awaiting the sidecar handshake to flush it (set in Connecting). */

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDevControlSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpDevControlSpec.cpp
@@ -252,6 +252,39 @@ void FUnrealMcpDevControlSpec::Define()
 				DevCtlBody(TEXT("{\"status\":\"Connected\"}")), &VM.Get(), Second);
 			TestEqual("cleared to empty", VM->GetAiAgents().Num(), 0);
 		});
+
+		It("forwards cloudAuthState so a SignInRequired verdict reaches the D4 ladder and /state renders it (d1)", [this]()
+		{
+			TSharedRef<FDevCtlRecording> Rec = MakeShared<FDevCtlRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = DevCtlMakeViewModel(Rec);
+			// Default config mode is Cloud; the DevCtl OnSendAuth stub always accepts, so the FIRST injected
+			// verdict spends the session's one unattended assisted initiation (→ Pending).
+			TSharedRef<FJsonObject> First = MakeShared<FJsonObject>();
+			const int32 FirstStatus = FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/inject/connection-status"),
+				DevCtlBody(TEXT("{\"status\":\"Connecting\",\"cloudAuthState\":\"SignInRequired\"}")), &VM.Get(), First);
+			TestEqual("first inject status", FirstStatus, 200);
+			TestEqual("assisted flow armed", First->GetStringField(TEXT("deviceAuthState")), FString(TEXT("Pending")));
+			TestTrue("auth-start reached the sidecar seam", Rec->AuthSent.Contains(TEXT("auth-start")));
+
+			// The assisted flow dies (terminal failed frame), then the SECOND verdict holds as the
+			// persistent sign-in-required indicator (the D4 carousel guard — no re-initiation).
+			TSharedRef<FJsonObject> FailedResult = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/inject/device-auth"),
+				DevCtlBody(TEXT("{\"state\":\"failed\",\"message\":\"The authorization request expired.\"}")), &VM.Get(), FailedResult);
+
+			TSharedRef<FJsonObject> Second = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(
+				TEXT("POST"), TEXT("/inject/connection-status"),
+				DevCtlBody(TEXT("{\"status\":\"Connecting\",\"cloudAuthState\":\"SignInRequired\"}")), &VM.Get(), Second);
+			TestEqual("persistent indicator echoed", Second->GetStringField(TEXT("deviceAuthState")), FString(TEXT("SignInRequired")));
+
+			// /state (the surface the smoke test + live window drive) reports the persistent state.
+			TSharedRef<FJsonObject> State = MakeShared<FJsonObject>();
+			FUnrealMcpDevControlServer::RouteRequest(TEXT("GET"), TEXT("/state"), nullptr, &VM.Get(), State);
+			TestEqual("state deviceAuthState", State->GetStringField(TEXT("deviceAuthState")), FString(TEXT("SignInRequired")));
+		});
 	});
 
 	Describe("Control mutators", [this]()

--- a/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
+++ b/UnrealMCP/Source/UnrealMcpEditorTests/Private/UnrealMcpEditorViewModelSpec.cpp
@@ -612,6 +612,179 @@ void FUnrealMcpEditorViewModelSpec::Define()
 		});
 	});
 
+	Describe("Cloud sign-in required (oauth-client-error-hygiene d1 — D4 assisted re-auth)", [this]()
+	{
+		It("initiates the assisted re-auth ONCE per session, opens the browser via the seam, then holds status-only (carousel guard)", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			// Default config mode is Cloud — the assisted path is armed. Count only auth-start frames.
+			auto SignInAuthStarts = [Rec]() { return Rec->AuthSent.FilterByPredicate([](const FString& T) { return T == TEXT("auth-start"); }).Num(); };
+
+			// The verdict envelope exactly as SidecarHost emits it: EmitStatusAsync(keepConnected ?
+			// "Connecting" : "Disconnected", cloudAuthState: "SignInRequired").
+			TSharedPtr<FJsonObject> Verdict = MakeShared<FJsonObject>();
+			Verdict->SetStringField(TEXT("connectionState"), TEXT("Connecting"));
+			Verdict->SetBoolField(TEXT("keepConnected"), true);
+			Verdict->SetStringField(TEXT("cloudAuthState"), TEXT("SignInRequired"));
+
+			// First verdict of the session: the ONE unattended initiation — auth-start sent, flow armed.
+			VM->ApplyStatus(Verdict);
+			TestEqual("assisted auth-start sent once", SignInAuthStarts(), 1);
+			TestEqual("pending after the assisted initiation",
+				static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Pending));
+
+			// The sidecar-owned flow answers with the verification URL → the browser opens ONCE via the seam
+			// (OnOpenBrowser — no real browser; the D4 "auto-open the default browser" leg).
+			TSharedPtr<FJsonObject> Pending = MakeShared<FJsonObject>();
+			Pending->SetStringField(TEXT("state"), TEXT("pending"));
+			Pending->SetStringField(TEXT("verificationUrl"), TEXT("https://ai-game.dev/device"));
+			Pending->SetStringField(TEXT("userCode"), TEXT("WXYZ-1234"));
+			VM->ApplyDeviceAuth(Pending);
+			TestEqual("browser opened once via the seam", Rec->OpenedUrls.Num(), 1);
+
+			// A repeated identical verdict while the flow is in flight: no re-initiation, no re-open, no stomp.
+			VM->ApplyStatus(Verdict);
+			TestEqual("no re-initiation while the flow is pending", SignInAuthStarts(), 1);
+			TestEqual("pending preserved",
+				static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Pending));
+
+			// The assisted flow expires unattended (the sidecar's terminal failed frame).
+			TSharedPtr<FJsonObject> Failed = MakeShared<FJsonObject>();
+			Failed->SetStringField(TEXT("state"), TEXT("failed"));
+			Failed->SetStringField(TEXT("message"), TEXT("The authorization request expired."));
+			VM->ApplyDeviceAuth(Failed);
+			TestEqual("failed after the unattended expiry",
+				static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Failed));
+
+			// Second same-reason verdict: the carousel guard — persistent status ONLY. No auth-start, no browser.
+			VM->ApplyStatus(Verdict);
+			TestEqual("no second unattended initiation (carousel guard)", SignInAuthStarts(), 1);
+			TestEqual("browser not re-opened", Rec->OpenedUrls.Num(), 1);
+			TestEqual("persistent sign-in-required status",
+				static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::SignInRequired));
+
+			// Every further identical status stays status-only (the once-gate holds for the whole session).
+			VM->ApplyStatus(Verdict);
+			TestEqual("still exactly one unattended initiation", SignInAuthStarts(), 1);
+			TestEqual("still sign-in-required",
+				static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::SignInRequired));
+
+			// The MANUAL Authorize button stays available after the guard engaged — the guard bounds only
+			// the unattended path, never the user's own action.
+			VM->Authorize();
+			TestEqual("manual Authorize still initiates", SignInAuthStarts(), 2);
+			TestEqual("pending after the manual Authorize",
+				static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Pending));
+		});
+
+		It("never stomps a device flow already in flight; the racing verdict does not consume the once-gate", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			auto SignInAuthStarts2 = [Rec]() { return Rec->AuthSent.FilterByPredicate([](const FString& T) { return T == TEXT("auth-start"); }).Num(); };
+
+			TSharedPtr<FJsonObject> Verdict = MakeShared<FJsonObject>();
+			Verdict->SetStringField(TEXT("connectionState"), TEXT("Connecting"));
+			Verdict->SetBoolField(TEXT("keepConnected"), true);
+			Verdict->SetStringField(TEXT("cloudAuthState"), TEXT("SignInRequired"));
+
+			// The user already pressed Authorize (manual flow in flight, browser instructions imminent).
+			VM->Authorize();
+			TestEqual("manual flow armed", SignInAuthStarts2(), 1);
+
+			// The verdict races in while Pending: it must neither collapse the flow nor double-initiate.
+			VM->ApplyStatus(Verdict);
+			TestEqual("no second auth-start while pending", SignInAuthStarts2(), 1);
+			TestEqual("pending preserved for the in-flight flow",
+				static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Pending));
+
+			// The manual flow dies; the NEXT verdict may spend the session's one unattended initiation —
+			// the racing verdict above did not consume the gate (positive control for the early return).
+			TSharedPtr<FJsonObject> Failed = MakeShared<FJsonObject>();
+			Failed->SetStringField(TEXT("state"), TEXT("failed"));
+			Failed->SetStringField(TEXT("message"), TEXT("Authorization was denied."));
+			VM->ApplyDeviceAuth(Failed);
+			VM->ApplyStatus(Verdict);
+			TestEqual("unattended initiation after the manual flow died", SignInAuthStarts2(), 2);
+			TestEqual("pending after the assisted initiation",
+				static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Pending));
+		});
+
+		It("renders but never auto-initiates outside Cloud mode; switching to Cloud re-arms it (positive control)", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+			auto SignInAuthStarts3 = [Rec]() { return Rec->AuthSent.FilterByPredicate([](const FString& T) { return T == TEXT("auth-start"); }).Num(); };
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Custom);
+
+			TSharedPtr<FJsonObject> Verdict = MakeShared<FJsonObject>();
+			Verdict->SetStringField(TEXT("connectionState"), TEXT("Disconnected"));
+			Verdict->SetBoolField(TEXT("keepConnected"), false);
+			Verdict->SetStringField(TEXT("cloudAuthState"), TEXT("SignInRequired"));
+
+			VM->ApplyStatus(Verdict);
+			TestEqual("no unattended auth-start in Custom mode", SignInAuthStarts3(), 0);
+			TestEqual("no browser open in Custom mode", Rec->OpenedUrls.Num(), 0);
+			TestEqual("state still rendered (truthful indicator)",
+				static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::SignInRequired));
+
+			// Positive control on the SAME fixture: Cloud mode DOES initiate — the negative half above can fail.
+			VM->SetConnectionMode(EUnrealMcpConnectionMode::Cloud);
+			VM->ApplyStatus(Verdict);
+			TestEqual("initiated once back in Cloud mode", SignInAuthStarts3(), 1);
+		});
+
+		It("ignores legacy and unknown cloudAuthState values; recognized values still act (§1.3 forward compatibility)", [this]()
+		{
+			TSharedRef<FRecording> Rec = MakeShared<FRecording>();
+			TSharedRef<FUnrealMcpEditorViewModel> VM = MakeViewModel(Rec);
+
+			// The legacy documented value (never emitted by a shipped sidecar) and a future unknown value:
+			// both must be IGNORED — no state change, no auth send, no crash (the tolerance the contract
+			// requires of every consumer so the value set can grow without a lockstep plugin release).
+			for (const TCHAR* Unrecognized : { TEXT("Unauthorized"), TEXT("SomeFutureState") })
+			{
+				TSharedPtr<FJsonObject> Status = MakeShared<FJsonObject>();
+				Status->SetStringField(TEXT("connectionState"), TEXT("Connected"));
+				Status->SetBoolField(TEXT("keepConnected"), true);
+				Status->SetStringField(TEXT("cloudAuthState"), Unrecognized);
+				VM->ApplyStatus(Status);
+				TestEqual("unrecognized value left the device-auth state alone",
+					static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Idle));
+			}
+			TestEqual("no auth frames sent for unrecognized values", Rec->AuthSent.Num(), 0);
+
+			// An absent field (Custom mode / pre-cloud sidecar) also leaves the state alone.
+			TSharedPtr<FJsonObject> NoField = MakeShared<FJsonObject>();
+			NoField->SetStringField(TEXT("connectionState"), TEXT("Connected"));
+			NoField->SetBoolField(TEXT("keepConnected"), true);
+			VM->ApplyStatus(NoField);
+			TestEqual("absent field left the device-auth state alone",
+				static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Idle));
+
+			// Positive control on the same fixture family: recognized values DO act — "Authorized" promotes…
+			TSharedPtr<FJsonObject> AuthorizedStatus = MakeShared<FJsonObject>();
+			AuthorizedStatus->SetStringField(TEXT("connectionState"), TEXT("Connected"));
+			AuthorizedStatus->SetBoolField(TEXT("keepConnected"), true);
+			AuthorizedStatus->SetStringField(TEXT("cloudAuthState"), TEXT("Authorized"));
+			VM->ApplyStatus(AuthorizedStatus);
+			TestEqual("Authorized promoted the indicator",
+				static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Authorized));
+
+			// …and a case-variant "signinrequired" demotes it (the matcher is case-insensitive, like the
+			// long-standing Authorized matcher) and runs the assisted initiation.
+			TSharedPtr<FJsonObject> LowerVerdict = MakeShared<FJsonObject>();
+			LowerVerdict->SetStringField(TEXT("connectionState"), TEXT("Connecting"));
+			LowerVerdict->SetBoolField(TEXT("keepConnected"), true);
+			LowerVerdict->SetStringField(TEXT("cloudAuthState"), TEXT("signinrequired"));
+			VM->ApplyStatus(LowerVerdict);
+			TestEqual("case-variant verdict initiated the assisted flow",
+				static_cast<int32>(VM->GetDeviceAuthState()), static_cast<int32>(EUnrealMcpDeviceAuthState::Pending));
+			TestTrue("auth-start sent for the case-variant verdict", Rec->AuthSent.Contains(TEXT("auth-start")));
+		});
+	});
+
 	Describe("Custom-mode host trimming (§7 validated field)", [this]()
 	{
 		It("trims surrounding whitespace before storing and pushing the dial target", [this]()

--- a/bridge/src/Ipc/IpcMessages.cs
+++ b/bridge/src/Ipc/IpcMessages.cs
@@ -350,7 +350,16 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Ipc
         /// <summary>One of <c>Connected</c> / <c>Connecting</c> / <c>Disconnected</c> / <c>Degraded</c>.</summary>
         [JsonPropertyName("connectionState")] public string ConnectionState { get; set; } = "Disconnected";
         [JsonPropertyName("keepConnected")] public bool KeepConnected { get; set; }
-        /// <summary>One of <c>Authorized</c> / <c>Unauthorized</c> (Cloud mode only; null in Custom).</summary>
+        /// <summary>
+        /// One of <c>Authorized</c> / <c>SignInRequired</c> (Cloud mode only; null in Custom, or when no cloud
+        /// credential of either kind is present). <c>Authorized</c>: an in-session bearer or a signed-in machine
+        /// credential backs the connection. <c>SignInRequired</c>: the machine credential died terminally (a
+        /// refresh was rejected with a dead-family verdict — the user must sign in again); emitted by the
+        /// <c>OnSignInRequired</c> subscription wired in <c>SidecarHost.Build</c>. The legacy documented value
+        /// <c>Unauthorized</c> was never emitted by any shipped sidecar. Consumers MUST tolerate unrecognized
+        /// values (ignore, never fail) so this set can grow without a lockstep plugin release — the C++
+        /// <c>ApplyStatus</c> honours that by matching known values and ignoring the rest.
+        /// </summary>
         [JsonPropertyName("cloudAuthState")] public string? CloudAuthState { get; set; }
         [JsonPropertyName("aiAgents")] public List<string> AiAgents { get; set; } = new();
     }

--- a/bridge/tests/IpcProtocolV2Tests.cs
+++ b/bridge/tests/IpcProtocolV2Tests.cs
@@ -182,5 +182,55 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             Assert.Equal("aGVsbG8=", respBack.Contents![1].Blob);   // base64 binary rides intact
             Assert.Null(respBack.Contents![1].Text);
         }
+
+        // --- §1.3 `status` cloudAuthState (oauth-client-error-hygiene d1) -----------------------------------
+
+        [Fact]
+        public void Status_CloudAuthState_SignInRequired_RoundTripsOnTheWire()
+        {
+            // The third contract value (IpcMessages.cs StatusMessage.CloudAuthState): a terminal dead-family
+            // verdict rides the status channel as "SignInRequired" — pin the exact wire spelling the C++
+            // ApplyStatus matches on, so a casing/rename drift is caught here rather than as a silent no-op
+            // in the editor (the C++ side deliberately IGNORES unrecognized values).
+            var status = new StatusMessage
+            {
+                ConnectionState = "Connecting",
+                KeepConnected = true,
+                CloudAuthState = "SignInRequired",
+            };
+
+            var json = JsonSerializer.Serialize(status, IpcProtocol.JsonOptions);
+            Assert.Contains("\"type\":\"status\"", json);
+            Assert.Contains("\"cloudAuthState\":\"SignInRequired\"", json);
+
+            var back = JsonSerializer.Deserialize<StatusMessage>(json, IpcProtocol.JsonOptions)!;
+            Assert.Equal("SignInRequired", back.CloudAuthState);
+            Assert.Equal("Connecting", back.ConnectionState);
+            Assert.True(back.KeepConnected);
+        }
+
+        [Theory]
+        [InlineData("Authorized")]    // the long-standing emitted value
+        [InlineData("Unauthorized")]  // legacy documented value (never emitted) — must still parse
+        [InlineData("SomeFutureState")] // a value from a NEWER peer — the string field must carry it, not throw
+        public void Status_LegacyAndUnknownCloudAuthValues_StillParse(string value)
+        {
+            // The CloudAuthState field is a plain string on the wire (no C#-side enum/validation), so a
+            // legacy or future value must deserialize losslessly — growing the value set can never break an
+            // older sidecar's parse. This is the C# half of the "tolerate the third value" contract; the C++
+            // half (ApplyStatus ignores unrecognized values) is locked in UnrealMcpEditorViewModelSpec.
+            var json = $"{{\"type\":\"status\",\"connectionState\":\"Connected\",\"keepConnected\":true,\"cloudAuthState\":\"{value}\",\"aiAgents\":[]}}";
+            var back = JsonSerializer.Deserialize<StatusMessage>(json, IpcProtocol.JsonOptions)!;
+            Assert.Equal(value, back.CloudAuthState);
+        }
+
+        [Fact]
+        public void Status_AbsentCloudAuthState_ParsesAsNull()
+        {
+            // Custom mode / no cloud credential: the field is simply absent (null) — the pre-cloud contract.
+            var json = "{\"type\":\"status\",\"connectionState\":\"Connected\",\"keepConnected\":true,\"aiAgents\":[]}";
+            var back = JsonSerializer.Deserialize<StatusMessage>(json, IpcProtocol.JsonOptions)!;
+            Assert.Null(back.CloudAuthState);
+        }
     }
 }

--- a/bridge/tests/MachineCredentialTests.cs
+++ b/bridge/tests/MachineCredentialTests.cs
@@ -453,5 +453,54 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
 
             host.Dispose(); // disposes the coordinator + subscription + provider without throwing
         }
+
+        // --- oauth-client-error-hygiene d1: dead-family verdict → "SignInRequired" on the status feed ----------
+
+        /// <summary>A refresher whose every attempt is the dead-family verdict (invalid_grant, 04 §3.5).</summary>
+        internal sealed class InvalidGrantRefresher : ITokenRefresher
+        {
+            public Task<TokenRefreshResult> RefreshAsync(string refreshToken, string? serverTarget, CancellationToken cancellationToken = default)
+                => Task.FromResult(TokenRefreshResult.Failure("refresh token expired", TokenRefreshFailureKind.InvalidGrant));
+        }
+
+        [Fact]
+        public async Task TerminalRefreshFailure_EmitsSignInRequiredStatus()
+        {
+            // d1 contract: SidecarHost.Build wires provider.OnSignInRequired → a status emit carrying
+            // cloudAuthState "SignInRequired" (the third documented StatusMessage value). Drive the only
+            // signal source — a terminal invalid_grant verdict, confirmed dead by the provider's
+            // post-failure re-read — through the REAL subscription, and pin the exact wire spelling the
+            // C++ ApplyStatus consumer matches on. Store + refresher are local fakes; no network.
+            var dir = NewStoreDir();
+            new MachineCredentialStore(dir).Write(new MachineCredentials
+            {
+                ServerTarget = "https://ai-game.dev",
+                Families = new MachineCredentialFamilies
+                {
+                    Plugin = new MachineCredentialFamily
+                    {
+                        AccessToken = "plugin-jwt", RefreshToken = "dead-refresh",
+                        ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+                        ClientId = "unreal-mcp-plugin", Scope = "mcp:plugin",
+                    },
+                },
+            });
+            using var host = new SidecarHost(NewIpc(), "0.1.0",
+                credentialStore: new MachineCredentialStore(dir),
+                tokenRefresher: new InvalidGrantRefresher());
+            var statuses = new List<StatusMessage>();
+            host.SetStatusEmitterForTest(s => { statuses.Add(s); return Task.CompletedTask; });
+            host.ApplyConnectionConfig(CloudConfig());
+            host.Build(); // wires the OnSignInRequired → status subscription
+
+            Assert.True(host.CredentialProvider!.IsSignedIn);
+            // Control (both halves): before the verdict, NO status claims SignInRequired — so the positive
+            // assert below cannot pass on an emit that predates the refresh failure.
+            Assert.DoesNotContain(statuses, s => s.CloudAuthState == "SignInRequired");
+
+            Assert.False(await host.CredentialProvider!.RefreshAsync()); // invalid_grant → dead family
+
+            Assert.Contains(statuses, s => s.CloudAuthState == "SignInRequired");
+        }
     }
 }


### PR DESCRIPTION
Closes the Unreal half of the silent-red dead-credential gap (taskflow `2026-08-24-oauth-client-error-hygiene`, task **d1**). The sidecar already emits `cloudAuthState: "SignInRequired"` on a terminal refresh verdict (`SidecarHost.cs` OnSignInRequired subscription); the contract documented only `Authorized`/`Unauthorized` and no UE-side consumer existed, so the user saw nothing.

## bridge (C#)
- `IpcMessages.cs`: `StatusMessage.CloudAuthState` now documents the real value set — `Authorized` / `SignInRequired` (null in Custom / no credential); consumers must tolerate unrecognized values.
- New tests (`IpcProtocolV2Tests`): SignInRequired wire round-trip pinning the exact spelling; legacy (`Authorized`/`Unauthorized`) and unknown values still parse; absent field parses null.
- New behavioral test (`MachineCredentialTests.TerminalRefreshFailure_EmitsSignInRequiredStatus`): a terminal `invalid_grant` refresh driven through the REAL `Build()` wiring emits a status carrying `SignInRequired` (with a same-fixture pre-verdict control). Plant-verified: removing `Build()` reddens it.

## UE plugin (C++)
- New `EUnrealMcpDeviceAuthState::SignInRequired`; `ApplyStatus` consumes the third value (case-insensitive, matching the Authorized matcher) and ignores unrecognized/legacy values — the tolerant-parse contract.
- **D4 recovery ladder**: on the first verdict of a session, ONE unattended assisted re-auth — `auth-start` to the sidecar-owned device flow; the flow's `device-auth` feed opens the default browser one-shot through the existing `OnOpenBrowser` seam (`FPlatformProcess::LaunchURL` in the window). **Carousel guard** (Unity c1 parity): a second same-reason verdict renders the persistent status only; recovery is the manual Authorize button. Never stomps an in-flight flow; never spawns/restarts the bridge unattended; Cloud-mode gated; the sidecar keeps ownership of all polling.
- Main window renders a persistent "Sign in required" line; DevControl labels the new state, and `/inject/connection-status` forwards an optional `cloudAuthState` + echoes `deviceAuthState` so smoke tests / the dev bridge can drive the ladder end-to-end.

## Evidence
- Bridge xUnit: **354/354 green** locally (includes `MachineAuthAdoptionTests`); plant on the new behavioral test RED → revert → GREEN.
- UE 5.7 Automation (`UnrealMcp` filter, headless, index.json authoritative): **401/401 Success**, including 5 new specs (once-gate, carousel guard, in-flight protection, Custom-mode gate + positive control, unknown-value tolerance, DevControl `/state` rendering).
- Once-gate plant (gate recording removed): exactly the carousel-guard assertions reddened ("no second unattended initiation ... was 2"), then GREEN after revert.
- **No `VersionName` bump** — r3 owns the release (`release.yml` is version-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVipj7Xi4HouAmmdCYSdmz