### PR TITLE
release: 0.16.0 — McpPlugin 8.3.0 (a1–a3 OAuth error hygiene) + SignInRequired D4 consumer

### DIFF
--- a/UnrealMCP/UnrealMCP.uplugin
+++ b/UnrealMCP/UnrealMCP.uplugin
@@ -1,7 +1,7 @@
 {
   "FileVersion": 3,
   "Version": 1,
-  "VersionName": "0.15.0",
+  "VersionName": "0.16.0",
   "FriendlyName": "Unreal MCP (AI Game Developer)",
   "Description": "Model Context Protocol (MCP) integration for the Unreal Editor. Exposes editor operations as AI Tools so MCP-aware AI assistants (Claude, Cursor, Copilot, ...) can inspect and drive your Unreal project. Requires Unreal Engine 5.5+ (no EngineVersion pin: UE treats that field as an exact-build match, not a floor, and would refuse to load on newer engines).",
   "Category": "AI",

--- a/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
+++ b/bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>com.IvanMurzak.Unreal.MCP.Bridge</RootNamespace>
     <AssemblyName>unreal-mcp-bridge</AssemblyName>
-    <Version>0.15.0</Version>
+    <Version>0.16.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2026 Ivan Murzak</Copyright>
@@ -51,7 +51,7 @@
 
   <!--
     Reused NuGet pins — normally owned by the upstream release pipelines and kept in lockstep
-    with Godot-MCP (Godot-MCP.csproj). Current: McpPlugin 8.1.0 + ReflectorNet 5.4.0.
+    with Godot-MCP (Godot-MCP.csproj). Current: McpPlugin 8.3.0 + ReflectorNet 5.4.0.
     The MCP/reflection stack is NOT forked. Historical context: the 6.8.0 bump consumed the new
     shared engine-agnostic com.IvanMurzak.McpPlugin.AgentConfig module (the AI-agent configurators
     + the AgentConfiguratorDescription UI-DTO) so the sidecar hosts the AI-agent configuration
@@ -89,6 +89,13 @@
     McpPlugin 7.5.0 -> 7.5.1: the downstream bump the entry above was preparing for, now landed. Patch
     release from MCP-Plugin-dotnet; its raised transitive ReflectorNet floor (>= 5.3.3) is already
     satisfied by the explicit ReflectorNet pin, so restore is clean (no NU1605).
+    McpPlugin 8.1.0 -> 8.3.0 (oauth-client-error-hygiene r3): carries the a1-a3 OAuth error-hygiene
+    wave — 401/refresher terminal-failure classification, the dead-credential-family memo (new public
+    SignInRequiredReason + optional recheck-period ctor), and the ConnectionCredentialCoordinator
+    stop/resume seam (new public additive ConnectionAttemptResult enum) — ending the unbounded
+    dead-credential reconnect flood. The sidecar's existing SignInRequired status emit pairs with the
+    UE-side D4 consumer (#285) shipped in this same release. ReflectorNet floor stays 5.4.0 (8.3.0
+    keeps it), so the explicit pin is unchanged.
   -->
   <!--
     Local-LIB dev toggle (auth-fixes f1b — parity with the GameDev-MCP-Server + Unity/Godot
@@ -123,7 +130,7 @@
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.4.0" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="8.1.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="8.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unreal-mcp-cli",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@baizor/gamedev-cli-core": "^0.4.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unreal-mcp-cli",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Cross-platform CLI tool for Unreal-MCP (Skills & MCP). Resolves and launches the Unreal editor with MCP connection env vars, runs MCP/system tools over HTTP, probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and manages the UnrealMCP plugin. Works with Claude Code, Cursor, Copilot, and any MCP client.",
   "type": "module",
   "main": "dist/lib.js",


### PR DESCRIPTION
## Release 0.16.0 (taskflow oauth-client-error-hygiene, task r3)

Ships the Unreal plugin + sidecar release carrying the shared-lib OAuth error-hygiene fix and the UE-side sign-in consumer. Unreal shares Unity's unbounded dead-credential reconnect default; adopting McpPlugin 8.3.0 ends its share of the 401 flood.

### What this PR changes
- **McpPlugin NuGet pin 8.1.0 → 8.3.0** (`bridge/src/com.IvanMurzak.Unreal.MCP.Bridge.csproj`) — carries MCP-Plugin-dotnet #211/#212/#213: 401/refresher terminal-failure classification, the dead-credential-family memo (public `SignInRequiredReason` + optional recheck period), and the `ConnectionCredentialCoordinator` stop/resume seam (public additive `ConnectionAttemptResult`). ReflectorNet floor stays 5.4.0 — explicit pin unchanged, restore clean (no NU1605).
- **Version 0.15.0 → 0.16.0** via `commands/bump-version.ps1` (uplugin `VersionName`, bridge csproj `<Version>`, `cli/package.json` + lock). Minor per the classify rule: one `feat` commit (#285) since `v0.15.0`.

### What the release carries from main
- #285 — SignInRequired on the status contract + UE-side D4 assisted re-auth consumer (browser-open, once-gated; merged without a VersionName bump — this PR owns the release trigger).

### Release mechanics
Merging this PR bumps `VersionName` on an untagged version ⇒ `release.yml` fires: test fan-out (bridge, cli, UE 5.5/5.6/5.7/5.8 Automation) → signed bridge artifacts → GitHub Release `v0.16.0` (packaged + source plugin zips + 4 signed bridge zips) → `unreal-mcp-cli@0.16.0` npm publish (OIDC) as the terminal leg. Verify by artifact, not workflow conclusion (runner-skip gotcha: `publish-release`/`publish-npm` must have RUN, not skipped).

### Local verification
- `dotnet restore` clean — no NU1605 (McpPlugin 8.3.0 keeps ReflectorNet 5.4.0)
- Bridge build: 0 warnings, 0 errors
- Bridge tests: **354/354 passed** against McpPlugin 8.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVipj7Xi4HouAmmdCYSdmz