### PR TITLE
feat(bridge): stamp the generated-by provenance marker into generated SKILL.md front matter

### DIFF
--- a/bridge/src/AgentConfig/SkillFileGenerator.cs
+++ b/bridge/src/AgentConfig/SkillFileGenerator.cs
@@ -53,20 +53,45 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.AgentConfig
         /// YAML front-matter key holding the provenance block. In the Skills file format used by Codex (and
         /// Anthropic Agent Skills) <c>metadata</c> is a declared front-matter field carrying a free-form mapping
         /// of extra keys, which is why the marker nests under it rather than sitting as a bare top-level key a
-        /// host would simply ignore.
+        /// host would simply ignore. (That framing is the shared library's own, restated here rather than
+        /// re-derived — nothing in this repository pins the host format.)
+        /// <para>
+        /// This and the two constants below are <c>public</c> to mirror the shared library, which publishes the
+        /// same three — so a later unification has a name-for-name seam. They are not consumed outside this
+        /// class today; the tests reach them through <c>InternalsVisibleTo</c> either way.
+        /// </para>
         /// </summary>
         public const string ProvenanceBlockKey = "metadata";
 
         /// <summary>
         /// Key, nested under <see cref="ProvenanceBlockKey"/>, marking a SKILL.md as written by a generator
-        /// rather than hand-authored by a user. A consumer that dedups generated skills against the live tool
-        /// catalog keys on this; an unmarked file is treated as hand-authored and always kept (fail-open).
+        /// rather than hand-authored by a user. It exists so a consumer that dedups generated skills against
+        /// the live tool catalog can tell the two apart and leave user-authored files alone; such a consumer
+        /// is expected to be fail-open (an unmarked file is kept). No consumer exists in this repository yet,
+        /// so the marker is currently inert here — and note that <see cref="PruneStaleSkillFolders"/> is NOT
+        /// one: it deletes on the presence of a SKILL.md, not on this marker.
+        /// <para>
+        /// Matching a marked file back to a catalog entry relies on the front matter's <c>name:</c> — see
+        /// <see cref="SanitizeSkillFolderName"/>, which is the identity on the kebab-case ids the registry
+        /// validates and lossy on anything else.
+        /// </para>
         /// </summary>
         public const string ProvenanceKey = "generated-by";
 
         /// <summary>
         /// Value written for <see cref="ProvenanceKey"/>. Deliberately carries NO version and NO timestamp, so
         /// regenerating an unchanged tool rewrites a byte-identical file.
+        /// <para>
+        /// The same two lines that <c>com.IvanMurzak.McpPlugin.Skills.SkillFileGenerator</c> emits — verified
+        /// against the MCP-Plugin-dotnet source at the time of writing, and NOT present in the released 8.3.0
+        /// this bridge pins, so nothing here fails if the shared value drifts. Re-check at the next McpPlugin
+        /// bump, and prefer emitting from the shared constants once a release carries them.
+        /// </para>
+        /// <para>
+        /// Same line CONTENT, not the same bytes: the shared generator uses <c>AppendLine</c>, so its
+        /// terminator is <c>Environment.NewLine</c>, while this one joins with <c>"\n"</c>. A consumer must
+        /// therefore match the marker per line, never as one raw byte run.
+        /// </para>
         /// </summary>
         public const string ProvenanceValue = "mcp-plugin-dotnet";
 
@@ -260,20 +285,18 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.AgentConfig
 
             var lines = new List<string>();
 
-            // YAML front-matter (name + description + the provenance marker).
+            // YAML front-matter.
             lines.Add("---");
             lines.Add($"name: {folderName}");
             lines.Add($"description: \"{yamlDesc}\"");
-            // Provenance marker — the LAST block INSIDE the front matter, immediately before the closing `---`,
-            // byte-identical to the shared com.IvanMurzak.McpPlugin AgentConfig generator's own marker (which
-            // Unity and the Godot C# addon inherit by subclassing; this class is independent, so it stamps its
-            // own). A consumer that dedups generated skills parses the front matter only, so a marker written
-            // after the closing `---` would be invisible to it.
-            //
-            // Written RAW from these constants, never through EscapeYamlQuoted: that helper escapes a single
-            // scalar and would collapse the nested mapping into a quoted string. Nothing tool-derived reaches
-            // these two lines, so a tool description cannot forge the marker — the description itself is
-            // single-lined and double-quoted above, which is what keeps it from breaking out of its scalar.
+            // Provenance marker (what it is FOR: see ProvenanceKey / ProvenanceValue). Three mechanical
+            // constraints hold here: it is the LAST block INSIDE the front matter, immediately before the
+            // closing `---`, because a consumer parses the front matter only and would never see it below;
+            // the two-space indent is what makes it a nested mapping rather than a sibling scalar; and it is
+            // written RAW from the constants, never through EscapeYamlQuoted, which escapes a single scalar
+            // and would collapse the nested mapping into a quoted string. Nothing tool-derived reaches these
+            // two lines, and the description above cannot break out of its own scalar to forge them — see
+            // SingleLineCapped for the mechanism and its limits.
             lines.Add($"{ProvenanceBlockKey}:");
             lines.Add($"  {ProvenanceKey}: {ProvenanceValue}");
             lines.Add("---");
@@ -395,6 +418,17 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.AgentConfig
 
         // --- Formatting helpers (mirror the C++ generator) ------------------------------------------
 
+        /// <summary>
+        /// Flatten a description to a single capped line for the YAML <c>description:</c> scalar.
+        /// <para>
+        /// Load-bearing beyond formatting: flattening CR/LF/tab is what stops a tool description from spanning
+        /// several front-matter lines and forging a second top-level <c>metadata:</c> block (see
+        /// <see cref="ProvenanceKey"/>). That guarantee is scoped to a real YAML parser — this does NOT
+        /// neutralise U+0085 / U+2028 / U+2029 or other C0 controls, which a purely line-oriented reader (a
+        /// regex under the <c>m</c> flag) would treat as line breaks. Long-standing behaviour; if you tighten
+        /// it, the marker's forgery guard is what you are strengthening.
+        /// </para>
+        /// </summary>
         internal static string SingleLineCapped(string input, int maxLen)
         {
             var flat = (input ?? string.Empty)

--- a/bridge/src/AgentConfig/SkillFileGenerator.cs
+++ b/bridge/src/AgentConfig/SkillFileGenerator.cs
@@ -32,7 +32,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.AgentConfig
     /// library: putting it upstream would force another NuGet release, and the SKILL.md shape (the param table
     /// derived from the input schema, the <c>unreal-mcp-cli run-tool</c> call form) is Unreal-specific.
     ///
-    /// Output shape (1:1 with the removed C++ generator): YAML front-matter (name + capped single-line description)
+    /// Output shape (1:1 with the removed C++ generator, plus the provenance marker): YAML front-matter (name +
+    /// capped single-line description + the <c>metadata: / generated-by:</c> marker that identifies the file as
+    /// generated rather than hand-authored — see <see cref="ProvenanceKey"/>)
     /// → <c># Title</c> → full description body → optional <c>**Hints:**</c> line → <c>## Input</c> (param table +
     /// the input JSON Schema fence) → optional <c>## Output</c> (output schema fence) → <c>## How to Call</c> (the
     /// plain token-free <c>unreal-mcp-cli run-tool</c> form). Idempotent: every SKILL.md is overwritten and stale
@@ -46,6 +48,27 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.AgentConfig
     {
         /// <summary>A defensive single-line cap for the YAML <c>description:</c> scalar (mirrors the C++ generator).</summary>
         public const int MaxSkillDescriptionLength = 1024;
+
+        /// <summary>
+        /// YAML front-matter key holding the provenance block. In the Skills file format used by Codex (and
+        /// Anthropic Agent Skills) <c>metadata</c> is a declared front-matter field carrying a free-form mapping
+        /// of extra keys, which is why the marker nests under it rather than sitting as a bare top-level key a
+        /// host would simply ignore.
+        /// </summary>
+        public const string ProvenanceBlockKey = "metadata";
+
+        /// <summary>
+        /// Key, nested under <see cref="ProvenanceBlockKey"/>, marking a SKILL.md as written by a generator
+        /// rather than hand-authored by a user. A consumer that dedups generated skills against the live tool
+        /// catalog keys on this; an unmarked file is treated as hand-authored and always kept (fail-open).
+        /// </summary>
+        public const string ProvenanceKey = "generated-by";
+
+        /// <summary>
+        /// Value written for <see cref="ProvenanceKey"/>. Deliberately carries NO version and NO timestamp, so
+        /// regenerating an unchanged tool rewrites a byte-identical file.
+        /// </summary>
+        public const string ProvenanceValue = "mcp-plugin-dotnet";
 
         private readonly ILogger? _logger;
 
@@ -237,10 +260,22 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.AgentConfig
 
             var lines = new List<string>();
 
-            // YAML front-matter (name + description).
+            // YAML front-matter (name + description + the provenance marker).
             lines.Add("---");
             lines.Add($"name: {folderName}");
             lines.Add($"description: \"{yamlDesc}\"");
+            // Provenance marker — the LAST block INSIDE the front matter, immediately before the closing `---`,
+            // byte-identical to the shared com.IvanMurzak.McpPlugin AgentConfig generator's own marker (which
+            // Unity and the Godot C# addon inherit by subclassing; this class is independent, so it stamps its
+            // own). A consumer that dedups generated skills parses the front matter only, so a marker written
+            // after the closing `---` would be invisible to it.
+            //
+            // Written RAW from these constants, never through EscapeYamlQuoted: that helper escapes a single
+            // scalar and would collapse the nested mapping into a quoted string. Nothing tool-derived reaches
+            // these two lines, so a tool description cannot forge the marker — the description itself is
+            // single-lined and double-quoted above, which is what keeps it from breaking out of its scalar.
+            lines.Add($"{ProvenanceBlockKey}:");
+            lines.Add($"  {ProvenanceKey}: {ProvenanceValue}");
             lines.Add("---");
             lines.Add(string.Empty);
 

--- a/bridge/tests/SkillFileGeneratorTests.cs
+++ b/bridge/tests/SkillFileGeneratorTests.cs
@@ -43,6 +43,9 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             catch { /* best-effort temp cleanup */ }
         }
 
+        /// <summary>Where <see cref="DemoTool"/>'s SKILL.md lands under the per-test temp root.</summary>
+        private string DemoSkillPath => Path.Combine(_root, "demo-tool", "SKILL.md");
+
         // A hand-built tool with one required + one optional param and a description carrying a literal pipe — the
         // same fixture shape the old C++ spec used to assert table escaping.
         private static ToolDescriptor DemoTool()
@@ -143,11 +146,11 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
 
             Assert.True(result.Success);
             Assert.Equal(2, result.FilesWritten);
-            Assert.True(File.Exists(Path.Combine(_root, "demo-tool", "SKILL.md")));
+            Assert.True(File.Exists(DemoSkillPath));
             Assert.True(File.Exists(Path.Combine(_root, "ping", "SKILL.md")));
             // The written content is the same as the pure builder produced.
             Assert.Equal(SkillFileGenerator.BuildSkillMarkdown(DemoTool()),
-                File.ReadAllText(Path.Combine(_root, "demo-tool", "SKILL.md")));
+                File.ReadAllText(DemoSkillPath));
         }
 
         [Fact]
@@ -260,6 +263,18 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
         private const string MarkerEntryLine = "  generated-by: mcp-plugin-dotnet";
 
         /// <summary>
+        /// Assert a marker line occurs exactly once in <paramref name="region"/>. `Assert.Equal(1, n)` and
+        /// `Assert.Single` have no message overload, so an `Assert.True` carries <paramref name="half"/> —
+        /// otherwise every one of these prints an indistinguishable "Expected: 1 / Actual: 2" and a red names
+        /// the test without naming which half broke.
+        /// </summary>
+        private static void AssertExactlyOne(string half, IEnumerable<string> region, string marker)
+        {
+            var found = region.Count(l => l == marker);
+            Assert.True(found == 1, $"{half}: expected exactly ONE '{marker.Trim()}' — found {found}");
+        }
+
+        /// <summary>
         /// The front-matter lines: everything strictly between the opening `---` and the next `---`. Splitting
         /// on '\n' only (never trimming) keeps a stray '\r' visible to the caller instead of silently absorbing
         /// it — a consumer parsing the front matter has to see the same bytes we do.
@@ -280,12 +295,17 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             Assert.True(gen.Generate(new List<ToolDescriptor> { DemoTool() }, _root).Success);
 
             // Assert against the file on DISK — that is the artifact a dedup consumer parses.
-            var lines = File.ReadAllText(Path.Combine(_root, "demo-tool", "SKILL.md")).Split('\n');
+            var lines = File.ReadAllText(DemoSkillPath).Split('\n');
 
             Assert.Equal("---", lines[0]);
             Assert.Equal("name: demo-tool", lines[1]);                     // `name:` unchanged and still FIRST
             Assert.Equal("description: \"Does a demo thing.\"", lines[2]);
-            Assert.Equal(MarkerBlockLine, lines[3]);                       // marker block key, top level
+            // PRESENCE and POSITION break for different reasons — a marker deleted outright vs one emitted
+            // below the closing `---`. The index equality alone discriminates them (-1 vs 6), but a bare -1
+            // reads as a puzzle, so the absent case gets its own named message first.
+            var markerIndex = Array.IndexOf(lines, MarkerBlockLine);
+            Assert.True(markerIndex >= 0, $"'{MarkerBlockLine}' is ABSENT from the generated document entirely");
+            Assert.Equal(3, markerIndex);                                  // ...and it sits INSIDE the front matter
             Assert.Equal(MarkerEntryLine, lines[4]);                       // exactly two leading spaces
             Assert.Equal("---", lines[5]);                                 // ...and it is the LAST block inside
         }
@@ -297,15 +317,21 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             var allLines = md.Split('\n');
             var frontMatter = FrontMatterLines(md);
 
-            // (1) Exactly one marker in the front matter. For this fixture the positional test above already
-            //     entails this much (its closing `---` at index 5 bounds the block) — the independent half is (2).
-            Assert.Equal(1, frontMatter.Count(l => l == MarkerBlockLine));
-            Assert.Equal(1, frontMatter.Count(l => l == MarkerEntryLine));
+            // (1) Exactly one marker in the front matter. For this fixture the positional test above entails
+            //     this much — but only via Generate_WritesOneSkillPerToolUnderSanitizedFolders, whose
+            //     whole-document equality is what ties that test's on-disk file to this builder's output.
+            //     Kept as the direct claim on the builder, so weakening that bridge does not silently leave
+            //     the builder path unguarded.
+            AssertExactlyOne("in-front-matter half", frontMatter, MarkerBlockLine);
+            AssertExactlyOne("in-front-matter half", frontMatter, MarkerEntryLine);
             // (2) ...and NOWHERE else in the document. This fixture's own text carries no marker, so a second
             //     occurrence anywhere below the front matter could only be one the generator emitted itself.
-            Assert.Equal(1, allLines.Count(l => l == MarkerBlockLine));
-            Assert.Equal(1, allLines.Count(l => l == MarkerEntryLine));
-            // (3) The published constants are the single source of those two literals.
+            AssertExactlyOne("nowhere-else half", allLines, MarkerBlockLine);
+            AssertExactlyOne("nowhere-else half", allLines, MarkerEntryLine);
+            // (3) The published constants compose the two literals the assertions above pin. This catches a
+            //     constant renamed or revalued out from under those literals; it does NOT prove the generator
+            //     READS the constants (a hardcoded emission with the constants intact satisfies everything
+            //     here), which C# affords no cheap assertion for.
             Assert.Equal(MarkerBlockLine, SkillFileGenerator.ProvenanceBlockKey + ":");
             Assert.Equal(MarkerEntryLine, "  " + SkillFileGenerator.ProvenanceKey + ": " + SkillFileGenerator.ProvenanceValue);
         }
@@ -343,18 +369,24 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             // Regeneration must rewrite a byte-identical file: the marker value carries no version and no
             // timestamp. Fresh generator instance AND a freshly constructed (equal-valued) descriptor on each
             // pass, so nothing is shared between them but the values.
+            //
+            // Generate_WritesOneSkillPerToolUnderSanitizedFolders already compares one written file against a
+            // rebuild, so it catches per-emission nondeterminism too. What is new here is the rest: a second
+            // generator INSTANCE (no cross-pass state), an overwrite of an existing file rather than a first
+            // write, and a BYTE comparison that would also catch an encoding or BOM change.
             var first = new SkillFileGenerator();
             Assert.True(first.Generate(new List<ToolDescriptor> { DemoTool() }, _root).Success);
-            var pass1 = File.ReadAllBytes(Path.Combine(_root, "demo-tool", "SKILL.md"));
+            var pass1 = File.ReadAllBytes(DemoSkillPath);
 
             var second = new SkillFileGenerator();
             Assert.True(second.Generate(new List<ToolDescriptor> { DemoTool() }, _root).Success);
-            var pass2 = File.ReadAllBytes(Path.Combine(_root, "demo-tool", "SKILL.md"));
+            var pass2 = File.ReadAllBytes(DemoSkillPath);
 
             Assert.Equal(pass1, pass2);
-            // Positive control — without it an equality over two MARKER-LESS files would score green.
+            // Positive control — without it an equality over two MARKER-LESS files would score green. ONE
+            // reading is the whole control: past the equality above the two decode to the same string, so a
+            // second Contains over pass2 could not fail whatever the generator did.
             Assert.Contains(MarkerEntryLine, Encoding.UTF8.GetString(pass1));
-            Assert.Contains(MarkerEntryLine, Encoding.UTF8.GetString(pass2));
         }
 
         [Fact]
@@ -372,7 +404,7 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             var gen = new SkillFileGenerator();
             Assert.True(gen.Generate(new List<ToolDescriptor> { DemoTool() }, _root).Success);
 
-            var content = File.ReadAllText(Path.Combine(_root, "demo-tool", "SKILL.md"));
+            var content = File.ReadAllText(DemoSkillPath);
             var closeIndex = content.IndexOf("\n---\n", StringComparison.Ordinal);
             Assert.True(closeIndex > 0, "front matter is never closed with an LF-delimited ---");
             var frontMatterRegion = content.Substring(0, closeIndex + "\n---\n".Length);

--- a/bridge/tests/SkillFileGeneratorTests.cs
+++ b/bridge/tests/SkillFileGeneratorTests.cs
@@ -11,6 +11,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
 using System.Text.Json.Nodes;
 using com.IvanMurzak.Unreal.MCP.Bridge.AgentConfig;
 using com.IvanMurzak.Unreal.MCP.Bridge.Ipc;
@@ -239,6 +241,144 @@ namespace com.IvanMurzak.Unreal.MCP.Bridge.Tests
             Assert.Equal(2, rows.Count);
             Assert.Contains(rows, r => r.StartsWith("| `name` | string | yes |"));
             Assert.Contains(rows, r => r.StartsWith("| `count` | integer | no |"));
+        }
+
+        // --- Provenance marker -------------------------------------------------------------------------
+        //
+        // A generated SKILL.md carries a front-matter marker identifying it as generated rather than
+        // hand-authored, so a consumer can dedup its own generated skills against the live tool catalog while
+        // leaving user-authored files alone. The marker is two literal lines, the LAST block inside the front
+        // matter:
+        //
+        //     metadata:
+        //       generated-by: mcp-plugin-dotnet
+        //
+        // The two-space indent is load-bearing — it is what makes this a nested YAML mapping rather than a
+        // sibling scalar — so these assertions compare whole lines POSITIONALLY and UN-TRIMMED.
+
+        private const string MarkerBlockLine = "metadata:";
+        private const string MarkerEntryLine = "  generated-by: mcp-plugin-dotnet";
+
+        /// <summary>
+        /// The front-matter lines: everything strictly between the opening `---` and the next `---`. Splitting
+        /// on '\n' only (never trimming) keeps a stray '\r' visible to the caller instead of silently absorbing
+        /// it — a consumer parsing the front matter has to see the same bytes we do.
+        /// </summary>
+        private static List<string> FrontMatterLines(string markdown)
+        {
+            var lines = new List<string>(markdown.Split('\n'));
+            Assert.Equal("---", lines[0]);                       // the document opens the front matter
+            var close = lines.IndexOf("---", 1);
+            Assert.True(close > 0, "front matter is never closed");
+            return lines.GetRange(1, close - 1);
+        }
+
+        [Fact]
+        public void Generate_StampsProvenanceMarkerAsTheLastFrontMatterBlock_PositionalAndUntrimmed()
+        {
+            var gen = new SkillFileGenerator();
+            Assert.True(gen.Generate(new List<ToolDescriptor> { DemoTool() }, _root).Success);
+
+            // Assert against the file on DISK — that is the artifact a dedup consumer parses.
+            var lines = File.ReadAllText(Path.Combine(_root, "demo-tool", "SKILL.md")).Split('\n');
+
+            Assert.Equal("---", lines[0]);
+            Assert.Equal("name: demo-tool", lines[1]);                     // `name:` unchanged and still FIRST
+            Assert.Equal("description: \"Does a demo thing.\"", lines[2]);
+            Assert.Equal(MarkerBlockLine, lines[3]);                       // marker block key, top level
+            Assert.Equal(MarkerEntryLine, lines[4]);                       // exactly two leading spaces
+            Assert.Equal("---", lines[5]);                                 // ...and it is the LAST block inside
+        }
+
+        [Fact]
+        public void BuildSkillMarkdown_ProvenanceMarkerAppearsExactlyOnce_InTheFrontMatterAndNowhereElse()
+        {
+            var md = SkillFileGenerator.BuildSkillMarkdown(DemoTool());
+            var allLines = md.Split('\n');
+            var frontMatter = FrontMatterLines(md);
+
+            // (1) Exactly one marker in the front matter. For this fixture the positional test above already
+            //     entails this much (its closing `---` at index 5 bounds the block) — the independent half is (2).
+            Assert.Equal(1, frontMatter.Count(l => l == MarkerBlockLine));
+            Assert.Equal(1, frontMatter.Count(l => l == MarkerEntryLine));
+            // (2) ...and NOWHERE else in the document. This fixture's own text carries no marker, so a second
+            //     occurrence anywhere below the front matter could only be one the generator emitted itself.
+            Assert.Equal(1, allLines.Count(l => l == MarkerBlockLine));
+            Assert.Equal(1, allLines.Count(l => l == MarkerEntryLine));
+            // (3) The published constants are the single source of those two literals.
+            Assert.Equal(MarkerBlockLine, SkillFileGenerator.ProvenanceBlockKey + ":");
+            Assert.Equal(MarkerEntryLine, "  " + SkillFileGenerator.ProvenanceKey + ": " + SkillFileGenerator.ProvenanceValue);
+        }
+
+        [Fact]
+        public void BuildSkillMarkdown_DescriptionCannotForgeASecondTopLevelMarker()
+        {
+            // A tool whose own description carries the marker text at line start. The front-matter description
+            // is single-lined and double-quoted, so this text can never escape its scalar — the front matter
+            // still holds exactly ONE top-level marker. (The verbatim multi-line text DOES reappear in the body
+            // below the closing `---`; the front matter is the only region a marker means anything in, which is
+            // why these counts are scoped to it.)
+            var forger = new ToolDescriptor
+            {
+                Name = "forge-tool",
+                Title = "Forge Tool",
+                Description = "Prose first.\n" + MarkerBlockLine + "\n" + MarkerEntryLine + "\nAnd more prose.",
+            };
+
+            var md = SkillFileGenerator.BuildSkillMarkdown(forger);
+            var frontMatter = FrontMatterLines(md);
+
+            Assert.Equal(1, frontMatter.Count(l => l == MarkerBlockLine));
+            Assert.Equal(1, frontMatter.Count(l => l == MarkerEntryLine));
+            // The forged text was flattened into the quoted description scalar rather than dropped.
+            Assert.Contains(frontMatter, l => l.StartsWith("description: \"Prose first. " + MarkerBlockLine));
+            // Positive control: the marker really is where we expect, so the counts above are not "1 by luck".
+            Assert.Equal(MarkerBlockLine, frontMatter[frontMatter.Count - 2]);
+            Assert.Equal(MarkerEntryLine, frontMatter[frontMatter.Count - 1]);
+        }
+
+        [Fact]
+        public void Generate_IsByteStable_AcrossAFreshGeneratorAndAFreshEqualValuedInput()
+        {
+            // Regeneration must rewrite a byte-identical file: the marker value carries no version and no
+            // timestamp. Fresh generator instance AND a freshly constructed (equal-valued) descriptor on each
+            // pass, so nothing is shared between them but the values.
+            var first = new SkillFileGenerator();
+            Assert.True(first.Generate(new List<ToolDescriptor> { DemoTool() }, _root).Success);
+            var pass1 = File.ReadAllBytes(Path.Combine(_root, "demo-tool", "SKILL.md"));
+
+            var second = new SkillFileGenerator();
+            Assert.True(second.Generate(new List<ToolDescriptor> { DemoTool() }, _root).Success);
+            var pass2 = File.ReadAllBytes(Path.Combine(_root, "demo-tool", "SKILL.md"));
+
+            Assert.Equal(pass1, pass2);
+            // Positive control — without it an equality over two MARKER-LESS files would score green.
+            Assert.Contains(MarkerEntryLine, Encoding.UTF8.GetString(pass1));
+            Assert.Contains(MarkerEntryLine, Encoding.UTF8.GetString(pass2));
+        }
+
+        [Fact]
+        public void Generate_WritesAnLfOnlyFrontMatter_SoTheMarkerNeedsNoCrlfNormalisation()
+        {
+            // The document skeleton is joined with "\n" (not AppendLine / Environment.NewLine), so the FRONT
+            // MATTER — the only region a marker means anything in — is LF-terminated on every platform, Windows
+            // included: a parser never sees a '\r' glued to the marker value.
+            //
+            // Scoped to the front matter deliberately. Further down the document the embedded JSON Schema fence
+            // is serialized by System.Text.Json with WriteIndented, whose JsonWriterOptions.NewLine defaults to
+            // Environment.NewLine — so a generated SKILL.md is MIXED-ending on Windows (LF skeleton, CRLF inside
+            // the fence). That is pre-existing and out of scope here; a whole-document "no \r" assertion would
+            // pass on Linux and fail on Windows, which is why this asserts the region the claim is about.
+            var gen = new SkillFileGenerator();
+            Assert.True(gen.Generate(new List<ToolDescriptor> { DemoTool() }, _root).Success);
+
+            var content = File.ReadAllText(Path.Combine(_root, "demo-tool", "SKILL.md"));
+            var closeIndex = content.IndexOf("\n---\n", StringComparison.Ordinal);
+            Assert.True(closeIndex > 0, "front matter is never closed with an LF-delimited ---");
+            var frontMatterRegion = content.Substring(0, closeIndex + "\n---\n".Length);
+
+            Assert.DoesNotContain("\r", frontMatterRegion);
+            Assert.Contains("\n" + MarkerEntryLine + "\n", frontMatterRegion);
         }
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -432,6 +432,31 @@ The plugin's editor module is the destination rather than a game module because 
 on `UnrealMcpRuntime` overrides a consumer's `TargetDenyList` and drags the plugin into packaged builds.
 A precompiled (marketplace) install has no C++ source on disk and is refused with that reason.
 
+**Every generated SKILL.md carries a provenance marker.** The YAML front matter closes with, as its LAST
+block before the closing `---`:
+
+```yaml
+metadata:
+  generated-by: mcp-plugin-dotnet
+```
+
+The two-space indent is load-bearing — it is what makes `generated-by` a nested mapping rather than a
+sibling top-level scalar. The value deliberately carries **no version and no timestamp**, so regenerating
+an unchanged tool rewrites a byte-identical file. It exists so a consumer can tell a generated skill from a
+hand-authored one and dedup only its own output against the live tool catalog (matching on the front
+matter's `name:`); such a consumer is expected to be **fail-open** — an unmarked file is kept. There is no
+such consumer in this repo yet, and `PruneStaleSkillFolders` is **not** one: it prunes on the presence of a
+`SKILL.md`, not on the marker.
+
+The same two lines the shared `com.IvanMurzak.McpPlugin.Skills.SkillFileGenerator` emits, but this class is
+independent of it rather than a subclass, so it stamps its own copy (unifying the two is a known deferred
+follow-up). Same line *content*, not the same bytes: the shared generator terminates with
+`Environment.NewLine` while this one joins the document with `"\n"`, so a consumer must match the marker
+per line, never as one raw byte run. This generator's front matter is therefore LF-only on every platform;
+note the `### Input JSON Schema` fences further down are serialized by `System.Text.Json` with
+`WriteIndented`, whose newline defaults to `Environment.NewLine`, so a generated `SKILL.md` is
+**mixed-ending on Windows** outside the front matter.
+
 **Consequence for callers.** `POST /api/tools/ping` no longer resolves. The CLI probes
 `/api/system-tools/ping` first and falls back to the legacy route only for a pre-§2.4 plugin
 (`cli/src/utils/probe.ts`); `scripts/connection_smoke.py` asserts `ping` is ABSENT from `tools/list` and

--- a/docs/SKILL-PROVENANCE-PLANTS.md
+++ b/docs/SKILL-PROVENANCE-PLANTS.md
@@ -1,0 +1,70 @@
+# SKILL.md provenance marker — plant log
+
+Verification artifact for the front-matter provenance marker emitted by
+`bridge/src/AgentConfig/SkillFileGenerator.cs`. Every generated per-tool `SKILL.md` carries, as the
+**last block inside the YAML front matter**:
+
+```yaml
+---
+name: actor-create
+description: "..."
+metadata:
+  generated-by: mcp-plugin-dotnet
+---
+```
+
+Byte-identical to the marker the shared `com.IvanMurzak.McpPlugin` AgentConfig generator writes (which
+Unity and the Godot C# addon inherit by subclassing). The two-space indent is load-bearing: it is what
+makes `generated-by` a nested mapping under `metadata` rather than a sibling top-level scalar.
+
+The point of the marker is that a consumer can tell a generated skill file from a hand-authored one and
+dedup only its own output. It is **fail-open**: an unmarked file is never excluded.
+
+## Why a plant log
+
+Every assertion below was proved to be able to FAIL, by mutating the generator and observing the
+specific test go red. A test that passes is only evidence once you know it can fail.
+
+Each plant was applied, verified and byte-exactly restored by the shared
+`plant_and_revert.py` harness (out-of-tree backups, checksum-verified restore — never a
+`git checkout --`), one at a time, against the whole bridge suite.
+
+- Verify command (per plant): `dotnet test bridge/Unreal-MCP-Bridge.sln --configuration Debug --verbosity normal`
+- Every plant collected **359 tests**, so no plant reddened the suite through an import or compile
+  break instead of through its own mutation.
+- Green before the round: `Test Run Successful. Total tests: 359 / Passed: 359`
+- Green after the round, on the restored tree: `Test Run Successful. Total tests: 359 / Passed: 359`
+
+## The round
+
+```
+SUMMARY  8/8 matched their expect | 8 RED | 0 GREEN | restore-failures 0
+```
+
+| # | Mutation (in `SkillFileGenerator.cs`) | Reddened test | Runner output |
+|---|---|---|---|
+| N1 | Marker block deleted — the front matter closes straight after `description:` | `Generate_StampsProvenanceMarkerAsTheLastFrontMatterBlock_PositionalAndUntrimmed` | `RED (exit 1)` · `Assert.Equal() Failure: Strings differ / Expected: "metadata:" / Actual: "---"` |
+| N2 | Marker block emitted **twice** inside the front matter | `BuildSkillMarkdown_ProvenanceMarkerAppearsExactlyOnce_InTheFrontMatterAndNowhereElse` | `RED (exit 1)` · `Assert.Equal() Failure: Values differ / Expected: 1 / Actual: 2` |
+| N3 | Marker entry emitted **without the two-space indent** (a sibling scalar, not a nested mapping) | `Generate_StampsProvenanceMarkerAsTheLastFrontMatterBlock_PositionalAndUntrimmed` | `RED (exit 1)` · `Expected: "  generated-by: mcp-plugin-dotnet" / Actual: "generated-by: mcp-plugin-dotnet"` |
+| N4 | Marker moved **after** the closing `---` (outside the front matter a consumer parses) | `Generate_StampsProvenanceMarkerAsTheLastFrontMatterBlock_PositionalAndUntrimmed` | `RED (exit 1)` · `Expected: "metadata:" / Actual: "---"` |
+| N5 | `SingleLineCapped` dropped from the `description:` scalar, so a multi-line tool description survives into the front matter | `BuildSkillMarkdown_DescriptionCannotForgeASecondTopLevelMarker` | `RED (exit 1)` · `Assert.Equal() Failure: Values differ / Expected: 1 / Actual: 2` — **the only test that reddened**, so the forgery guard is proved on its own |
+| N6 | Marker value suffixed with `-{DateTime.UtcNow.Ticks}` (a version/timestamp in the value) | `Generate_IsByteStable_AcrossAFreshGeneratorAndAFreshEqualValuedInput` | `RED (exit 1)` · `Assert.Equal() Failure: Collections differ / Expected: [···, 48, 57, 49, 54, 52, ···] / Actual: [···, 48, 57, 50, 54, 52, ···]` |
+| N7 | Document joined with `"\r\n"` instead of `"\n"` | `Generate_WritesAnLfOnlyFrontMatter_SoTheMarkerNeedsNoCrlfNormalisation` | `RED (exit 1)` · `front matter is never closed with an LF-delimited ---` |
+| N8 | A **second** marker emitted below the front matter, leaving the front matter itself correct | `BuildSkillMarkdown_ProvenanceMarkerAppearsExactlyOnce_InTheFrontMatterAndNowhereElse` | `RED (exit 1)` · `Assert.Equal() Failure: Values differ / Expected: 1 / Actual: 2` — **the only test that reddened**; the positional test stayed green, which is what makes the "and nowhere else" half independently proved |
+
+Both directions are covered: N1 proves the marker test reddens when the marker is **removed**; N2 / N3 /
+N4 / N8 prove the exactly-once and positional tests redden when it is emitted **twice, at the wrong
+indent, or in the wrong place**.
+
+## Line endings
+
+The document skeleton is joined with `"\n"`, so the **front matter is LF-only on every platform,
+Windows included** — a marker parser never sees a `\r` glued to the value, and needs no CRLF
+normalization for this generator's output. Pinned by `Generate_WritesAnLfOnlyFrontMatter_...` and
+proved falsifiable by N7.
+
+Further down the document the `### Input JSON Schema` / `### Output JSON Schema` fences are serialized
+by `System.Text.Json` with `WriteIndented = true`, whose `JsonWriterOptions.NewLine` defaults to
+`Environment.NewLine` — so a generated `SKILL.md` is **mixed-ending on Windows** (LF skeleton, CRLF
+inside those fences). That is pre-existing behaviour, outside the front matter, and is not changed
+here; it is recorded so nobody re-derives it from a surprising diff.

--- a/docs/SKILL-PROVENANCE-PLANTS.md
+++ b/docs/SKILL-PROVENANCE-PLANTS.md
@@ -13,21 +13,18 @@ metadata:
 ---
 ```
 
-Byte-identical to the marker the shared `com.IvanMurzak.McpPlugin` AgentConfig generator writes (which
-Unity and the Godot C# addon inherit by subclassing). The two-space indent is load-bearing: it is what
-makes `generated-by` a nested mapping under `metadata` rather than a sibling top-level scalar.
-
-The point of the marker is that a consumer can tell a generated skill file from a hand-authored one and
-dedup only its own output. It is **fail-open**: an unmarked file is never excluded.
+**The marker's contract — its shape, its position, the fail-open expectation, and how it relates to the
+shared generator's — lives in [`ARCHITECTURE.md`](ARCHITECTURE.md) §2.4, which is authoritative.** This
+file does not restate it; it records only the evidence that the tests pinning it can actually fail.
 
 ## Why a plant log
 
 Every assertion below was proved to be able to FAIL, by mutating the generator and observing the
 specific test go red. A test that passes is only evidence once you know it can fail.
 
-Each plant was applied, verified and byte-exactly restored by the shared
-`plant_and_revert.py` harness (out-of-tree backups, checksum-verified restore — never a
-`git checkout --`), one at a time, against the whole bridge suite.
+Each plant was applied on its own, verified against the whole bridge suite, then restored from an
+out-of-tree backup and checksum-verified — never reverted with `git checkout --`, which would have
+taken uncommitted work with it.
 
 - Verify command (per plant): `dotnet test bridge/Unreal-MCP-Bridge.sln --configuration Debug --verbosity normal`
 - Every plant collected **359 tests**, so no plant reddened the suite through an import or compile
@@ -38,33 +35,35 @@ Each plant was applied, verified and byte-exactly restored by the shared
 ## The round
 
 ```
-SUMMARY  8/8 matched their expect | 8 RED | 0 GREEN | restore-failures 0
+SUMMARY  11/11 matched their expect | 11 RED | 0 GREEN | restore-failures 0
 ```
 
-| # | Mutation (in `SkillFileGenerator.cs`) | Reddened test | Runner output |
-|---|---|---|---|
-| N1 | Marker block deleted — the front matter closes straight after `description:` | `Generate_StampsProvenanceMarkerAsTheLastFrontMatterBlock_PositionalAndUntrimmed` | `RED (exit 1)` · `Assert.Equal() Failure: Strings differ / Expected: "metadata:" / Actual: "---"` |
-| N2 | Marker block emitted **twice** inside the front matter | `BuildSkillMarkdown_ProvenanceMarkerAppearsExactlyOnce_InTheFrontMatterAndNowhereElse` | `RED (exit 1)` · `Assert.Equal() Failure: Values differ / Expected: 1 / Actual: 2` |
-| N3 | Marker entry emitted **without the two-space indent** (a sibling scalar, not a nested mapping) | `Generate_StampsProvenanceMarkerAsTheLastFrontMatterBlock_PositionalAndUntrimmed` | `RED (exit 1)` · `Expected: "  generated-by: mcp-plugin-dotnet" / Actual: "generated-by: mcp-plugin-dotnet"` |
-| N4 | Marker moved **after** the closing `---` (outside the front matter a consumer parses) | `Generate_StampsProvenanceMarkerAsTheLastFrontMatterBlock_PositionalAndUntrimmed` | `RED (exit 1)` · `Expected: "metadata:" / Actual: "---"` |
-| N5 | `SingleLineCapped` dropped from the `description:` scalar, so a multi-line tool description survives into the front matter | `BuildSkillMarkdown_DescriptionCannotForgeASecondTopLevelMarker` | `RED (exit 1)` · `Assert.Equal() Failure: Values differ / Expected: 1 / Actual: 2` — **the only test that reddened**, so the forgery guard is proved on its own |
-| N6 | Marker value suffixed with `-{DateTime.UtcNow.Ticks}` (a version/timestamp in the value) | `Generate_IsByteStable_AcrossAFreshGeneratorAndAFreshEqualValuedInput` | `RED (exit 1)` · `Assert.Equal() Failure: Collections differ / Expected: [···, 48, 57, 49, 54, 52, ···] / Actual: [···, 48, 57, 50, 54, 52, ···]` |
-| N7 | Document joined with `"\r\n"` instead of `"\n"` | `Generate_WritesAnLfOnlyFrontMatter_SoTheMarkerNeedsNoCrlfNormalisation` | `RED (exit 1)` · `front matter is never closed with an LF-delimited ---` |
-| N8 | A **second** marker emitted below the front matter, leaving the front matter itself correct | `BuildSkillMarkdown_ProvenanceMarkerAppearsExactlyOnce_InTheFrontMatterAndNowhereElse` | `RED (exit 1)` · `Assert.Equal() Failure: Values differ / Expected: 1 / Actual: 2` — **the only test that reddened**; the positional test stayed green, which is what makes the "and nowhere else" half independently proved |
+**The "Attributed test" column names the test the plant is marked on — the one whose failure is the
+evidence — not the only test that went red.** A mutation to shared emission code legitimately reddens
+several tests at once; the per-plant total is given so that breadth is visible rather than implied
+away. Where a plant reddened exactly **one** test, that is called out, because it means the claim is
+proved on its own rather than through a sibling assertion.
 
-Both directions are covered: N1 proves the marker test reddens when the marker is **removed**; N2 / N3 /
-N4 / N8 prove the exactly-once and positional tests redden when it is emitted **twice, at the wrong
-indent, or in the wrong place**.
+**Every plant in a shared-marker group fails with different text.** Proving a mutation *can* redden a
+test and being able to *tell two reds apart* are different properties; the second is what makes a
+future failure diagnosable, and it is the reason N1/N4 and N2/N8 carry the wording they do.
 
-## Line endings
+| # | Mutation (in `SkillFileGenerator.cs`) | Attributed test | Runner output | Reds |
+|---|---|---|---|---|
+| N1 | Marker block deleted — the front matter closes straight after `description:` | `Generate_StampsProvenanceMarkerAsTheLastFrontMatterBlock_PositionalAndUntrimmed` | `RED (exit 1)` · `'metadata:' is ABSENT from the generated document entirely` | 5 |
+| N2 | Marker block emitted **twice** inside the front matter | `BuildSkillMarkdown_ProvenanceMarkerAppearsExactlyOnce_InTheFrontMatterAndNowhereElse` | `RED (exit 1)` · `in-front-matter half: expected exactly ONE 'metadata:' — found 2` | 3 |
+| N3 | Marker entry emitted **without the two-space indent** (a sibling scalar, not a nested mapping) | `Generate_StampsProvenanceMarkerAsTheLastFrontMatterBlock_PositionalAndUntrimmed` | `RED (exit 1)` · `Assert.Equal() Failure: Strings differ / Expected: "  generated-by: mcp-plugin-dotnet" / Actual: "generated-by: mcp-plugin-dotnet"` | 5 |
+| N4 | Marker moved **after** the closing `---` (outside the front matter a consumer parses) | `Generate_StampsProvenanceMarkerAsTheLastFrontMatterBlock_PositionalAndUntrimmed` | `RED (exit 1)` · `Assert.Equal() Failure: Values differ / Expected: 3 / Actual: 4` (the marker's index moved out of the front matter) | 4 |
+| N5 | `SingleLineCapped` dropped from the `description:` scalar, so a multi-line tool description survives into the front matter | `BuildSkillMarkdown_DescriptionCannotForgeASecondTopLevelMarker` | `RED (exit 1)` · `Assert.Equal() Failure: Values differ / Expected: 1 / Actual: 2` — **the only test that reddened**, so the forgery guard is proved on its own | 1 |
+| N6 | Marker value suffixed with `-{DateTime.UtcNow.Ticks}` (a version/timestamp in the value) | `Generate_IsByteStable_AcrossAFreshGeneratorAndAFreshEqualValuedInput` | `RED (exit 1)` · `Assert.Equal() Failure: Collections differ / Expected: [···, 55, 52, 51, 50, 50, ···] / Actual: [···, 55, 52, 52, 51, 53, ···]` | 6 |
+| N7 | Document joined with `"\r\n"` instead of `"\n"` | `Generate_WritesAnLfOnlyFrontMatter_SoTheMarkerNeedsNoCrlfNormalisation` | `RED (exit 1)` · `front matter is never closed with an LF-delimited ---` | 4 |
+| N8 | A **second** marker emitted below the front matter, leaving the front matter itself correct | `BuildSkillMarkdown_ProvenanceMarkerAppearsExactlyOnce_InTheFrontMatterAndNowhereElse` | `RED (exit 1)` · `nowhere-else half: expected exactly ONE 'metadata:' — found 2` — **the only test that reddened**; the positional test stayed green, which is what makes the "and nowhere else" half independently proved | 1 |
+| N9 | `name:` and `description:` emitted in the opposite order | `Generate_StampsProvenanceMarkerAsTheLastFrontMatterBlock_PositionalAndUntrimmed` | `RED (exit 1)` · `Assert.Equal() Failure: Strings differ / Expected: "name: demo-tool" / Actual: "description: "Does a demo thing.""` — **the only test that reddened** | 1 |
+| N10 | An extra front-matter key emitted **after** the marker — marker present, correctly indented, simply no longer the last block | `Generate_StampsProvenanceMarkerAsTheLastFrontMatterBlock_PositionalAndUntrimmed` | `RED (exit 1)` · `Assert.Equal() Failure: Strings differ / Expected: "---" / Actual: "extra: 1"` | 2 |
+| N11 | A lone `\r` glued to the marker value while the document join stays `"\n"` | `Generate_WritesAnLfOnlyFrontMatter_SoTheMarkerNeedsNoCrlfNormalisation` | `RED (exit 1)` · `Assert.DoesNotContain() Failure: Sub-string found / String: ···":\n  generated-by: mcp-plugin-dotnet\r\n---\n" / Found: "\r"` | 4 |
 
-The document skeleton is joined with `"\n"`, so the **front matter is LF-only on every platform,
-Windows included** — a marker parser never sees a `\r` glued to the value, and needs no CRLF
-normalization for this generator's output. Pinned by `Generate_WritesAnLfOnlyFrontMatter_...` and
-proved falsifiable by N7.
-
-Further down the document the `### Input JSON Schema` / `### Output JSON Schema` fences are serialized
-by `System.Text.Json` with `WriteIndented = true`, whose `JsonWriterOptions.NewLine` defaults to
-`Environment.NewLine` — so a generated `SKILL.md` is **mixed-ending on Windows** (LF skeleton, CRLF
-inside those fences). That is pre-existing behaviour, outside the front matter, and is not changed
-here; it is recorded so nobody re-derives it from a surprising diff.
+Both directions are covered. **Removal:** N1. **Wrong shape or wrong place:** N2 / N3 / N4 / N8 / N10
+(twice, un-indented, outside the front matter, duplicated below it, no longer last). **Order:** N9
+pins that `name:` stays first. **Value stability:** N6. **Line endings:** N7 and N11 — and they are
+not redundant, because N7 aborts the test at its earlier "closed with an LF-delimited `---`" guard,
+so N11 is what proves the `DoesNotContain("\r")` assertion itself can fail.


### PR DESCRIPTION
## Summary

- **`bridge/src/AgentConfig/SkillFileGenerator.cs`** now stamps the provenance marker as the **last
  block inside the YAML front matter**, immediately before the closing `---`:

  ```yaml
  ---
  name: actor-create
  description: "..."
  metadata:
    generated-by: mcp-plugin-dotnet
  ---
  ```

  Three published constants (`ProvenanceBlockKey` / `ProvenanceKey` / `ProvenanceValue`) mirror the
  shared generator's, so the two literals have a single source. The value carries **no version and no
  timestamp** — regeneration stays byte-stable.
- **Five new xUnit cases** in `bridge/tests/SkillFileGeneratorTests.cs`, the marker's contract
  documented in **`docs/ARCHITECTURE.md` §2.4**, and a committed plant log at
  **`docs/SKILL-PROVENANCE-PLANTS.md`**.

## Why

This class is an independent `sealed` class, **not** a subclass of the shared generator, so it never
inherited the marker. It writes **per-tool** skills whose folder/`name:` values match live catalog tool
names (`actor-create`, `ping`) — exactly the files a marker-aware skills dedup is meant to exclude.
Without the marker those files read as *hand-authored* and are kept (such a dedup is fail-open), so the
feature would cover 2 of 3 engines.

Nothing is broken today: the failure is fail-**open**. This is completeness, not a defect.

## How this relates to the shared generator — three corrections

These were stated too strongly in the first revision of this PR and are now fixed in code comments and
in `ARCHITECTURE.md`:

1. The shared type is **`com.IvanMurzak.McpPlugin.Skills.SkillFileGenerator`**, not the `AgentConfig`
   module.
2. It is the **same two lines, not the same bytes**. The shared generator appends with `AppendLine`
   (so `Environment.NewLine`, CRLF on Windows); this one joins the document with `"\n"`. A consumer
   must match the marker **per line, never as one raw byte run** — matching the raw byte sequence
   would match Unreal's output and miss Unity's on Windows.
3. The shared marker is **not in the released `com.IvanMurzak.McpPlugin` 8.3.0** this bridge pins —
   verified by scanning `generated-by` (UTF-8 and UTF-16LE) across all three TFM DLLs of the cached
   package: 0 hits, while the `SkillFileGenerator` type itself is present. So it lives only in the
   MCP-Plugin-dotnet source today, nothing in this repo breaks if the shared value drifts, and
   Unity/Godot do not carry the marker yet either. Recorded as a re-check at the next McpPlugin bump.

## The marker is written raw, and cannot be forged — with the limit stated

The two marker lines are emitted **raw** from the constants, never through `EscapeYamlQuoted` — that
helper escapes a single scalar and would collapse the nested mapping into a quoted string. Nothing
tool-derived reaches those lines.

**Requested check — does the writer indent multi-line descriptions?** It does not, and it does not need
to: `SingleLineCapped` replaces every `\r\n` / `\n` / `\r` / tab with a space, collapses runs, caps at
1024 chars, and the result is emitted inside a **double-quoted** scalar. A multi-line description can
therefore never occupy more than one front-matter line, so it cannot break out of its scalar and forge
a second top-level `metadata:` block. Plant-proved by N5, not asserted.

**Recorded limit (pre-existing, unchanged here).** That guarantee is scoped to a real YAML parser.
`SingleLineCapped` does not neutralise `U+0085` / `U+2028` / `U+2029` or other C0 controls, which a
purely line-oriented consumer (a regex under the `m` flag) would treat as line breaks. This is
long-standing behaviour of the `description:` scalar, not something this change introduces — but the
marker is what makes it newly load-bearing, so it is now documented on `SingleLineCapped` itself,
where someone editing that helper will see it. Hardening it is a follow-up, deliberately out of scope
for a marker-only task.

**Also recorded, also out of scope:** `PruneStaleSkillFolders` deletes a stale folder on the *presence
of a `SKILL.md`*, not on this marker — so the "fail-open" property is an expectation of a future
external consumer, not a guarantee this repo makes internally. Called out explicitly in the code and
in `ARCHITECTURE.md` so the file does not appear to promise something it breaks 120 lines later.

## Evidence — plant log, 11/11 RED, 0 GREEN, both directions

Full artifact committed at `docs/SKILL-PROVENANCE-PLANTS.md`. Each plant applied, verified and
byte-exactly restored one at a time (out-of-tree backups, checksum-verified restore), verify command
`dotnet test bridge/Unreal-MCP-Bridge.sln --configuration Debug --verbosity normal`:

| # | Mutation | Attributed test | Runner line | Reds |
|---|---|---|---|---|
| N1 | marker block deleted | `..._PositionalAndUntrimmed` | `'metadata:' is ABSENT from the generated document entirely` | 5 |
| N2 | marker emitted **twice** | `...AppearsExactlyOnce...` | `in-front-matter half: expected exactly ONE 'metadata:' — found 2` | 3 |
| N3 | marker entry **un-indented** | `..._PositionalAndUntrimmed` | `Expected: "  generated-by: mcp-plugin-dotnet" / Actual: "generated-by: mcp-plugin-dotnet"` | 5 |
| N4 | marker moved **after** the closing `---` | `..._PositionalAndUntrimmed` | `Expected: 3 / Actual: 4` (the marker's index left the front matter) | 4 |
| N5 | `SingleLineCapped` dropped from the description scalar | `...DescriptionCannotForgeASecondTopLevelMarker` | `Expected: 1 / Actual: 2` — **only that test reddened** | 1 |
| N6 | marker value suffixed with `DateTime.UtcNow.Ticks` | `...IsByteStable...` | `Collections differ` | 6 |
| N7 | document joined with `"\r\n"` | `...WritesAnLfOnlyFrontMatter_...` | `front matter is never closed with an LF-delimited ---` | 4 |
| N8 | a **second** marker below the front matter, front matter left correct | `...AppearsExactlyOnce...` | `nowhere-else half: expected exactly ONE 'metadata:' — found 2` — **only that test reddened** | 1 |
| N9 | `name:` / `description:` order swapped | `..._PositionalAndUntrimmed` | `Expected: "name: demo-tool" / Actual: "description: ..."` — **only that test reddened** | 1 |
| N10 | an extra front-matter key **after** the marker | `..._PositionalAndUntrimmed` | `Expected: "---" / Actual: "extra: 1"` | 2 |
| N11 | a lone `\r` glued to the marker value, join left as `"\n"` | `...WritesAnLfOnlyFrontMatter_...` | `Assert.DoesNotContain() ... Found: "\r"` | 4 |

`SUMMARY 11/11 matched their expect | 11 RED | 0 GREEN | restore-failures 0`

Every plant collected **359** tests, so no RED came from an import or compile break. Green before the
round and again on the restored tree: `Total tests: 359 / Passed: 359`.

**Both directions.** Removal: N1. Wrong shape or place: N2 / N3 / N4 / N8 / N10. Order: N9. Value
stability: N6. Line endings: N7 and N11.

**Every plant in a shared-marker group fails with different text** — proving a mutation *can* redden a
test and being able to *tell two reds apart* are different properties, and only the second makes a
future failure diagnosable.

## What the review pass changed (first revision → now)

- **Deleted an assertion that could not fail.** In the byte-stability test, past
  `Assert.Equal(pass1, pass2)` the two buffers decode to the same string, so a second
  `Assert.Contains` over `pass2` was unfalsifiable under every mutation. One reading is the whole
  positive control.
- **N1 and N4 used to fail identically** (`Expected: "metadata:" / Actual: "---"`), as did **N2 and
  N8** (`Expected: 1 / Actual: 2`). Presence is now split from position, and the exactly-once halves
  carry distinct messages, so each red names the half that broke.
- **Three plants added (N9 / N10 / N11)** for assertions the first round left unproven: `name:` stays
  first, the marker really is the *last* block, and the `DoesNotContain("\r")` claim — which N7 never
  reaches, because it aborts that test at the earlier "closed with an LF-delimited `---`" guard.

## Line endings (recorded, per the task's CRLF note)

This writer joins the document with `"\n"`, **not** `AppendLine` / `Environment.NewLine` — so the
**front matter is LF-only on every platform, Windows included**. A marker parser needs no CRLF
normalization for this generator's output. Pinned by a test and proved falsifiable by N7 and N11.

Separately, and **not changed here**: the `### Input JSON Schema` / `### Output JSON Schema` fences
further down are serialized by `System.Text.Json` with `WriteIndented = true`, whose
`JsonWriterOptions.NewLine` defaults to `Environment.NewLine` — so a generated `SKILL.md` is
**mixed-ending on Windows** (LF skeleton, CRLF inside those fences), byte-stable on one machine but not
byte-identical across platforms. Outside the front matter, out of scope, recorded so nobody
re-derives it from a surprising diff.

## Known follow-ups (deliberately not done here)

- `SkillFileGenerator` duplicates the shared generator's marker rather than subclassing or consuming
  it. Restructuring is a larger refactor with its own risk and was explicitly left out of scope; the
  constants are published so a later unification has a name-for-name seam. Once a McpPlugin release
  carries the marker, emit from the shared constants instead.
- Harden the `description:` scalar against `U+0085` / `U+2028` / `U+2029` and C0 controls (see above).
- Decide whether `PruneStaleSkillFolders` should become provenance-aware. Note
  `SkillGenerateToolTests` currently *pins* the name-based behaviour, so changing it is a deliberate
  contract change, not a bug fix.

## Test plan

- [x] Target-specific local tests passed (see profile `test.md`) — Suite 4 (bridge `dotnet build` +
      xUnit): **0 errors, 359/359 passing** (354 pre-existing + 5 new).
- [x] Plant round: 11/11 RED, 0 GREEN, individually attributed, every shared-marker group failing
      distinguishably; tree restored byte-exactly and green after.
- [x] No `UnrealMCP/**`, `cli/**` or `.github/workflows/**` files touched, so no other suite applies;
      not a tool-family change, so the live bridge e2e (Suite 7) does not apply.
- [x] No version bump, no NuGet-pin change, no release action.

Taskflow `2026-08-28-tool-catalog`, task **d1**.
